### PR TITLE
Annotate IDL GUID so clang-format will not interfere

### DIFF
--- a/rpc_interface/rpc_interface.idl
+++ b/rpc_interface/rpc_interface.idl
@@ -13,7 +13,9 @@ import "wtypes.idl";
 // Interface Attributes
 //
 
+// clang-format off
 [uuid(6bef171d-7205-4b63-a1e5-d00f01e6a0c1), version(1.0), pointer_default(unique)]
+    // clang-format on
 
     interface ebpf_service_interface {
         // TODO: (Issue #208): This is a duplicate of EbpfMapDescriptor


### PR DESCRIPTION
Without the annotation, clang-format would convert
`uuid(6bef171d-7205-4b63-a1e5-d00f01e6a0c1)`
to
`uuid(6bef171d - 7205 - 4b63 - a1e5 - d00f01e6a0c1)`
which would be invalid.

Fixes #269

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>