### PR TITLE
Change ebpfsvc to LocalService

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -67,7 +67,7 @@ On the defender machine, do the following:
 9. Do `sc start EbpfCore`
 10. Do `sc create NetEbpfExt type=kernel start=boot binpath=%windir%\system32\drivers\netebpfext.sys`
 11. Do `sc start NetEbpfExt`
-12. Do `sc create ebpfsvc start= auto binpath=%windir%\system32\ebpfsvc.exe type=own`
+12. Do `sc create ebpfsvc start= auto binpath=%windir%\system32\ebpfsvc.exe type=own obj= "NT AUTHORITY\LocalService" password= ""`
 13. Do `sc start ebpfsvc`
 14. Do `netsh add helper %windir%\system32\ebpfnetsh.dll`
 15. Install [clang](https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win64.exe)

--- a/ebpfsvc/svcmain.cpp
+++ b/ebpfsvc/svcmain.cpp
@@ -76,22 +76,22 @@ service_install()
         return;
     }
 
-    // Create the service
+    // Create the service as LocalService.
 
     service = CreateService(
-        scmanager,                 // SCM database
-        SERVICE_NAME,              // name of service
-        SERVICE_NAME,              // service name to display
-        SERVICE_ALL_ACCESS,        // desired access
-        SERVICE_WIN32_OWN_PROCESS, // service type
-        SERVICE_DEMAND_START,      // start type
-        SERVICE_ERROR_NORMAL,      // error control type
-        path,                      // path to service's binary
-        nullptr,                   // no load ordering group
-        nullptr,                   // no tag identifier
-        nullptr,                   // no dependencies
-        nullptr,                   // LocalSystem account
-        nullptr);                  // no password
+        scmanager,                     // SCM database
+        SERVICE_NAME,                  // name of service
+        SERVICE_NAME,                  // service name to display
+        SERVICE_ALL_ACCESS,            // desired access
+        SERVICE_WIN32_OWN_PROCESS,     // service type
+        SERVICE_AUTO_START,            // start type
+        SERVICE_ERROR_NORMAL,          // error control type
+        path,                          // path to service's binary
+        nullptr,                       // no load ordering group
+        nullptr,                       // no tag identifier
+        nullptr,                       // no dependencies
+        L"NT AUTHORITY\\LocalService", // LocalService account
+        nullptr);                      // no password
 
     if (service == nullptr) {
         CloseServiceHandle(scmanager);

--- a/tests/client/service_helper.cpp
+++ b/tests/client/service_helper.cpp
@@ -35,21 +35,21 @@ QueryService:
             return error;
         }
 
-        // Install the service
+        // Install the service as LocalService.
         service_handle = CreateService(
-            scm_handle,                // SCM database
-            service_name.c_str(),      // name of service
-            service_name.c_str(),      // service name to display
-            SERVICE_ALL_ACCESS,        // desired access
-            SERVICE_WIN32_OWN_PROCESS, // service type
-            SERVICE_AUTO_START,        // start type
-            SERVICE_ERROR_NORMAL,      // error control type
-            file_path,                 // path to service's binary
-            nullptr,                   // no load ordering group
-            nullptr,                   // no tag identifier
-            nullptr,                   // no dependencies
-            nullptr,                   // LocalSystem account
-            nullptr);                  // no password
+            scm_handle,                    // SCM database
+            service_name.c_str(),          // name of service
+            service_name.c_str(),          // service name to display
+            SERVICE_ALL_ACCESS,            // desired access
+            SERVICE_WIN32_OWN_PROCESS,     // service type
+            SERVICE_AUTO_START,            // start type
+            SERVICE_ERROR_NORMAL,          // error control type
+            file_path,                     // path to service's binary
+            nullptr,                       // no load ordering group
+            nullptr,                       // no tag identifier
+            nullptr,                       // no dependencies
+            L"NT AUTHORITY\\LocalService", // LocalService account
+            nullptr);                      // no password
 
         if (service_handle == nullptr) {
             error = GetLastError();


### PR DESCRIPTION
Fixes #257.

1. Changes the test code and install code to install sbpfsvc as local service.
2. Updates the doc with the sc.exe command to create service as localservice.