### PR TITLE
Replace "information" with "info" for consistency

### DIFF
--- a/ebpf-for-windows.sln
+++ b/ebpf-for-windows.sln
@@ -89,7 +89,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "service", "service", "{4B0B
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ebpfsvc", "ebpfsvc\eBPFSvc.vcxproj", "{BA065B6A-38F8-4197-8F66-87C84AFAD513}"
 EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "encode_program_information", "tools\encode_program_information\encode_program_information.vcxproj", "{FA9BB88D-8259-40C1-9422-BDEDF9E9CE68}"
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "encode_program_info", "tools\encode_program_info\encode_program_info.vcxproj", "{FA9BB88D-8259-40C1-9422-BDEDF9E9CE68}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ebpf_client", "tests\client\ebpf_client.vcxproj", "{3C195972-46BB-491D-8820-0500FF4BA8B7}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -22,7 +22,7 @@ EXPORTS
 	ebpf_api_get_next_map
 	ebpf_api_get_pinned_map
 	ebpf_api_get_next_program
-	ebpf_api_program_query_information
+	ebpf_api_program_query_info
 	ebpf_api_link_program
 	ebpf_api_close_handle
 	ebpf_api_get_pinned_map_info

--- a/ebpfsvc/svcmain.cpp
+++ b/ebpfsvc/svcmain.cpp
@@ -59,7 +59,7 @@ service_install()
     SC_HANDLE scmanager = nullptr;
     SC_HANDLE service = nullptr;
     TCHAR path[MAX_PATH];
-    SERVICE_SID_INFO sid_information = {0};
+    SERVICE_SID_INFO sid_info = {0};
     int result = ERROR_SUCCESS;
 
     if (!GetModuleFileName(nullptr, path, MAX_PATH)) {
@@ -102,8 +102,8 @@ service_install()
     }
 
     // Set service SID type to restricted.
-    sid_information.dwServiceSidType = SERVICE_SID_TYPE_RESTRICTED;
-    if (!ChangeServiceConfig2(service, SERVICE_CONFIG_SERVICE_SID_INFO, &sid_information)) {
+    sid_info.dwServiceSidType = SERVICE_SID_TYPE_RESTRICTED;
+    if (!ChangeServiceConfig2(service, SERVICE_CONFIG_SERVICE_SID_INFO, &sid_info)) {
         result = GetLastError();
         goto Exit;
     }

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -207,21 +207,21 @@ extern "C"
         uint32_t* max_entries);
 
     /**
-     * @brief Query information about an eBPF program.
+     * @brief Query info about an eBPF program.
      * @param[in] handle Handle to an eBPF program.
      * @param[out] execution_type On success, contains the execution type.
      * @param[out] file_name On success, contains the file name.
      * @param[out] section_name On success, contains the section name.
      */
     uint32_t
-    ebpf_api_program_query_information(
+    ebpf_api_program_query_info(
         ebpf_handle_t handle, ebpf_execution_type_t* execution_type, const char** file_name, const char** section_name);
 
     /**
      * @brief Get list of programs and stats in an ELF eBPF file.
      * @param[in] file Name of ELF file containing eBPF program.
      * @param[in] section Optionally, the name of the section to query.
-     * @param[in] verbose Obtain additional information about the programs.
+     * @param[in] verbose Obtain additional info about the programs.
      * @param[out] data On success points to a list of eBPF programs.
      * @param[out] error_message On failure points to a text description of
      *  the error.
@@ -276,7 +276,7 @@ extern "C"
      * @brief Convert an eBPF program to human readable byte code.
      * @param[in] file Name of ELF file containing eBPF program.
      * @param[in] section The name of the section to query.
-     * @param[in] verbose Obtain additional information about the programs.
+     * @param[in] verbose Obtain additional info about the programs.
      * @param[out] report Points to a text section describing why the program
      *  failed verification.
      * @param[out] error_message On failure points to a text description of
@@ -357,10 +357,10 @@ extern "C"
     ebpf_api_close_handle(ebpf_handle_t handle);
 
     /**
-     * @brief Returns an array of \ref ebpf_map_information_t for all pinned maps.
+     * @brief Returns an array of \ref ebpf_map_info_t for all pinned maps.
      *
      * @param[out] map_count Number of pinned maps.
-     * @param[out] map_info Array of ebpf_map_information_t for pinned maps.
+     * @param[out] map_info Array of ebpf_map_info_t for pinned maps.
      *
      * @retval EBPF_SUCCESS The API suceeded.
      * @retval EBPF_NO_MEMORY Out of memory.
@@ -368,10 +368,10 @@ extern "C"
      */
     ebpf_result_t
     ebpf_api_get_pinned_map_info(
-        _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_information_t** map_info);
+        _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info);
 
     /**
-     * @brief Helper Function to free array of \ref ebpf_map_information_t allocated by
+     * @brief Helper Function to free array of \ref ebpf_map_info_t allocated by
      * \ref ebpf_api_get_pinned_map_info function.
      *
      * @param[in] map_count Length of array to be freed.
@@ -379,7 +379,7 @@ extern "C"
      */
     void
     ebpf_api_map_info_free(
-        uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_information_t* map_info);
+        uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info);
 
     /**
      * @brief Load eBPF programs from an ELF file based on default load

--- a/include/ebpf_core_structs.h
+++ b/include/ebpf_core_structs.h
@@ -15,8 +15,8 @@
 /**
  * @brief eBPF Map Information
  */
-typedef struct _ebpf_map_information
+typedef struct _ebpf_map_info
 {
     ebpf_map_definition_t definition;
     _Field_z_ char* pin_path;
-} ebpf_map_information_t;
+} ebpf_map_info_t;

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -37,12 +37,12 @@ typedef struct _ebpf_helper_function_prototype
     ebpf_argument_type_t arguments[5];
 } ebpf_helper_function_prototype_t;
 
-typedef struct _ebpf_program_information
+typedef struct _ebpf_program_info
 {
     ebpf_program_type_descriptor_t program_type_descriptor;
     uint32_t count_of_helpers;
     MIDL([size_is(count_of_helpers)]) ebpf_helper_function_prototype_t* helper_prototype;
-} ebpf_program_information_t;
+} ebpf_program_info_t;
 
 typedef struct _ebpf_helper_function_addresses
 {
@@ -52,6 +52,6 @@ typedef struct _ebpf_helper_function_addresses
 
 typedef struct _ebpf_program_data
 {
-    ebpf_program_information_t* program_information;
+    ebpf_program_info_t* program_info;
     ebpf_helper_function_addresses_t* helper_function_addresses;
 } ebpf_program_data_t;

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -267,12 +267,11 @@ ebpf_api_elf_enumerate_sections(
                 }
             }
 
-            sequence.emplace_back(tlv_pack<tlv_sequence>(
-                {tlv_pack(raw_program.section.c_str()),
-                 tlv_pack(raw_program.info.type.name.c_str()),
-                 tlv_pack(raw_program.info.map_descriptors.size()),
-                 tlv_pack(convert_ebpf_program_to_bytes(raw_program.prog)),
-                 tlv_pack(stats_sequence)}));
+            sequence.emplace_back(tlv_pack<tlv_sequence>({tlv_pack(raw_program.section.c_str()),
+                                                          tlv_pack(raw_program.info.type.name.c_str()),
+                                                          tlv_pack(raw_program.info.map_descriptors.size()),
+                                                          tlv_pack(convert_ebpf_program_to_bytes(raw_program.prog)),
+                                                          tlv_pack(stats_sequence)}));
         }
 
         auto retval = tlv_pack(sequence);

--- a/libs/api/Verifier.h
+++ b/libs/api/Verifier.h
@@ -20,4 +20,4 @@ load_byte_code(
     _Outptr_result_maybenull_z_ const char** error_message) noexcept;
 
 ebpf_result_t
-get_program_type_info(const ebpf_program_information_t** info);
+get_program_type_info(const ebpf_program_info_t** info);

--- a/libs/api/api.vcxproj
+++ b/libs/api/api.vcxproj
@@ -187,7 +187,7 @@
     <ProjectReference Include="..\..\rpc_interface\rpc_interface.vcxproj">
       <Project>{1423245d-0249-40fc-a077-ff7780acfe3f}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\tools\encode_program_information\encode_program_information.vcxproj">
+    <ProjectReference Include="..\..\tools\encode_program_info\encode_program_info.vcxproj">
       <Project>{fa9bb88d-8259-40c1-9422-bdedf9e9ce68}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -52,8 +52,7 @@ ebpf_get_program_byte_code(
     _Outptr_result_maybenull_ const char** error_message);
 
 ebpf_result_t
-get_program_information_data(
-    ebpf_program_type_t program_type, _Outptr_ ebpf_program_information_t** program_information);
+get_program_info_data(ebpf_program_type_t program_type, _Outptr_ ebpf_program_info_t** program_info);
 
 void
 clean_up_ebpf_program(_In_ _Post_invalid_ ebpf_program_t* program);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -471,10 +471,9 @@ ebpf_api_get_next_map(ebpf_handle_t previous_handle, ebpf_handle_t* next_handle)
 uint32_t
 ebpf_api_get_next_program(ebpf_handle_t previous_handle, ebpf_handle_t* next_handle)
 {
-    _ebpf_operation_get_next_program_request request{
-        sizeof(request),
-        ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM,
-        reinterpret_cast<uint64_t>(previous_handle)};
+    _ebpf_operation_get_next_program_request request{sizeof(request),
+                                                     ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM,
+                                                     reinterpret_cast<uint64_t>(previous_handle)};
 
     _ebpf_operation_get_next_program_reply reply;
 
@@ -498,16 +497,14 @@ ebpf_api_map_query_definition(
 }
 
 uint32_t
-ebpf_api_program_query_information(
+ebpf_api_program_query_info(
     ebpf_handle_t handle, ebpf_execution_type_t* execution_type, const char** file_name, const char** section_name)
 {
     ebpf_protocol_buffer_t reply_buffer(1024);
-    _ebpf_operation_query_program_information_request request{
-        sizeof(request),
-        ebpf_operation_id_t::EBPF_OPERATION_QUERY_PROGRAM_INFORMATION,
-        reinterpret_cast<uint64_t>(handle)};
+    _ebpf_operation_query_program_info_request request{
+        sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_QUERY_PROGRAM_INFO, reinterpret_cast<uint64_t>(handle)};
 
-    auto reply = reinterpret_cast<_ebpf_operation_query_program_information_reply*>(reply_buffer.data());
+    auto reply = reinterpret_cast<_ebpf_operation_query_program_info_reply*>(reply_buffer.data());
 
     uint32_t retval = invoke_ioctl(request, reply_buffer);
     if (retval != ERROR_SUCCESS) {
@@ -569,17 +566,17 @@ ebpf_api_close_handle(ebpf_handle_t handle)
 
 ebpf_result_t
 ebpf_api_get_pinned_map_info(
-    _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_information_t** map_info)
+    _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info)
 {
     ebpf_result_t result = EBPF_SUCCESS;
-    ebpf_operation_get_map_information_request_t request = {
-        sizeof(request), EBPF_OPERATION_GET_MAP_INFORMATION, reinterpret_cast<uint64_t>(INVALID_HANDLE_VALUE)};
+    ebpf_operation_get_map_info_request_t request = {
+        sizeof(request), EBPF_OPERATION_GET_MAP_INFO, reinterpret_cast<uint64_t>(INVALID_HANDLE_VALUE)};
     ebpf_protocol_buffer_t reply_buffer;
-    ebpf_operation_get_map_information_reply_t* reply = nullptr;
+    ebpf_operation_get_map_info_reply_t* reply = nullptr;
     size_t min_expected_buffer_length = 0;
     size_t serialized_buffer_length = 0;
     uint16_t local_map_count = 0;
-    ebpf_map_information_t* local_map_info = nullptr;
+    ebpf_map_info_t* local_map_info = nullptr;
     size_t output_buffer_length = 4 * 1024;
     uint8_t attempt_count = 0;
 
@@ -591,7 +588,7 @@ ebpf_api_get_pinned_map_info(
     while (attempt_count < IOCTL_MAX_ATTEMPTS) {
         size_t reply_length;
         result = ebpf_safe_size_t_add(
-            EBPF_OFFSET_OF(ebpf_operation_get_map_information_reply_t, data), output_buffer_length, &reply_length);
+            EBPF_OFFSET_OF(ebpf_operation_get_map_info_reply_t, data), output_buffer_length, &reply_length);
         if (result != EBPF_SUCCESS)
             goto Exit;
 
@@ -611,7 +608,7 @@ ebpf_api_get_pinned_map_info(
         if ((result != EBPF_SUCCESS) && (result != EBPF_INSUFFICIENT_BUFFER))
             goto Exit;
 
-        reply = reinterpret_cast<ebpf_operation_get_map_information_reply_t*>(reply_buffer.data());
+        reply = reinterpret_cast<ebpf_operation_get_map_info_reply_t*>(reply_buffer.data());
 
         if (result == EBPF_INSUFFICIENT_BUFFER) {
             output_buffer_length = reply->size;
@@ -633,11 +630,9 @@ ebpf_api_get_pinned_map_info(
         goto Exit;
 
     // Check if the data buffer in IOCTL reply is at least as long as the
-    // minimum expected length needed to hold the array of ebpf map information objects.
+    // minimum expected length needed to hold the array of ebpf map info objects.
     result = ebpf_safe_size_t_multiply(
-        EBPF_OFFSET_OF(ebpf_serialized_map_information_t, pin_path),
-        (size_t)local_map_count,
-        &min_expected_buffer_length);
+        EBPF_OFFSET_OF(ebpf_serialized_map_info_t, pin_path), (size_t)local_map_count, &min_expected_buffer_length);
     if (result != EBPF_SUCCESS)
         goto Exit;
 
@@ -648,8 +643,7 @@ ebpf_api_get_pinned_map_info(
     }
 
     // Deserialize reply buffer.
-    result =
-        ebpf_deserialize_map_information_array(serialized_buffer_length, reply->data, local_map_count, &local_map_info);
+    result = ebpf_deserialize_map_info_array(serialized_buffer_length, reply->data, local_map_count, &local_map_info);
     if (result != EBPF_SUCCESS)
         goto Exit;
 
@@ -668,9 +662,9 @@ Exit:
 
 void
 ebpf_api_map_info_free(
-    const uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_information_t* map_info)
+    const uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info)
 {
-    ebpf_map_information_array_free(map_count, const_cast<ebpf_map_information_t*>(map_info));
+    ebpf_map_info_array_free(map_count, const_cast<ebpf_map_info_t*>(map_info));
 }
 
 void

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -34,9 +34,8 @@ allocate_string(const std::string& string, uint32_t* length) noexcept
 std::vector<uint8_t>
 convert_ebpf_program_to_bytes(const std::vector<ebpf_inst>& instructions)
 {
-    return {
-        reinterpret_cast<const uint8_t*>(instructions.data()),
-        reinterpret_cast<const uint8_t*>(instructions.data()) + instructions.size() * sizeof(ebpf_inst)};
+    return {reinterpret_cast<const uint8_t*>(instructions.data()),
+            reinterpret_cast<const uint8_t*>(instructions.data()) + instructions.size() * sizeof(ebpf_inst)};
 }
 
 int

--- a/libs/api_common/api_common.vcxproj
+++ b/libs/api_common/api_common.vcxproj
@@ -185,7 +185,7 @@
     <ClInclude Include="windows_platform_common.hpp" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\tools\encode_program_information\encode_program_information.vcxproj">
+    <ProjectReference Include="..\..\tools\encode_program_info\encode_program_info.vcxproj">
       <Project>{fa9bb88d-8259-40c1-9422-bdedf9e9ce68}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/libs/api_common/map_descriptors.hpp
+++ b/libs/api_common/map_descriptors.hpp
@@ -28,4 +28,4 @@ uintptr_t
 get_map_handle_at_index(size_t index);
 
 void
-clear_program_information_cache();
+clear_program_info_cache();

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -63,7 +63,7 @@ EbpfProgramType
 get_program_type_windows(const GUID& program_type)
 {
     // TODO: (Issue #67) Make an IOCTL call to fetch the program context
-    //       information and then fill the EbpfProgramType struct.
+    //       info and then fill the EbpfProgramType struct.
     for (const EbpfProgramType t : windows_program_types) {
         if (t.platform_specific_data != 0) {
             if (IsEqualGUID(*(GUID*)t.platform_specific_data, program_type)) {

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -242,7 +242,7 @@ _find_program_handle(const char* filename, const char* section)
         const char* program_file_name;
         const char* program_section_name;
         ebpf_execution_type_t program_execution_type;
-        status = ebpf_api_program_query_information(
+        status = ebpf_api_program_query_info(
             program_handle, &program_execution_type, &program_file_name, &program_section_name);
         if (status != ERROR_SUCCESS) {
             break;
@@ -519,7 +519,7 @@ handle_ebpf_show_programs(
         }
 
         // TODO(issue #83): we also need the program type so we can filter on it.
-        status = ebpf_api_program_query_information(
+        status = ebpf_api_program_query_info(
             program_handle, &program_execution_type, &program_file_name, &program_section_name);
 
         if (status != ERROR_SUCCESS) {

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -71,18 +71,17 @@ extern "C"
     ebpf_program_get_properties(ebpf_program_t* program, ebpf_program_parameters_t* program_parameters);
 
     /**
-     * @brief Get the program information data from the program information
+     * @brief Get the program info data from the program info
      *  extension.
      *
      * @param[in] program Program that loaded the extension.
-     * @param[out] program_information_data Pointer to the program information.
+     * @param[out] program_info_data Pointer to the program info.
      * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_ERROR_EXTENSION_FAILED_TO_LOAD The program information isn't
+     * @retval EBPF_ERROR_EXTENSION_FAILED_TO_LOAD The program info isn't
      *  available.
      */
     ebpf_result_t
-    ebpf_program_get_program_information_data(
-        const ebpf_program_t* program, const ebpf_extension_data_t** program_information_data);
+    ebpf_program_get_program_info_data(const ebpf_program_t* program, const ebpf_extension_data_t** program_info_data);
 
     /**
      * @brief Associate a set of maps with this program instance.

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -20,14 +20,14 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_GET_NEXT_MAP,
     EBPF_OPERATION_GET_NEXT_PROGRAM,
     EBPF_OPERATION_QUERY_MAP_DEFINITION,
-    EBPF_OPERATION_QUERY_PROGRAM_INFORMATION,
+    EBPF_OPERATION_QUERY_PROGRAM_INFO,
     EBPF_OPERATION_UPDATE_PINNING,
     EBPF_OPERATION_GET_PINNING,
     EBPF_OPERATION_LINK_PROGRAM,
     EBPF_OPERATION_CLOSE_HANDLE,
     EBPF_OPERATION_GET_EC_FUNCTION,
-    EBPF_OPERATION_GET_PROGRAM_INFORMATION,
-    EBPF_OPERATION_GET_MAP_INFORMATION,
+    EBPF_OPERATION_GET_PROGRAM_INFO,
+    EBPF_OPERATION_GET_MAP_INFO,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -172,20 +172,20 @@ typedef struct _ebpf_operation_query_map_definition_reply
     struct _ebpf_map_definition map_definition;
 } ebpf_operation_query_map_definition_reply;
 
-typedef struct _ebpf_operation_query_program_information_request
+typedef struct _ebpf_operation_query_program_info_request
 {
     struct _ebpf_operation_header header;
     uint64_t handle;
-} ebpf_operation_query_program_information_request;
+} ebpf_operation_query_program_info_request;
 
-typedef struct _ebpf_operation_query_program_information_reply
+typedef struct _ebpf_operation_query_program_info_reply
 {
     struct _ebpf_operation_header header;
     ebpf_code_type_t code_type;
     uint16_t file_name_offset;
     uint16_t section_name_offset;
     uint8_t data[1];
-} ebpf_operation_query_program_information_reply;
+} ebpf_operation_query_program_info_reply;
 
 typedef struct _ebpf_operation_map_get_next_key_request
 {
@@ -251,30 +251,30 @@ typedef struct _ebpf_operation_get_ec_function_reply
     uint64_t address;
 } ebpf_operation_get_ec_function_reply_t;
 
-typedef struct _ebpf_operation_get_program_information_request
+typedef struct _ebpf_operation_get_program_info_request
 {
     struct _ebpf_operation_header header;
     ebpf_program_type_t program_type;
-} ebpf_operation_get_program_information_request_t;
+} ebpf_operation_get_program_info_request_t;
 
-typedef struct _ebpf_operation_get_program_information_reply
+typedef struct _ebpf_operation_get_program_info_reply
 {
     struct _ebpf_operation_header header;
     uint16_t version;
     size_t size;
     uint8_t data[1];
-} ebpf_operation_get_program_information_reply_t;
+} ebpf_operation_get_program_info_reply_t;
 
-typedef struct _ebpf_operation_get_map_information_request
+typedef struct _ebpf_operation_get_map_info_request
 {
     struct _ebpf_operation_header header;
     uint64_t handle;
-} ebpf_operation_get_map_information_request_t;
+} ebpf_operation_get_map_info_request_t;
 
-typedef struct _ebpf_operation_get_map_information_reply
+typedef struct _ebpf_operation_get_map_info_reply
 {
     struct _ebpf_operation_header header;
     uint16_t map_count;
     size_t size;
     uint8_t data[1];
-} ebpf_operation_get_map_information_reply_t;
+} ebpf_operation_get_map_info_reply_t;

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -128,11 +128,11 @@ TEST_CASE("program", "[execution_context]")
 
     const ebpf_utf8_string_t program_name{(uint8_t*)("foo"), 3};
     const ebpf_utf8_string_t section_name{(uint8_t*)("bar"), 3};
-    program_information_provider_t program_information_provider(EBPF_PROGRAM_TYPE_BIND);
+    program_info_provider_t program_info_provider(EBPF_PROGRAM_TYPE_BIND);
 
     const ebpf_program_parameters_t program_parameters{EBPF_PROGRAM_TYPE_BIND, program_name, section_name};
     ebpf_program_parameters_t returned_program_parameters{};
-    const ebpf_extension_data_t* program_information_data;
+    const ebpf_extension_data_t* program_info_data;
 
     REQUIRE(ebpf_program_initialize(program.get(), &program_parameters) == EBPF_SUCCESS);
 
@@ -143,9 +143,9 @@ TEST_CASE("program", "[execution_context]")
             &returned_program_parameters.program_type,
             sizeof(program_parameters.program_type)) == 0);
 
-    REQUIRE(ebpf_program_get_program_information_data(program.get(), &program_information_data) == EBPF_SUCCESS);
+    REQUIRE(ebpf_program_get_program_info_data(program.get(), &program_info_data) == EBPF_SUCCESS);
 
-    REQUIRE(program_information_data != nullptr);
+    REQUIRE(program_info_data != nullptr);
 
     ebpf_map_t* maps[] = {map.get()};
 

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -135,10 +135,7 @@ ebpf_epoch_initiate()
             ebpf_non_preemptible_work_item_t* work_item_context = NULL;
             _ebpf_epoch_cpu_table[cpu_id].epoch = _ebpf_current_epoch;
             return_value = ebpf_allocate_non_preemptible_work_item(
-                &work_item_context,
-                cpu_id,
-                _ebpf_epoch_update_cpu_entry,
-                &_ebpf_epoch_cpu_table[cpu_id]);
+                &work_item_context, cpu_id, _ebpf_epoch_update_cpu_entry, &_ebpf_epoch_cpu_table[cpu_id]);
 
             if (return_value != EBPF_SUCCESS) {
                 _ebpf_epoch_cpu_table_size = cpu_id;

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -688,13 +688,13 @@ extern "C"
     ebpf_get_trampoline_function(
         _In_ const ebpf_trampoline_table_t* trampoline_table, size_t index, _Out_ void** function);
 
-    typedef struct _ebpf_program_information ebpf_program_information_t;
+    typedef struct _ebpf_program_info ebpf_program_info_t;
 
     /**
-     * @brief Serialize an ebpf_program_information_t structure into a flat
+     * @brief Serialize an ebpf_program_info_t structure into a flat
      *  buffer.
      *
-     * @param[in] program_information ebpf_program_information_t to be serialized.
+     * @param[in] program_info ebpf_program_info_t to be serialized.
      * @param[out] buffer On success, the buffer that contains the serialized
      *  structure. Must be freed by caller using ebpf_free.
      * @param[out] buffer_size On success, the size of the serialized buffer.
@@ -703,17 +703,17 @@ extern "C"
      *  operation.
      */
     ebpf_result_t
-    ebpf_program_information_encode(
-        _In_ const ebpf_program_information_t* program_information,
+    ebpf_program_info_encode(
+        _In_ const ebpf_program_info_t* program_info,
         _Outptr_result_bytebuffer_(*buffer_size) uint8_t** buffer,
         _Out_ unsigned long* buffer_size);
 
     /**
-     * @brief Deserialize an ebpf_program_information_t structure from a flat
+     * @brief Deserialize an ebpf_program_info_t structure from a flat
      *  buffer.
      *
-     * @param[out] program_information On success, a newly allocated
-     *  ebpf_program_information_t with the data from the flat buffer. Must be
+     * @param[out] program_info On success, a newly allocated
+     *  ebpf_program_info_t with the data from the flat buffer. Must be
      *  freed by the caller using ebpf_free.
      * @param[in] buffer Buffer containing the serialized structure.
      * @param[in] buffer_size Size of the buffer.
@@ -722,8 +722,8 @@ extern "C"
      *  operation.
      */
     ebpf_result_t
-    ebpf_program_information_decode(
-        _Outptr_ ebpf_program_information_t** program_information,
+    ebpf_program_info_decode(
+        _Outptr_ ebpf_program_info_t** program_info,
         _In_ _Readable_bytes_(buffer_size) const uint8_t* buffer,
         size_t buffer_size);
 

--- a/libs/platform/ebpf_program_types.acf
+++ b/libs/platform/ebpf_program_types.acf
@@ -2,5 +2,5 @@
 // SPDX-License-Identifier: MIT
 
 [explicit_handle] interface ebpf_program_types {
-    typedef[encode, decode, allocate(all_nodes)] ebpf_program_information_pointer_t;
+    typedef[encode, decode, allocate(all_nodes)] ebpf_program_info_pointer_t;
 }

--- a/libs/platform/ebpf_program_types.c
+++ b/libs/platform/ebpf_program_types.c
@@ -7,19 +7,19 @@
 #include "ebpf_program_types_c.c"
 
 ebpf_result_t
-ebpf_program_information_encode(
-    _In_ const ebpf_program_information_t* program_information,
+ebpf_program_info_encode(
+    _In_ const ebpf_program_info_t* program_info,
     _Outptr_result_bytebuffer_(*buffer_size) uint8_t** buffer,
     _Out_ unsigned long* buffer_size)
 {
     handle_t handle = NULL;
-    ebpf_program_information_pointer_t local_program_information = (ebpf_program_information_t*)program_information;
+    ebpf_program_info_pointer_t local_program_info = (ebpf_program_info_t*)program_info;
     *buffer_size = 0;
     RPC_STATUS status = MesEncodeDynBufferHandleCreate((char**)buffer, buffer_size, &handle);
     if (status != RPC_S_OK)
         return EBPF_NO_MEMORY;
 
-    RpcTryExcept { ebpf_program_information_pointer_t_Encode(handle, &local_program_information); }
+    RpcTryExcept { ebpf_program_info_pointer_t_Encode(handle, &local_program_info); }
     RpcExcept(RpcExceptionFilter(RpcExceptionCode())) { status = RpcExceptionCode(); }
     RpcEndExcept;
 
@@ -29,14 +29,14 @@ ebpf_program_information_encode(
 }
 
 ebpf_result_t
-ebpf_program_information_decode(
-    _Outptr_ ebpf_program_information_t** program_information,
+ebpf_program_info_decode(
+    _Outptr_ ebpf_program_info_t** program_info,
     _In_ _Readable_bytes_(buffer_size) const uint8_t* buffer,
     size_t buffer_size)
 {
     ebpf_result_t return_value;
     handle_t handle = NULL;
-    ebpf_program_information_pointer_t local_program_information = NULL;
+    ebpf_program_info_pointer_t local_program_info = NULL;
     uint8_t* local_buffer = NULL;
 
     if (buffer_size > ULONG_MAX) {
@@ -58,7 +58,7 @@ ebpf_program_information_decode(
         goto Done;
     }
 
-    RpcTryExcept { ebpf_program_information_pointer_t_Decode(handle, &local_program_information); }
+    RpcTryExcept { ebpf_program_info_pointer_t_Decode(handle, &local_program_info); }
     RpcExcept(RpcExceptionFilter(RpcExceptionCode())) { status = RpcExceptionCode(); }
     RpcEndExcept;
 
@@ -67,7 +67,7 @@ ebpf_program_information_decode(
         goto Done;
     }
 
-    *program_information = local_program_information;
+    *program_info = local_program_info;
     return_value = EBPF_SUCCESS;
 
 Done:

--- a/libs/platform/ebpf_program_types.idl
+++ b/libs/platform/ebpf_program_types.idl
@@ -6,5 +6,5 @@ import "wtypes.idl";
 interface ebpf_program_types
 {
 #include "ebpf_program_types.h"
-    typedef ebpf_program_information_t* ebpf_program_information_pointer_t;
+    typedef ebpf_program_info_t* ebpf_program_info_pointer_t;
 }

--- a/libs/platform/ebpf_serialize.h
+++ b/libs/platform/ebpf_serialize.h
@@ -17,28 +17,28 @@ extern "C"
     /**
      * @brief eBPF Internal Map Information
      */
-    typedef struct _ebpf_map_information_internal
+    typedef struct _ebpf_map_info_internal
     {
         ebpf_map_definition_t definition;
         ebpf_utf8_string_t pin_path;
-    } ebpf_map_information_internal_t;
+    } ebpf_map_info_internal_t;
 
     /**
      * @brief Serialized eBPF Map Information.
      */
-    typedef struct _ebpf_serialized_map_information
+    typedef struct _ebpf_serialized_map_info
     {
         ebpf_map_definition_t definition;
         uint16_t pin_path_length;
         uint8_t pin_path[1];
-    } ebpf_serialized_map_information_t;
+    } ebpf_serialized_map_info_t;
 
     /**
-     * @brief Serialize array of ebpf_map_information_t onto output buffer.
+     * @brief Serialize array of ebpf_map_info_t onto output buffer.
      *
-     * @param[in]  map_count Length of input array of ebpf_map_information_internal_t structs.
-     * @param[in]  map_info Array of ebpf_map_information_t to serialize.
-     * @param[out]  output_buffer Caller specified output buffer to write serialized data into.
+     * @param[in]  map_count Length of input array of ebpf_map_info_internal_t structs.
+     * @param[in]  map_info Array of ebpf_map_info_t to serialize.
+     * @param[out] output_buffer Caller specified output buffer to write serialized data into.
      * @param[in]  output_buffer_length Output buffer length.
      * @param[out] serialized_data_length Length of successfully serialized data.
      * @param[out] required_length Length of buffer required to serialize input array.
@@ -47,48 +47,48 @@ extern "C"
      * @retval EBPF_ERROR_INSUFFICIENT_BUFFER The output buffer is insufficient to store serialized data.
      */
     ebpf_result_t
-    ebpf_serialize_internal_map_information_array(
+    ebpf_serialize_internal_map_info_array(
         uint16_t map_count,
-        _In_count_(map_count) const ebpf_map_information_internal_t* map_info,
+        _In_count_(map_count) const ebpf_map_info_internal_t* map_info,
         _Out_writes_bytes_to_(output_buffer_length, *serialized_data_length) uint8_t* output_buffer,
         size_t output_buffer_length,
         _Out_ size_t* serialized_data_length,
         _Out_ size_t* required_length);
 
     /**
-     * @brief Deserialize input buffer to an array of ebpf_map_information_t.
+     * @brief Deserialize input buffer to an array of \ref ebpf_map_info_t.
      *
      * @param[in] input_buffer_length Input buffer length.
      * @param[in] input_buffer Input buffer that will be de-serialized.
      * @param[in] map_count Caller specified expected length of output array.
-     * @param[out] map_info Array of ebpf_map_information_t deserialized from input buffer.
+     * @param[out] map_info Array of ebpf_map_info_t deserialized from input buffer.
      *
      * @retval EBPF_SUCCESS The de-serialization was successful.
      * @retval EBPF_INVALID_ARGUMENT One or more input parameters are incorrect.
      * @retval EBPF_NO_MEMORY Output array could not be allocated.
      */
     ebpf_result_t
-    ebpf_deserialize_map_information_array(
+    ebpf_deserialize_map_info_array(
         size_t input_buffer_length,
         _In_reads_bytes_(input_buffer_length) const uint8_t* input_buffer,
         uint16_t map_count,
-        _Outptr_result_buffer_maybenull_(map_count) ebpf_map_information_t** map_info);
+        _Outptr_result_buffer_maybenull_(map_count) ebpf_map_info_t** map_info);
 
     /**
-     * @brief Helper Function to free array of ebpf_map_information_t allocated by
-     * ebpf_deserialize_map_information_array function.
+     * @brief Helper Function to free array of ebpf_map_info_t allocated by
+     * ebpf_deserialize_map_info_array function.
      *
      * @param[in] map_count Length of array to be freed.
      * @param[in] map_info Map to be freed.
      */
     void
-    ebpf_map_information_array_free(
-        uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ ebpf_map_information_t* map_info);
+    ebpf_map_info_array_free(
+        uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ ebpf_map_info_t* map_info);
 
     /**
-     * @brief Serialize ebpf_program_information_t onto output buffer.
+     * @brief Serialize ebpf_program_info_t onto output buffer.
      *
-     * @param[in]  program_info Pointer to program_map_information_t to serialize.
+     * @param[in]  program_info Pointer to program_map_info_t to serialize.
      * @param[out] output_buffer Caller specified output buffer to write serialized data into.
      * @param[in]  output_buffer_length Output buffer length.
      * @param[out] serialized_data_length Length of successfully serialized data.
@@ -99,38 +99,38 @@ extern "C"
      * @retval EBPF_ERROR_INSUFFICIENT_BUFFER The output buffer is insufficient to store serialized data.
      */
     ebpf_result_t
-    ebpf_serialize_program_information(
-        _In_ const ebpf_program_information_t* program_info,
+    ebpf_serialize_program_info(
+        _In_ const ebpf_program_info_t* program_info,
         _Out_writes_bytes_to_(output_buffer_length, *serialized_data_length) uint8_t* output_buffer,
         size_t output_buffer_length,
         _Out_ size_t* serialized_data_length,
         _Out_ size_t* required_length);
 
     /**
-     * @brief Deserialize input buffer to an array of ebpf_map_information_t.
+     * @brief Deserialize input buffer to an array of ebpf_map_info_t.
      *
      * @param[in] input_buffer_length Input buffer length.
      * @param[in] input_buffer Input buffer that will be de-serialized.
-     * @param[out] program_info Pointer to ebpf_program_information_t deserialized from input buffer.
+     * @param[out] program_info Pointer to ebpf_program_info_t deserialized from input buffer.
      *
      * @retval EBPF_SUCCESS The de-serialization was successful.
      * @retval EBPF_INVALID_ARGUMENT One or more input parameters are incorrect.
      * @retval EBPF_NO_MEMORY Output array could not be allocated.
      */
     ebpf_result_t
-    ebpf_deserialize_program_information(
+    ebpf_deserialize_program_info(
         size_t input_buffer_length,
         _In_reads_bytes_(input_buffer_length) const uint8_t* input_buffer,
-        _Outptr_ ebpf_program_information_t** program_info);
+        _Outptr_ ebpf_program_info_t** program_info);
 
     /**
-     * @brief Helper Function to free ebpf_program_information_t allocated by
-     * ebpf_deserialize_program_information().
+     * @brief Helper Function to free ebpf_program_info_t allocated by
+     * ebpf_deserialize_program_info().
      *
-     * @param[in] program_info Program information to be freed.
+     * @param[in] program_info Program info to be freed.
      */
     void
-    ebpf_program_information_free(_In_opt_ _Post_invalid_ ebpf_program_information_t* program_info);
+    ebpf_program_info_free(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info);
 
 #ifdef __cplusplus
 }

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -266,9 +266,9 @@ ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, i
 void
 ebpf_get_cpu_count(_Out_ uint32_t* cpu_count)
 {
-    SYSTEM_INFO system_information;
-    GetNativeSystemInfo(&system_information);
-    *cpu_count = system_information.dwNumberOfProcessors;
+    SYSTEM_INFO system_info;
+    GetNativeSystemInfo(&system_info);
+    *cpu_count = system_info.dwNumberOfProcessors;
 }
 
 bool

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -222,7 +222,7 @@ void
 ebpf_clear_thread_local_storage() noexcept
 {
     clear_map_descriptors();
-    clear_program_information_cache();
+    clear_program_info_cache();
 }
 
 ebpf_result_t

--- a/libs/service/service.vcxproj
+++ b/libs/service/service.vcxproj
@@ -184,7 +184,7 @@
     <ProjectReference Include="..\..\rpc_interface\rpc_interface.vcxproj">
       <Project>{1423245d-0249-40fc-a077-ff7780acfe3f}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\tools\encode_program_information\encode_program_information.vcxproj">
+    <ProjectReference Include="..\..\tools\encode_program_info\encode_program_info.vcxproj">
       <Project>{fa9bb88d-8259-40c1-9422-bdedf9e9ce68}</Project>
     </ProjectReference>
   </ItemGroup>

--- a/libs/service/verifier_service.cpp
+++ b/libs/service/verifier_service.cpp
@@ -51,8 +51,8 @@ verify_byte_code(
     uint32_t* error_message_size)
 {
     const ebpf_platform_t* platform = &g_ebpf_platform_windows_service;
-    std::vector<ebpf_inst> instructions{
-        (ebpf_inst*)byte_code, (ebpf_inst*)byte_code + byte_code_size / sizeof(ebpf_inst)};
+    std::vector<ebpf_inst> instructions{(ebpf_inst*)byte_code,
+                                        (ebpf_inst*)byte_code + byte_code_size / sizeof(ebpf_inst)};
     program_info info{platform};
     std::string section;
     std::string file;

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -33,7 +33,7 @@ Environment:
 
 #include "ebpf_ext_attach_provider.h"
 // ebpf_bind_program_data.h and ebpf_xdp_program_data.h are generated
-// headers. encode_program_information generates them from the structs
+// headers. encode_program_info generates them from the structs
 // in ebpf_nethooks.h. This workaround exists due to the inability
 // to call RPC serialization services from kernel mode. Once we switch
 // to a different serializer, we can get rid of this workaround.
@@ -46,8 +46,8 @@ Environment:
 
 static ebpf_ext_attach_hook_provider_registration_t* _ebpf_xdp_hook_provider_registration = NULL;
 static ebpf_ext_attach_hook_provider_registration_t* _ebpf_bind_hook_provider_registration = NULL;
-static ebpf_extension_provider_t* _ebpf_xdp_program_information_provider = NULL;
-static ebpf_extension_provider_t* _ebpf_bind_program_information_provider = NULL;
+static ebpf_extension_provider_t* _ebpf_xdp_program_info_provider = NULL;
+static ebpf_extension_provider_t* _ebpf_bind_program_info_provider = NULL;
 
 #define RTL_COUNT_OF(arr) (sizeof(arr) / sizeof(arr[0]))
 
@@ -71,24 +71,24 @@ static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {sizeof(xdp_md_t
                                                                  EBPF_OFFSET_OF(xdp_md_t, data),
                                                                  EBPF_OFFSET_OF(xdp_md_t, data_end),
                                                                  EBPF_OFFSET_OF(xdp_md_t, data_meta)};
-static ebpf_program_information_t _ebpf_xdp_program_information = {{"xdp", &_ebpf_xdp_context_descriptor, {0}},
-                                                                   EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-                                                                   _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_xdp_program_info = {{"xdp", &_ebpf_xdp_context_descriptor, {0}},
+                                                     EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
+                                                     _ebpf_map_helper_function_prototype};
 
-static ebpf_program_data_t _ebpf_xdp_program_data = {&_ebpf_xdp_program_information, NULL};
+static ebpf_program_data_t _ebpf_xdp_program_data = {&_ebpf_xdp_program_info, NULL};
 
-static ebpf_extension_data_t _ebpf_xdp_program_information_provider_data = {
+static ebpf_extension_data_t _ebpf_xdp_program_info_provider_data = {
     NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_xdp_program_data), &_ebpf_xdp_program_data};
 
 static ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
     sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
-static ebpf_program_information_t _ebpf_bind_program_information = {{"bind", &_ebpf_bind_context_descriptor, {0}},
-                                                                    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-                                                                    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_bind_program_info = {{"bind", &_ebpf_bind_context_descriptor, {0}},
+                                                      EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
+                                                      _ebpf_map_helper_function_prototype};
 
-static ebpf_program_data_t _ebpf_bind_program_data = {&_ebpf_bind_program_information, NULL};
+static ebpf_program_data_t _ebpf_bind_program_data = {&_ebpf_bind_program_info, NULL};
 
-static ebpf_extension_data_t _ebpf_bind_program_information_provider_data = {
+static ebpf_extension_data_t _ebpf_bind_program_info_provider_data = {
     NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_bind_program_data), &_ebpf_bind_program_data};
 // Callout and sublayer GUIDs
 
@@ -673,28 +673,28 @@ net_ebpf_ext_unregister_providers()
 }
 
 void
-net_ebpf_ext_program_information_provider_unregister()
+net_ebpf_ext_program_info_provider_unregister()
 {
-    ebpf_provider_unload(_ebpf_xdp_program_information_provider);
-    ebpf_provider_unload(_ebpf_bind_program_information_provider);
+    ebpf_provider_unload(_ebpf_xdp_program_info_provider);
+    ebpf_provider_unload(_ebpf_bind_program_info_provider);
 }
 
 NTSTATUS
-net_ebpf_ext_program_information_provider_register()
+net_ebpf_ext_program_info_provider_register()
 {
     ebpf_result_t return_value;
     ebpf_extension_data_t* provider_data;
     ebpf_program_data_t* program_data;
 
-    provider_data = &_ebpf_xdp_program_information_provider_data;
+    provider_data = &_ebpf_xdp_program_info_provider_data;
     program_data = (ebpf_program_data_t*)provider_data->data;
-    program_data->program_information->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_XDP;
+    program_data->program_info->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_XDP;
 
     return_value = ebpf_provider_load(
-        &_ebpf_xdp_program_information_provider,
+        &_ebpf_xdp_program_info_provider,
         &EBPF_PROGRAM_TYPE_XDP,
         NULL,
-        &_ebpf_xdp_program_information_provider_data,
+        &_ebpf_xdp_program_info_provider_data,
         NULL,
         NULL,
         NULL,
@@ -704,15 +704,15 @@ net_ebpf_ext_program_information_provider_register()
         goto Done;
     }
 
-    provider_data = &_ebpf_bind_program_information_provider_data;
+    provider_data = &_ebpf_bind_program_info_provider_data;
     program_data = (ebpf_program_data_t*)provider_data->data;
-    program_data->program_information->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_BIND;
+    program_data->program_info->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_BIND;
 
     return_value = ebpf_provider_load(
-        &_ebpf_bind_program_information_provider,
+        &_ebpf_bind_program_info_provider,
         &EBPF_PROGRAM_TYPE_BIND,
         NULL,
-        &_ebpf_bind_program_information_provider_data,
+        &_ebpf_bind_program_info_provider_data,
         NULL,
         NULL,
         NULL,
@@ -724,7 +724,7 @@ net_ebpf_ext_program_information_provider_register()
 
 Done:
     if (return_value != EBPF_SUCCESS) {
-        net_ebpf_ext_program_information_provider_unregister();
+        net_ebpf_ext_program_info_provider_unregister();
         return STATUS_UNSUCCESSFUL;
     } else
         return STATUS_SUCCESS;

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -56,17 +56,17 @@ void
 net_ebpf_ext_unregister_providers();
 
 /**
- * @brief Register program information providers with eBPF core.
+ * @brief Register program info providers with eBPF core.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
  * @retval STATUS_UNSUCCESSFUL Operation failed.
  */
 NTSTATUS
-net_ebpf_ext_program_information_provider_register();
+net_ebpf_ext_program_info_provider_register();
 
 /**
- * @brief Unregister program information providers from eBPF core.
+ * @brief Unregister program info providers from eBPF core.
  *
  */
 void
-net_ebpf_ext_program_information_provider_unregister();
+net_ebpf_ext_program_info_provider_unregister();

--- a/netebpfext/net_ebpf_ext_drv.c
+++ b/netebpfext/net_ebpf_ext_drv.c
@@ -47,7 +47,7 @@ static _Function_class_(EVT_WDF_DRIVER_UNLOAD) _IRQL_requires_same_
 
     _net_ebpf_ext_driver_unloading_flag = TRUE;
 
-    net_ebpf_ext_program_information_provider_unregister();
+    net_ebpf_ext_program_info_provider_unregister();
 
     net_ebpf_ext_unregister_providers();
 
@@ -120,7 +120,7 @@ __net_ebpf_ext_driver_initialize_objects(
         goto Exit;
     }
 
-    status = net_ebpf_ext_program_information_provider_register();
+    status = net_ebpf_ext_program_info_provider_register();
     if (!NT_SUCCESS(status)) {
         goto Exit;
     }

--- a/rpc_interface/rpc_interface.idl
+++ b/rpc_interface/rpc_interface.idl
@@ -70,9 +70,8 @@ import "wtypes.idl";
             [ out, ref ] uint32_t * logs_size,
             [ out, size_is(, *logs_size), ref ] char** logs);
 
-        ebpf_result_t verify_program([ in, ref ] ebpf_program_verify_info * info, [out] uint32_t * logs_size, [
-            out,
-            size_is(, *logs_size),
-            ref
-        ] char** logs);
+        ebpf_result_t verify_program(
+            [ in, ref ] ebpf_program_verify_info * info,
+            [out] uint32_t * logs_size,
+            [ out, size_is(, *logs_size), ref ] char** logs);
     }

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -93,7 +93,7 @@ _test_program_load(
     const char* program_section_name;
     ebpf_execution_type_t program_execution_type;
     REQUIRE(
-        ebpf_api_program_query_information(
+        ebpf_api_program_query_info(
             program_handle, &program_execution_type, &program_file_name, &program_section_name) == ERROR_SUCCESS);
 
     // Set the default execution type to JIT. This will eventually

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -162,7 +162,7 @@ droppacket_test(ebpf_execution_type_t execution_type)
     const char* error_message = NULL;
 
     single_instance_hook_t hook;
-    program_information_provider_t xdp_program_information(EBPF_PROGRAM_TYPE_XDP);
+    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
 
     REQUIRE(
         (result = ebpf_api_load_program(
@@ -232,7 +232,7 @@ divide_by_zero_test(ebpf_execution_type_t execution_type)
     const char* error_message = NULL;
 
     single_instance_hook_t hook;
-    program_information_provider_t xdp_program_information(EBPF_PROGRAM_TYPE_XDP);
+    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
 
     REQUIRE(
         (result = ebpf_api_load_program(
@@ -323,7 +323,7 @@ bindmonitor_test(ebpf_execution_type_t execution_type)
     uint64_t fake_pid = 12345;
     uint32_t result;
 
-    program_information_provider_t bind_program_information(EBPF_PROGRAM_TYPE_BIND);
+    program_info_provider_t bind_program_info(EBPF_PROGRAM_TYPE_BIND);
 
     REQUIRE(
         (result = ebpf_api_load_program(
@@ -465,7 +465,7 @@ TEST_CASE("map_pinning_test", "[end_to_end]")
     uint32_t count_of_map_handles = 2;
     uint32_t result;
 
-    program_information_provider_t bind_program_information(EBPF_PROGRAM_TYPE_BIND);
+    program_info_provider_t bind_program_info(EBPF_PROGRAM_TYPE_BIND);
 
     REQUIRE(
         (result = ebpf_api_load_program(
@@ -546,7 +546,7 @@ TEST_CASE("enumerate_and_query_maps", "[end_to_end]")
     uint32_t count_of_map_handles = 2;
     uint32_t result;
 
-    program_information_provider_t bind_program_information(EBPF_PROGRAM_TYPE_BIND);
+    program_info_provider_t bind_program_info(EBPF_PROGRAM_TYPE_BIND);
 
     REQUIRE(
         (result = ebpf_api_load_program(
@@ -611,7 +611,7 @@ TEST_CASE("enumerate_and_query_programs", "[end_to_end]")
     const char* file_name = nullptr;
     const char* section_name = nullptr;
 
-    program_information_provider_t xdp_program_information(EBPF_PROGRAM_TYPE_XDP);
+    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
 
     REQUIRE(
         (result = ebpf_api_load_program(
@@ -644,7 +644,7 @@ TEST_CASE("enumerate_and_query_programs", "[end_to_end]")
     ebpf_execution_type_t type;
     program_handle = INVALID_HANDLE_VALUE;
     REQUIRE(ebpf_api_get_next_program(program_handle, &program_handle) == EBPF_SUCCESS);
-    REQUIRE(ebpf_api_program_query_information(program_handle, &type, &file_name, &section_name) == EBPF_SUCCESS);
+    REQUIRE(ebpf_api_program_query_info(program_handle, &type, &file_name, &section_name) == EBPF_SUCCESS);
     REQUIRE(type == EBPF_EXECUTION_JIT);
     REQUIRE(strcmp(file_name, SAMPLE_PATH "droppacket.o") == 0);
     ebpf_free_string(file_name);
@@ -655,7 +655,7 @@ TEST_CASE("enumerate_and_query_programs", "[end_to_end]")
     section_name = nullptr;
     REQUIRE(ebpf_api_get_next_program(program_handle, &program_handle) == EBPF_SUCCESS);
     REQUIRE(program_handle != INVALID_HANDLE_VALUE);
-    REQUIRE(ebpf_api_program_query_information(program_handle, &type, &file_name, &section_name) == EBPF_SUCCESS);
+    REQUIRE(ebpf_api_program_query_info(program_handle, &type, &file_name, &section_name) == EBPF_SUCCESS);
     REQUIRE(type == EBPF_EXECUTION_INTERPRET);
     REQUIRE(strcmp(file_name, SAMPLE_PATH "droppacket.o") == 0);
     REQUIRE(strcmp(section_name, "xdp") == 0);

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -119,51 +119,51 @@ static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {sizeof(xdp_md_t
                                                                  EBPF_OFFSET_OF(xdp_md_t, data),
                                                                  EBPF_OFFSET_OF(xdp_md_t, data_end),
                                                                  EBPF_OFFSET_OF(xdp_md_t, data_meta)};
-static ebpf_program_information_t _ebpf_xdp_program_information = {{"xdp", &_ebpf_xdp_context_descriptor, {0}},
-                                                                   EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-                                                                   _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_xdp_program_info = {{"xdp", &_ebpf_xdp_context_descriptor, {0}},
+                                                     EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
+                                                     _ebpf_map_helper_function_prototype};
 
-static ebpf_program_data_t _ebpf_xdp_program_data = {&_ebpf_xdp_program_information, NULL};
+static ebpf_program_data_t _ebpf_xdp_program_data = {&_ebpf_xdp_program_info, NULL};
 
-static ebpf_extension_data_t _ebpf_xdp_program_information_provider_data = {
+static ebpf_extension_data_t _ebpf_xdp_program_info_provider_data = {
     TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_xdp_program_data), &_ebpf_xdp_program_data};
 
 static ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
     sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
-static ebpf_program_information_t _ebpf_bind_program_information = {{"bind", &_ebpf_bind_context_descriptor, {0}},
-                                                                    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-                                                                    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_bind_program_info = {{"bind", &_ebpf_bind_context_descriptor, {0}},
+                                                      EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
+                                                      _ebpf_map_helper_function_prototype};
 
-static ebpf_program_data_t _ebpf_bind_program_data = {&_ebpf_bind_program_information, NULL};
+static ebpf_program_data_t _ebpf_bind_program_data = {&_ebpf_bind_program_info, NULL};
 
-static ebpf_extension_data_t _ebpf_bind_program_information_provider_data = {
+static ebpf_extension_data_t _ebpf_bind_program_info_provider_data = {
     TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_bind_program_data), &_ebpf_bind_program_data};
 
-typedef class _program_information_provider
+typedef class _program_info_provider
 {
   public:
-    _program_information_provider(ebpf_program_type_t program_type) : program_type(program_type)
+    _program_info_provider(ebpf_program_type_t program_type) : program_type(program_type)
     {
         ebpf_program_data_t* program_data;
         if (program_type == EBPF_PROGRAM_TYPE_XDP) {
-            provider_data = &_ebpf_xdp_program_information_provider_data;
+            provider_data = &_ebpf_xdp_program_info_provider_data;
             program_data = (ebpf_program_data_t*)provider_data->data;
-            program_data->program_information->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_XDP;
+            program_data->program_info->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_XDP;
         } else if (program_type == EBPF_PROGRAM_TYPE_BIND) {
-            provider_data = &_ebpf_bind_program_information_provider_data;
+            provider_data = &_ebpf_bind_program_info_provider_data;
             program_data = (ebpf_program_data_t*)provider_data->data;
-            program_data->program_information->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_BIND;
+            program_data->program_info->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_BIND;
         }
 
         REQUIRE(
             ebpf_provider_load(&provider, &program_type, nullptr, provider_data, nullptr, nullptr, nullptr, nullptr) ==
             EBPF_SUCCESS);
     }
-    ~_program_information_provider() { ebpf_provider_unload(provider); }
+    ~_program_info_provider() { ebpf_provider_unload(provider); }
 
   private:
     ebpf_program_type_t program_type;
 
     ebpf_extension_data_t* provider_data;
     ebpf_extension_provider_t* provider;
-} program_information_provider_t;
+} program_info_provider_t;

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -15,7 +15,7 @@ ebpf_test_pinned_map_enum()
     const int pinned_map_count = 10;
     std::string pin_path_prefix = "\\ebpf\\map\\";
     uint16_t map_count = 0;
-    ebpf_map_information_t* map_info = nullptr;
+    ebpf_map_info_t* map_info = nullptr;
 
     REQUIRE(
         (result = ebpf_api_create_map(EBPF_MAP_TYPE_ARRAY, sizeof(uint32_t), sizeof(uint64_t), 1024, 0, &map_handle)) ==

--- a/tests/libs/util/service_helper.cpp
+++ b/tests/libs/util/service_helper.cpp
@@ -12,7 +12,7 @@ service_install_helper::initialize()
 {
     int error;
     int retry_count = 0;
-    SERVICE_SID_INFO sid_information = {0};
+    SERVICE_SID_INFO sid_info = {0};
 
     if (initialized) {
         return ERROR_SUCCESS;
@@ -64,8 +64,8 @@ QueryService:
         }
 
         // Set service SID type to restricted.
-        sid_information.dwServiceSidType = SERVICE_SID_TYPE_RESTRICTED;
-        if (!ChangeServiceConfig2(service_handle, SERVICE_CONFIG_SERVICE_SID_INFO, &sid_information)) {
+        sid_info.dwServiceSidType = SERVICE_SID_TYPE_RESTRICTED;
+        if (!ChangeServiceConfig2(service_handle, SERVICE_CONFIG_SERVICE_SID_INFO, &sid_info)) {
             error = GetLastError();
             printf("ChangeServiceConfig2 for %ws failed, 0x%x.\n", service_name.c_str(), error);
             return error;

--- a/tests/sample/divide_by_zero.c
+++ b/tests/sample/divide_by_zero.c
@@ -9,12 +9,11 @@
 #include "ebpf.h"
 
 #pragma clang section data = "maps"
-ebpf_map_definition_t test_map = {
-    .size = sizeof(ebpf_map_definition_t),
-    .type = EBPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(uint32_t),
-    .value_size = sizeof(uint32_t),
-    .max_entries = 1};
+ebpf_map_definition_t test_map = {.size = sizeof(ebpf_map_definition_t),
+                                  .type = EBPF_MAP_TYPE_ARRAY,
+                                  .key_size = sizeof(uint32_t),
+                                  .value_size = sizeof(uint32_t),
+                                  .max_entries = 1};
 
 #pragma clang section text = "xdp"
 uint32_t

--- a/tests/sample/droppacket.c
+++ b/tests/sample/droppacket.c
@@ -9,12 +9,11 @@
 #include "ebpf.h"
 
 #pragma clang section data = "maps"
-ebpf_map_definition_t port_map = {
-    .size = sizeof(ebpf_map_definition_t),
-    .type = EBPF_MAP_TYPE_ARRAY,
-    .key_size = sizeof(uint32_t),
-    .value_size = sizeof(uint64_t),
-    .max_entries = 1};
+ebpf_map_definition_t port_map = {.size = sizeof(ebpf_map_definition_t),
+                                  .type = EBPF_MAP_TYPE_ARRAY,
+                                  .key_size = sizeof(uint32_t),
+                                  .value_size = sizeof(uint64_t),
+                                  .max_entries = 1};
 
 #pragma clang section text = "xdp"
 int

--- a/tools/encode_program_info/encode_program_info.cpp
+++ b/tools/encode_program_info/encode_program_info.cpp
@@ -9,8 +9,7 @@
 #include "ebpf_windows.h"
 
 static ebpf_result_t
-_emit_program_information_file(
-    const char* file_name, const char* symbol_name, uint8_t* buffer, unsigned long buffer_size)
+_emit_program_info_file(const char* file_name, const char* symbol_name, uint8_t* buffer, unsigned long buffer_size)
 {
     unsigned long index;
     FILE* output;
@@ -55,15 +54,15 @@ _encode_bind()
     ebpf_context_descriptor_t bind_context_descriptor = {
         sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
     ebpf_program_type_descriptor_t bind_program_type = {"bind", &bind_context_descriptor, EBPF_PROGRAM_TYPE_BIND};
-    ebpf_program_information_t bind_program_information = {
+    ebpf_program_info_t bind_program_info = {
         bind_program_type, EBPF_COUNT_OF(_ebpf_helper_function_prototype), _ebpf_helper_function_prototype};
 
-    return_value = ebpf_program_information_encode(&bind_program_information, &buffer, &buffer_size);
+    return_value = ebpf_program_info_encode(&bind_program_info, &buffer, &buffer_size);
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
-    return_value = _emit_program_information_file(
-        "ebpf_bind_program_data.h", "_ebpf_encoded_bind_program_information_data", buffer, buffer_size);
+    return_value = _emit_program_info_file(
+        "ebpf_bind_program_data.h", "_ebpf_encoded_bind_program_info_data", buffer, buffer_size);
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
@@ -86,15 +85,15 @@ _encode_xdp()
                                                         EBPF_OFFSET_OF(xdp_md_t, data_end),
                                                         EBPF_OFFSET_OF(xdp_md_t, data_meta)};
     ebpf_program_type_descriptor_t xdp_program_type = {"xdp", &xdp_context_descriptor, EBPF_PROGRAM_TYPE_XDP};
-    ebpf_program_information_t xdp_program_information = {
+    ebpf_program_info_t xdp_program_info = {
         xdp_program_type, EBPF_COUNT_OF(_ebpf_helper_function_prototype), _ebpf_helper_function_prototype};
 
-    return_value = ebpf_program_information_encode(&xdp_program_information, &buffer, &buffer_size);
+    return_value = ebpf_program_info_encode(&xdp_program_info, &buffer, &buffer_size);
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
-    return_value = _emit_program_information_file(
-        "ebpf_xdp_program_data.h", "_ebpf_encoded_xdp_program_information_data", buffer, buffer_size);
+    return_value =
+        _emit_program_info_file("ebpf_xdp_program_data.h", "_ebpf_encoded_xdp_program_info_data", buffer, buffer_size);
     if (return_value != EBPF_SUCCESS)
         goto Done;
 

--- a/tools/encode_program_info/encode_program_info.vcxproj
+++ b/tools/encode_program_info/encode_program_info.vcxproj
@@ -26,8 +26,9 @@
     <VCProjectVersion>16.0</VCProjectVersion>
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{fa9bb88d-8259-40c1-9422-bdedf9e9ce68}</ProjectGuid>
-    <RootNamespace>encodeprograminformation</RootNamespace>
+    <RootNamespace>encodeprograminfo</RootNamespace>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+    <ProjectName>encode_program_info</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -132,7 +133,7 @@
     </Link>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
-$(OutputPath)\encode_program_information.exe</Command>
+$(OutputPath)encode_program_info.exe</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Encoding Program Information</Message>
@@ -159,7 +160,7 @@ $(OutputPath)\encode_program_information.exe</Command>
     </Link>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
-$(OutputPath)\encode_program_information.exe</Command>
+$(OutputPath)encode_program_info.exe</Command>
     </CustomBuildStep>
     <CustomBuildStep>
       <Message>Encoding Program Information</Message>
@@ -169,7 +170,7 @@ $(OutputPath)\encode_program_information.exe</Command>
     </CustomBuildStep>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClCompile Include="encode_program_information.cpp" />
+    <ClCompile Include="encode_program_info.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\libs\platform\user\platform_user.vcxproj">

--- a/tools/encode_program_info/encode_program_info.vcxproj.filters
+++ b/tools/encode_program_info/encode_program_info.vcxproj.filters
@@ -19,7 +19,7 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="encode_program_information.cpp">
+    <ClCompile Include="encode_program_info.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/tools/port_quota/port_quota.cpp
+++ b/tools/port_quota/port_quota.cpp
@@ -149,11 +149,10 @@ struct
     const char* name;
     const char* help;
     operation_t operation;
-} commands[]{
-    {"load", "load\tLoad the port quota eBPF program", load},
-    {"unload", "unload\tUnload the port quota eBPF program", unload},
-    {"stats", "stats\tShow stats from the port quota eBPF program", stats},
-    {"limit", "limit value\tSet the port quota limit", limit}};
+} commands[]{{"load", "load\tLoad the port quota eBPF program", load},
+             {"unload", "unload\tUnload the port quota eBPF program", unload},
+             {"stats", "stats\tShow stats from the port quota eBPF program", stats},
+             {"limit", "limit value\tSet the port quota limit", limit}};
 
 void
 print_usage(char* path)


### PR DESCRIPTION
Previously some places had "info" and some had "information".
Both appear in dictionaries, so guidance to avoid abbreviations does not apply.
Doing this now since it affects publicly visible APIs.

Fixes #314

Signed-off-by: Dave Thaler <dthaler@microsoft.com>