### PR TITLE
Fix doxygen error when there are no changes to commit

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -42,6 +42,8 @@ jobs:
         doxygen
         cd docs/html
         git add .
+        if [ -n "$(git status --porcelain)" ]; then
         git commit -s -m "Updated documentation"
         git remote set-url origin https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/microsoft/ebpf-for-windows.git
         git push
+        fi


### PR DESCRIPTION
Previously the script worked when there were changes and
generates an error when there's actually nothing to do
because "git commit" returns exit code 1 when there's nothing to do.

This updates the github workflow to only commit when there's something
to commit.  For more discussion see
https://stackoverflow.com/questions/5139290/how-to-check-if-theres-nothing-to-be-committed-in-the-current-branch

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>