### PR TITLE
move map helper function prototypes to EC

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -11,7 +11,7 @@
 #include "ebpf_program_types.h"
 #include "ebpf_serialize.h"
 
-GUID ebpf_generic_helper_function_interface_id = {/* 8d2a1d3f-9ce6-473d-b48e-17aa5c5581fe */
+GUID ebpf_general_helper_function_interface_id = {/* 8d2a1d3f-9ce6-473d-b48e-17aa5c5581fe */
                                                   0x8d2a1d3f,
                                                   0x9ce6,
                                                   0x473d,
@@ -90,7 +90,7 @@ ebpf_core_initiate()
 
     return_value = ebpf_provider_load(
         &_ebpf_global_helper_function_provider_context,
-        &ebpf_generic_helper_function_interface_id,
+        &ebpf_general_helper_function_interface_id,
         NULL,
         &_ebpf_global_helper_function_extension_data,
         NULL,

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -11,11 +11,11 @@
 #include "ebpf_program_types.h"
 #include "ebpf_serialize.h"
 
-GUID ebpf_global_helper_function_interface_id = {/* 8d2a1d3f-9ce6-473d-b48e-17aa5c5581fe */
-                                                 0x8d2a1d3f,
-                                                 0x9ce6,
-                                                 0x473d,
-                                                 {0xb4, 0x8e, 0x17, 0xaa, 0x5c, 0x55, 0x81, 0xfe}};
+GUID ebpf_generic_helper_function_interface_id = {/* 8d2a1d3f-9ce6-473d-b48e-17aa5c5581fe */
+                                                  0x8d2a1d3f,
+                                                  0x9ce6,
+                                                  0x473d,
+                                                  {0xb4, 0x8e, 0x17, 0xaa, 0x5c, 0x55, 0x81, 0xfe}};
 
 static ebpf_pinning_table_t* _ebpf_core_map_pinning_table = NULL;
 
@@ -32,15 +32,15 @@ _ebpf_core_map_delete_element(ebpf_map_t* map, const uint8_t* key);
 #define EBPF_CORE_GLOBAL_HELPER_EXTENSION_VERSION 0
 
 static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = {
-    {1,
+    {(uint32_t)(intptr_t)ebpf_map_lookup_element,
      "ebpf_map_lookup_element",
      EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {2,
+    {(uint32_t)(intptr_t)ebpf_map_update_element,
      "ebpf_map_update_element",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
-    {3,
+    {(uint32_t)(intptr_t)ebpf_map_delete_element,
      "ebpf_map_delete_element",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}}};
@@ -90,7 +90,7 @@ ebpf_core_initiate()
 
     return_value = ebpf_provider_load(
         &_ebpf_global_helper_function_provider_context,
-        &ebpf_global_helper_function_interface_id,
+        &ebpf_generic_helper_function_interface_id,
         NULL,
         &_ebpf_global_helper_function_extension_data,
         NULL,
@@ -710,7 +710,7 @@ _ebpf_core_protocol_get_program_info(
     if (retval != EBPF_SUCCESS)
         goto Done;
 
-    retval = ebpf_program_get_program_info_data(program, &program_info);
+    retval = ebpf_program_get_program_info(program, &program_info);
     if (retval != EBPF_SUCCESS)
         goto Done;
     if (program_info == NULL) {
@@ -731,7 +731,7 @@ _ebpf_core_protocol_get_program_info(
     }
 
 Done:
-    ebpf_program_free_program_info_data(program_info);
+    ebpf_program_free_program_info(program_info);
     ebpf_object_release_reference((ebpf_object_t*)program);
     return retval;
 }

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -12,7 +12,7 @@ extern "C"
 #endif
 #include "ebpf_protocol.h"
 
-    extern GUID ebpf_generic_helper_function_interface_id;
+    extern GUID ebpf_general_helper_function_interface_id;
 
     typedef uint32_t(__stdcall* ebpf_hook_function)(uint8_t*);
 

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -12,7 +12,7 @@ extern "C"
 #endif
 #include "ebpf_protocol.h"
 
-    extern GUID ebpf_global_helper_function_interface_id;
+    extern GUID ebpf_generic_helper_function_interface_id;
 
     typedef uint32_t(__stdcall* ebpf_hook_function)(uint8_t*);
 

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -6,6 +6,7 @@
 #include "ebpf_link.h"
 #include "ebpf_maps.h"
 #include "ebpf_platform.h"
+#include "ebpf_program_types.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -75,13 +76,25 @@ extern "C"
      *  extension.
      *
      * @param[in] program Program that loaded the extension.
-     * @param[out] program_info_data Pointer to the program info.
+     * @param[out] program_info Pointer to the output allocated program info. Must be freed by caller by calling
+     * ebpf_program_free_program_info_data().
      * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT One or more arguments are invalid.
+     * @retval EBPF_ARITHMETIC_OVERFLOW An arithmetic overflow has occured.
+     * @retval EBPF_NO_MEMORY Output program info could not be allocated.
      * @retval EBPF_ERROR_EXTENSION_FAILED_TO_LOAD The program info isn't
      *  available.
      */
     ebpf_result_t
-    ebpf_program_get_program_info_data(const ebpf_program_t* program, const ebpf_extension_data_t** program_info_data);
+    ebpf_program_get_program_info_data(_In_ const ebpf_program_t* program, _Outptr_ ebpf_program_info_t** program_info);
+
+    /**
+     * @brief Free the program info data allocated by ebpf_program_get_program_info_data().
+     *
+     * @param[in] program_info Program info to be freed.
+     */
+    void
+    ebpf_program_free_program_info_data(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info);
 
     /**
      * @brief Associate a set of maps with this program instance.

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -72,29 +72,28 @@ extern "C"
     ebpf_program_get_properties(ebpf_program_t* program, ebpf_program_parameters_t* program_parameters);
 
     /**
-     * @brief Get the program info data from the program info
-     *  extension.
+     * @brief Get the program info from the program info extension.
      *
      * @param[in] program Program that loaded the extension.
      * @param[out] program_info Pointer to the output allocated program info. Must be freed by caller by calling
-     * ebpf_program_free_program_info_data().
+     * ebpf_program_free_program_info().
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT One or more arguments are invalid.
-     * @retval EBPF_ARITHMETIC_OVERFLOW An arithmetic overflow has occured.
+     * @retval EBPF_ARITHMETIC_OVERFLOW An arithmetic overflow has occurred.
      * @retval EBPF_NO_MEMORY Output program info could not be allocated.
      * @retval EBPF_ERROR_EXTENSION_FAILED_TO_LOAD The program info isn't
      *  available.
      */
     ebpf_result_t
-    ebpf_program_get_program_info_data(_In_ const ebpf_program_t* program, _Outptr_ ebpf_program_info_t** program_info);
+    ebpf_program_get_program_info(_In_ const ebpf_program_t* program, _Outptr_ ebpf_program_info_t** program_info);
 
     /**
-     * @brief Free the program info data allocated by ebpf_program_get_program_info_data().
+     * @brief Free the program info allocated by ebpf_program_get_program_info().
      *
      * @param[in] program_info Program info to be freed.
      */
     void
-    ebpf_program_free_program_info_data(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info);
+    ebpf_program_free_program_info(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info);
 
     /**
      * @brief Associate a set of maps with this program instance.

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -132,7 +132,7 @@ TEST_CASE("program", "[execution_context]")
 
     const ebpf_program_parameters_t program_parameters{EBPF_PROGRAM_TYPE_BIND, program_name, section_name};
     ebpf_program_parameters_t returned_program_parameters{};
-    const ebpf_extension_data_t* program_info_data;
+    ebpf_program_info_t* program_info;
 
     REQUIRE(ebpf_program_initialize(program.get(), &program_parameters) == EBPF_SUCCESS);
 
@@ -143,9 +143,9 @@ TEST_CASE("program", "[execution_context]")
             &returned_program_parameters.program_type,
             sizeof(program_parameters.program_type)) == 0);
 
-    REQUIRE(ebpf_program_get_program_info_data(program.get(), &program_info_data) == EBPF_SUCCESS);
-
-    REQUIRE(program_info_data != nullptr);
+    REQUIRE(ebpf_program_get_program_info_data(program.get(), &program_info) == EBPF_SUCCESS);
+    REQUIRE(program_info != nullptr);
+    ebpf_program_free_program_info_data(program_info);
 
     ebpf_map_t* maps[] = {map.get()};
 

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -143,9 +143,9 @@ TEST_CASE("program", "[execution_context]")
             &returned_program_parameters.program_type,
             sizeof(program_parameters.program_type)) == 0);
 
-    REQUIRE(ebpf_program_get_program_info_data(program.get(), &program_info) == EBPF_SUCCESS);
+    REQUIRE(ebpf_program_get_program_info(program.get(), &program_info) == EBPF_SUCCESS);
     REQUIRE(program_info != nullptr);
-    ebpf_program_free_program_info_data(program_info);
+    ebpf_program_free_program_info(program_info);
 
     ebpf_map_t* maps[] = {map.get()};
 

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -19,7 +19,7 @@ extern "C"
 #define EBPF_SYMBOLIC_DEVICE_NAME L"\\GLOBAL??\\EbpfIoDevice"
 #define EBPF_DEVICE_WIN32_NAME L"\\\\.\\EbpfIoDevice"
 
-#define EBPF_MAX_GLOBAL_HELPER_FUNCTION 0xFFFF
+#define EBPF_MAX_GENERIC_HELPER_FUNCTION 0xFFFF
 
 #define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \
     {                                         \

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -19,7 +19,7 @@ extern "C"
 #define EBPF_SYMBOLIC_DEVICE_NAME L"\\GLOBAL??\\EbpfIoDevice"
 #define EBPF_DEVICE_WIN32_NAME L"\\\\.\\EbpfIoDevice"
 
-#define EBPF_MAX_GENERIC_HELPER_FUNCTION 0xFFFF
+#define EBPF_MAX_GENERAL_HELPER_FUNCTION 0xFFFF
 
 #define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \
     {                                         \

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -53,27 +53,11 @@ static ebpf_extension_provider_t* _ebpf_bind_program_info_provider = NULL;
 
 #define NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION 0
 
-static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = {
-    {1,
-     "ebpf_map_lookup_element",
-     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {2,
-     "ebpf_map_update_element",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
-    {3,
-     "ebpf_map_delete_element",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}}};
-
 static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {sizeof(xdp_md_t),
                                                                  EBPF_OFFSET_OF(xdp_md_t, data),
                                                                  EBPF_OFFSET_OF(xdp_md_t, data_end),
                                                                  EBPF_OFFSET_OF(xdp_md_t, data_meta)};
-static ebpf_program_info_t _ebpf_xdp_program_info = {{"xdp", &_ebpf_xdp_context_descriptor, {0}},
-                                                     EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-                                                     _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_xdp_program_info = {{"xdp", &_ebpf_xdp_context_descriptor, {0}}, 0, NULL};
 
 static ebpf_program_data_t _ebpf_xdp_program_data = {&_ebpf_xdp_program_info, NULL};
 
@@ -82,9 +66,7 @@ static ebpf_extension_data_t _ebpf_xdp_program_info_provider_data = {
 
 static ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
     sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
-static ebpf_program_info_t _ebpf_bind_program_info = {{"bind", &_ebpf_bind_context_descriptor, {0}},
-                                                      EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-                                                      _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_bind_program_info = {{"bind", &_ebpf_bind_context_descriptor, {0}}, 0, NULL};
 
 static ebpf_program_data_t _ebpf_bind_program_data = {&_ebpf_bind_program_info, NULL};
 

--- a/tests/ext/drv/test_ext.c
+++ b/tests/ext/drv/test_ext.c
@@ -29,15 +29,15 @@ static ebpf_context_descriptor_t _test_ebpf_context_descriptor = {sizeof(test_pr
 
 // Test Extension Helper function prototype descriptors.
 static ebpf_helper_function_prototype_t _test_ebpf_extension_helper_function_prototype[] = {
-    {EBPF_MAX_GLOBAL_HELPER_FUNCTION + 1,
+    {EBPF_MAX_GENERIC_HELPER_FUNCTION + 1,
      "test_ebpf_extension_helper_function1",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
-    {EBPF_MAX_GLOBAL_HELPER_FUNCTION + 2,
+    {EBPF_MAX_GENERIC_HELPER_FUNCTION + 2,
      "test_ebpf_extension_helper_function2",
      EBPF_RETURN_TYPE_VOID,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}},
-    {EBPF_MAX_GLOBAL_HELPER_FUNCTION + 3,
+    {EBPF_MAX_GENERIC_HELPER_FUNCTION + 3,
      "test_ebpf_extension_helper_function3",
      EBPF_RETURN_TYPE_VOID,
      {EBPF_ARGUMENT_TYPE_ANYTHING}}};

--- a/tests/ext/drv/test_ext.c
+++ b/tests/ext/drv/test_ext.c
@@ -29,15 +29,15 @@ static ebpf_context_descriptor_t _test_ebpf_context_descriptor = {sizeof(test_pr
 
 // Test Extension Helper function prototype descriptors.
 static ebpf_helper_function_prototype_t _test_ebpf_extension_helper_function_prototype[] = {
-    {EBPF_MAX_GENERIC_HELPER_FUNCTION + 1,
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 1,
      "test_ebpf_extension_helper_function1",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
-    {EBPF_MAX_GENERIC_HELPER_FUNCTION + 2,
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 2,
      "test_ebpf_extension_helper_function2",
      EBPF_RETURN_TYPE_VOID,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}},
-    {EBPF_MAX_GENERIC_HELPER_FUNCTION + 3,
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 3,
      "test_ebpf_extension_helper_function3",
      EBPF_RETURN_TYPE_VOID,
      {EBPF_ARGUMENT_TYPE_ANYTHING}}};


### PR DESCRIPTION
This partially addresses #291 .

The net ebpf extensions used to have the map helper function prototypes in both the xdp and bind program info. This PR moves those to the global helper program info in ebpf_core.

get_helper_prototype_windows callback from verifier uses global_program_info.type.platform_specific_data stored in TLS to get the program type guid, which is supplied during program verification call. This program type stored in TLS is used to obtain the program info from EC by invoking an IOCTL. The IOCTL handler invokes ebpf_program_get_program_info_data which calls program initialize, which in turn loads the extension corresponding to the input program type, and returns the program info provider data (which includes helper function prototypes).

The ebpf_program_get_program_info_data function is now modified to get the program info from both the program type extension and global helper NPI provider implemented by the EC itself. The latter contains the prototypes for global map helper functions. The helper prototypes from both the global and program type specific functions are combined to create a program_info_t object which is later serialized and returned as IOCTL output.