### PR TITLE
Add doxygen documentation on ebpf helpers

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -2255,6 +2255,8 @@ INCLUDE_FILE_PATTERNS  =
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
 PREDEFINED             = __declspec(x)= \
+                         __doxygen= \
+                         "EBPF_HELPER(ret, name, args)=ret name args" \
                          _In_= \
                          _In_z_= \
                          _In_opt_= \

--- a/include/ebpf_helpers.h
+++ b/include/ebpf_helpers.h
@@ -6,17 +6,53 @@
 
 #include "ebpf_structs.h"
 
+#ifndef __doxygen
+#define EBPF_HELPER(return_type, name, args) typedef return_type(*name##_t) args
+#endif
+
 // This file contains APIs for global helpers that are
 // exposed for use by all eBPF programs.
 
-typedef void* (*ebpf_map_lookup_element_t)(ebpf_map_definition_t* map, void* key);
+/**
+ * @brief Get a pointer to an entry in the map.
+ *
+ * @param[in] map Map to search.
+ * @param[in] key Key to use when searching map.
+ * @return Pointer to the value if found or NULL.
+ */
+EBPF_HELPER(void*, ebpf_map_lookup_element, (ebpf_map_definition_t * map, void* key));
+#ifndef __doxygen
 #define ebpf_map_lookup_element ((ebpf_map_lookup_element_t)1)
+#endif
 
-typedef int64_t (*ebpf_map_update_element_t)(ebpf_map_definition_t* map, void* key, void* data, uint64_t flags);
+/**
+ * @brief Insert or update an entry in the map.
+ *
+ * @param[in] map Map to update.
+ * @param[in] key Key to use when searching and updating the map.
+ * @param[in] value Value to insert into the map.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+ *  entry.
+ */
+EBPF_HELPER(int64_t, ebpf_map_update_element, (ebpf_map_definition_t * map, void* key, void* value, uint64_t flags));
+#ifndef __doxygen
 #define ebpf_map_update_element ((ebpf_map_update_element_t)2)
+#endif
 
-typedef int64_t (*ebpf_map_delete_element_t)(ebpf_map_definition_t* map, void* key);
+/**
+ * @brief Remove an entry from the map.
+ *
+ * @param[in] map Map to update.
+ * @param[in] key Key to use when searching and updating the map.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_INVALID_ARGUMENT One or more parameters are
+ *  invalid.
+ */
+EBPF_HELPER(int64_t, ebpf_map_delete_element, (ebpf_map_definition_t * map, void* key));
+#ifndef __doxygen
 #define ebpf_map_delete_element ((ebpf_map_delete_element_t)3)
+#endif
 
 //
 // Defines for cross-platform compatibility.


### PR DESCRIPTION
Before this change, the API docs at
https://microsoft.github.io/ebpf-for-windows/ebpf__helpers_8h.html
just show the typedefs.  This PR updates the documentation so that the
helpers are documented just like normal public APIs would be.

This is the first step towards addressing #259

Signed-off-by: Dave Thaler <dthaler@microsoft.com>