### PR TITLE
Simplify names of some ebpf_result codes

### DIFF
--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -90,7 +90,7 @@ _ebpf_result_to_ntstatus(ebpf_result_t result)
         status = STATUS_NOT_SUPPORTED;
         break;
     }
-    case EBPF_ERROR_INSUFFICIENT_BUFFER: {
+    case EBPF_INSUFFICIENT_BUFFER: {
         status = STATUS_BUFFER_OVERFLOW;
         break;
     }

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -66,7 +66,7 @@ _ebpf_result_to_ntstatus(ebpf_result_t result)
         status = STATUS_INSUFFICIENT_RESOURCES;
         break;
     }
-    case EBPF_ERROR_NOT_FOUND: {
+    case EBPF_KEY_NOT_FOUND: {
         status = STATUS_NOT_FOUND;
         break;
     }
@@ -74,19 +74,19 @@ _ebpf_result_to_ntstatus(ebpf_result_t result)
         status = STATUS_INVALID_PARAMETER;
         break;
     }
-    case EBPF_ERROR_BLOCKED_BY_POLICY: {
+    case EBPF_BLOCKED_BY_POLICY: {
         status = STATUS_CONTENT_BLOCKED;
         break;
     }
-    case EBPF_ERROR_NO_MORE_KEYS: {
+    case EBPF_NO_MORE_KEYS: {
         status = STATUS_NO_MORE_MATCHES;
         break;
     }
-    case EBPF_ERROR_INVALID_HANDLE: {
+    case EBPF_INVALID_OBJECT: {
         status = STATUS_INVALID_HANDLE;
         break;
     }
-    case EBPF_ERROR_NOT_SUPPORTED: {
+    case EBPF_OPERATION_NOT_SUPPORTED: {
         status = STATUS_NOT_SUPPORTED;
         break;
     }
@@ -95,7 +95,7 @@ _ebpf_result_to_ntstatus(ebpf_result_t result)
         break;
     }
     default:
-        status = STATUS_INVALID_PARAMETER;
+        status = STATUS_UNSUCCESSFUL;
     }
 
     return status;

--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -16,7 +16,7 @@ extern "C"
         EBPF_SUCCESS,
 
         // Program verification failed.
-        EBPF_VALIDATION_FAILED,
+        EBPF_VERIFICATION_FAILED,
 
         // JIT compilation failed.
         EBPF_JIT_COMPILATION_FAILED,
@@ -42,10 +42,10 @@ extern "C"
         // Invalid ELF file path.
         EBPF_FILE_NOT_FOUND,
 
-        // Program or map already pinned.
+        // The program or map already pinned to a different path.
         EBPF_ALREADY_PINNED,
 
-        // Program or map is not pinned.
+        // The program or map is not pinned.
         EBPF_NOT_PINNED,
 
         // Low memory.
@@ -54,41 +54,38 @@ extern "C"
         // The program is too large.
         EBPF_PROGRAM_TOO_LARGE,
 
-        // RPC exception.
+        // An RPC exception occurred.
         EBPF_RPC_EXCEPTION,
 
-        // Handle is already initialized.
+        // The handle was already initialized.
         EBPF_ALREADY_INITIALIZED,
 
         // Generic failure code for all other errors.
         EBPF_FAILED,
 
         // Operation is not supported.
-        EBPF_ERROR_NOT_SUPPORTED,
+        EBPF_OPERATION_NOT_SUPPORTED,
 
-        // The requested item was not found.
-        EBPF_ERROR_NOT_FOUND,
+        // The requested key was not found.
+        EBPF_KEY_NOT_FOUND,
 
         // Access was denied for the requested operation.
-        EBPF_ERROR_ACCESS_DENIED,
+        EBPF_ACCESS_DENIED,
 
         // The operation was blocked by policy.
-        EBPF_ERROR_BLOCKED_BY_POLICY,
+        EBPF_BLOCKED_BY_POLICY,
 
         // Arithmetic overflow occurred.
-        EBPF_ERROR_ARITHMETIC_OVERFLOW,
+        EBPF_ARITHMETIC_OVERFLOW,
 
         // The eBPF extension failed to load.
-        EBPF_ERROR_EXTENSION_FAILED_TO_LOAD,
+        EBPF_EXTENSION_FAILED_TO_LOAD,
 
         // A buffer of insufficient size was supplied.
-        EBPF_ERROR_INSUFFICIENT_BUFFER,
+        EBPF_INSUFFICIENT_BUFFER,
 
         // The enumeration found no more keys.
-        EBPF_ERROR_NO_MORE_KEYS,
-
-        // The handle was invalid.
-        EBPF_ERROR_INVALID_HANDLE,
+        EBPF_NO_MORE_KEYS,
     } ebpf_result_t;
 
 #ifdef __cplusplus

--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -72,7 +72,7 @@ extern "C"
         // Access was denied for the requested operation.
         EBPF_ACCESS_DENIED,
 
-        // The operation was blocked by policy.
+        // The operation was blocked for all requesters by policy.
         EBPF_BLOCKED_BY_POLICY,
 
         // Arithmetic overflow occurred.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -247,7 +247,7 @@ ebpf_api_load_program(
         }
 
         if (get_map_descriptor_size() > *count_of_map_handles) {
-            result = EBPF_ERROR_INSUFFICIENT_BUFFER;
+            result = EBPF_INSUFFICIENT_BUFFER;
             goto Done;
         }
 

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -608,12 +608,12 @@ ebpf_api_get_pinned_map_info(
         // Invoke IOCTL.
         result = windows_error_to_ebpf_result(invoke_ioctl(request, reply_buffer));
 
-        if ((result != EBPF_SUCCESS) && (result != EBPF_ERROR_INSUFFICIENT_BUFFER))
+        if ((result != EBPF_SUCCESS) && (result != EBPF_INSUFFICIENT_BUFFER))
             goto Exit;
 
         reply = reinterpret_cast<ebpf_operation_get_map_information_reply_t*>(reply_buffer.data());
 
-        if (result == EBPF_ERROR_INSUFFICIENT_BUFFER) {
+        if (result == EBPF_INSUFFICIENT_BUFFER) {
             output_buffer_length = reply->size;
             attempt_count++;
             continue;

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -83,7 +83,7 @@ windows_error_to_ebpf_result(uint32_t error)
         break;
 
     case ERROR_NOT_FOUND:
-        result = EBPF_ERROR_NOT_FOUND;
+        result = EBPF_KEY_NOT_FOUND;
         break;
 
     case ERROR_INVALID_PARAMETER:
@@ -91,19 +91,19 @@ windows_error_to_ebpf_result(uint32_t error)
         break;
 
     case ERROR_NO_MORE_ITEMS:
-        result = EBPF_ERROR_NO_MORE_KEYS;
+        result = EBPF_NO_MORE_KEYS;
         break;
 
     case ERROR_INVALID_HANDLE:
-        result = EBPF_ERROR_INVALID_HANDLE;
+        result = EBPF_INVALID_OBJECT;
         break;
 
     case ERROR_NOT_SUPPORTED:
-        result = EBPF_ERROR_NOT_SUPPORTED;
+        result = EBPF_OPERATION_NOT_SUPPORTED;
         break;
 
     case ERROR_MORE_DATA:
-        result = EBPF_ERROR_INSUFFICIENT_BUFFER;
+        result = EBPF_INSUFFICIENT_BUFFER;
         break;
 
     case ERROR_FILE_NOT_FOUND:

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -132,7 +132,7 @@ _ebpf_core_protocol_load_code(_In_ const ebpf_operation_load_code_request_t* req
 
     if (request->code_type == EBPF_CODE_NATIVE) {
         if (_ebpf_core_code_integrity_state == EBPF_CODE_INTEGRITY_HYPER_VISOR_KERNEL_MODE) {
-            retval = EBPF_ERROR_BLOCKED_BY_POLICY;
+            retval = EBPF_BLOCKED_BY_POLICY;
             goto Done;
         }
     }
@@ -351,7 +351,7 @@ _ebpf_core_protocol_map_find_element(
 
     value = ebpf_map_find_entry(map, request->key);
     if (value == NULL) {
-        retval = EBPF_ERROR_NOT_FOUND;
+        retval = EBPF_KEY_NOT_FOUND;
         goto Done;
     }
 
@@ -711,7 +711,7 @@ _ebpf_core_protocol_get_program_information(
     required_length += program_information_data->size;
 
     if (required_length > reply_length) {
-        retval = EBPF_ERROR_INSUFFICIENT_BUFFER;
+        retval = EBPF_INSUFFICIENT_BUFFER;
         goto Done;
     }
 
@@ -987,10 +987,10 @@ ebpf_core_get_protocol_handler_properties(
     *minimum_reply_size = 0;
 
     if (operation_id >= EBPF_COUNT_OF(_ebpf_protocol_handlers) || operation_id < EBPF_OPERATION_RESOLVE_HELPER)
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
 
     if (!_ebpf_protocol_handlers[operation_id].dispatch.protocol_handler_no_reply)
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
 
     *minimum_request_size = _ebpf_protocol_handlers[operation_id].minimum_request_size;
     *minimum_reply_size = _ebpf_protocol_handlers[operation_id].minimum_reply_size;
@@ -1007,7 +1007,7 @@ ebpf_core_invoke_protocol_handler(
     ebpf_result_t retval;
 
     if (operation_id >= EBPF_COUNT_OF(_ebpf_protocol_handlers) || operation_id < EBPF_OPERATION_RESOLVE_HELPER) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
 
     retval = ebpf_epoch_enter();

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -37,7 +37,7 @@ ebpf_map_create(const ebpf_map_definition_t* ebpf_map_definition, ebpf_map_t** e
         return EBPF_INVALID_ARGUMENT;
 
     if (!ebpf_map_function_tables[type].create_map)
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
 
     local_map = ebpf_map_function_tables[type].create_map(ebpf_map_definition);
     if (!local_map)
@@ -163,7 +163,7 @@ ebpf_delete_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
     key_value = *(uint32_t*)key;
 
     if (key_value > map->ebpf_map_definition.max_entries)
-        return EBPF_ERROR_NOT_FOUND;
+        return EBPF_KEY_NOT_FOUND;
 
     uint8_t* entry = &map->data[key_value * map->ebpf_map_definition.value_size];
     memset(entry, 0, map->ebpf_map_definition.value_size);
@@ -184,7 +184,7 @@ ebpf_next_array_map_key(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_
         key_value = 0;
 
     if (key_value >= map->ebpf_map_definition.max_entries)
-        return EBPF_ERROR_NO_MORE_KEYS;
+        return EBPF_NO_MORE_KEYS;
 
     *(uint32_t*)next_key = key_value;
 

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -435,10 +435,10 @@ ebpf_program_get_program_information_data(
     const ebpf_program_t* program, const ebpf_extension_data_t** program_information_data)
 {
     if (program->program_invalidated)
-        return EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
 
     if (!program->program_information_data)
-        return EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
 
     *program_information_data = program->program_information_data;
 

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -63,7 +63,7 @@ test_crud_operations(ebpf_map_type_t map_type)
             map.get(), reinterpret_cast<const uint8_t*>(&bad_key), reinterpret_cast<const uint8_t*>(&bad_value)) ==
         EBPF_INVALID_ARGUMENT);
 
-    REQUIRE(ebpf_map_delete_entry(map.get(), reinterpret_cast<const uint8_t*>(&bad_key)) == EBPF_ERROR_NOT_FOUND);
+    REQUIRE(ebpf_map_delete_entry(map.get(), reinterpret_cast<const uint8_t*>(&bad_key)) == EBPF_KEY_NOT_FOUND);
 
     for (uint32_t key = 0; key < 10; key++) {
         uint64_t* value =
@@ -88,7 +88,7 @@ test_crud_operations(ebpf_map_type_t map_type)
     REQUIRE(
         ebpf_map_next_key(
             map.get(), reinterpret_cast<const uint8_t*>(&previous_key), reinterpret_cast<uint8_t*>(&next_key)) ==
-        EBPF_ERROR_NO_MORE_KEYS);
+        EBPF_NO_MORE_KEYS);
 
     for (uint32_t key = 0; key < 10; key++) {
         REQUIRE(ebpf_map_delete_entry(map.get(), reinterpret_cast<const uint8_t*>(&key)) == EBPF_SUCCESS);

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -209,7 +209,7 @@ ebpf_epoch_enter()
     } else {
         uint32_t current_cpu = ebpf_get_current_cpu();
         if (current_cpu >= _ebpf_epoch_cpu_table_size) {
-            return EBPF_ERROR_NOT_SUPPORTED;
+            return EBPF_OPERATION_NOT_SUPPORTED;
         }
 
         _ebpf_epoch_cpu_table[current_cpu].epoch = _ebpf_current_epoch;
@@ -377,7 +377,7 @@ ebpf_epoch_get_release_epoch(int64_t* release_epoch)
         }
     ebpf_lock_unlock(&_ebpf_epoch_thread_table_lock, &lock_state);
 
-    if (return_value != EBPF_ERROR_NO_MORE_KEYS) {
+    if (return_value != EBPF_NO_MORE_KEYS) {
         return return_value;
     }
 

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -114,7 +114,7 @@ ebpf_hash_table_find(ebpf_hash_table_t* hash_table, const uint8_t* key, uint8_t*
         *value = entry + hash_table->key_size;
         retval = EBPF_SUCCESS;
     } else {
-        retval = EBPF_ERROR_NOT_FOUND;
+        retval = EBPF_KEY_NOT_FOUND;
     }
     return retval;
 }
@@ -166,7 +166,7 @@ ebpf_hash_table_delete(ebpf_hash_table_t* hash_table, const uint8_t* key)
     RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
 
     result = RtlDeleteElementGenericTableAvl(table, (uint8_t*)key);
-    return result ? EBPF_SUCCESS : EBPF_ERROR_NOT_FOUND;
+    return result ? EBPF_SUCCESS : EBPF_KEY_NOT_FOUND;
 }
 
 ebpf_result_t
@@ -196,7 +196,7 @@ ebpf_hash_table_next_key_and_value(
             // Start at the beginning of the table.
             entry = RtlEnumerateGenericTableAvl(table, TRUE);
             if (entry == NULL) {
-                return EBPF_ERROR_NO_MORE_KEYS;
+                return EBPF_NO_MORE_KEYS;
             }
 
             // Advance the cursor until we reach the first entry that is greater than
@@ -212,7 +212,7 @@ ebpf_hash_table_next_key_and_value(
         }
     }
     if (entry == NULL) {
-        result = EBPF_ERROR_NO_MORE_KEYS;
+        result = EBPF_NO_MORE_KEYS;
         goto Exit;
     } else {
         memcpy(next_key, entry, hash_table->key_size);

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -238,7 +238,7 @@ ebpf_pinning_table_enumerate_entries(
             (uint8_t*)&next_object_name,
             (uint8_t**)&next_pinning_entry);
 
-        if (result == EBPF_ERROR_NO_MORE_KEYS) {
+        if (result == EBPF_NO_MORE_KEYS) {
             // Reached end of hashtable.
             result = EBPF_SUCCESS;
             break;

--- a/libs/platform/ebpf_serialize.c
+++ b/libs/platform/ebpf_serialize.c
@@ -49,7 +49,7 @@ ebpf_serialize_core_map_information_array(
 
     // Output buffer too small.
     if (output_buffer_length < *required_length) {
-        result = EBPF_ERROR_INSUFFICIENT_BUFFER;
+        result = EBPF_INSUFFICIENT_BUFFER;
         goto Exit;
     }
 

--- a/libs/platform/ebpf_trampoline.c
+++ b/libs/platform/ebpf_trampoline.c
@@ -100,7 +100,7 @@ Exit:
 #elif
     UNREFERENCED_PARAMETER(trampoline_table);
     UNREFERENCED_PARAMETER(dispatch_table);
-    return EBPF_ERROR_NOT_SUPPORTED;
+    return EBPF_OPERATION_NOT_SUPPORTED;
 #endif
 }
 

--- a/libs/platform/kernel/ebpf_extension_kernel.c
+++ b/libs/platform/kernel/ebpf_extension_kernel.c
@@ -148,7 +148,7 @@ ebpf_extension_load(
 
     status = ExUuidCreate(&local_client_context->client_id.Guid);
     if (!NT_SUCCESS(status)) {
-        return_value = EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+        return_value = EBPF_EXTENSION_FAILED_TO_LOAD;
         goto Done;
     }
 
@@ -170,14 +170,14 @@ ebpf_extension_load(
 
     status = NmrRegisterClient(client_characteristics, local_client_context, &local_client_context->nmr_client_handle);
     if (!NT_SUCCESS(status)) {
-        return_value = EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+        return_value = EBPF_EXTENSION_FAILED_TO_LOAD;
         goto Done;
     }
 
     if (!local_client_context->provider_is_attached) {
         ebpf_extension_unload(local_client_context);
         local_client_context = NULL;
-        return_value = EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+        return_value = EBPF_EXTENSION_FAILED_TO_LOAD;
         goto Done;
     }
 
@@ -324,7 +324,7 @@ ebpf_provider_load(
 
     status = ExUuidCreate(&local_provider_context->provider_id.Guid);
     if (!NT_SUCCESS(status)) {
-        return_value = EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+        return_value = EBPF_EXTENSION_FAILED_TO_LOAD;
         goto Done;
     }
 
@@ -347,7 +347,7 @@ ebpf_provider_load(
     status = NmrRegisterProvider(
         provider_characteristics, local_provider_context, &local_provider_context->nmr_provider_handle);
     if (!NT_SUCCESS(status)) {
-        return_value = EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+        return_value = EBPF_EXTENSION_FAILED_TO_LOAD;
         goto Done;
     }
 

--- a/libs/platform/kernel/ebpf_handle_kernel.c
+++ b/libs/platform/kernel/ebpf_handle_kernel.c
@@ -46,13 +46,13 @@ ebpf_handle_create(ebpf_handle_t* handle, ebpf_object_t* object)
         0);
 
     if (!NT_SUCCESS(status)) {
-        return_value = EBPF_ERROR_NOT_SUPPORTED;
+        return_value = EBPF_OPERATION_NOT_SUPPORTED;
         goto Done;
     }
 
     status = ObReferenceObjectByHandle(file_handle, 0, NULL, UserMode, &file_object, NULL);
     if (!NT_SUCCESS(status)) {
-        return_value = EBPF_ERROR_NOT_SUPPORTED;
+        return_value = EBPF_OPERATION_NOT_SUPPORTED;
         goto Done;
     }
 
@@ -76,7 +76,7 @@ ebpf_result_t
 ebpf_handle_close(ebpf_handle_t handle)
 {
     if (!NT_SUCCESS(ObCloseHandle((HANDLE)handle, UserMode)))
-        return EBPF_ERROR_INVALID_HANDLE;
+        return EBPF_INVALID_OBJECT;
     else
         return EBPF_SUCCESS;
 }
@@ -91,23 +91,23 @@ ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_
 
     status = ObReferenceObjectByHandle((HANDLE)handle, 0, NULL, UserMode, &file_object, NULL);
     if (!NT_SUCCESS(status)) {
-        return_value = EBPF_ERROR_INVALID_HANDLE;
+        return_value = EBPF_INVALID_OBJECT;
         goto Done;
     }
 
     if (file_object->DeviceObject != ebpf_driver_get_device_object()) {
-        return_value = EBPF_ERROR_INVALID_HANDLE;
+        return_value = EBPF_INVALID_OBJECT;
         goto Done;
     }
 
     local_object = (ebpf_object_t*)file_object->FsContext2;
     if (local_object == NULL) {
-        return_value = EBPF_ERROR_INVALID_HANDLE;
+        return_value = EBPF_INVALID_OBJECT;
         goto Done;
     }
 
     if ((object_type != EBPF_OBJECT_UNKNOWN) && (ebpf_object_get_type(local_object) != object_type)) {
-        return_value = EBPF_ERROR_INVALID_HANDLE;
+        return_value = EBPF_INVALID_OBJECT;
         goto Done;
     }
 
@@ -127,5 +127,5 @@ ebpf_get_next_handle_by_type(ebpf_handle_t previous_handle, ebpf_object_type_t o
     UNREFERENCED_PARAMETER(previous_handle);
     UNREFERENCED_PARAMETER(object_type);
     UNREFERENCED_PARAMETER(next_handle);
-    return EBPF_ERROR_NOT_SUPPORTED;
+    return EBPF_OPERATION_NOT_SUPPORTED;
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -159,7 +159,7 @@ ebpf_safe_size_t_add(size_t augend, size_t addend, size_t* result)
 ebpf_result_t
 ebpf_safe_size_t_subtract(size_t minuend, size_t subtrahend, size_t* result)
 {
-    return RtlSizeTSub(minuend, subtrahend, result) == STATUS_SUCCESS ? EBPF_SUCCESS : EBPF_ERROR_ARITHMETIC_OVERFLOW;
+    return RtlSizeTSub(minuend, subtrahend, result) == STATUS_SUCCESS ? EBPF_SUCCESS : EBPF_ARITHMETIC_OVERFLOW;
 }
 
 void

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -140,21 +140,20 @@ ebpf_get_code_integrity_state(ebpf_code_integrity_state_t* state)
                      : EBPF_CODE_INTEGRITY_DEFAULT;
         return EBPF_SUCCESS;
     } else {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
 }
 
 ebpf_result_t
 ebpf_safe_size_t_multiply(size_t multiplicand, size_t multiplier, size_t* result)
 {
-    return RtlSizeTMult(multiplicand, multiplier, result) == STATUS_SUCCESS ? EBPF_SUCCESS
-                                                                            : EBPF_ERROR_ARITHMETIC_OVERFLOW;
+    return RtlSizeTMult(multiplicand, multiplier, result) == STATUS_SUCCESS ? EBPF_SUCCESS : EBPF_ARITHMETIC_OVERFLOW;
 }
 
 ebpf_result_t
 ebpf_safe_size_t_add(size_t augend, size_t addend, size_t* result)
 {
-    return RtlSizeTAdd(augend, addend, result) == STATUS_SUCCESS ? EBPF_SUCCESS : EBPF_ERROR_ARITHMETIC_OVERFLOW;
+    return RtlSizeTAdd(augend, addend, result) == STATUS_SUCCESS ? EBPF_SUCCESS : EBPF_ARITHMETIC_OVERFLOW;
 }
 
 ebpf_result_t
@@ -402,9 +401,9 @@ ebpf_access_check(
             KernelMode,
             &granted_access,
             &status)) {
-        result = EBPF_ERROR_ACCESS_DENIED;
+        result = EBPF_ACCESS_DENIED;
     } else {
-        result = NT_SUCCESS(status) ? EBPF_SUCCESS : EBPF_ERROR_ACCESS_DENIED;
+        result = NT_SUCCESS(status) ? EBPF_SUCCESS : EBPF_ACCESS_DENIED;
     }
 
     SeUnlockSubjectContext(&subject_context);

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -296,7 +296,7 @@ TEST_CASE("access_check", "[access_check]")
 
     REQUIRE(ebpf_validate_security_descriptor(sd, sd_size) == EBPF_SUCCESS);
 
-    REQUIRE((result = ebpf_access_check(sd, 1, &generic_mapping), LocalFree(sd), result == EBPF_ERROR_ACCESS_DENIED));
+    REQUIRE((result = ebpf_access_check(sd, 1, &generic_mapping), LocalFree(sd), result == EBPF_ACCESS_DENIED));
 }
 
 TEST_CASE("memory_map_test", "[memory_map_test]")

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -347,7 +347,7 @@ TEST_CASE("serialize_map_test", "[serialize_map_test]")
     // Serialize.
     ebpf_result_t result = ebpf_serialize_core_map_information_array(
         map_count, core_map_info_array, buffer, buffer_length, &serialized_length, &required_length);
-    REQUIRE(result == EBPF_ERROR_INSUFFICIENT_BUFFER);
+    REQUIRE(result == EBPF_INSUFFICIENT_BUFFER);
 
     buffer = static_cast<uint8_t*>(calloc(required_length, 1));
     buffer_length = required_length;

--- a/libs/platform/user/ebpf_extension_user.c
+++ b/libs/platform/user/ebpf_extension_user.c
@@ -51,7 +51,7 @@ ebpf_extension_load(
     ebpf_lock_lock(&_ebpf_provider_table_lock, &state);
 
     if (!_ebpf_provider_table) {
-        return_value = EBPF_ERROR_NOT_FOUND;
+        return_value = EBPF_EXTENSION_FAILED_TO_LOAD;
         goto Done;
     }
 
@@ -72,7 +72,7 @@ ebpf_extension_load(
     return_value =
         ebpf_hash_table_find(_ebpf_provider_table, (const uint8_t*)interface_id, (uint8_t**)&hash_table_find_result);
     if (return_value != EBPF_SUCCESS) {
-        return_value = EBPF_ERROR_NOT_FOUND;
+        return_value = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
     local_extension_provider = *hash_table_find_result;
@@ -93,7 +93,7 @@ ebpf_extension_load(
             client_data,
             client_dispatch_table);
         if (return_value != EBPF_SUCCESS) {
-            return_value = EBPF_ERROR_NOT_FOUND;
+            return_value = EBPF_EXTENSION_FAILED_TO_LOAD;
             goto Done;
         }
     }
@@ -235,7 +235,7 @@ ebpf_provider_unload(ebpf_extension_provider_t* provider_context)
     ebpf_hash_table_delete(_ebpf_provider_table, (const uint8_t*)&provider_context->interface_id);
 
     return_value = ebpf_hash_table_next_key(_ebpf_provider_table, NULL, (uint8_t*)&next_key);
-    if (return_value == EBPF_ERROR_NO_MORE_KEYS) {
+    if (return_value == EBPF_NO_MORE_KEYS) {
         ebpf_hash_table_destroy(_ebpf_provider_table);
         _ebpf_provider_table = NULL;
     }

--- a/libs/platform/user/ebpf_handle_user.c
+++ b/libs/platform/user/ebpf_handle_user.c
@@ -75,7 +75,7 @@ ebpf_handle_close(ebpf_handle_t handle)
         _ebpf_handle_table[handle] = NULL;
         return_value = EBPF_SUCCESS;
     } else
-        return_value = EBPF_ERROR_INVALID_HANDLE;
+        return_value = EBPF_INVALID_OBJECT;
     ebpf_lock_unlock(&_ebpf_handle_table_lock, &state);
     return return_value;
 }
@@ -87,7 +87,7 @@ ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_
     ebpf_lock_state_t state;
 
     if (handle > EBPF_COUNT_OF(_ebpf_handle_table))
-        return EBPF_ERROR_INVALID_HANDLE;
+        return EBPF_INVALID_OBJECT;
 
     ebpf_lock_lock(&_ebpf_handle_table_lock, &state);
     if ((_ebpf_handle_table[handle] != NULL) &&
@@ -96,7 +96,7 @@ ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_
         *object = _ebpf_handle_table[handle];
         return_value = EBPF_SUCCESS;
     } else
-        return_value = EBPF_ERROR_INVALID_HANDLE;
+        return_value = EBPF_INVALID_OBJECT;
 
     ebpf_lock_unlock(&_ebpf_handle_table_lock, &state);
     return return_value;
@@ -110,7 +110,7 @@ ebpf_get_next_handle_by_type(ebpf_handle_t previous_handle, ebpf_object_type_t o
     previous_handle++;
 
     if (previous_handle > EBPF_COUNT_OF(_ebpf_handle_table))
-        return EBPF_ERROR_INVALID_HANDLE;
+        return EBPF_INVALID_OBJECT;
 
     ebpf_lock_lock(&_ebpf_handle_table_lock, &state);
     for (*next_handle = previous_handle; *next_handle < EBPF_COUNT_OF(_ebpf_handle_table); (*next_handle)++) {

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -56,32 +56,32 @@ ebpf_platform_initiate()
 
     ntdll_module = LoadLibrary(L"ntdll.dll");
     if (ntdll_module == nullptr) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
 
     if (!resolve_function(ntdll_module, RtlInitializeGenericTableAvl, "RtlInitializeGenericTableAvl")) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
     if (!resolve_function(ntdll_module, RtlEnumerateGenericTableAvl, "RtlEnumerateGenericTableAvl")) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
     if (!resolve_function(ntdll_module, RtlDeleteElementGenericTableAvl, "RtlDeleteElementGenericTableAvl")) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
     if (!resolve_function(ntdll_module, RtlLookupElementGenericTableAvl, "RtlLookupElementGenericTableAvl")) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
     if (!resolve_function(ntdll_module, RtlEnumerateGenericTableAvl, "RtlEnumerateGenericTableAvl")) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
     if (!resolve_function(
             ntdll_module,
             RtlLookupFirstMatchingElementGenericTableAvl,
             "RtlLookupFirstMatchingElementGenericTableAvl")) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
     if (!resolve_function(ntdll_module, RtlInsertElementGenericTableAvl, "RtlInsertElementGenericTableAvl")) {
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
     }
 
     // Note: This is safe because ntdll is never unloaded becuase
@@ -192,13 +192,13 @@ ebpf_memory_descriptor_get_base_address(ebpf_memory_descriptor_t* memory_descrip
 ebpf_result_t
 ebpf_safe_size_t_multiply(size_t multiplicand, size_t multiplier, size_t* result)
 {
-    return SUCCEEDED(SizeTMult(multiplicand, multiplier, result)) ? EBPF_SUCCESS : EBPF_ERROR_ARITHMETIC_OVERFLOW;
+    return SUCCEEDED(SizeTMult(multiplicand, multiplier, result)) ? EBPF_SUCCESS : EBPF_ARITHMETIC_OVERFLOW;
 }
 
 ebpf_result_t
 ebpf_safe_size_t_add(size_t augend, size_t addend, size_t* result)
 {
-    return SUCCEEDED(SizeTAdd(augend, addend, result)) ? EBPF_SUCCESS : EBPF_ERROR_ARITHMETIC_OVERFLOW;
+    return SUCCEEDED(SizeTAdd(augend, addend, result)) ? EBPF_SUCCESS : EBPF_ARITHMETIC_OVERFLOW;
 }
 
 ebpf_result_t
@@ -306,7 +306,7 @@ ebpf_allocate_non_preemptible_work_item(
     UNREFERENCED_PARAMETER(cpu_id);
     UNREFERENCED_PARAMETER(work_item_routine);
     UNREFERENCED_PARAMETER(work_item_context);
-    return EBPF_ERROR_NOT_SUPPORTED;
+    return EBPF_OPERATION_NOT_SUPPORTED;
 }
 
 void
@@ -422,12 +422,12 @@ ebpf_access_check(
     bool is_impersonating = false;
 
     if (!ImpersonateSelf(SecurityImpersonation)) {
-        result = EBPF_ERROR_ACCESS_DENIED;
+        result = EBPF_ACCESS_DENIED;
         goto Done;
     }
     is_impersonating = true;
     if (!OpenThreadToken(GetCurrentThread(), TOKEN_QUERY, TRUE, &token)) {
-        result = EBPF_ERROR_ACCESS_DENIED;
+        result = EBPF_ACCESS_DENIED;
         goto Done;
     }
 
@@ -442,9 +442,9 @@ ebpf_access_check(
             &access_status)) {
         DWORD err = GetLastError();
         printf("LastError: %d\n", err);
-        result = EBPF_ERROR_ACCESS_DENIED;
+        result = EBPF_ACCESS_DENIED;
     } else {
-        result = access_status ? EBPF_SUCCESS : EBPF_ERROR_ACCESS_DENIED;
+        result = access_status ? EBPF_SUCCESS : EBPF_ACCESS_DENIED;
     }
 
 Done:

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -204,7 +204,7 @@ ebpf_safe_size_t_add(size_t augend, size_t addend, size_t* result)
 ebpf_result_t
 ebpf_safe_size_t_subtract(size_t minuend, size_t subtrahend, size_t* result)
 {
-    return SUCCEEDED(SizeTSub(minuend, subtrahend, result)) ? EBPF_SUCCESS : EBPF_ERROR_ARITHMETIC_OVERFLOW;
+    return SUCCEEDED(SizeTSub(minuend, subtrahend, result)) ? EBPF_SUCCESS : EBPF_ARITHMETIC_OVERFLOW;
 }
 
 void

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -43,7 +43,7 @@ _build_helper_id_to_address_map(
 
     // uBPF jitter supports a maximum of 64 helper functions
     if (helper_id_mapping.size() > 64)
-        return EBPF_ERROR_NOT_SUPPORTED;
+        return EBPF_OPERATION_NOT_SUPPORTED;
 
     ebpf_protocol_buffer_t request_buffer(
         offsetof(ebpf_operation_resolve_helper_request_t, helper_id) + sizeof(uint32_t) * helper_id_mapping.size());
@@ -158,7 +158,7 @@ _resolve_maps_in_byte_code(ebpf_handle_t program_handle, ebpf_code_buffer_t& byt
 
     for (size_t index = 0; index < map_handles.size(); index++) {
         if (map_handles[index] > get_map_descriptor_size()) {
-            return EBPF_ERROR_INVALID_HANDLE;
+            return EBPF_INVALID_OBJECT;
         }
         request->map_handle[index] = get_map_handle_at_index((int)map_handles[index] - 1);
     }
@@ -258,7 +258,7 @@ ebpf_verify_program(
         auto message = err.what();
         *logs = allocate_error_string(message, logs_size);
 
-        result = EBPF_VALIDATION_FAILED;
+        result = EBPF_VERIFICATION_FAILED;
     } catch (...) {
         result = EBPF_FAILED;
     }
@@ -397,7 +397,7 @@ ebpf_verify_and_load_program(
         auto message = err.what();
         *error_message = allocate_error_string(message, error_message_size);
 
-        result = EBPF_VALIDATION_FAILED;
+        result = EBPF_VERIFICATION_FAILED;
     } catch (...) {
         result = EBPF_FAILED;
     }

--- a/libs/service/verifier_service.cpp
+++ b/libs/service/verifier_service.cpp
@@ -26,7 +26,7 @@ _analyze(raw_program& raw_prog, const char** error_message, uint32_t* error_mess
     std::variant<InstructionSeq, std::string> prog_or_error = unmarshal(raw_prog);
     if (!std::holds_alternative<InstructionSeq>(prog_or_error)) {
         *error_message = allocate_error_string(std::get<std::string>(prog_or_error), error_message_size);
-        return EBPF_VALIDATION_FAILED; // Error;
+        return EBPF_VERIFICATION_FAILED; // Error;
     }
     InstructionSeq& prog = std::get<InstructionSeq>(prog_or_error);
 
@@ -43,7 +43,7 @@ _analyze(raw_program& raw_prog, const char** error_message, uint32_t* error_mess
         (void)ebpf_verify_program(oss, prog, raw_prog.info, &options, &stats);
 
         *error_message = allocate_error_string(oss.str(), error_message_size);
-        return EBPF_VALIDATION_FAILED; // Error;
+        return EBPF_VERIFICATION_FAILED; // Error;
     }
     return EBPF_SUCCESS; // Success.
 }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -623,7 +623,7 @@ _net_ebpf_ext_provider_client_attach_callback(
 {
     net_ebpf_ext_hook_provider_registration_t* hook_registration = (net_ebpf_ext_hook_provider_registration_t*)context;
     if (hook_registration->client_binding_context)
-        return EBPF_ERROR_EXTENSION_FAILED_TO_LOAD;
+        return EBPF_EXTENSION_FAILED_TO_LOAD;
 
     hook_registration->client_binding_context = client_binding_context;
     hook_registration->client_id = *client_id;

--- a/tests/client/main.cpp
+++ b/tests/client/main.cpp
@@ -155,7 +155,7 @@ TEST_CASE("verify-program-droppacket_unsafe", "[verify-program-droppacket_unsafe
             verifier_message = nullptr;
         }
     }
-    REQUIRE((result == (int)EBPF_VALIDATION_FAILED));
+    REQUIRE((result == (int)EBPF_VERIFICATION_FAILED));
     REQUIRE(verifier_message_size > 0);
 
     ebpf_api_free_string(verifier_message);

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -116,13 +116,13 @@ Fail:
         case EBPF_NO_MEMORY:
             SetLastError(ERROR_OUTOFMEMORY);
             break;
-        case EBPF_ERROR_NOT_FOUND:
+        case EBPF_KEY_NOT_FOUND:
             SetLastError(ERROR_NOT_FOUND);
             break;
         case EBPF_INVALID_ARGUMENT:
             SetLastError(ERROR_INVALID_PARAMETER);
             break;
-        case EBPF_ERROR_NO_MORE_KEYS:
+        case EBPF_NO_MORE_KEYS:
             SetLastError(ERROR_NO_MORE_ITEMS);
             break;
         case EBPF_ERROR_INSUFFICIENT_BUFFER:

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -125,7 +125,7 @@ Fail:
         case EBPF_NO_MORE_KEYS:
             SetLastError(ERROR_NO_MORE_ITEMS);
             break;
-        case EBPF_ERROR_INSUFFICIENT_BUFFER:
+        case EBPF_INSUFFICIENT_BUFFER:
             SetLastError(ERROR_MORE_DATA);
             break;
         default:


### PR DESCRIPTION
* Remove `_ERROR_` for consistency
* Combine EBPF_INVALID_HANDLE and EBPF_INVALID_OBJECT so that the latter is returned by ebpfapi not the former since handles are an internal implementation detail
* Rename EBPF_ERROR_NOT_FOUND to EBPF_KEY_NOT_FOUND for consistency with the associated description.
* Change code that returned EBPF_ERROR_NOT_FOUND for a case other than a key, to use a different appropriate result, so the description stays correct.
* Rename EBPF_VALIDATION_FAILED to EBPF_VERIFICATION_FAILED for consistency with the associated description.

Fixes #212

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>