### PR TITLE
Suppress C26451

### DIFF
--- a/Analyze.default.ruleset
+++ b/Analyze.default.ruleset
@@ -25,8 +25,7 @@
     <Rule Id="C26449" Action="Error" />
     <!-- Arithmetic overflow: '%operator%' operation causes overflow at compile time. Use a wider type to store the operands -->
     <Rule Id="C26450" Action="Warning" />
-    <!-- Arithmetic overflow: Using operator 'operator' on a size-a byte value and then casting the result to a size-b byte value. Cast the value to the wider type before calling operator 'operator' to avoid overflow -->
-    <Rule Id="C26451" Action="Warning" />
+    <Rule Id="C26451" Action="Error" />
     <Rule Id="C26452" Action="Error" />
     <Rule Id="C26453" Action="Error" />
     <Rule Id="C26454" Action="Error" />

--- a/Analyze.default.ruleset
+++ b/Analyze.default.ruleset
@@ -7,10 +7,26 @@
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
     <!-- All rules marked as Warning should be switched to Error once all instances are resolved. -->
     <!-- Resolving an instance can be done via either locally suppressing it or fixing the issue. -->
-    <Rule Id="C26100" Action="Error" />
-    <Rule Id="C26101" Action="Error" />
     <!-- warning C26110: Caller failing to hold lock <lock> before calling function <func> -->
     <Rule Id="C26110" Action="Warning" />
+    <!-- warning C28023: The function being assigned or passed should have a _Function_class_ annotation for at least one of the class(es) in: <classlist> -->
+    <Rule Id="C28023" Action="Warning" />
+    <!-- warning C28193: The variable holds a value that must be examined -->
+    <Rule Id="C28193" Action="Warning" />
+    <!-- warning C6001: using uninitialized memory <variable> -->
+    <Rule Id="C6001" Action="Warning" />
+    <!-- warning C6031: return value ignored: called-function could return unexpected value -->
+    <Rule Id="C6031" Action="Warning" />
+    <!-- warning C6054: string <variable> may not be zero-terminated -->
+    <Rule Id="C6054" Action="Warning" />
+    <!-- warning C6101: Returning uninitialized memory -->
+    <Rule Id="C6101" Action="Warning" />
+    <!-- warning C6385: invalid data: accessing buffer-name, the readable size is size1 bytes, but size2 bytes may be read: Lines: x, y -->
+    <Rule Id="C6385" Action="Warning" />
+    <!-- warning C6386: buffer overrun: accessing <buffer name>, the writable size is <size1> bytes, but <size2> bytes may be written: Lines: x, y -->
+    <Rule Id="C6386" Action="Warning" />
+    <Rule Id="C26100" Action="Error" />
+    <Rule Id="C26101" Action="Error" />
     <Rule Id="C26111" Action="Error" />
     <Rule Id="C26112" Action="Error" />
     <Rule Id="C26115" Action="Error" />
@@ -18,40 +34,30 @@
     <Rule Id="C26117" Action="Error" />
     <Rule Id="C26140" Action="Error" />
     <Rule Id="C26437" Action="Error" />
-    <!-- "This kind of function may not throw. Declare it 'noexcept'." -->
-    <Rule Id="C26439" Action="Warning" />
+    <Rule Id="C26439" Action="Error" />
     <Rule Id="C26441" Action="Error" />
     <Rule Id="C26444" Action="Error" />
     <Rule Id="C26449" Action="Error" />
-    <!-- Arithmetic overflow: '%operator%' operation causes overflow at compile time. Use a wider type to store the operands -->
-    <Rule Id="C26450" Action="Warning" />
+    <Rule Id="C26450" Action="Error" />
     <Rule Id="C26451" Action="Error" />
     <Rule Id="C26452" Action="Error" />
     <Rule Id="C26453" Action="Error" />
     <Rule Id="C26454" Action="Error" />
     <Rule Id="C26478" Action="Error" />
     <Rule Id="C26479" Action="Error" />
-    <!-- Variable '%variable%' is uninitialized. Always initialize a member variable (type.6). -->
-    <Rule Id="C26495" Action="Warning" />
+    <Rule Id="C26495" Action="Error" />
     <Rule Id="C26498" Action="Error" />
     <Rule Id="C26810" Action="Error" />
     <Rule Id="C26811" Action="Error" />
-    <!-- Warning C26812: Prefer 'enum class' over 'enum' (Enum.3) -->
-    <Rule Id="C26812" Action="Warning" />
+    <Rule Id="C26812" Action="Error" />
     <Rule Id="C26815" Action="Error" />
-    <!-- Warning C26816 The pointer points to memory allocated on the stack (ES.65) -->
-    <Rule Id="C26816" Action="Warning" />
-    <!-- Potentially expensive copy of variable name in range-for loop. Consider making it a const reference (es.71). -->
-    <Rule Id="C26817" Action="Warning" />
-    <!-- Unannotated fallthrough between switch labels (es.78). -->
-    <Rule Id="C26819" Action="Warning" />
-    <!-- Assigning by value when a const-reference would suffice, use const auto& instead (p.9). -->
-    <Rule Id="C26820" Action="Warning" />
+    <Rule Id="C26816" Action="Error" />
+    <Rule Id="C26817" Action="Error" />
+    <Rule Id="C26819" Action="Error" />
+    <Rule Id="C26820" Action="Error" />
     <Rule Id="C28020" Action="Error" />
     <Rule Id="C28021" Action="Error" />
     <Rule Id="C28022" Action="Error" />
-    <!-- warning C28023: The function being assigned or passed should have a _Function_class_ annotation for at least one of the class(es) in: <classlist> -->
-    <Rule Id="C28023" Action="Warning" />
     <Rule Id="C28024" Action="Error" />
     <Rule Id="C28039" Action="Error" />
     <Rule Id="C28112" Action="Error" />
@@ -65,8 +71,6 @@
     <Rule Id="C28164" Action="Error" />
     <Rule Id="C28182" Action="Error" />
     <Rule Id="C28183" Action="Error" />
-    <!-- warning C28193: The variable holds a value that must be examined -->
-    <Rule Id="C28193" Action="Warning" />
     <Rule Id="C28196" Action="Error" />
     <Rule Id="C28202" Action="Error" />
     <Rule Id="C28203" Action="Error" />
@@ -149,22 +153,14 @@
     <Rule Id="C33010" Action="Error" />
     <Rule Id="C33011" Action="Error" />
     <Rule Id="C33020" Action="Error" />
-    <!-- warning C6001: using uninitialized memory <variable> -->
-    <Rule Id="C6001" Action="Warning" />
     <Rule Id="C6011" Action="Error" />
     <Rule Id="C6029" Action="Error" />
-    <!-- warning C6031: return value ignored: called-function could return unexpected value -->
-    <Rule Id="C6031" Action="Warning" />
     <Rule Id="C6053" Action="Error" />
-    <!-- warning C6054: string <variable> may not be zero-terminated -->
-    <Rule Id="C6054" Action="Warning" />
     <Rule Id="C6059" Action="Error" />
     <Rule Id="C6063" Action="Error" />
     <Rule Id="C6064" Action="Error" />
     <Rule Id="C6066" Action="Error" />
     <Rule Id="C6067" Action="Error" />
-    <!-- warning C6101: Returning uninitialized memory -->
-    <Rule Id="C6101" Action="Warning" />
     <Rule Id="C6200" Action="Error" />
     <Rule Id="C6201" Action="Error" />
     <Rule Id="C6214" Action="Error" />
@@ -236,10 +232,6 @@
     <Rule Id="C6381" Action="Error" />
     <Rule Id="C6383" Action="Error" />
     <Rule Id="C6384" Action="Error" />
-    <!-- warning C6385: invalid data: accessing buffer-name, the readable size is size1 bytes, but size2 bytes may be read: Lines: x, y -->
-    <Rule Id="C6385" Action="Warning" />
-    <!-- warning C6386: buffer overrun: accessing <buffer name>, the writable size is <size1> bytes, but <size2> bytes may be written: Lines: x, y -->
-    <Rule Id="C6386" Action="Warning" />
     <Rule Id="C6387" Action="Error" />
     <Rule Id="C6388" Action="Error" />
     <Rule Id="C6500" Action="Error" />

--- a/external/Analyze.external.ruleset
+++ b/external/Analyze.external.ruleset
@@ -10,5 +10,19 @@
       <Rule Id="C6011" Action="Warning" />
       <!-- Arithmetic overflow: Using operator 'operator' on a size-a byte value and then casting the result to a size-b byte value. Cast the value to the wider type before calling operator 'operator' to avoid overflow -->
       <Rule Id="C26451" Action="Warning" />
+      <!-- Variable '%variable%' is uninitialized. Always initialize a member variable (type.6). -->
+      <Rule Id="C26495" Action="Warning" />
+      <!-- Warning C26812: Prefer 'enum class' over 'enum' (Enum.3) -->
+      <Rule Id="C26812" Action="Warning" />
+      <!-- "This kind of function may not throw. Declare it 'noexcept'." -->
+      <Rule Id="C26439" Action="Warning" />
+    <!-- Arithmetic overflow: '%operator%' operation causes overflow at compile time. Use a wider type to store the operands -->
+    <Rule Id="C26450" Action="Warning" />
+    <!-- Unannotated fallthrough between switch labels (es.78). -->
+    <Rule Id="C26819" Action="Warning" />
+    <!-- Potentially expensive copy of variable name in range-for loop. Consider making it a const reference (es.71). -->
+    <Rule Id="C26817" Action="Warning" />
+    <!-- Assigning by value when a const-reference would suffice, use const auto& instead (p.9). -->
+    <Rule Id="C26820" Action="Warning" />
   </Rules>
 </RuleSet>

--- a/external/Analyze.external.ruleset
+++ b/external/Analyze.external.ruleset
@@ -8,5 +8,7 @@
   <Rules AnalyzerId="Microsoft.Analyzers.NativeCodeAnalysis" RuleNamespace="Microsoft.Rules.Native">
       <!-- Set this to warning due to https://github.com/vbpf/ebpf-verifier/issues/239 -->
       <Rule Id="C6011" Action="Warning" />
+      <!-- Arithmetic overflow: Using operator 'operator' on a size-a byte value and then casting the result to a size-b byte value. Cast the value to the wider type before calling operator 'operator' to avoid overflow -->
+      <Rule Id="C26451" Action="Warning" />
   </Rules>
 </RuleSet>

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -17,12 +17,18 @@
 #pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
                                  // 'type2', possible loss of data
 #pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not
+                                 // throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 #include "ebpf_xdp_program_data.h"
 #pragma warning(push)
 #pragma warning(disable : 6011)  // 'Dereferencing NULL pointer - https://github.com/vbpf/ebpf-verifier/issues/239
 #pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26495) // Always initialize a member variable
 #include "elfio/elfio.hpp"
 #pragma warning(pop)
 #include "platform.hpp"

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -12,25 +12,9 @@
 #include "ebpf_bind_program_data.h"
 #include "ebpf_platform.h"
 #include "ebpf_program_types.h"
-#pragma warning(push)
-#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
-                                 // 'type2', possible loss of data
-#pragma warning(disable : 26451) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26439) // This kind of function may not
-                                 // throw. Declare it 'noexcept'
-#pragma warning(disable : 26495) // Always initialize a member variable
-#include "ebpf_verifier.hpp"
-#pragma warning(pop)
+#include "ebpf_verifier_wrapper.hpp"
 #include "ebpf_xdp_program_data.h"
-#pragma warning(push)
-#pragma warning(disable : 6011)  // 'Dereferencing NULL pointer - https://github.com/vbpf/ebpf-verifier/issues/239
-#pragma warning(disable : 26451) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26495) // Always initialize a member variable
-#include "elfio/elfio.hpp"
-#pragma warning(pop)
+#include "elfio_wrapper.hpp"
 #include "platform.hpp"
 #include "tlv.h"
 #include "windows_platform.hpp"

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -13,14 +13,16 @@
 #include "ebpf_platform.h"
 #include "ebpf_program_types.h"
 #pragma warning(push)
-#pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
-                                // 'type2', possible loss of data
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 #include "ebpf_xdp_program_data.h"
 #pragma warning(push)
-#pragma warning(disable : 6011) // 'Dereferencing NULL pointer - https://github.com/vbpf/ebpf-verifier/issues/239
+#pragma warning(disable : 6011)  // 'Dereferencing NULL pointer - https://github.com/vbpf/ebpf-verifier/issues/239
+#pragma warning(disable : 26451) // Arithmetic overflow
 #include "elfio/elfio.hpp"
 #pragma warning(pop)
 #include "platform.hpp"
@@ -273,11 +275,12 @@ ebpf_api_elf_enumerate_sections(
                 }
             }
 
-            sequence.emplace_back(tlv_pack<tlv_sequence>({tlv_pack(raw_program.section.c_str()),
-                                                          tlv_pack(raw_program.info.type.name.c_str()),
-                                                          tlv_pack(raw_program.info.map_descriptors.size()),
-                                                          tlv_pack(convert_ebpf_program_to_bytes(raw_program.prog)),
-                                                          tlv_pack(stats_sequence)}));
+            sequence.emplace_back(tlv_pack<tlv_sequence>(
+                {tlv_pack(raw_program.section.c_str()),
+                 tlv_pack(raw_program.info.type.name.c_str()),
+                 tlv_pack(raw_program.info.map_descriptors.size()),
+                 tlv_pack(convert_ebpf_program_to_bytes(raw_program.prog)),
+                 tlv_pack(stats_sequence)}));
         }
 
         auto retval = tlv_pack(sequence);

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -41,7 +41,8 @@ typedef struct _ebpf_object
     std::vector<ebpf_map_t*> maps;
 } ebpf_object_t;
 
-_Return_type_success_(return == ERROR_SUCCESS) uint32_t ebpf_get_program_byte_code(
+ebpf_result_t
+ebpf_get_program_byte_code(
     _In_z_ const char* file_name,
     _In_z_ const char* section_name,
     bool mock_map_fd,

--- a/libs/api/crab_verifier_wrapper.hpp
+++ b/libs/api/crab_verifier_wrapper.hpp
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma warning(push)
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not
+                                 // throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
+#include "crab_verifier.hpp"
+#pragma warning(pop)

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -946,7 +946,7 @@ ebpf_program_next(_In_opt_ const struct _ebpf_program* previous, _In_ const stru
         program = object->programs[0];
     } else {
         size_t programs_count = object->programs.size();
-        for (int i = 0; i < programs_count; i++) {
+        for (size_t i = 0; i < programs_count; i++) {
             if (object->programs[i] == previous && i < programs_count - 1) {
                 program = object->programs[i + 1];
                 break;
@@ -998,7 +998,7 @@ ebpf_map_next(_In_opt_ const struct _ebpf_map* previous, _In_ const struct _ebpf
         map = object->maps[0];
     } else {
         size_t maps_count = object->maps.size();
-        for (int i = 0; i < maps_count; i++) {
+        for (size_t i = 0; i < maps_count; i++) {
             if (object->maps[i] == previous && i < maps_count - 1) {
                 map = object->maps[i + 1];
                 break;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -151,7 +151,8 @@ Exit:
     return windows_error_to_ebpf_result(error);
 }
 
-_Return_type_success_(return == ERROR_SUCCESS) uint32_t ebpf_get_program_byte_code(
+ebpf_result_t
+ebpf_get_program_byte_code(
     _In_z_ const char* file_name,
     _In_z_ const char* section_name,
     bool mock_map_fd,
@@ -160,7 +161,7 @@ _Return_type_success_(return == ERROR_SUCCESS) uint32_t ebpf_get_program_byte_co
     _Out_ int* map_descriptors_count,
     _Outptr_result_maybenull_ const char** error_message)
 {
-    uint32_t result = ERROR_SUCCESS;
+    ebpf_result_t result = EBPF_SUCCESS;
 
     clear_map_descriptors();
     *map_descriptors = nullptr;
@@ -181,7 +182,7 @@ _Return_type_success_(return == ERROR_SUCCESS) uint32_t ebpf_get_program_byte_co
     if (*map_descriptors_count > 0) {
         *map_descriptors = new EbpfMapDescriptor[*map_descriptors_count];
         if (*map_descriptors == nullptr) {
-            result = ERROR_NOT_ENOUGH_MEMORY;
+            result = EBPF_NO_MEMORY;
             goto Done;
         }
         for (int i = 0; i < *map_descriptors_count; i++) {

--- a/libs/api/elfio_wrapper.hpp
+++ b/libs/api/elfio_wrapper.hpp
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma warning(push)
+#pragma warning(disable : 6011)  // 'Dereferencing NULL pointer - https://github.com/vbpf/ebpf-verifier/issues/239
+#pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26495) // Always initialize a member variable
+#include "elfio/elfio.hpp"
+#pragma warning(pop)

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -3,18 +3,7 @@
 #include <cassert>
 #include <stdexcept>
 #include "api_internal.h"
-#pragma warning(push)
-#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
-                                 // 'type2', possible loss of data
-#pragma warning(disable : 26451) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26439) // This kind of function may not
-                                 // throw. Declare it 'noexcept'
-#pragma warning(disable : 26495) // Always initialize a member variable
-#include "crab_verifier.hpp"
-#pragma warning(pop)
+#include "crab_verifier_wrapper.hpp"
 #include "api_common.hpp"
 #include "ebpf_api.h"
 #include "ebpf_helpers.h"

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -4,9 +4,10 @@
 #include <stdexcept>
 #include "api_internal.h"
 #pragma warning(push)
-#pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
-                                // 'type2', possible loss of data
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
 #include "crab_verifier.hpp"
 #pragma warning(pop)
 #include "api_common.hpp"

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -8,6 +8,11 @@
 #pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
                                  // 'type2', possible loss of data
 #pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not
+                                 // throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
 #include "crab_verifier.hpp"
 #pragma warning(pop)
 #include "api_common.hpp"

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -12,9 +12,10 @@
 #include "device_helper.hpp"
 
 #pragma warning(push)
-#pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
-                                // 'type2', possible loss of data
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 
@@ -39,8 +40,9 @@ allocate_string(const std::string& string, uint32_t* length) noexcept
 std::vector<uint8_t>
 convert_ebpf_program_to_bytes(const std::vector<ebpf_inst>& instructions)
 {
-    return {reinterpret_cast<const uint8_t*>(instructions.data()),
-            reinterpret_cast<const uint8_t*>(instructions.data()) + instructions.size() * sizeof(ebpf_inst)};
+    return {
+        reinterpret_cast<const uint8_t*>(instructions.data()),
+        reinterpret_cast<const uint8_t*>(instructions.data()) + instructions.size() * sizeof(ebpf_inst)};
 }
 
 int

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -11,17 +11,7 @@
 #include "ebpf_result.h"
 #include "device_helper.hpp"
 
-#pragma warning(push)
-#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
-                                 // 'type2', possible loss of data
-#pragma warning(disable : 26451) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26439) // This kind of function may not
-                                 // throw. Declare it 'noexcept'
-#pragma warning(disable : 26495) // Always initialize a member variable
-#include "ebpf_verifier.hpp"
-#pragma warning(pop)
+#include "ebpf_verifier_wrapper.hpp"
 
 thread_local static const ebpf_program_type_t* _global_program_type = nullptr;
 thread_local static const ebpf_attach_type_t* _global_attach_type = nullptr;

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -16,6 +16,10 @@
 #pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
                                  // 'type2', possible loss of data
 #pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not
+                                 // throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 

--- a/libs/api_common/ebpf_verifier_wrapper.hpp
+++ b/libs/api_common/ebpf_verifier_wrapper.hpp
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma warning(push)
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not
+                                 // throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
+#include "ebpf_verifier.hpp"
+#pragma warning(pop)

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -10,6 +10,9 @@
 #pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
                                  // 'type2', possible loss of data
 #pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
 #include "crab_verifier.hpp"
 #pragma warning(pop)
 #include "ebpf_api.h"

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -6,9 +6,10 @@
 #include "api_internal.h"
 #include "api_common.hpp"
 #pragma warning(push)
-#pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
-                                // 'type2', possible loss of data
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
 #include "crab_verifier.hpp"
 #pragma warning(pop)
 #include "ebpf_api.h"

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -5,16 +5,7 @@
 #include <stdexcept>
 #include "api_internal.h"
 #include "api_common.hpp"
-#pragma warning(push)
-#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
-                                 // 'type2', possible loss of data
-#pragma warning(disable : 26451) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
-#pragma warning(disable : 26495) // Always initialize a member variable
-#include "crab_verifier.hpp"
-#pragma warning(pop)
+#include "crab_verifier_wrapper.hpp"
 #include "ebpf_api.h"
 #include "ebpf_helpers.h"
 #include "helpers.hpp"

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#include "catch2\catch.hpp"
+#include "catch_wrapper.hpp"
 #include "ebpf_core.h"
 #include "ebpf_maps.h"
 #include "ebpf_object.h"
@@ -44,7 +44,7 @@ test_crud_operations(ebpf_map_type_t map_type)
         map.reset(local_map);
     }
     for (uint32_t key = 0; key < 10; key++) {
-        uint64_t value = key * key;
+        uint64_t value = static_cast<uint64_t>(key) * static_cast<uint64_t>(key);
         REQUIRE(
             ebpf_map_update_entry(
                 map.get(), reinterpret_cast<const uint8_t*>(&key), reinterpret_cast<const uint8_t*>(&value)) ==

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -553,12 +553,13 @@ extern "C"
      * @param[in] client_data_length Length of the client data.
      * @param[in] client_dispatch_table Table of function pointers the client
      *  exposes.
-     * @param[out] provider_binding_context Provider binding context.
+     * @param[out] provider_binding_context Provider binding context or NULL if
+        the caller doesn't care.
      * @param[out] provider_data Opaque provider data.
      * @param[out] provider_dispatch_table Table of function pointers the
      *  provider exposes.
      * @param[in] extension_changed Callback invoked when a provider attaches
-     *  or detaches.
+     *  or detaches. NULL if not used.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_FOUND The provider was not found.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -549,12 +549,12 @@ extern "C"
      * @param[out] client_context Context used to unload the extension.
      * @param[in] interface_id GUID representing the identity of the interface.
      * @param[in] client_binding_context Opaque per-instance pointer passed to the extension.
-     * @param[in] client_data Opaque client data passed to the extension.
+     * @param[in] client_data Opaque client data passed to the extension or
+        NULL if there is none.
      * @param[in] client_data_length Length of the client data.
      * @param[in] client_dispatch_table Table of function pointers the client
-     *  exposes.
-     * @param[out] provider_binding_context Provider binding context or NULL if
-        the caller doesn't care.
+     *  exposes or NULL if there is none.
+     * @param[out] provider_binding_context Provider binding context. Can be NULL.
      * @param[out] provider_data Opaque provider data.
      * @param[out] provider_dispatch_table Table of function pointers the
      *  provider exposes.

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -10,7 +10,7 @@
 #include <thread>
 #include <sddl.h>
 
-#include "catch2\catch.hpp"
+#include "catch_wrapper.hpp"
 #include "ebpf_bind_program_data.h"
 #include "ebpf_epoch.h"
 #include "ebpf_nethooks.h"
@@ -51,7 +51,7 @@ TEST_CASE("pinning_test", "[platform]")
 
     typedef struct _some_object
     {
-        ebpf_object_t object;
+        ebpf_object_t object{};
         std::string name;
     } some_object_t;
 

--- a/libs/service/verifier_service.cpp
+++ b/libs/service/verifier_service.cpp
@@ -8,16 +8,7 @@
 #include "api_common.hpp"
 #include "ebpf_api.h"
 #include "ebpf_platform.h"
-#pragma warning(push)
-#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
-                                 // 'type2', possible loss of data
-#pragma warning(disable : 26451) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
-#pragma warning(disable : 26495) // Always initialize a member variable
-#include "ebpf_verifier.hpp"
-#pragma warning(pop)
+#include "ebpf_verifier_wrapper.hpp"
 #include "platform.hpp"
 #include "Verifier.h"
 #include "tlv.h"

--- a/libs/service/verifier_service.cpp
+++ b/libs/service/verifier_service.cpp
@@ -9,9 +9,13 @@
 #include "ebpf_api.h"
 #include "ebpf_platform.h"
 #pragma warning(push)
-#pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
-                                // 'type2', possible loss of data
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 #include "platform.hpp"
@@ -56,8 +60,8 @@ verify_byte_code(
     uint32_t* error_message_size)
 {
     const ebpf_platform_t* platform = &g_ebpf_platform_windows_service;
-    std::vector<ebpf_inst> instructions{(ebpf_inst*)byte_code,
-                                        (ebpf_inst*)byte_code + byte_code_size / sizeof(ebpf_inst)};
+    std::vector<ebpf_inst> instructions{
+        (ebpf_inst*)byte_code, (ebpf_inst*)byte_code + byte_code_size / sizeof(ebpf_inst)};
     program_info info{platform};
     std::string section;
     std::string file;

--- a/libs/service/windows_platform_service.cpp
+++ b/libs/service/windows_platform_service.cpp
@@ -5,16 +5,7 @@
 #include <stdexcept>
 #include "api_common.hpp"
 #include "api_internal.h"
-#pragma warning(push)
-#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
-                                 // 'type2', possible loss of data
-#pragma warning(disable : 26451) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
-#pragma warning(disable : 26495) // Always initialize a member variable
-#include "crab_verifier.hpp"
-#pragma warning(pop)
+#include "crab_verifier_wrapper.hpp"
 #include "ebpf_api.h"
 #include "ebpf_helpers.h"
 #include "helpers.hpp"

--- a/libs/service/windows_platform_service.cpp
+++ b/libs/service/windows_platform_service.cpp
@@ -6,9 +6,13 @@
 #include "api_common.hpp"
 #include "api_internal.h"
 #pragma warning(push)
-#pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
-                                // 'type2', possible loss of data
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
 #include "crab_verifier.hpp"
 #pragma warning(pop)
 #include "ebpf_api.h"

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -8,7 +8,7 @@
 #include <thread>
 
 #include "api_test.h"
-#include "catch2\catch.hpp"
+#include "catch_wrapper.hpp"
 #include "common_tests.h"
 #include "service_helper.h"
 

--- a/tests/client/ebpf_client.vcxproj
+++ b/tests/client/ebpf_client.vcxproj
@@ -125,7 +125,7 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)libs\api;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)rpc_interface;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)\ebpfsvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)libs\api;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)rpc_interface;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)\ebpfsvc;$(SolutionDir)\libs\api_common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -142,7 +142,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)libs\api;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)rpc_interface;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)\ebpfsvc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)libs\api;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)rpc_interface;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)\ebpfsvc;$(SolutionDir)\libs\api_common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/tests/client/main.cpp
+++ b/tests/client/main.cpp
@@ -31,7 +31,7 @@ _get_program_byte_code_helper(const char* file_name, const char* section_name, e
 {
     EbpfMapDescriptor* descriptors = nullptr;
     int descriptors_count;
-    uint32_t result = ERROR_SUCCESS;
+    ebpf_result_t result = EBPF_SUCCESS;
     const char* error_message = nullptr;
     std::vector<ebpf_program_t*> programs;
     ebpf_program_t* program;
@@ -49,7 +49,7 @@ _get_program_byte_code_helper(const char* file_name, const char* section_name, e
          error_message ? printf("ebpf_get_program_byte_code failed with %s\n", error_message) : 0,
          ebpf_free_string(error_message),
          error_message = nullptr,
-         result == ERROR_SUCCESS));
+         result == EBPF_SUCCESS));
 
     REQUIRE(programs.size() == 1);
     program = programs[0];

--- a/tests/client/main.cpp
+++ b/tests/client/main.cpp
@@ -4,12 +4,16 @@
 #define CATCH_CONFIG_MAIN
 
 #include "api_internal.h"
-#include "catch2\catch.hpp"
+#include "catch_wrapper.hpp"
 #include "ebpf_api.h"
 #pragma warning(push)
-#pragma warning(disable : 4100) // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244) // 'conversion' conversion from 'type1' to
-                                // 'type2', possible loss of data
+#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
+#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
+                                 // 'type2', possible loss of data
+#pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
 #include "ebpf_verifier.hpp"
 #pragma warning(pop)
 #include "header.h"

--- a/tests/client/main.cpp
+++ b/tests/client/main.cpp
@@ -6,16 +6,7 @@
 #include "api_internal.h"
 #include "catch_wrapper.hpp"
 #include "ebpf_api.h"
-#pragma warning(push)
-#pragma warning(disable : 4100)  // 'identifier' : unreferenced formal parameter
-#pragma warning(disable : 4244)  // 'conversion' conversion from 'type1' to
-                                 // 'type2', possible loss of data
-#pragma warning(disable : 26451) // Arithmetic overflow
-#pragma warning(disable : 26450) // Arithmetic overflow
-#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
-#pragma warning(disable : 26495) // Always initialize a member variable
-#include "ebpf_verifier.hpp"
-#pragma warning(pop)
+#include "ebpf_verifier_wrapper.hpp"
 #include "header.h"
 #include "rpc_client.h"
 #include "rpc_interface_h.h"

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -8,7 +8,7 @@
 #include <thread>
 #include <WinSock2.h>
 
-#include "catch2\catch.hpp"
+#include "catch_wrapper.hpp"
 #include "common_tests.h"
 #include "ebpf_bind_program_data.h"
 #include "ebpf_xdp_program_data.h"

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -4,7 +4,7 @@
 #include <windows.h>
 #include <netsh.h> // Must be included after windows.h
 #include "capture_helper.hpp"
-#include "catch2\catch.hpp"
+#include "catch_wrapper.hpp"
 #include "elf.h"
 #include "programs.h"
 #include "test_helper.hpp"

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -3,7 +3,7 @@
 
 // Common test functions used by end to end and component tests.
 
-#include "catch2\catch.hpp"
+#include "catch_wrapper.hpp"
 #include "common_tests.h"
 
 void

--- a/tests/libs/common/common_tests.vcxproj
+++ b/tests/libs/common/common_tests.vcxproj
@@ -123,7 +123,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -142,7 +142,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/tests/libs/util/catch_wrapper.hpp
+++ b/tests/libs/util/catch_wrapper.hpp
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma warning(push)
+#pragma warning(disable : 26451) // Arithmetic overflow
+#pragma warning(disable : 26450) // Arithmetic overflow
+#pragma warning(disable : 26439) // This kind of function may not throw. Declare it 'noexcept'
+#pragma warning(disable : 26495) // Always initialize a member variable
+#pragma warning(disable : 26812) // Prefer 'enum class' over 'enum'
+#pragma warning(disable : 26816) // The pointer points to memory allocated on the stack
+#include "catch2\catch.hpp"
+#pragma warning(pop)


### PR DESCRIPTION
Suppress [C26451](https://docs.microsoft.com/en-us/cpp/code-quality/c26451).

Code in ELFIO and Boost are flagged for possible arithmetic overflow, but I think these are false positives. Suppressing this warning around code that pulls in ELFIO and Boost.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>