### PR TITLE
Make netsh "show verification" command display max instruction count

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -216,6 +216,13 @@ extern "C"
     ebpf_api_elf_disassemble_section(
         const char* file, const char* section, const char** disassembly, const char** error_message);
 
+    typedef struct
+    {
+        int total_unreachable;
+        int total_warnings;
+        int max_instruction_count;
+    } ebpf_api_verifier_stats_t;
+
     /**
      * @brief Convert an eBPF program to human readable byte code.
      * @param[in] file Name of ELF file containing eBPF program.
@@ -225,10 +232,16 @@ extern "C"
      *  failed verification.
      * @param[out] error_message On failure points to a text description of
      *  the error.
+     * @param[out] stats If non-NULL, returns verification statistics.
      */
     uint32_t
     ebpf_api_elf_verify_section(
-        const char* file, const char* section, bool verbose, const char** report, const char** error_message);
+        const char* file,
+        const char* section,
+        bool verbose,
+        const char** report,
+        const char** error_message,
+        ebpf_api_verifier_stats_t* stats);
 
     /**
      * @brief Free a TLV returned from ebpf_api_elf_enumerate_sections

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -159,7 +159,12 @@ ebpf_api_elf_disassemble_section(
 
 uint32_t
 ebpf_api_elf_verify_section(
-    const char* file, const char* section, bool verbose, const char** report, const char** error_message)
+    const char* file,
+    const char* section,
+    bool verbose,
+    const char** report,
+    const char** error_message,
+    ebpf_api_verifier_stats_t* stats)
 {
     std::ostringstream error;
 
@@ -183,9 +188,9 @@ ebpf_api_elf_verify_section(
         }
         auto& program = std::get<InstructionSeq>(programOrError);
 
-        // Try again without simplifying.
         verifier_options.no_simplify = true;
-        bool res = ebpf_verify_program(output, program, raw_program.info, &verifier_options);
+        bool res =
+            ebpf_verify_program(output, program, raw_program.info, &verifier_options, (ebpf_verifier_stats_t*)stats);
         if (!res) {
             error << "Verification failed";
             *error_message = allocate_error_string(error.str());

--- a/libs/service/verifier_service.cpp
+++ b/libs/service/verifier_service.cpp
@@ -32,14 +32,15 @@ analyze(raw_program& raw_prog, const char** error_message, uint32_t* error_messa
 
     // First try optimized for the success case.
     ebpf_verifier_options_t options = ebpf_verifier_default_options;
+    ebpf_verifier_stats_t stats;
     options.check_termination = true;
-    bool res = ebpf_verify_program(std::cout, prog, raw_prog.info, &options);
+    bool res = ebpf_verify_program(std::cout, prog, raw_prog.info, &options, &stats);
     if (!res) {
         // On failure, retry to get the more detailed error message.
         std::ostringstream oss;
         options.no_simplify = true;
         options.print_failures = true;
-        (void)ebpf_verify_program(oss, prog, raw_prog.info, &options);
+        (void)ebpf_verify_program(oss, prog, raw_prog.info, &options, &stats);
 
         *error_message = allocate_error_string(oss.str(), error_message_size);
         return 1; // Error;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -401,11 +401,12 @@ TEST_CASE("verify section", "[verify section]")
     const char* report = nullptr;
     uint32_t result;
 
-    REQUIRE(
-        (result = ebpf_api_elf_verify_section(SAMPLE_PATH "droppacket.o", "xdp", false, &report, &error_message),
-         ebpf_api_free_string(error_message),
-         error_message = nullptr,
-         result == 0));
+    ebpf_api_verifier_stats_t stats;
+    REQUIRE((
+        result = ebpf_api_elf_verify_section(SAMPLE_PATH "droppacket.o", "xdp", false, &report, &error_message, &stats),
+        ebpf_api_free_string(error_message),
+        error_message = nullptr,
+        result == 0));
     REQUIRE(report != nullptr);
     ebpf_api_free_string(report);
 }

--- a/tools/netsh/elf.cpp
+++ b/tools/netsh/elf.cpp
@@ -238,11 +238,13 @@ handle_ebpf_show_verification(
 
     const char* report;
     const char* error_message;
+    ebpf_api_verifier_stats_t stats;
 
-    status =
-        ebpf_api_elf_verify_section(filename.c_str(), section.c_str(), level == VL_VERBOSE, &report, &error_message);
+    status = ebpf_api_elf_verify_section(
+        filename.c_str(), section.c_str(), level == VL_VERBOSE, &report, &error_message, &stats);
     if (status == ERROR_SUCCESS) {
         std::cout << report;
+        std::cout << "\nProgram terminates within " << stats.max_instruction_count << " instructions\n";
         return NO_ERROR;
     } else {
         if (error_message) {


### PR DESCRIPTION
For now, create a type ebpf_api_verifier_stats_t that mirrors the verifier's ebpf_verifier_stats_t struct.

Fixes #193

Signed-off-by: Dave Thaler <dthaler@microsoft.com>