### PR TITLE
Clean up compiler warnings

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -58,6 +58,9 @@ extern "C"
      * @param[in] execution_type How this program should be run in the execution
      * context.
      * @param[out] handle Handle to eBPF program.
+     * @param[in,out] count_of_map_handles On input, contains the maximum number of map_handles to return.
+     * On output, contains the actual number of map_handles returned.
+     * @param[out] map_handles Array of map handles to be filled in.
      * @param[out] error_message Error message describing what failed.
      */
     uint32_t

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -491,7 +491,7 @@ ebpf_api_load_program(
     byte_code.resize(byte_code_size);
     result = resolve_maps_in_byte_code(program_handle, byte_code);
     if (result != ERROR_SUCCESS) {
-        return result;
+        goto Done;
     }
 
     result = resolve_ec_function(EBPF_EC_FUNCTION_LOG, &log_function_address);

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -38,7 +38,7 @@ test_crud_operations(ebpf_map_type_t map_type)
     _ebpf_core_initializer core;
 
     ebpf_map_definition_t map_definition{
-        sizeof(ebpf_map_definition_t), map_type, sizeof(uint32_t), sizeof(uint64_t), 10};
+        sizeof(ebpf_map_definition_t), (uint32_t)map_type, sizeof(uint32_t), sizeof(uint64_t), 10};
     map_ptr map;
     {
         ebpf_map_t* local_map;

--- a/rpc_interface/rpc_interface.idl
+++ b/rpc_interface/rpc_interface.idl
@@ -64,10 +64,10 @@ import "wtypes.idl";
         ebpf_result_t verify_and_jit_program(
             [ in, ref ] ebpf_program_load_info * info,
             [ out, ref ] uint32_t * logs_size,
-            [ out, size_is(, *logs_size), ref ] const char** logs);
+            [ out, size_is(, *logs_size), ref ] char** logs);
 
         ebpf_result_t verify_program(
             [ in, ref ] ebpf_program_verify_info * info,
             [out] uint32_t * logs_size,
-            [ out, size_is(, *logs_size), ref ] const char** logs);
+            [ out, size_is(, *logs_size), ref ] char** logs);
     }

--- a/tests/client/rpc_client.cpp
+++ b/tests/client/rpc_client.cpp
@@ -26,7 +26,7 @@ ebpf_rpc_verify_program(ebpf_program_verify_info* info, const char** logs, uint3
     unsigned long code;
     int result;
 
-    RpcTryExcept { result = (int)ebpf_client_verify_program(info, logs_size, logs); }
+    RpcTryExcept { result = (int)ebpf_client_verify_program(info, logs_size, const_cast<char**>(logs)); }
     RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
     {
         code = RpcExceptionCode();

--- a/tests/sample/droppacket_unsafe.c
+++ b/tests/sample/droppacket_unsafe.c
@@ -33,6 +33,5 @@ DropPacket(xdp_md_t* ctx)
             rc = XDP_DROP;
         }
     }
-Done:
     return rc;
 }

--- a/tools/netsh/programs.cpp
+++ b/tools/netsh/programs.cpp
@@ -146,7 +146,7 @@ handle_ebpf_add_program(
     ebpf_api_close_handle(_program_handle);
 
     const char* error_message = nullptr;
-    uint32_t count_of_map_handles = sizeof(_map_handles);
+    uint32_t count_of_map_handles = _countof(_map_handles);
     status = ebpf_api_load_program(
         filename.c_str(),
         section.c_str(),


### PR DESCRIPTION
The IDL was generating MIDL2279 because it used const on an [out] param,
which is warned against since RPC marshaling copies the result into new
memory.  See https://marc.info/?l=ms-dcom&m=103440617317922 for some
discussion.

Other changes should hopefully be obvious.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>