### PR TITLE
Fix references to ebpfverifier project

### DIFF
--- a/src/ebpf/dll/ebpfapi.vcxproj
+++ b/src/ebpf/dll/ebpfapi.vcxproj
@@ -126,7 +126,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\ebpf-verifier\build\ebpfverifier.vcxproj">
-      <Project>{bd587773-916f-365f-82c0-2e8db12f40a0}</Project>
+      <Project>{7d5b4e68-c0fa-3f86-9405-f6400219b440}</Project>
     </ProjectReference>
     <ProjectReference Include="..\libs\api\api.vcxproj">
       <Project>{c8bf60c3-40a9-43ad-891a-8aa34f1c3a68}</Project>

--- a/src/test/end_to_end/end_to_end.vcxproj
+++ b/src/test/end_to_end/end_to_end.vcxproj
@@ -107,7 +107,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\external\ebpf-verifier\build\ebpfverifier.vcxproj">
-      <Project>{bd587773-916f-365f-82c0-2e8db12f40a0}</Project>
+      <Project>{7d5b4e68-c0fa-3f86-9405-f6400219b440}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\ebpf\libs\api\api.vcxproj">
       <Project>{c8bf60c3-40a9-43ad-891a-8aa34f1c3a68}</Project>


### PR DESCRIPTION
The GUID referenced didn't match the project's GUID in the ebpf-demo.sln file or in the ebpfverifier.vcxproj file.
There are two issues here, originally caused by the same root cause discussed in https://github.com/vbpf/ebpf-verifier/pull/204.   That is, cmake generates a project GUID based on the file path by default.  So on different machines where people used different file paths, the GUID would be different.  This then apparently resulted in different checkins touching different files at different times, resulting in inconsistency in this project.

Thus this fix has two parts: 
1. make ebpfverifier.vcxproj use a constant GUID.  That change is https://github.com/vbpf/ebpf-verifier/pull/204 for which I used the GUID that appeared in the SLN file in this repo.
2. make everything in this repo use the same constant GUID.  That change is in this PR.

This PR also needs to update the ebpfverifier submodule to reference the fixed commit once merged.
Hence marking this as Draft until that merge happens.

Fixes #18 

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>