### PR TITLE
Add some more SAL annotations and clean up some code analysis warnings

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#include "ebpf_link.h"
-
-#include "ebpf_object.h"
-#include "ebpf_program.h"
 #include "ebpf_epoch.h"
+#include "ebpf_link.h"
+#include "ebpf_object.h"
 #include "ebpf_platform.h"
+#include "ebpf_program.h"
 
 typedef struct _ebpf_link
 {
@@ -22,8 +21,8 @@ typedef struct _ebpf_link
     ebpf_extension_dispatch_table_t* provider_dispatch_table;
 } ebpf_link_t;
 
-ebpf_result_t
-_ebpf_link_instance_invoke(const ebpf_link_t* link, void* program_context, uint32_t* result);
+static ebpf_result_t
+_ebpf_link_instance_invoke(_In_ const ebpf_link_t* link, _In_ void* program_context, _Out_ uint32_t* result);
 
 static struct
 {
@@ -128,8 +127,8 @@ ebpf_link_detach_program(ebpf_link_t* link)
     link->program = NULL;
 }
 
-ebpf_result_t
-_ebpf_link_instance_invoke(const ebpf_link_t* link, void* program_context, uint32_t* result)
+static ebpf_result_t
+_ebpf_link_instance_invoke(_In_ const ebpf_link_t* link, _In_ void* program_context, _Out_ uint32_t* result)
 {
     ebpf_result_t return_value;
     if (!link)

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1,8 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#include "ebpf_maps.h"
 #include "ebpf_epoch.h"
+#include "ebpf_maps.h"
 #include "ebpf_object.h"
 
 typedef struct _ebpf_core_map
@@ -26,7 +26,7 @@ typedef struct _ebpf_map_function_table
 extern ebpf_map_function_table_t ebpf_map_function_tables[EBPF_MAP_TYPE_ARRAY + 1];
 
 ebpf_result_t
-ebpf_map_create(const ebpf_map_definition_t* ebpf_map_definition, ebpf_map_t** ebpf_map)
+ebpf_map_create(_In_ const ebpf_map_definition_t* ebpf_map_definition, _Outptr_ ebpf_map_t** ebpf_map)
 {
     ebpf_map_t* local_map = NULL;
     size_t type = ebpf_map_definition->type;
@@ -51,32 +51,32 @@ ebpf_map_create(const ebpf_map_definition_t* ebpf_map_definition, ebpf_map_t** e
     return EBPF_SUCCESS;
 }
 
-ebpf_map_definition_t*
-ebpf_map_get_definition(ebpf_map_t* map)
+const ebpf_map_definition_t*
+ebpf_map_get_definition(_In_ const ebpf_map_t* map)
 {
     return &map->ebpf_map_definition;
 }
 
 uint8_t*
-ebpf_map_find_entry(ebpf_map_t* map, const uint8_t* key)
+ebpf_map_find_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key)
 {
     return ebpf_map_function_tables[map->ebpf_map_definition.type].find_entry(map, key);
 }
 
 ebpf_result_t
-ebpf_map_update_entry(ebpf_map_t* map, const uint8_t* key, const uint8_t* value)
+ebpf_map_update_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value)
 {
     return ebpf_map_function_tables[map->ebpf_map_definition.type].update_entry(map, key, value);
 }
 
 ebpf_result_t
-ebpf_map_delete_entry(ebpf_map_t* map, const uint8_t* key)
+ebpf_map_delete_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key)
 {
     return ebpf_map_function_tables[map->ebpf_map_definition.type].delete_entry(map, key);
 }
 
 ebpf_result_t
-ebpf_map_next_key(ebpf_map_t* map, const uint8_t* previous_key, uint8_t* next_key)
+ebpf_map_next_key(_In_ ebpf_map_t* map, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
 {
     return ebpf_map_function_tables[map->ebpf_map_definition.type].next_key(map, previous_key, next_key);
 }

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -23,7 +23,7 @@ extern "C"
      *  map.
      */
     ebpf_result_t
-    ebpf_map_create(const ebpf_map_definition_t* ebpf_map_definition, ebpf_map_t** map);
+    ebpf_map_create(_In_ const ebpf_map_definition_t* ebpf_map_definition, _Outptr_ ebpf_map_t** map);
 
     /**
      * @brief Get a pointer to the map definition.
@@ -31,8 +31,8 @@ extern "C"
      * @param[in] map Map to get definition from.
      * @return Pointer to map definition.
      */
-    ebpf_map_definition_t*
-    ebpf_map_get_definition(ebpf_map_t* map);
+    const ebpf_map_definition_t*
+    ebpf_map_get_definition(_In_ const ebpf_map_t* map);
 
     /**
      * @brief Get a pointer to an entry in the map.
@@ -42,7 +42,7 @@ extern "C"
      * @return Pointer to the value if found or NULL.
      */
     uint8_t*
-    ebpf_map_find_entry(ebpf_map_t* map, const uint8_t* key);
+    ebpf_map_find_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key);
 
     /**
      * @brief Insert or update an entry in the map.
@@ -55,7 +55,7 @@ extern "C"
      *  entry.
      */
     ebpf_result_t
-    ebpf_map_update_entry(ebpf_map_t* map, const uint8_t* key, const uint8_t* value);
+    ebpf_map_update_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value);
 
     /**
      * @brief Remove an entry from the map.
@@ -67,21 +67,22 @@ extern "C"
      *  invalid.
      */
     ebpf_result_t
-    ebpf_map_delete_entry(ebpf_map_t* map, const uint8_t* key);
+    ebpf_map_delete_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key);
 
     /**
      * @brief Retrieve the next key from the map.
      *
      * @param[in] map Map to search.
      * @param[in] previous_key The previous key need not be present. This will
-     * return the next key lexicographically after the specified key.
-     * @param[in] next_key Next key on success.
+     * return the next key lexicographically after the specified key.  A value of
+     * null indicates that the first key is to be returned.
+     * @param[out] next_key Next key on success.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MORE_KEYS There is no key following the specified
      * key in lexicographically order.
      */
     ebpf_result_t
-    ebpf_map_next_key(ebpf_map_t* map, const uint8_t* previous_key, uint8_t* next_key);
+    ebpf_map_next_key(_In_ ebpf_map_t* map, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1,12 +1,11 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#include "ebpf_program.h"
-
 #include "ebpf_core.h"
 #include "ebpf_epoch.h"
 #include "ebpf_link.h"
 #include "ebpf_object.h"
+#include "ebpf_program.h"
 
 typedef struct _FILE FILE;
 #include "ubpf.h"
@@ -389,7 +388,7 @@ Done:
 }
 
 void
-ebpf_program_invoke(ebpf_program_t* program, void* context, uint32_t* result)
+ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out_ uint32_t* result)
 {
     if (!program || program->program_invalidated)
         return;

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -132,7 +132,7 @@ extern "C"
      * @param[out] result Output from the program.
      */
     void
-    ebpf_program_invoke(ebpf_program_t* program, void* context, uint32_t* result);
+    ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out_ uint32_t* result);
 
     /**
      * @brief Get the address of a helper function.

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -18,7 +18,7 @@ struct _ebpf_hash_table
 // Compare can be called with a partial struct only containing the key.
 // Do not access beyond map->ebpf_map_definition.key_size bytes.
 static RTL_GENERIC_COMPARE_RESULTS
-_ebpf_hash_map_compare(struct _RTL_AVL_TABLE* avl_table, void* first_struct, void* second_struct)
+_ebpf_hash_map_compare(_In_ struct _RTL_AVL_TABLE* avl_table, _In_ void* first_struct, _In_ void* second_struct)
 {
     ebpf_hash_table_t* table = (ebpf_hash_table_t*)avl_table;
 
@@ -108,10 +108,7 @@ ebpf_hash_table_destroy(_Pre_maybenull_ _Post_invalid_ ebpf_hash_table_t* hash_t
 }
 
 ebpf_result_t
-ebpf_hash_table_find(
-    _In_ ebpf_hash_table_t* hash_table,
-    _In_ _Pre_readable_byte_size_(hash_table->key_size) const uint8_t* key,
-    _Outptr_ _Post_readable_size_(hash_table->value_size) uint8_t** value)
+ebpf_hash_table_find(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _Outptr_ uint8_t** value)
 {
     ebpf_result_t retval;
     RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
@@ -129,10 +126,7 @@ ebpf_hash_table_find(
 }
 
 ebpf_result_t
-ebpf_hash_table_update(
-    _In_ ebpf_hash_table_t* hash_table,
-    _In_ _Pre_readable_byte_size_(hash_table->key_size) const uint8_t* key,
-    _In_ _Pre_readable_byte_size_(hash_table->value_size) const uint8_t* value)
+ebpf_hash_table_update(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _In_ const uint8_t* value)
 {
     ebpf_result_t retval;
     RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
@@ -172,8 +166,7 @@ Done:
 }
 
 ebpf_result_t
-ebpf_hash_table_delete(
-    _In_ ebpf_hash_table_t* hash_table, _In_ _Pre_readable_byte_size_(hash_table->key_size) const uint8_t* key)
+ebpf_hash_table_delete(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key)
 {
     BOOLEAN result;
     RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
@@ -186,8 +179,8 @@ ebpf_result_t
 ebpf_hash_table_next_key_and_value(
     _In_ ebpf_hash_table_t* hash_table,
     _In_opt_ const uint8_t* previous_key,
-    _Out_ _Writable_bytes_(hash_table->key_size) uint8_t* next_key,
-    _Outptr_opt_ _Post_readable_size_(hash_table->value_size) uint8_t** value)
+    _Out_ uint8_t* next_key,
+    _Outptr_opt_ uint8_t** value)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
@@ -239,9 +232,7 @@ Exit:
 
 ebpf_result_t
 ebpf_hash_table_next_key(
-    _In_ ebpf_hash_table_t* hash_table,
-    _In_opt_ _Pre_readable_byte_size_(hash_table->key_size) const uint8_t* previous_key,
-    _Out_ _Post_readable_size_(hash_table->value_size) uint8_t* next_key)
+    _In_ ebpf_hash_table_t* hash_table, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
 {
     return ebpf_hash_table_next_key_and_value(hash_table, previous_key, next_key, NULL);
 }

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -412,10 +412,7 @@ extern "C"
      * @retval EBPF_NOT_FOUND Key not found in hash table.
      */
     ebpf_result_t
-    ebpf_hash_table_find(
-        _In_ ebpf_hash_table_t* hash_table,
-        _In_ _Pre_readable_byte_size_(hash_table->key_size) const uint8_t* key,
-        _Outptr_ _Post_readable_size_(hash_table->value_size) uint8_t** value);
+    ebpf_hash_table_find(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _Outptr_ uint8_t** value);
 
     /**
      * @brief Insert or update an entry in the hash table.
@@ -428,10 +425,7 @@ extern "C"
      *  entry in the hash table.
      */
     ebpf_result_t
-    ebpf_hash_table_update(
-        _In_ ebpf_hash_table_t* hash_table,
-        _In_ _Pre_readable_byte_size_(hash_table->key_size) const uint8_t* key,
-        _In_ _Pre_readable_byte_size_(hash_table->value_size) const uint8_t* value);
+    ebpf_hash_table_update(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _In_ const uint8_t* value);
 
     /**
      * @brief Remove an entry from the hash table.
@@ -442,8 +436,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      */
     ebpf_result_t
-    ebpf_hash_table_delete(
-        _In_ ebpf_hash_table_t* hash_table, _In_ _Pre_readable_byte_size_(hash_table->key_size) const uint8_t* key);
+    ebpf_hash_table_delete(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key);
 
     /**
      * @brief Find the next key in the hash table.
@@ -457,9 +450,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_hash_table_next_key(
-        _In_ ebpf_hash_table_t* hash_table,
-        _In_opt_ _Pre_readable_byte_size_(hash_table->key_size) const uint8_t* previous_key,
-        _Out_ _Post_readable_size_(hash_table->value_size) uint8_t* next_key);
+        _In_ ebpf_hash_table_t* hash_table, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
 
     /**
      * @brief Returns the next (key, value) pair in the hash table.
@@ -476,8 +467,8 @@ extern "C"
     ebpf_hash_table_next_key_and_value(
         _In_ ebpf_hash_table_t* hash_table,
         _In_opt_ const uint8_t* previous_key,
-        _Out_ _Writable_bytes_(hash_table->key_size) uint8_t* next_key,
-        _Outptr_opt_ _Post_readable_size_(hash_table->value_size) uint8_t** next_value);
+        _Out_ uint8_t* next_key,
+        _Outptr_opt_ uint8_t** next_value);
 
     /**
      * @brief Get the number of keys in the hash table
@@ -562,7 +553,7 @@ extern "C"
      * @param[in] client_data_length Length of the client data.
      * @param[in] client_dispatch_table Table of function pointers the client
      *  exposes.
-     * @param[in] provider_id GUID representing the extension to load.
+     * @param[out] provider_binding_context Provider binding context.
      * @param[out] provider_data Opaque provider data.
      * @param[out] provider_dispatch_table Table of function pointers the
      *  provider exposes.
@@ -578,12 +569,12 @@ extern "C"
         _Outptr_ ebpf_extension_client_t** client_context,
         _In_ const GUID* interface_id,
         _In_ void* client_binding_context,
-        _In_ const ebpf_extension_data_t* client_data,
-        _In_ const ebpf_extension_dispatch_table_t* client_dispatch_table,
-        _In_ void** provider_binding_context,
+        _In_opt_ const ebpf_extension_data_t* client_data,
+        _In_opt_ const ebpf_extension_dispatch_table_t* client_dispatch_table,
+        _Outptr_opt_ void** provider_binding_context,
         _Outptr_ const ebpf_extension_data_t** provider_data,
         _Outptr_ const ebpf_extension_dispatch_table_t** provider_dispatch_table,
-        _In_ ebpf_extension_change_callback_t extension_changed);
+        _In_opt_ ebpf_extension_change_callback_t extension_changed);
 
     /**
      * @brief Unload an extension.
@@ -622,8 +613,8 @@ extern "C"
     ebpf_provider_load(
         _Outptr_ ebpf_extension_provider_t** provider_context,
         _In_ const GUID* interface_id,
-        _In_ void* provider_binding_context,
-        _In_ const ebpf_extension_data_t* provider_data,
+        _In_opt_ void* provider_binding_context,
+        _In_opt_ const ebpf_extension_data_t* provider_data,
         _In_ const ebpf_extension_dispatch_table_t* provider_dispatch_table,
         _In_ void* callback_context,
         _In_ ebpf_provider_client_attach_callback_t client_attach_callback,

--- a/libs/platform/kernel/ebpf_extension_kernel.c
+++ b/libs/platform/kernel/ebpf_extension_kernel.c
@@ -115,12 +115,12 @@ ebpf_extension_load(
     _Outptr_ ebpf_extension_client_t** client_context,
     _In_ const GUID* interface_id,
     _In_ void* client_binding_context,
-    _In_ const ebpf_extension_data_t* client_data,
-    _In_ const ebpf_extension_dispatch_table_t* client_dispatch_table,
-    _In_ void** provider_binding_context,
+    _In_opt_ const ebpf_extension_data_t* client_data,
+    _In_opt_ const ebpf_extension_dispatch_table_t* client_dispatch_table,
+    _Outptr_opt_ void** provider_binding_context,
     _Outptr_ const ebpf_extension_data_t** provider_data,
     _Outptr_ const ebpf_extension_dispatch_table_t** provider_dispatch_table,
-    _In_ ebpf_extension_change_callback_t extension_changed)
+    _In_opt_ ebpf_extension_change_callback_t extension_changed)
 {
     ebpf_result_t return_value;
     ebpf_extension_client_t* local_client_context;
@@ -290,8 +290,8 @@ ebpf_result_t
 ebpf_provider_load(
     _Outptr_ ebpf_extension_provider_t** provider_context,
     _In_ const GUID* interface_id,
-    _In_ void* provider_binding_context,
-    _In_ const ebpf_extension_data_t* provider_data,
+    _In_opt_ void* provider_binding_context,
+    _In_opt_ const ebpf_extension_data_t* provider_data,
     _In_ const ebpf_extension_dispatch_table_t* provider_dispatch_table,
     _In_ void* callback_context,
     _In_ ebpf_provider_client_attach_callback_t client_attach_callback,

--- a/libs/platform/user/ebpf_extension_user.c
+++ b/libs/platform/user/ebpf_extension_user.c
@@ -32,12 +32,12 @@ ebpf_extension_load(
     _Outptr_ ebpf_extension_client_t** client_context,
     _In_ const GUID* interface_id,
     _In_ void* client_binding_context,
-    _In_ const ebpf_extension_data_t* client_data,
-    _In_ const ebpf_extension_dispatch_table_t* client_dispatch_table,
-    _In_ void** provider_binding_context,
+    _In_opt_ const ebpf_extension_data_t* client_data,
+    _In_opt_ const ebpf_extension_dispatch_table_t* client_dispatch_table,
+    _Outptr_opt_ void** provider_binding_context,
     _Outptr_ const ebpf_extension_data_t** provider_data,
     _Outptr_ const ebpf_extension_dispatch_table_t** provider_dispatch_table,
-    _In_ ebpf_extension_change_callback_t extension_changed)
+    _In_opt_ ebpf_extension_change_callback_t extension_changed)
 {
     ebpf_result_t return_value;
     ebpf_lock_state_t state;
@@ -153,7 +153,7 @@ ebpf_provider_load(
     _Outptr_ ebpf_extension_provider_t** provider_context,
     _In_ const GUID* interface_id,
     _In_ void* provider_binding_context,
-    _In_ const ebpf_extension_data_t* provider_data,
+    _In_opt_ const ebpf_extension_data_t* provider_data,
     _In_ const ebpf_extension_dispatch_table_t* provider_dispatch_table,
     _In_ void* callback_context,
     _In_ ebpf_provider_client_attach_callback_t client_attach_callback,


### PR DESCRIPTION
* Make a couple of `_In_` arguments be const
* Add `_opt_` to a number of arguments that can be NULL
* Add SAL annotation to a few more APIs that were missing it
* Remove annotations like `_Pre_readable_byte_size_(hash_table->key_size)` since they just give code analysis warnings such as:
```
c:\git\dthaler\ebpf-for-windows\libs\platform\ebpf_platform.h(445): warning C28230: The type of '_Param_(1)' has no member 'key_size'.
c:\git\dthaler\ebpf-for-windows\libs\platform\ebpf_platform.h(445): warning C28285: For function 'ebpf_hash_table_delete' '_Param_(2)' syntax error in 'SAL_readableTo(byteCount(__formal(0,hash_table)->key_size))' near 'key_size))'.
```

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>