### PR TITLE
Add build task to github workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,63 @@
+# For documentation on the github environment, see
+# https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners
+#
+# For documentation on the syntax of this file, see
+# https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+name: MSBuild
+
+on: [push]
+
+env:
+  # Path to the solution file relative to the root of the project.
+  SOLUTION_FILE_PATH: ebpf-demo.sln
+
+  # Configuration type to build.
+  # You can convert this to a build matrix if you need coverage of multiple configuration types.
+  # https://docs.github.com/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+  BUILD_CONFIGURATION: Release
+
+  BUILD_PLATFORM: x64
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'recursive'
+
+    - name: Add MSBuild to PATH
+      uses: microsoft/setup-msbuild@v1
+
+    - name: Install LLVM and Clang
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        curl -fsSL -o LLVM8.exe https://github.com/llvm/llvm-project/releases/download/llvmorg-8.0.1/LLVM-8.0.1-win64.exe
+        7z x LLVM8.exe -y -o"C:/Program Files/LLVM"
+        echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+    - name: Restore NuGet packages
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: nuget restore ${{env.SOLUTION_FILE_PATH}}
+
+    - name: Install Boost
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        $Url = "https://sourceforge.net/projects/boost/files/boost-binaries/1.72.0/boost_1_72_0-msvc-14.2-64.exe"
+        (New-Object System.Net.WebClient).DownloadFile($Url, "$env:TEMP\boost.exe")
+        Start-Process -Wait -FilePath "$env:TEMP\boost.exe" "/SILENT","/SP-","/SUPPRESSMSGBOXES","/DIR=C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
+
+    - name: Create verifier project
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        $env:BOOST_ROOT="C:\hostedtoolcache\windows\Boost\1.72.0\x86_64"
+        cd external\ebpf-verifier
+        mkdir build
+        cmake -B build
+
+    - name: Build
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      # Add additional options to the MSBuild command line here (like platform or verbosity level).
+      # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}}

--- a/Nuget.config
+++ b/Nuget.config
@@ -10,8 +10,4 @@
   <activePackageSource>
     <add key="All" value="(Aggregate source)" />
   </activePackageSource>
-  <packageSources>
-    <clear />
-    <add key="edgeos_windows_ebpf_feed" value="https://msazure.pkgs.visualstudio.com/One/_packaging/edgeos_windows_ebpf_feed/nuget/v3/index.json" />
-  </packageSources>
 </configuration>


### PR DESCRIPTION
This PR adds a CI gate to verify that the project builds, using github workflows.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>