### PR TITLE
Increase stack size for eBPF programs to 512 bytes

### DIFF
--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -30,4 +30,6 @@
 #define stderr 0
 #define fprintf NULL
 
+#define UBPF_STACK_SIZE 512
+
 #include "ubpf_vm.c"

--- a/libs/ubpf/user/ubpf_user.c
+++ b/libs/ubpf/user/ubpf_user.c
@@ -14,6 +14,7 @@
 #pragma warning(disable : 4267)
 
 #include <endian.h>
+#define UBPF_STACK_SIZE 512
 
 #include "ubpf_jit_x86_64.c"
 #include "ubpf_vm.c"


### PR DESCRIPTION
Increase stack size for eBPF programs to 512 bytes

Signed-off-by: Alan Jowett <alanjo@microsoft.com>