### PR TITLE
Remap helper_ids to range [0,63]

### DIFF
--- a/libs/api/api.vcxproj
+++ b/libs/api/api.vcxproj
@@ -182,6 +182,9 @@
     <ClInclude Include="windows_platform.hpp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\rpc_interface\rpc_interface.vcxproj">
+      <Project>{1423245d-0249-40fc-a077-ff7780acfe3f}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\tools\encode_program_information\encode_program_information.vcxproj">
       <Project>{fa9bb88d-8259-40c1-9422-bdedf9e9ce68}</Project>
     </ProjectReference>

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -24,9 +24,9 @@ _build_helper_id_to_address_map(
     ebpf_handle_t program_handle, ebpf_code_buffer_t& byte_code, std::vector<uint64_t>& helper_addresses)
 {
     // Note:
-    // eBPF supports helper IDs in the range [0, MAXUINT32]
+    // eBPF supports helper IDs in the range [1, MAXUINT32]
     // uBPF jitter only supports helper IDs in the range [0,63]
-    // Build a table to map [0, MAXUINT32] -> [0,63]
+    // Build a table to map [1, MAXUINT32] -> [0,63]
     std::map<uint32_t, uint32_t> helper_id_mapping;
 
     ebpf_inst* instructions = reinterpret_cast<ebpf_inst*>(byte_code.data());
@@ -78,7 +78,7 @@ _build_helper_id_to_address_map(
         address = reply->address[index++];
     }
 
-    // Replace old helper_ids in range [0, MAXUINT32] with new helper ids in range [0,63]
+    // Replace old helper_ids in range [1, MAXUINT32] with new helper ids in range [0,63]
     for (index = 0; index < byte_code.size() / sizeof(ebpf_inst); index++) {
         ebpf_inst& instruction = instructions[index];
         if (instruction.opcode != INST_OP_CALL) {

--- a/libs/service/service.vcxproj
+++ b/libs/service/service.vcxproj
@@ -179,6 +179,9 @@
     <ClInclude Include="windows_platform_service.hpp" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\rpc_interface\rpc_interface.vcxproj">
+      <Project>{1423245d-0249-40fc-a077-ff7780acfe3f}</Project>
+    </ProjectReference>
     <ProjectReference Include="..\..\tools\encode_program_information\encode_program_information.vcxproj">
       <Project>{fa9bb88d-8259-40c1-9422-bdedf9e9ce68}</Project>
     </ProjectReference>


### PR DESCRIPTION
eBPF supports helper IDs in the range [0, MAXUINT32]
uBPF jitter only supports helper IDs in the range [0,63]

This fix works around the issue by remapping helper_ids that are used in the program to the permitted range.

Resolves: #204 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>