### PR TITLE
Add additional netsh tests

### DIFF
--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -338,6 +338,9 @@ ebpf_api_elf_verify_section(
 
     std::ostringstream output;
 
+    *report = nullptr;
+    *error_message = nullptr;
+
     try {
         const ebpf_platform_t* platform = &g_ebpf_platform_windows;
         ebpf_verifier_options_t verifier_options = ebpf_verifier_default_options;
@@ -376,6 +379,7 @@ ebpf_api_elf_verify_section(
     } catch (std::exception ex) {
         error << "Failed to load eBPF program from " << file;
         *error_message = allocate_string(error.str());
+        return 1;
     }
 
     return 0;

--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -246,7 +246,7 @@ handle_ebpf_show_verification(
         return NO_ERROR;
     } else {
         if (error_message) {
-            std::cerr << "error: " << error_message << std::endl;
+            std::cerr << error_message << std::endl;
         }
         if (report) {
             std::cerr << "\nVerification report:\n" << report << std::endl;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -10,12 +10,11 @@
 
 #include "catch2\catch.hpp"
 #include "common_tests.h"
-#include "ebpf_api.h"
 #include "ebpf_bind_program_data.h"
-#include "ebpf_core.h"
 #include "ebpf_xdp_program_data.h"
 #include "helpers.h"
 #include "mock.h"
+#include "test_helper.hpp"
 #include "tlv.h"
 namespace ebpf {
 #pragma warning(push)
@@ -148,36 +147,6 @@ prepare_udp_packet(uint16_t udp_length)
 
     return packet;
 }
-
-class _test_helper_end_to_end
-{
-  public:
-    _test_helper_end_to_end()
-    {
-        device_io_control_handler = GlueDeviceIoControl;
-        create_file_handler = GlueCreateFileW;
-        close_handle_handler = GlueCloseHandle;
-        REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
-        ec_initialized = true;
-        REQUIRE(ebpf_api_initiate() == EBPF_SUCCESS);
-        api_initialized = true;
-    }
-    ~_test_helper_end_to_end()
-    {
-        if (api_initialized)
-            ebpf_api_terminate();
-        if (ec_initialized)
-            ebpf_core_terminate();
-
-        device_io_control_handler = nullptr;
-        create_file_handler = nullptr;
-        close_handle_handler = nullptr;
-    }
-
-  private:
-    bool ec_initialized = false;
-    bool api_initialized = false;
-};
 
 #define SAMPLE_PATH ""
 

--- a/tests/end_to_end/test_helper.hpp
+++ b/tests/end_to_end/test_helper.hpp
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+#include "ebpf_api.h"
+#include "ebpf_core.h"
+#include "mock.h"
+
+BOOL
+GlueCloseHandle(ebpf_handle_t hObject);
+
+ebpf_handle_t
+GlueCreateFileW(
+    PCWSTR lpFileName,
+    DWORD dwDesiredAccess,
+    DWORD dwShareMode,
+    PSECURITY_ATTRIBUTES lpSecurityAttributes,
+    DWORD dwCreationDisposition,
+    DWORD dwFlagsAndAttributes,
+    ebpf_handle_t hTemplateFile);
+
+BOOL
+GlueDeviceIoControl(
+    ebpf_handle_t hDevice,
+    DWORD dwIoControlCode,
+    PVOID lpInBuffer,
+    DWORD nInBufferSize,
+    LPVOID lpOutBuffer,
+    DWORD nOutBufferSize,
+    PDWORD lpBytesReturned,
+    OVERLAPPED* lpOverlapped);
+
+class _test_helper_end_to_end
+{
+  public:
+    _test_helper_end_to_end()
+    {
+        device_io_control_handler = GlueDeviceIoControl;
+        create_file_handler = GlueCreateFileW;
+        close_handle_handler = GlueCloseHandle;
+        REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+        ec_initialized = true;
+        REQUIRE(ebpf_api_initiate() == EBPF_SUCCESS);
+        api_initialized = true;
+    }
+    ~_test_helper_end_to_end()
+    {
+        if (api_initialized)
+            ebpf_api_terminate();
+        if (ec_initialized)
+            ebpf_core_terminate();
+
+        device_io_control_handler = nullptr;
+        create_file_handler = nullptr;
+        close_handle_handler = nullptr;
+    }
+
+  private:
+    bool ec_initialized = false;
+    bool api_initialized = false;
+};

--- a/tests/unit/test.vcxproj
+++ b/tests/unit/test.vcxproj
@@ -206,6 +206,7 @@
   <ItemGroup>
     <ClInclude Include="..\end_to_end\helpers.h" />
     <ClInclude Include="..\end_to_end\mock.h" />
+    <ClInclude Include="..\end_to_end\test_helper.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets" />

--- a/tests/unit/test.vcxproj.filters
+++ b/tests/unit/test.vcxproj.filters
@@ -48,5 +48,8 @@
     <ClInclude Include="..\end_to_end\mock.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\end_to_end\test_helper.hpp">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Add tests for "show verification" and a minimal test for "show programs"
Fix a couple bugs that the tests uncovered
Remove duplicate "error: error:" prefix in messages on verification

Fixes #240

Signed-off-by: Dave Thaler <dthaler@ntdev.microsoft.com>