### PR TITLE
Fix netsh display of program type

### DIFF
--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -108,7 +108,7 @@ ebpf_api_elf_enumerate_sections(
             }
 
             sequence.emplace_back(tlv_pack<tlv_sequence>({tlv_pack(raw_program.section.c_str()),
-                                                          tlv_pack(raw_program.info.type.platform_specific_data),
+                                                          tlv_pack(raw_program.info.type.name.c_str()),
                                                           tlv_pack(raw_program.info.map_descriptors.size()),
                                                           tlv_pack(convert_ebpf_program_to_bytes(raw_program.prog)),
                                                           tlv_pack(stats_sequence)}));

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -378,7 +378,7 @@ TEST_CASE("enum section", "[enum sections]")
         auto stats_secton = tlv_next(program_bytes);
 
         REQUIRE(static_cast<tlv_type_t>(section_name->type) == tlv_type_t::STRING);
-        REQUIRE(static_cast<tlv_type_t>(type->type) == tlv_type_t::UINT);
+        REQUIRE(static_cast<tlv_type_t>(type->type) == tlv_type_t::STRING);
         REQUIRE(static_cast<tlv_type_t>(map_count->type) == tlv_type_t::UINT);
         REQUIRE(static_cast<tlv_type_t>(program_bytes->type) == tlv_type_t::BLOB);
         REQUIRE(static_cast<tlv_type_t>(stats_secton->type) == tlv_type_t::SEQUENCE);

--- a/tools/netsh/elf.cpp
+++ b/tools/netsh/elf.cpp
@@ -151,8 +151,8 @@ handle_ebpf_show_sections(
 
     if (level == VL_NORMAL) {
         std::cout << "\n";
-        std::cout << "             Section    Type  # Maps    Size\n";
-        std::cout << "====================  ======  ======  ======\n";
+        std::cout << "             Section       Type  # Maps    Size\n";
+        std::cout << "====================  =========  ======  ======\n";
     }
     for (auto current_section = tlv_child(section_data); current_section != tlv_next(section_data);
          current_section = tlv_next(current_section)) {
@@ -162,13 +162,13 @@ handle_ebpf_show_sections(
         auto program_bytes = tlv_next(map_count);
         auto stats_section = tlv_next(program_bytes);
         if (level == VL_NORMAL) {
-            std::cout << std::setw(20) << std::right << tlv_value<std::string>(section_name) << "  " << std::setw(6)
-                      << tlv_value<uint64_t>(type) << "  " << std::setw(6) << tlv_value<size_t>(map_count) << "  "
+            std::cout << std::setw(20) << std::right << tlv_value<std::string>(section_name) << "  " << std::setw(9)
+                      << tlv_value<std::string>(type) << "  " << std::setw(6) << tlv_value<size_t>(map_count) << "  "
                       << std::setw(6) << (program_bytes->length - offsetof(tlv_type_length_value_t, value)) / 8 << "\n";
         } else {
             std::cout << "\n";
             std::cout << "Section      : " << tlv_value<std::string>(section_name) << "\n";
-            std::cout << "Program Type : " << tlv_value<uint64_t>(type) << "\n";
+            std::cout << "Program Type : " << tlv_value<std::string>(type) << "\n";
             std::cout << "# Maps       : " << tlv_value<size_t>(map_count) << "\n";
             std::cout << "Size         : " << (program_bytes->length - offsetof(tlv_type_length_value_t, value)) / 8
                       << " instructions\n";


### PR DESCRIPTION
Since the native program type changed from int to GUID the display has been
broken (it displays a useless pointer value).  This fix makes it display
the string name of the type.

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>