### PR TITLE
Add doxygen documentation on enum values

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2214,7 +2214,7 @@ ENABLE_PREPROCESSING   = YES
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-MACRO_EXPANSION        = NO
+MACRO_EXPANSION        = YES
 
 # If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
 # the macro expansion is limited to the macros specified with the PREDEFINED and
@@ -2222,7 +2222,7 @@ MACRO_EXPANSION        = NO
 # The default value is: NO.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-EXPAND_ONLY_PREDEF     = NO
+EXPAND_ONLY_PREDEF     = YES
 
 # If the SEARCH_INCLUDES tag is set to YES, the include files in the
 # INCLUDE_PATH will be searched if a #include is found.
@@ -2254,7 +2254,20 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             =
+PREDEFINED             = __declspec(x)= \
+                         _In_= \
+                         _In_z_= \
+                         _In_opt_= \
+                         _In_opt_count_(x)= \
+                         _Out_= \
+                         _Outptr_= \
+                         _Outptr_result_buffer_maybenull_= \
+                         _Outptr_result_maybenull_z_= \
+                         _Post_invalid_= \
+                         _Post_ptr_invalid_= \
+                         _Ret_maybenull_= \
+                         _Return_type_success_(x)= \
+                         _Success_(x)=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/include/ebpf_execution_type.h
+++ b/include/ebpf_execution_type.h
@@ -10,9 +10,9 @@ extern "C"
 
     typedef enum _ebpf_execution_type
     {
-        EBPF_EXECUTION_ANY,
-        EBPF_EXECUTION_JIT,
-        EBPF_EXECUTION_INTERPRET
+        EBPF_EXECUTION_ANY,      ///< Execute in JIT-compiled or interpreted mode, per system policy.
+        EBPF_EXECUTION_JIT,      ///< Execute in JIT-compiled mode.
+        EBPF_EXECUTION_INTERPRET ///< Execute in interpreted mode.
     } ebpf_execution_type_t;
 
 #ifdef __cplusplus

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -19,8 +19,8 @@ typedef struct xdp_md
 
 typedef enum _xdp_action
 {
-    XDP_PASS = 1,
-    XDP_DROP = 2
+    XDP_PASS = 1, ///< Allow the packet to pass.
+    XDP_DROP = 2  ///< Drop the packet.
 } xdp_action_t;
 
 // BIND hook
@@ -37,14 +37,14 @@ typedef struct _bind_md
 
 typedef enum _bind_operation
 {
-    BIND_OPERATION_BIND,      // Entry to bind
-    BIND_OPERATION_POST_BIND, // After port allocation
-    BIND_OPERATION_UNBIND,    // Release port
+    BIND_OPERATION_BIND,      ///< Entry to bind.
+    BIND_OPERATION_POST_BIND, ///< After port allocation.
+    BIND_OPERATION_UNBIND,    ///< Release port.
 } bind_operation_t;
 
 typedef enum _bind_action
 {
-    BIND_PERMIT,
-    BIND_DENY,
-    BIND_REDIRECT,
+    BIND_PERMIT,   ///< Permit the bind operation.
+    BIND_DENY,     ///< Deny the bind operation.
+    BIND_REDIRECT, ///< Change the bind endpoint.
 } bind_action_t;

--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -14,82 +14,82 @@ extern "C"
 
 #pragma warning(disable : 26812) // Prefer enum class
     typedef _Return_type_success_(return == EBPF_SUCCESS) enum ebpf_result {
-        // The operation was successful.
+        /// The operation was successful.
         EBPF_SUCCESS,
 
-        // Program verification failed.
+        /// Program verification failed.
         EBPF_VERIFICATION_FAILED,
 
-        // JIT compilation failed.
+        /// JIT compilation failed.
         EBPF_JIT_COMPILATION_FAILED,
 
-        // Program load failed.
+        /// Program load failed.
         EBPF_PROGRAM_LOAD_FAILED,
 
-        // Invalid FD provided.
+        /// Invalid FD provided.
         EBPF_INVALID_FD,
 
-        // Invalid object provided (ebpf_object, ebpf_map, ebpf_program).
+        /// Invalid object provided (ebpf_object, ebpf_map, ebpf_program).
         EBPF_INVALID_OBJECT,
 
-        // An invalid argument was supplied.
+        /// An invalid argument was supplied.
         EBPF_INVALID_ARGUMENT,
 
-        // No pinned map or program exists for the path provided.
+        /// No pinned map or program exists for the path provided.
         EBPF_OBJECT_NOT_FOUND,
 
-        // A program or map is already pinned with the same path.
+        /// A program or map is already pinned with the same path.
         EBPF_OBJECT_ALREADY_EXISTS,
 
-        // Invalid ELF file path.
+        /// Invalid ELF file path.
         EBPF_FILE_NOT_FOUND,
 
-        // The program or map already pinned to a different path.
+        /// The program or map already pinned to a different path.
         EBPF_ALREADY_PINNED,
 
-        // The program or map is not pinned.
+        /// The program or map is not pinned.
         EBPF_NOT_PINNED,
 
-        // Low memory.
+        /// Low memory.
         EBPF_NO_MEMORY,
 
-        // The program is too large.
+        /// The program is too large.
         EBPF_PROGRAM_TOO_LARGE,
 
-        // An RPC exception occurred.
+        /// An RPC exception occurred.
         EBPF_RPC_EXCEPTION,
 
-        // The handle was already initialized.
+        /// The handle was already initialized.
         EBPF_ALREADY_INITIALIZED,
 
-        // A failure occurred in parsing the ELF file.
+        /// A failure occurred in parsing the ELF file.
         EBPF_ELF_PARSING_FAILED,
 
-        // Generic failure code for all other errors.
+        /// Generic failure code for all other errors.
         EBPF_FAILED,
 
-        // Operation is not supported.
+        /// Operation is not supported.
         EBPF_OPERATION_NOT_SUPPORTED,
 
-        // The requested key was not found.
+        /// The requested key was not found.
         EBPF_KEY_NOT_FOUND,
 
-        // Access was denied for the requested operation.
+        /// Access was denied for the requested operation.
         EBPF_ACCESS_DENIED,
 
-        // The operation was blocked for all requesters by policy.
+        /// The operation was blocked for all requesters by policy.
         EBPF_BLOCKED_BY_POLICY,
 
-        // Arithmetic overflow occurred.
+        /// Arithmetic overflow occurred.
         EBPF_ARITHMETIC_OVERFLOW,
 
-        // The eBPF extension failed to load.
+        /// The eBPF extension failed to load.
         EBPF_EXTENSION_FAILED_TO_LOAD,
 
-        // A buffer of insufficient size was supplied.
+        /// A buffer of insufficient size was supplied.
         EBPF_INSUFFICIENT_BUFFER,
 
-        // The enumeration found no more keys.
+        /// The enumeration found no more keys.
         EBPF_NO_MORE_KEYS,
     } ebpf_result_t;
 

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -1,7 +1,5 @@
-/*
- *  Copyright (c) Microsoft Corporation
- *  SPDX-License-Identifier: MIT
- */
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
 
 // This file contains eBPF definitions common to eBPF programs, core execution engine
 // as well as eBPF API library.
@@ -13,9 +11,9 @@
 
 typedef enum _ebpf_map_type
 {
-    EBPF_MAP_TYPE_UNSPECIFIED = 0,
-    EBPF_MAP_TYPE_HASH = 1,
-    EBPF_MAP_TYPE_ARRAY = 2,
+    EBPF_MAP_TYPE_UNSPECIFIED = 0, ///< Unspecified map type.
+    EBPF_MAP_TYPE_HASH = 1,        ///< Hash table.
+    EBPF_MAP_TYPE_ARRAY = 2,       ///< Array, wehere the map key is the array index.
 } ebpf_map_type_t;
 
 /**

--- a/include/ebpf_windows.h
+++ b/include/ebpf_windows.h
@@ -12,7 +12,7 @@ typedef GUID ebpf_attach_type_t;
 
 typedef enum _ebpf_helper_function
 {
-    EBPF_LOOKUP_ELEMENT = 1,
-    EBPF_UPDATE_ELEMENT = 2,
-    EBPF_DELETE_ELEMENT = 3,
+    EBPF_LOOKUP_ELEMENT = 1, ///< Look up a map element.
+    EBPF_UPDATE_ELEMENT = 2, ///< Update map element.
+    EBPF_DELETE_ELEMENT = 3, ///< Delete a map element.
 } ebpf_helper_function_t;

--- a/include/tlv.h
+++ b/include/tlv.h
@@ -1,7 +1,5 @@
-/*
- *  Copyright (c) Microsoft Corporation
- *  SPDX-License-Identifier: MIT
- */
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
 #pragma once
 #include <stdint.h>
 #include <string>
@@ -9,11 +7,11 @@
 
 typedef enum class _tlv_type
 {
-    BLOB,
-    UINT,
-    INT,
-    STRING,
-    SEQUENCE
+    BLOB,    ///< Opaque byte blob.
+    UINT,    ///< Unsigned integer.
+    INT,     ///< Signed integer.
+    STRING,  ///< String.
+    SEQUENCE ///< Sequence of other tlv_type_t values.
 } tlv_type_t;
 
 typedef struct _tlv_type_length_value


### PR DESCRIPTION
* Make all enum values have a description in the generated API docs
* Also remove SAL annotation from the generated docs, since SAL
  breaks doxygen type detection

Signed-off-by: Dave Thaler <dthaler@microsoft.com>