### PR TITLE
Remove allocations from executable memory pool

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -62,9 +62,8 @@ ebpf_core_initiate()
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
-    _ebpf_global_helper_function_dispatch_table = ebpf_allocate(
-        EBPF_OFFSET_OF(ebpf_extension_dispatch_table_t, function) + sizeof(_ebpf_program_helpers),
-        EBPF_MEMORY_NO_EXECUTE);
+    _ebpf_global_helper_function_dispatch_table =
+        ebpf_allocate(EBPF_OFFSET_OF(ebpf_extension_dispatch_table_t, function) + sizeof(_ebpf_program_helpers));
     if (!_ebpf_global_helper_function_dispatch_table) {
         return_value = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -46,7 +46,7 @@ _ebpf_link_free(ebpf_object_t* object)
 ebpf_result_t
 ebpf_link_create(ebpf_link_t** link)
 {
-    *link = ebpf_epoch_allocate(sizeof(ebpf_link_t), EBPF_MEMORY_NO_EXECUTE);
+    *link = ebpf_epoch_allocate(sizeof(ebpf_link_t));
     if (*link == NULL)
         return EBPF_NO_MEMORY;
 
@@ -65,7 +65,7 @@ ebpf_link_initialize(
 
     ebpf_safe_size_t_add(sizeof(ebpf_extension_data_t), context_data_length, &client_data_length);
 
-    link->client_data = ebpf_allocate(client_data_length, EBPF_MEMORY_NO_EXECUTE);
+    link->client_data = ebpf_allocate(client_data_length);
     if (!link->client_data)
         return EBPF_NO_MEMORY;
 

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -102,7 +102,7 @@ ebpf_create_array_map(_In_ const ebpf_map_definition_t* map_definition)
     }
 
     // allocate
-    map = ebpf_allocate(map_entry_size, EBPF_MEMORY_NO_EXECUTE);
+    map = ebpf_allocate(map_entry_size);
     if (map == NULL) {
         goto Done;
     }
@@ -198,7 +198,7 @@ ebpf_create_hash_map(_In_ const ebpf_map_definition_t* map_definition)
     size_t map_size = sizeof(ebpf_core_map_t);
     ebpf_core_map_t* map = NULL;
 
-    map = ebpf_allocate(map_size, EBPF_MEMORY_NO_EXECUTE);
+    map = ebpf_allocate(map_size);
     if (map == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -12,6 +12,8 @@
 #include "ebpf_program.h"
 #include "helpers.h"
 
+#define PAGE_SIZE 4096
+
 class _ebpf_core_initializer
 {
   public:
@@ -166,8 +168,10 @@ TEST_CASE("program")
     REQUIRE(ebpf_update_trampoline_table(table, &provider_dispatch_table1) == EBPF_SUCCESS);
     REQUIRE(ebpf_get_trampoline_function(table, 0, reinterpret_cast<void**>(&test_function)) == EBPF_SUCCESS);
 
+    // Size of the actual function is unknown, but we know the allocation is on page granularity.
     REQUIRE(
-        ebpf_program_load_machine_code(program.get(), reinterpret_cast<uint8_t*>(test_function), 4096) == EBPF_SUCCESS);
+        ebpf_program_load_machine_code(program.get(), reinterpret_cast<uint8_t*>(test_function), PAGE_SIZE) ==
+        EBPF_SUCCESS);
     uint32_t result = 0;
     ebpf_program_invoke(program.get(), nullptr, &result);
     REQUIRE(result == TEST_FUNCTION_RETURN);

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -124,8 +124,7 @@ ebpf_epoch_initiate()
     if (ebpf_is_non_preemptible_work_item_supported()) {
         ebpf_get_cpu_count(&_ebpf_epoch_cpu_table_size);
 
-        _ebpf_epoch_cpu_table =
-            ebpf_allocate(_ebpf_epoch_cpu_table_size * sizeof(ebpf_epoch_cpu_entry_t), EBPF_MEMORY_NO_EXECUTE);
+        _ebpf_epoch_cpu_table = ebpf_allocate(_ebpf_epoch_cpu_table_size * sizeof(ebpf_epoch_cpu_entry_t));
         if (!_ebpf_epoch_cpu_table) {
             return_value = EBPF_NO_MEMORY;
             goto Error;
@@ -270,11 +269,11 @@ ebpf_epoch_flush()
 }
 
 void*
-ebpf_epoch_allocate(size_t size, ebpf_memory_type_t type)
+ebpf_epoch_allocate(size_t size)
 {
     ebpf_epoch_allocation_header_t* header;
     size += sizeof(ebpf_epoch_allocation_header_t);
-    header = (ebpf_epoch_allocation_header_t*)ebpf_allocate(size, type);
+    header = (ebpf_epoch_allocation_header_t*)ebpf_allocate(size);
     if (header)
         header++;
 
@@ -409,7 +408,7 @@ _ebpf_flush_worker(void* context)
 ebpf_epoch_work_item_t*
 ebpf_epoch_allocate_work_item(void* callback_context, void (*callback)(void* context))
 {
-    ebpf_epoch_work_item_t* work_item = ebpf_allocate(sizeof(ebpf_epoch_work_item_t), EBPF_MEMORY_NO_EXECUTE);
+    ebpf_epoch_work_item_t* work_item = ebpf_allocate(sizeof(ebpf_epoch_work_item_t));
     if (!work_item) {
         return NULL;
     }

--- a/libs/platform/ebpf_epoch.h
+++ b/libs/platform/ebpf_epoch.h
@@ -52,7 +52,7 @@ extern "C"
      * @returns Pointer to memory block allocated, or null on failure.
      */
     void*
-    ebpf_epoch_allocate(size_t size, ebpf_memory_type_t type);
+    ebpf_epoch_allocate(size_t size);
 
     /**
      * @brief Free memory under epoch control.

--- a/libs/platform/ebpf_epoch.h
+++ b/libs/platform/ebpf_epoch.h
@@ -48,7 +48,6 @@ extern "C"
     /**
      * @brief Allocate memory under epoch control.
      * @param[in] size Size of memory to allocate
-     * @param[in] type Allocate memory as executable vs non-executable
      * @returns Pointer to memory block allocated, or null on failure.
      */
     void*

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -10,7 +10,7 @@ struct _ebpf_hash_table
     ebpf_hash_table_compare_result_t (*compare_function)(const uint8_t* key1, const uint8_t* key2);
     size_t key_size;
     size_t value_size;
-    void* (*allocate)(size_t size, ebpf_memory_type_t type);
+    void* (*allocate)(size_t size);
     void (*free)(void* memory);
 };
 
@@ -42,7 +42,7 @@ static void*
 _ebpf_hash_table_allocate(struct _RTL_AVL_TABLE* avl_table, unsigned long byte_size)
 {
     ebpf_hash_table_t* table = (ebpf_hash_table_t*)avl_table;
-    return table->allocate(byte_size, EBPF_MEMORY_NO_EXECUTE);
+    return table->allocate(byte_size);
 }
 
 static void
@@ -55,7 +55,7 @@ _ebpf_hash_table_free(struct _RTL_AVL_TABLE* avl_table, void* buffer)
 ebpf_result_t
 ebpf_hash_table_create(
     ebpf_hash_table_t** hash_table,
-    void* (*allocate)(size_t size, ebpf_memory_type_t type),
+    void* (*allocate)(size_t size),
     void (*free)(void* memory),
     size_t key_size,
     size_t value_size,
@@ -65,7 +65,7 @@ ebpf_hash_table_create(
     ebpf_hash_table_t* table = NULL;
 
     // allocate
-    table = ebpf_allocate(sizeof(ebpf_hash_table_t), EBPF_MEMORY_NO_EXECUTE);
+    table = ebpf_allocate(sizeof(ebpf_hash_table_t));
     if (table == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -134,7 +134,7 @@ ebpf_hash_table_update(ebpf_hash_table_t* hash_table, const uint8_t* key, const 
         goto Done;
     }
 
-    temp = ebpf_allocate(temp_size, EBPF_MEMORY_NO_EXECUTE);
+    temp = ebpf_allocate(temp_size);
     if (!temp) {
         retval = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -114,7 +114,7 @@ ebpf_duplicate_utf8_string(ebpf_utf8_string_t* destination, const ebpf_utf8_stri
         destination->length = 0;
         return EBPF_SUCCESS;
     } else {
-        destination->value = ebpf_allocate(source->length, EBPF_MEMORY_NO_EXECUTE);
+        destination->value = ebpf_allocate(source->length);
         if (!destination->value)
             return EBPF_NO_MEMORY;
         memcpy(destination->value, source->value, source->length);

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -54,7 +54,7 @@ ebpf_result_t
 ebpf_pinning_table_allocate(ebpf_pinning_table_t** pinning_table)
 {
     ebpf_result_t return_value;
-    *pinning_table = ebpf_allocate(sizeof(ebpf_pinning_table_t), EBPF_MEMORY_NO_EXECUTE);
+    *pinning_table = ebpf_allocate(sizeof(ebpf_pinning_table_t));
     if (*pinning_table == NULL) {
         return_value = EBPF_NO_MEMORY;
         goto Done;
@@ -115,7 +115,7 @@ ebpf_pinning_table_insert(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_s
     const ebpf_utf8_string_t* existing_key = name;
     ebpf_pinning_entry_t** existing_pinning_entry;
 
-    new_pinning_entry = ebpf_allocate(sizeof(ebpf_pinning_entry_t), EBPF_MEMORY_NO_EXECUTE);
+    new_pinning_entry = ebpf_allocate(sizeof(ebpf_pinning_entry_t));
     if (!new_pinning_entry) {
         return_value = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -609,8 +609,8 @@ extern "C"
     /**
      * @brief Allocate a new empty trampoline table of entry_count size.
      *
-     * @param entry_count Maximum number of functions to build trampolines for.
-     * @param trampoline_table Pointer to memory that holds the trampoline
+     * @param[in] entry_count Maximum number of functions to build trampolines for.
+     * @param[out] trampoline_table Pointer to memory that holds the trampoline
      * table on success.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
@@ -622,7 +622,7 @@ extern "C"
     /**
      * @brief Free a previously allocated trampoline table.
      *
-     * @param trampoline_table Pointer to trampoline table to free.
+     * @param[in] trampoline_table Pointer to trampoline table to free.
      */
     void
     ebpf_free_trampoline_table(ebpf_trampoline_table_t* trampoline_table);
@@ -630,8 +630,8 @@ extern "C"
     /**
      * @brief Populate the function pointers in a trampoline table.
      *
-     * @param trampoline_table Trampoline table to populate.
-     * @param dispatch_table Dispatch table to populate from.
+     * @param[in] trampoline_table Trampoline table to populate.
+     * @param[in] dispatch_table Dispatch table to populate from.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
@@ -643,9 +643,9 @@ extern "C"
     /**
      * @brief Get the address of a trampoline function.
      *
-     * @param trampoline_table Trampoline table to query.
-     * @param index Index of function to get.
-     * @param function Pointer to memory that contains the function on success.
+     * @param[in] trampoline_table Trampoline table to query.
+     * @param[in] index Index of function to get.
+     * @param[out] function Pointer to memory that contains the function on success.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.

--- a/libs/platform/ebpf_program_types.c
+++ b/libs/platform/ebpf_program_types.c
@@ -41,7 +41,7 @@ ebpf_program_information_decode(
         goto Done;
     }
 
-    local_buffer = ebpf_allocate(buffer_size, EBPF_MEMORY_NO_EXECUTE);
+    local_buffer = ebpf_allocate(buffer_size);
     if (!local_buffer) {
         return_value = EBPF_NO_MEMORY;
         goto Done;
@@ -77,7 +77,7 @@ Done:
 void* __RPC_USER
 MIDL_user_allocate(size_t size)
 {
-    return ebpf_allocate(size, EBPF_MEMORY_NO_EXECUTE);
+    return ebpf_allocate(size);
 }
 
 void __RPC_USER

--- a/libs/platform/ebpf_trampoline.c
+++ b/libs/platform/ebpf_trampoline.c
@@ -110,7 +110,7 @@ ebpf_get_trampoline_function(const ebpf_trampoline_table_t* trampoline_table, si
     ebpf_trampoline_entry_t* local_entries;
     ebpf_result_t return_value;
 
-    if (index > trampoline_table->entry_count) {
+    if (index >= trampoline_table->entry_count) {
         return_value = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }

--- a/libs/platform/ebpf_trampoline.c
+++ b/libs/platform/ebpf_trampoline.c
@@ -6,42 +6,125 @@
 #include "ebpf_platform.h"
 #include "ebpf_epoch.h"
 
+#pragma pack(push)
+#pragma pack(1)
+typedef struct _ebpf_trampoline_entry
+{
+    uint16_t load_rax;
+    void* indirect_address;
+    uint16_t jmp_rax;
+    void* address;
+} ebpf_trampoline_entry_t;
+#pragma pack(pop)
+
+typedef struct _ebpf_trampoline_table
+{
+    ebpf_memory_descriptor_t* memory_descriptor;
+    size_t entry_count;
+} ebpf_trampoline_table_t;
+
 ebpf_result_t
-ebpf_build_trampoline_table(
-    size_t* entry_count, ebpf_trampoline_entry_t** entries, const ebpf_extension_dispatch_table_t* dispatch_table)
+ebpf_allocate_trampoline_table(size_t entry_count, ebpf_trampoline_table_t** trampoline_table)
+{
+    ebpf_result_t return_value;
+    ebpf_trampoline_table_t* local_trampoline_table = NULL;
+
+    local_trampoline_table = ebpf_allocate(sizeof(ebpf_trampoline_table_t));
+    if (!local_trampoline_table) {
+        return_value = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+    local_trampoline_table->entry_count = entry_count;
+    local_trampoline_table->memory_descriptor = ebpf_map_memory(entry_count * sizeof(ebpf_trampoline_entry_t));
+    if (!local_trampoline_table->memory_descriptor) {
+        return_value = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    *trampoline_table = local_trampoline_table;
+    local_trampoline_table = NULL;
+    return_value = EBPF_SUCCESS;
+Exit:
+    ebpf_free_trampoline_table(local_trampoline_table);
+    return return_value;
+}
+
+void
+ebpf_free_trampoline_table(ebpf_trampoline_table_t* trampoline_table)
+{
+    if (trampoline_table) {
+        ebpf_unmap_memory(trampoline_table->memory_descriptor);
+        ebpf_free(trampoline_table);
+    }
+}
+
+ebpf_result_t
+ebpf_update_trampoline_table(
+    ebpf_trampoline_table_t* trampoline_table, const ebpf_extension_dispatch_table_t* dispatch_table)
 {
 #if defined(_AMD64_)
+
     size_t function_count = (dispatch_table->size - EBPF_OFFSET_OF(ebpf_extension_dispatch_table_t, function)) /
                             sizeof(dispatch_table->function[0]);
-    ebpf_trampoline_entry_t* local_entries = *entries;
-    size_t local_entry_count = *entry_count;
+    ebpf_trampoline_entry_t* local_entries;
+    ebpf_result_t return_value;
 
-    // If there is no existing table, allocate a new table.
-    if (local_entries == NULL) {
-        local_entry_count = function_count;
-        local_entries = ebpf_epoch_allocate(local_entry_count * sizeof(ebpf_trampoline_entry_t), EBPF_MEMORY_EXECUTE);
-        if (local_entries == NULL)
-            return EBPF_NO_MEMORY;
-    } else {
-        // Verify the existing table is the correct size
-        if (local_entry_count != function_count)
-            return EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+    if (function_count != trampoline_table->entry_count) {
+        return_value = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
+    return_value = ebpf_protect_memory(trampoline_table->memory_descriptor, EBPF_PAGE_PROTECT_READ_WRITE);
+    if (return_value != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
+    local_entries =
+        (ebpf_trampoline_entry_t*)ebpf_memory_descriptor_get_base_address(trampoline_table->memory_descriptor);
+    if (!local_entries) {
+        return_value = EBPF_NO_MEMORY;
+        goto Exit;
     }
 
     size_t index;
-    for (index = 0; index < local_entry_count; index++) {
+    for (index = 0; index < trampoline_table->entry_count; index++) {
         local_entries[index].load_rax = 0xa148;
         local_entries[index].indirect_address = &local_entries[index].address;
         local_entries[index].jmp_rax = 0xe0ff;
         local_entries[index].address = (void*)dispatch_table->function[index];
     }
-    *entry_count = local_entry_count;
-    *entries = local_entries;
-    return EBPF_SUCCESS;
+
+Exit:
+    return_value = ebpf_protect_memory(trampoline_table->memory_descriptor, EBPF_PAGE_PROTECT_READ_EXECUTE);
+    return return_value;
 #elif
-    UNREFERENCED_PARAMETER(entry_count);
-    UNREFERENCED_PARAMETER(ebpf_trampoline_entry_t);
+    UNREFERENCED_PARAMETER(trampoline_table);
     UNREFERENCED_PARAMETER(dispatch_table);
     return EBPF_ERROR_NOT_SUPPORTED;
 #endif
+}
+
+ebpf_result_t
+ebpf_get_trampoline_function(const ebpf_trampoline_table_t* trampoline_table, size_t index, void** function)
+{
+    ebpf_trampoline_entry_t* local_entries;
+    ebpf_result_t return_value;
+
+    if (index > trampoline_table->entry_count) {
+        return_value = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
+    local_entries =
+        (ebpf_trampoline_entry_t*)ebpf_memory_descriptor_get_base_address(trampoline_table->memory_descriptor);
+    if (!local_entries) {
+        return_value = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    *function = &(local_entries[index]);
+
+    return_value = EBPF_SUCCESS;
+Exit:
+    return return_value;
 }

--- a/libs/platform/kernel/ebpf_extension_kernel.c
+++ b/libs/platform/kernel/ebpf_extension_kernel.c
@@ -129,7 +129,7 @@ ebpf_extension_load(
     NPI_REGISTRATION_INSTANCE* client_registration_instance;
     NTSTATUS status;
 
-    local_client_context = ebpf_allocate(sizeof(ebpf_extension_client_t), EBPF_MEMORY_NO_EXECUTE);
+    local_client_context = ebpf_allocate(sizeof(ebpf_extension_client_t));
 
     if (!local_client_context) {
         return_value = EBPF_NO_MEMORY;
@@ -231,8 +231,8 @@ _ebpf_extension_provider_attach_client(
         goto Done;
     }
 
-    local_provider_binding_context = (ebpf_extension_provider_binding_context*)ebpf_allocate(
-        sizeof(ebpf_extension_provider_binding_context), EBPF_MEMORY_NO_EXECUTE);
+    local_provider_binding_context =
+        (ebpf_extension_provider_binding_context*)ebpf_allocate(sizeof(ebpf_extension_provider_binding_context));
 
     if (!local_provider_binding_context) {
         status = STATUS_NOINTERFACE;
@@ -303,7 +303,7 @@ ebpf_provider_load(
     NPI_REGISTRATION_INSTANCE* provider_registration_instance;
     NTSTATUS status;
 
-    local_provider_context = ebpf_allocate(sizeof(ebpf_extension_provider_t), EBPF_MEMORY_NO_EXECUTE);
+    local_provider_context = ebpf_allocate(sizeof(ebpf_extension_provider_t));
 
     if (!local_provider_context) {
         return_value = EBPF_NO_MEMORY;

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -31,10 +31,9 @@ ebpf_platform_terminate()
 {}
 
 void*
-ebpf_allocate(size_t size, ebpf_memory_type_t type)
+ebpf_allocate(size_t size)
 {
-    return ExAllocatePool2(
-        type == EBPF_MEMORY_EXECUTE ? POOL_FLAG_NON_PAGED_EXECUTE : POOL_FLAG_NON_PAGED, size, EBPF_POOL_TAG);
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED_EXECUTE, size, EBPF_POOL_TAG);
 }
 
 void
@@ -266,7 +265,7 @@ ebpf_allocate_non_preemptible_work_item(
     void (*work_item_routine)(void* work_item_context, void* parameter_1),
     void* work_item_context)
 {
-    *work_item = ebpf_allocate(sizeof(ebpf_non_preemptible_work_item_t), EBPF_MEMORY_NO_EXECUTE);
+    *work_item = ebpf_allocate(sizeof(ebpf_non_preemptible_work_item_t));
     if (*work_item == NULL) {
         return EBPF_NO_MEMORY;
     }
@@ -318,7 +317,7 @@ ebpf_allocate_timer_work_item(
     void (*work_item_routine)(void* work_item_context),
     void* work_item_context)
 {
-    *timer_work_item = ebpf_allocate(sizeof(ebpf_timer_work_item_t), EBPF_MEMORY_NO_EXECUTE);
+    *timer_work_item = ebpf_allocate(sizeof(ebpf_timer_work_item_t));
     if (*timer_work_item == NULL)
         return EBPF_NO_MEMORY;
 

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -33,7 +33,7 @@ ebpf_platform_terminate()
 void*
 ebpf_allocate(size_t size)
 {
-    return ExAllocatePool2(POOL_FLAG_NON_PAGED_EXECUTE, size, EBPF_POOL_TAG);
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED, size, EBPF_POOL_TAG);
 }
 
 void

--- a/libs/platform/user/ebpf_extension_user.c
+++ b/libs/platform/user/ebpf_extension_user.c
@@ -55,7 +55,7 @@ ebpf_extension_load(
         goto Done;
     }
 
-    local_extension_client = ebpf_allocate(sizeof(ebpf_extension_client_t), EBPF_MEMORY_NO_EXECUTE);
+    local_extension_client = ebpf_allocate(sizeof(ebpf_extension_client_t));
     if (!local_extension_client) {
         return_value = EBPF_NO_MEMORY;
         goto Done;
@@ -180,7 +180,7 @@ ebpf_provider_load(
         goto Done;
     }
 
-    local_extension_provider = ebpf_allocate(sizeof(ebpf_extension_provider_t), EBPF_MEMORY_NO_EXECUTE);
+    local_extension_provider = ebpf_allocate(sizeof(ebpf_extension_provider_t));
     if (!local_extension_provider) {
         return_value = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -16,8 +16,8 @@
 
 #include <stdlib.h>
 
-#define malloc(X) ebpf_allocate((X), EBPF_MEMORY_NO_EXECUTE)
-#define calloc(X, Y) ebpf_allocate((X) * (Y), EBPF_MEMORY_NO_EXECUTE)
+#define malloc(X) ebpf_allocate((X))
+#define calloc(X, Y) ebpf_allocate((X) * (Y))
 #define free(X) ebpf_free(X)
 
 #include <endian.h>

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -705,8 +705,8 @@ _net_ebpf_ext_program_information_encode_xdp()
     const uint8_t* buffer = _ebpf_encoded_xdp_program_information_data;
     unsigned long buffer_size = sizeof(_ebpf_encoded_xdp_program_information_data);
 
-    _ebpf_xdp_program_information_provider_data = (ebpf_extension_data_t*)ebpf_allocate(
-        EBPF_OFFSET_OF(ebpf_extension_data_t, data) + buffer_size, EBPF_MEMORY_NO_EXECUTE);
+    _ebpf_xdp_program_information_provider_data =
+        (ebpf_extension_data_t*)ebpf_allocate(EBPF_OFFSET_OF(ebpf_extension_data_t, data) + buffer_size);
 
     if (_ebpf_xdp_program_information_provider_data == NULL) {
         return_value = EBPF_NO_MEMORY;
@@ -732,8 +732,8 @@ _net_ebpf_ext_program_information_encode_bind()
     const uint8_t* buffer = _ebpf_encoded_bind_program_information_data;
     unsigned long buffer_size = sizeof(_ebpf_encoded_bind_program_information_data);
 
-    _ebpf_bind_program_information_provider_data = (ebpf_extension_data_t*)ebpf_allocate(
-        EBPF_OFFSET_OF(ebpf_extension_data_t, data) + buffer_size, EBPF_MEMORY_NO_EXECUTE);
+    _ebpf_bind_program_information_provider_data =
+        (ebpf_extension_data_t*)ebpf_allocate(EBPF_OFFSET_OF(ebpf_extension_data_t, data) + buffer_size);
 
     if (_ebpf_bind_program_information_provider_data == NULL) {
         return_value = EBPF_NO_MEMORY;


### PR DESCRIPTION
Remove allocations from executable memory pool

Resolves: #237 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>