### PR TITLE
Code review comments from PR 246

### DIFF
--- a/include/ebpf_core_structs.h
+++ b/include/ebpf_core_structs.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <sal.h>
 #include <stdint.h>
 #include "ebpf_structs.h"
 

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -731,10 +731,10 @@ static ebpf_result_t
 _ebpf_core_protocol_convert_pinning_entries_to_map_information_array(
     uint16_t entry_count,
     _In_count_(entry_count) ebpf_pinning_entry_t* pinning_entries,
-    _Outptr_result_buffer_maybenull_(entry_count) ebpf_core_map_information_t** map_info)
+    _Outptr_result_buffer_maybenull_(entry_count) ebpf_map_information_internal_t** map_info)
 {
     ebpf_result_t result = EBPF_SUCCESS;
-    ebpf_core_map_information_t* local_map_info = NULL;
+    ebpf_map_information_internal_t* local_map_info = NULL;
     uint16_t index;
 
     if (map_info == NULL) {
@@ -745,7 +745,8 @@ _ebpf_core_protocol_convert_pinning_entries_to_map_information_array(
     if ((entry_count == 0) || (pinning_entries == NULL))
         goto Exit;
 
-    local_map_info = (ebpf_core_map_information_t*)ebpf_allocate(sizeof(ebpf_core_map_information_t) * entry_count);
+    local_map_info =
+        (ebpf_map_information_internal_t*)ebpf_allocate(sizeof(ebpf_map_information_internal_t) * entry_count);
     if (local_map_info == NULL) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -753,7 +754,7 @@ _ebpf_core_protocol_convert_pinning_entries_to_map_information_array(
 
     for (index = 0; index < entry_count; index++) {
         ebpf_pinning_entry_t* source = &pinning_entries[index];
-        ebpf_core_map_information_t* destination = &local_map_info[index];
+        ebpf_map_information_internal_t* destination = &local_map_info[index];
         ebpf_map_definition_t* map_definition;
         if (ebpf_object_get_type(source->object) != EBPF_OBJECT_MAP) {
             // Bad object type.
@@ -780,7 +781,7 @@ Exit:
 static ebpf_result_t
 _ebpf_core_protocol_serialize_map_information_reply(
     uint16_t map_count,
-    _In_count_(map_count) const ebpf_core_map_information_t* map_info,
+    _In_count_(map_count) const ebpf_map_information_internal_t* map_info,
     size_t output_buffer_length,
     _In_ ebpf_operation_get_map_information_reply_t* map_info_reply)
 {
@@ -816,7 +817,7 @@ _ebpf_core_protocol_get_map_information(
     ebpf_result_t result = EBPF_SUCCESS;
     uint16_t entry_count = 0;
     ebpf_pinning_entry_t* pinning_entries = NULL;
-    ebpf_core_map_information_t* map_info = NULL;
+    ebpf_map_information_internal_t* map_info = NULL;
 
     UNREFERENCED_PARAMETER(request);
 

--- a/libs/platform/ebpf_serialize.c
+++ b/libs/platform/ebpf_serialize.c
@@ -20,7 +20,7 @@ ebpf_map_information_array_free(uint16_t map_count, _In_count_(map_count) const 
 ebpf_result_t
 ebpf_serialize_core_map_information_array(
     uint16_t map_count,
-    _In_count_(map_count) const ebpf_core_map_information_t* map_info,
+    _In_count_(map_count) const ebpf_map_information_internal_t* map_info,
     _Out_writes_bytes_to_(output_buffer_length, *serialized_data_length) uint8_t* output_buffer,
     size_t output_buffer_length,
     _Out_ size_t* serialized_data_length,
@@ -58,7 +58,7 @@ ebpf_serialize_core_map_information_array(
 
     for (map_index = 0; map_index < map_count; map_index++) {
         size_t serialized_map_information_length;
-        const ebpf_core_map_information_t* source = &map_info[map_index];
+        const ebpf_map_information_internal_t* source = &map_info[map_index];
         ebpf_serialized_map_information_t* destination = (ebpf_serialized_map_information_t*)current;
 
         // Compute required length for serialized map information.

--- a/libs/platform/ebpf_serialize.h
+++ b/libs/platform/ebpf_serialize.h
@@ -6,8 +6,8 @@
 
 #pragma once
 
-#include "ebpf_platform.h"
 #include "ebpf_core_structs.h"
+#include "ebpf_platform.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -17,11 +17,11 @@ extern "C"
     /**
      * @brief eBPF Core Map Information
      */
-    typedef struct _ebpf_core_map_information
+    typedef struct _ebpf_map_information_internal
     {
         ebpf_map_definition_t definition;
         ebpf_utf8_string_t pin_path;
-    } ebpf_core_map_information_t;
+    } ebpf_map_information_internal_t;
 
     /**
      * @brief Serialized eBPF Map Information.
@@ -36,7 +36,7 @@ extern "C"
     /**
      * @brief Serialize array of ebpf_map_information_t onto output buffer.
      *
-     * @param[in]  map_count Length of input array of ebpf_core_map_information_t structs.
+     * @param[in]  map_count Length of input array of ebpf_map_information_internal_t structs.
      * @param[in]  map_info Array of ebpf_map_information_t to serialize.
      * @param[out]  output_buffer Caller specified output buffer to write serialized data into.
      * @param[in]  output_buffer_length Output buffer length.
@@ -49,7 +49,7 @@ extern "C"
     ebpf_result_t
     ebpf_serialize_core_map_information_array(
         uint16_t map_count,
-        _In_count_(map_count) const ebpf_core_map_information_t* map_info,
+        _In_count_(map_count) const ebpf_map_information_internal_t* map_info,
         _Out_writes_bytes_to_(output_buffer_length, *serialized_data_length) uint8_t* output_buffer,
         size_t output_buffer_length,
         _Out_ size_t* serialized_data_length,

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -318,7 +318,7 @@ TEST_CASE("serialize_map_test", "[serialize_map_test]")
     _test_helper test_helper;
 
     const int map_count = 10;
-    ebpf_core_map_information_t core_map_info_array[map_count] = {};
+    ebpf_map_information_internal_t core_map_info_array[map_count] = {};
     std::string pin_path_prefix = "\\ebpf\\map\\";
     std::vector<std::string> pin_paths;
     size_t buffer_length = 0;
@@ -327,13 +327,13 @@ TEST_CASE("serialize_map_test", "[serialize_map_test]")
     size_t serialized_length;
     ebpf_map_information_t* map_info_array;
 
-    // Construct the array of ebpf_core_map_information_t to be serialized.
+    // Construct the array of ebpf_map_information_internal_t to be serialized.
     for (int i = 0; i < map_count; i++) {
         pin_paths.push_back(pin_path_prefix + std::to_string(i));
     }
 
     for (int i = 0; i < map_count; i++) {
-        ebpf_core_map_information_t* map_info = &core_map_info_array[i];
+        ebpf_map_information_internal_t* map_info = &core_map_info_array[i];
         map_info->definition.size = (i + 1) * 32;
         map_info->definition.type = static_cast<ebpf_map_type_t>(i % (EBPF_MAP_TYPE_ARRAY + 1));
         map_info->definition.key_size = i + 1;
@@ -362,7 +362,7 @@ TEST_CASE("serialize_map_test", "[serialize_map_test]")
 
     // Verify de-serialized map info array matches input.
     for (int i = 0; i < map_count; i++) {
-        ebpf_core_map_information_t* input_map_info = &core_map_info_array[i];
+        ebpf_map_information_internal_t* input_map_info = &core_map_info_array[i];
         ebpf_map_information_t* map_info = &map_info_array[i];
         REQUIRE(memcmp(&map_info->definition, &input_map_info->definition, sizeof(ebpf_map_definition_t)) == 0);
         REQUIRE(strnlen_s(map_info->pin_path, EBPF_MAX_PIN_PATH_LENGTH) == input_map_info->pin_path.length);


### PR DESCRIPTION
This PR addresses a couple of comments from merged PR https://github.com/microsoft/ebpf-for-windows/pull/246
- arrange header includes alphabetically in serialize.h
- rename ebpf_core_map_information_t to ebpf_map_information_internal_t