### PR TITLE
Merge eBPF types with the types in ebpf-verifier

### DIFF
--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -14,36 +14,7 @@ typedef unsigned long long uint64_t;
 #include <guiddef.h>
 #include <stdint.h>
 #endif
-
-typedef enum _ebpf_helper_return_type
-{
-    EBPF_RETURN_TYPE_INTEGER = 0,
-    EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-    EBPF_RETURN_TYPE_VOID,
-} ebpf_helper_return_type_t;
-
-typedef enum _ebpf_helper_argument_type
-{
-    EBPF_ARGUMENT_TYPE_DONTCARE = 0,
-    EBPF_ARGUMENT_TYPE_ANYTHING, // All values are valid, e.g., 64-bit flags.
-    EBPF_ARGUMENT_TYPE_CONST_SIZE,
-    EBPF_ARGUMENT_TYPE_CONST_SIZE_OR_ZERO,
-    EBPF_ARGUMENT_TYPE_PTR_TO_CTX,
-    EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
-    EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY,
-    EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE,
-    EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-    EBPF_ARGUMENT_TYPE_PTR_TO_MEM_OR_NULL,
-    EBPF_ARGUMENT_TYPE_PTR_TO_UNINIT_MEM,
-} ebpf_helper_argument_type_t;
-
-typedef struct _ebpf_context_descriptor
-{
-    int size; // Size of ctx struct.
-    int data; // Offset into ctx struct of pointer to data.
-    int end;  // Offset into ctx struct of pointer to end of data.
-    int meta; // Offset into ctx struct of pointer to metadata.
-} ebpf_context_descriptor_t;
+#include "../external/ebpf-verifier/src/ebpf_base.h"
 
 typedef struct _ebpf_program_type_descriptor
 {
@@ -59,8 +30,8 @@ typedef struct _ebpf_helper_function_prototype
     uint32_t helper_id;
     MIDL([string])
     const char* name;
-    ebpf_helper_return_type_t return_type;
-    ebpf_helper_argument_type_t arguments[5];
+    ebpf_return_type_t return_type;
+    ebpf_argument_type_t arguments[5];
 } ebpf_helper_function_prototype_t;
 
 typedef struct _ebpf_program_information

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <stdint.h>
+#include "../external/ebpf-verifier/src/ebpf_base.h"
 
 typedef enum _ebpf_map_type
 {

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -15,7 +15,6 @@
 #pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
 #pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
                                 // 'type2', possible loss of data
-#undef VOID
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 #include "ebpf_xdp_program_data.h"

--- a/libs/api/Verifier.h
+++ b/libs/api/Verifier.h
@@ -6,9 +6,7 @@
 #include "config.hpp"
 #include "ebpf_program_types.h"
 #include "ebpf_result.h"
-#undef VOID
 #include "platform.hpp"
-#define VOID void
 typedef int (*map_create_fp)(
     uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
 

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -11,7 +11,6 @@
 #pragma warning(pop)
 #include "api_common.hpp"
 #include "ebpf_api.h"
-#undef VOID
 #include "ebpf_helpers.h"
 #include "helpers.hpp"
 #include "map_descriptors.hpp"

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -15,7 +15,6 @@
 #pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
 #pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
                                 // 'type2', possible loss of data
-#undef VOID
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -15,7 +15,6 @@
 #include "ebpf_result.h"
 #include "ebpf_xdp_program_data.h"
 #include "platform.h"
-#undef VOID
 #include "platform.hpp"
 
 static ebpf_handle_t _device_handle = INVALID_HANDLE_VALUE;

--- a/libs/api_common/windows_helpers.cpp
+++ b/libs/api_common/windows_helpers.cpp
@@ -13,7 +13,6 @@
 #include "ebpf_result.h"
 #include "ebpf_xdp_program_data.h"
 #include "platform.h"
-#undef VOID
 #include "platform.hpp"
 
 struct guid_compare
@@ -146,8 +145,7 @@ get_helper_prototype_windows(unsigned int n)
     }
     EbpfHelperPrototype verifier_prototype = {0};
 
-    // TODO (issue #153): remove duplicate struct for ebpf_context_descriptor_t so no cast is needed.
-    verifier_prototype.context_descriptor = (EbpfContextDescriptor*)info->program_type_descriptor.context_descriptor;
+    verifier_prototype.context_descriptor = info->program_type_descriptor.context_descriptor;
 
     ebpf_helper_function_prototype_t* raw_prototype = _get_helper_function_prototype(info, n);
     if (raw_prototype == nullptr) {
@@ -155,14 +153,10 @@ get_helper_prototype_windows(unsigned int n)
     }
     verifier_prototype.name = raw_prototype->name;
 
-    // TODO (issue #153): remove duplicate enum for ebpf_helper_return_type_t so no cast is needed.
-    // Today one is a C++ enum class and the other is a C enum, but the values match.
-    verifier_prototype.return_type = (EbpfHelperReturnType)raw_prototype->return_type;
+    verifier_prototype.return_type = raw_prototype->return_type;
 
     for (int i = 0; i < 5; i++) {
-        // TODO (issue #153): remove duplicate enum for ebpf_helper_argument_type_t so no cast is needed.
-        // Today one is a C++ enum class and the other is a C enum, but the values match.
-        verifier_prototype.argument_type[i] = (EbpfHelperArgumentType)raw_prototype->arguments[i];
+        verifier_prototype.argument_type[i] = raw_prototype->arguments[i];
     }
 
     return verifier_prototype;

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -12,7 +12,6 @@
 #include "crab_verifier.hpp"
 #pragma warning(pop)
 #include "ebpf_api.h"
-#undef VOID
 #include "ebpf_helpers.h"
 #include "helpers.hpp"
 #include "map_descriptors.hpp"
@@ -34,7 +33,7 @@
 // the preprocessor treat a prefix list as one macro argument.
 #define COMMA ,
 
-const EbpfContextDescriptor g_xdp_context_descriptor = {
+const ebpf_context_descriptor_t g_xdp_context_descriptor = {
     24, // Size of ctx struct.
     0,  // Offset into ctx struct of pointer to data, or -1 if none.
     8,  // Offset into ctx struct of pointer to end of data, or -1 if none.
@@ -44,7 +43,7 @@ const EbpfContextDescriptor g_xdp_context_descriptor = {
 const EbpfProgramType windows_xdp_program_type =
     PTYPE("xdp", &g_xdp_context_descriptor, (uint64_t)&EBPF_PROGRAM_TYPE_XDP, {"xdp"});
 
-const EbpfContextDescriptor g_bind_context_descriptor = {
+const ebpf_context_descriptor_t g_bind_context_descriptor = {
     43, // Size of ctx struct.
     0,  // Offset into ctx struct of pointer to data, or -1 if none.
     8,  // Offset into ctx struct of pointer to end of data, or -1 if none.

--- a/libs/service/verifier_service.cpp
+++ b/libs/service/verifier_service.cpp
@@ -12,7 +12,6 @@
 #pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
 #pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
                                 // 'type2', possible loss of data
-#undef VOID
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 #include "platform.hpp"

--- a/libs/service/verifier_service.h
+++ b/libs/service/verifier_service.h
@@ -4,7 +4,6 @@
 #pragma once
 
 #include "config.hpp"
-#undef VOID
 #include "platform.hpp"
 
 ebpf_result_t

--- a/libs/service/windows_platform_service.cpp
+++ b/libs/service/windows_platform_service.cpp
@@ -12,7 +12,6 @@
 #include "crab_verifier.hpp"
 #pragma warning(pop)
 #include "ebpf_api.h"
-#undef VOID
 #include "ebpf_helpers.h"
 #include "helpers.hpp"
 #include "platform.hpp"

--- a/tests/client/main.cpp
+++ b/tests/client/main.cpp
@@ -10,7 +10,6 @@
 #pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
 #pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
                                 // 'type2', possible loss of data
-#undef VOID
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 #include "header.h"


### PR DESCRIPTION
Remove duplicate types:
* ebpf_helper_return_type_t
* ebpf_helper_argument_type_t
* ebpf_context_descriptor_t

This PR requires https://github.com/vbpf/ebpf-verifier/pull/238 to be merged first.

Fixes #153

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>