### PR TITLE
Add prog array map type and bpf_tail_call() helper

### DIFF
--- a/Analyze.default.ruleset
+++ b/Analyze.default.ruleset
@@ -30,7 +30,11 @@
     <Rule Id="C26498" Action="Error" />
     <Rule Id="C26810" Action="Error" />
     <Rule Id="C26811" Action="Error" />
-    <Rule Id="C26812" Action="Error" />
+    <!-- C++ uses C enums (not C++ enum classes) which generates C26812.  This
+         is intentional so that the same enums can be used by both C and C++ code.
+         so should not be treated as an error.
+      -->
+    <Rule Id="C26812" Action="Warning" />
     <Rule Id="C26815" Action="Error" />
     <Rule Id="C26816" Action="Error" />
     <Rule Id="C26817" Action="Error" />

--- a/include/bpf.h
+++ b/include/bpf.h
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma warning(push)
+#include "../external/libbpf/src/bpf.h"
+#pragma warning(pop)

--- a/include/ebpf_helpers.h
+++ b/include/ebpf_helpers.h
@@ -52,10 +52,23 @@ EBPF_HELPER(int64_t, bpf_map_update_elem, (struct bpf_map * map, void* key, void
  * @param[in] map Map to update.
  * @param[in] key Key to use when searching and updating the map.
  * @retval EBPF_SUCCESS The operation was successful.
- * @retval EBPF_INVALID_ARGUMENT One or more parameters are
- *  invalid.
+ * @retval EBPF_INVALID_ARGUMENT One or more parameters are invalid.
  */
 EBPF_HELPER(int64_t, bpf_map_delete_elem, (struct bpf_map * map, void* key));
 #ifndef __doxygen
 #define bpf_map_delete_elem ((bpf_map_delete_elem_t)3)
+#endif
+
+/**
+ * @brief Perform a tail call into another eBPF program.
+ *
+ * @param[in] ctx Context to pass to the called program.
+ * @param[in] prog_array_map Map of program fds.
+ * @param[in] index Index in map of program to call.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_INVALID_ARGUMENT One or more parameters are invalid.
+ */
+EBPF_HELPER(int, bpf_tail_call, (void* ctx, struct bpf_map* prog_array_map, uint32_t index));
+#ifndef __doxygen
+#define bpf_tail_call ((bpf_tail_call_t)4)
 #endif

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -13,7 +13,9 @@ typedef enum bpf_map_type
 {
     BPF_MAP_TYPE_UNSPECIFIED = 0, ///< Unspecified map type.
     BPF_MAP_TYPE_HASH = 1,        ///< Hash table.
-    BPF_MAP_TYPE_ARRAY = 2,       ///< Array, wehere the map key is the array index.
+    BPF_MAP_TYPE_ARRAY = 2,       ///< Array, where the map key is the array index.
+    BPF_MAP_TYPE_PROG_ARRAY =
+        3, ///< Array of program fds usable with bpf_tail_call, where the map key is the array index.
 } ebpf_map_type_t;
 
 /**

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -102,7 +102,7 @@ load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* sectionname,
     _In_ ebpf_verifier_options_t* verifier_options,
-    _Out_ std::vector<ebpf_program_t*>& programs,
+    _Out_ ebpf_object_t& object,
     _Outptr_result_maybenull_z_ const char** error_message) noexcept
 {
     ebpf_result_t result = EBPF_SUCCESS;
@@ -118,25 +118,25 @@ load_byte_code(
             section_name = std::string(sectionname);
         }
 
-        auto raw_progams = read_elf(file_name, section_name, verifier_options, platform);
-        if (raw_progams.size() == 0) {
+        auto raw_programs = read_elf(file_name, section_name, verifier_options, platform);
+        if (raw_programs.size() == 0) {
             result = EBPF_ELF_PARSING_FAILED;
             goto Exit;
         }
 
         // read_elf() also returns a section with name ".text".
         // Remove that section from the list of programs returned.
-        for (int i = 0; i < raw_progams.size(); i++) {
-            if (raw_progams[i].section == ".text") {
-                raw_progams.erase(raw_progams.begin() + i);
+        for (int i = 0; i < raw_programs.size(); i++) {
+            if (raw_programs[i].section == ".text") {
+                raw_programs.erase(raw_programs.begin() + i);
                 break;
             }
         }
 
         // For each program/section parsed, program type should be same.
         if (get_global_program_type() == nullptr) {
-            ebpf_program_type_t program_type = *(const GUID*)raw_progams[0].info.type.platform_specific_data;
-            for (auto& raw_program : raw_progams) {
+            ebpf_program_type_t program_type = *(const GUID*)raw_programs[0].info.type.platform_specific_data;
+            for (auto& raw_program : raw_programs) {
                 if (raw_program.info.type.platform_specific_data == 0) {
                     result = EBPF_ELF_PARSING_FAILED;
                     goto Exit;
@@ -150,7 +150,7 @@ load_byte_code(
             }
         }
 
-        for (auto& raw_program : raw_progams) {
+        for (auto& raw_program : raw_programs) {
             program = (ebpf_program_t*)calloc(1, sizeof(ebpf_program_t));
             if (program == nullptr) {
                 result = EBPF_NO_MEMORY;
@@ -189,18 +189,19 @@ load_byte_code(
                 }
             }
             program->byte_code_size = static_cast<uint32_t>(ebpf_bytes);
-            programs.emplace_back(program);
+            program->object = &object;
+            object.programs.emplace_back(program);
             program = nullptr;
         }
 
         // Get program names for each section.
-        for (auto& iterator : programs) {
+        for (auto& iterator : object.programs) {
             section_to_program_map.emplace_back(iterator->section_name, std::string());
         }
 
         _get_section_and_program_name(file_name, section_to_program_map);
         int index = 0;
-        for (auto& iterator : programs) {
+        for (auto& iterator : object.programs) {
             iterator->program_name = _strdup(section_to_program_map[index].program_name.c_str());
             if (iterator->program_name == nullptr) {
                 result = EBPF_NO_MEMORY;
@@ -231,7 +232,7 @@ Exit:
             program = nullptr;
         }
 
-        clean_up_ebpf_programs(programs);
+        clean_up_ebpf_programs(object.programs);
     }
 
     return result;

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -102,7 +102,7 @@ load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* sectionname,
     _In_ ebpf_verifier_options_t* verifier_options,
-    _Out_ ebpf_object_t& object,
+    _Inout_ ebpf_object_t& object,
     _Outptr_result_maybenull_z_ const char** error_message) noexcept
 {
     ebpf_result_t result = EBPF_SUCCESS;

--- a/libs/api/Verifier.h
+++ b/libs/api/Verifier.h
@@ -16,7 +16,7 @@ load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* sectionname,
     _In_ ebpf_verifier_options_t* verifier_options,
-    _Out_ std::vector<ebpf_program_t*>& programs,
+    _Out_ ebpf_object_t& object,
     _Outptr_result_maybenull_z_ const char** error_message) noexcept;
 
 ebpf_result_t

--- a/libs/api/Verifier.h
+++ b/libs/api/Verifier.h
@@ -16,7 +16,7 @@ load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* sectionname,
     _In_ ebpf_verifier_options_t* verifier_options,
-    _Out_ ebpf_object_t& object,
+    _Inout_ ebpf_object_t& object,
     _Outptr_result_maybenull_z_ const char** error_message) noexcept;
 
 ebpf_result_t

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -149,7 +149,7 @@ _Ret_maybenull_ ebpf_program_t*
 ebpf_program_lookup(fd_t fd);
 
 /**
- * @brief Update an element in an eBPF map.
+ * @brief Update an element in an eBPF map that uses handles with values.
  * @param[in] handle Handle to eBPF map.
  * @param[in] key_size Size of the key buffer.
  * @param[in] key Pointer to buffer containing key.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -46,7 +46,7 @@ ebpf_get_program_byte_code(
     _In_z_ const char* file_name,
     _In_z_ const char* section_name,
     bool mock_map_fd,
-    std::vector<ebpf_program_t*>& programs,
+    _Out_ ebpf_object_t& object,
     _Outptr_result_maybenull_ EbpfMapDescriptor** map_descriptors,
     _Out_ int* map_descriptors_count,
     _Outptr_result_maybenull_ const char** error_message);
@@ -129,3 +129,41 @@ ebpf_map_get_fd(_In_ const struct bpf_map* map);
  */
 void
 ebpf_object_close(_In_ _Post_invalid_ struct bpf_object* object);
+
+/**
+ * @brief Get the map with a given fd.
+ *
+ * @param[in] fd File descriptor to resolve.
+ * @returns Pointer to map, or NULL if not found.
+ */
+_Ret_maybenull_ ebpf_map_t*
+ebpf_map_lookup(fd_t fd);
+
+/**
+ * @brief Get the program with a given fd.
+ *
+ * @param[in] fd File descriptor to resolve.
+ * @returns Pointer to program, or NULL if not found.
+ */
+_Ret_maybenull_ ebpf_program_t*
+ebpf_program_lookup(fd_t fd);
+
+/**
+ * @brief Update an element in an eBPF map.
+ * @param[in] handle Handle to eBPF map.
+ * @param[in] key_size Size of the key buffer.
+ * @param[in] key Pointer to buffer containing key.
+ * @param[in] value_size Size of the value buffer.
+ * @param[in] value Pointer to buffer containing value.
+ * @param[in] value_handle Handle associated with value.
+ * @retval 0 The operation was successful.
+ * @retval other The operation failed.
+ */
+uint32_t
+ebpf_api_map_update_element_with_handle(
+    ebpf_handle_t handle,
+    uint32_t key_size,
+    _In_ const uint8_t* key,
+    uint32_t value_size,
+    _In_ const uint8_t* value,
+    ebpf_handle_t value_handle);

--- a/libs/api/libbpf_map.cpp
+++ b/libs/api/libbpf_map.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "api_internal.h"
+#include "bpf.h"
 #pragma warning(push)
 #pragma warning(disable : 4200)
 #include "libbpf.h"
@@ -181,4 +182,46 @@ int
 bpf_map__fd(const struct bpf_map* map)
 {
     return map ? map->map_fd : libbpf_err(-EINVAL);
+}
+
+int
+bpf_map_update_elem(int fd, const void* key, const void* value, uint64_t flags)
+{
+    if (flags != 0) {
+        return libbpf_err(EBPF_INVALID_ARGUMENT);
+    }
+
+    ebpf_map_t* map = ebpf_map_lookup(fd);
+    if (map == nullptr) {
+        return libbpf_err(EBPF_INVALID_FD);
+    }
+
+    uint32_t result = 0;
+    switch (map->map_definition.type) {
+    case BPF_MAP_TYPE_PROG_ARRAY: {
+        fd_t program_fd = *(fd_t*)value;
+        ebpf_program_t* program = ebpf_program_lookup(program_fd);
+        if (program == nullptr) {
+            return libbpf_err(EBPF_INVALID_FD);
+        }
+        result = ebpf_api_map_update_element_with_handle(
+            map->map_handle,
+            map->map_definition.key_size,
+            (const uint8_t*)key,
+            map->map_definition.value_size,
+            (const uint8_t*)value,
+            program->handle);
+        break;
+    }
+    default:
+        result = ebpf_api_map_update_element(
+            map->map_handle,
+            map->map_definition.key_size,
+            (const uint8_t*)key,
+            map->map_definition.value_size,
+            (const uint8_t*)value);
+        break;
+    }
+
+    return libbpf_err(result);
 }

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -366,7 +366,7 @@ _ebpf_core_protocol_map_find_element(
         goto Done;
     }
 
-    value = ebpf_map_find_entry(map, request->key, FALSE);
+    value = ebpf_map_find_entry(map, request->key, 0);
     if (value == NULL) {
         retval = EBPF_KEY_NOT_FOUND;
         goto Done;
@@ -916,7 +916,7 @@ Exit:
 static void*
 _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 {
-    return ebpf_map_find_entry(map, key, TRUE);
+    return ebpf_map_find_entry(map, key, EBPF_MAP_FIND_ENTRY_FLAG_HELPER);
 }
 
 static int64_t

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -52,10 +52,9 @@ static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = 
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING}},
 };
 
-static ebpf_program_info_t _ebpf_global_helper_program_info = {
-    {"global_helper", NULL, {0}},
-    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_global_helper_program_info = {{"global_helper", NULL, {0}},
+                                                               EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
+                                                               _ebpf_map_helper_function_prototype};
 
 static const void* _ebpf_general_helpers[] = {NULL,
                                               (void*)&_ebpf_core_map_find_element,
@@ -616,9 +615,9 @@ static ebpf_result_t
 _ebpf_core_protocol_update_pinning(_In_ const struct _ebpf_operation_update_map_pinning_request* request)
 {
     ebpf_result_t retval;
-    const ebpf_utf8_string_t name = {
-        (uint8_t*)request->name,
-        request->header.length - EBPF_OFFSET_OF(ebpf_operation_update_pinning_request_t, name)};
+    const ebpf_utf8_string_t name = {(uint8_t*)request->name,
+                                     request->header.length -
+                                         EBPF_OFFSET_OF(ebpf_operation_update_pinning_request_t, name)};
     ebpf_object_t* object = NULL;
 
     if (name.length == 0) {
@@ -937,7 +936,7 @@ static long
 _ebpf_core_tail_call(void* context, ebpf_map_t* map, uint32_t index)
 {
     // Get program from map[index].
-    ebpf_program_t* callee = (ebpf_program_t*)ebpf_get_object_from_array_map(map, index);
+    ebpf_program_t* callee = ebpf_map_get_program_from_entry(map, (uint8_t*)&index, sizeof(index));
     if (callee == NULL) {
         return -1;
     }

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -39,10 +39,11 @@ extern "C"
      *
      * @param[in] map Map to search.
      * @param[in] key Key to use when searching map.
+     * @param[in] is_helper True if called by an eBPF program.
      * @return Pointer to the value if found or NULL.
      */
     uint8_t*
-    ebpf_map_find_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key);
+    ebpf_map_find_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, int is_helper);
 
     /**
      * @brief Insert or update an entry in the map.
@@ -56,6 +57,21 @@ extern "C"
      */
     ebpf_result_t
     ebpf_map_update_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value);
+
+    /**
+     * @brief Insert or update an entry in the map.
+     *
+     * @param[in] map Map to update.
+     * @param[in] key Key to use when searching and updating the map.
+     * @param[in] value Value to insert into the map.
+     * @param[in] value_handle Handle associated with the value.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  entry.
+     */
+    ebpf_result_t
+    ebpf_map_update_entry_with_handle(
+        _In_ ebpf_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, uintptr_t value_handle);
 
     /**
      * @brief Remove an entry from the map.
@@ -83,6 +99,18 @@ extern "C"
      */
     ebpf_result_t
     ebpf_map_next_key(_In_ ebpf_map_t* map, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
+
+    /**
+     * @brief Get an object from a map entry that holds objects, such
+     * as a program array or map of maps.  The object returned holds a
+     * reference that the caller is responsible for releasing.
+     *
+     * @param[in] map Array map to search.
+     * @param[in] index The index into the array.
+     * @returns Object pointer, or NULL if none.
+     */
+    _Ret_maybenull_ struct _ebpf_object*
+    ebpf_get_object_from_array_map(_In_ ebpf_map_t* map, uint32_t index);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -101,16 +101,17 @@ extern "C"
     ebpf_map_next_key(_In_ ebpf_map_t* map, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
 
     /**
-     * @brief Get an object from a map entry that holds objects, such
-     * as a program array or map of maps.  The object returned holds a
-     * reference that the caller is responsible for releasing.
+     * @brief Get a program from an entry in a map that holds programs.  The
+     * program returned holds a reference that the caller is responsible for
+     * releasing.
      *
-     * @param[in] map Array map to search.
-     * @param[in] index The index into the array.
-     * @returns Object pointer, or NULL if none.
+     * @param[in] map Map to search.
+     * @param[in] key Pointer to key to search for.
+     * @param[in] key_size Size of value to search for.
+     * @returns Program pointer, or NULL if none.
      */
-    _Ret_maybenull_ struct _ebpf_object*
-    ebpf_get_object_from_array_map(_In_ ebpf_map_t* map, uint32_t index);
+    _Ret_maybenull_ struct _ebpf_program*
+    ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, size_t key_size);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -34,16 +34,17 @@ extern "C"
     const ebpf_map_definition_t*
     ebpf_map_get_definition(_In_ const ebpf_map_t* map);
 
+#define EBPF_MAP_FIND_ENTRY_FLAG_HELPER 0x01 /* Called by an eBPF program */
     /**
      * @brief Get a pointer to an entry in the map.
      *
      * @param[in] map Map to search.
      * @param[in] key Key to use when searching map.
-     * @param[in] is_helper True if called by an eBPF program.
+     * @param[in] flags Zero or more EBPF_MAP_FIND_ENTRY_FLAG_* flags.
      * @return Pointer to the value if found or NULL.
      */
     uint8_t*
-    ebpf_map_find_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, int is_helper);
+    ebpf_map_find_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, int flags);
 
     /**
      * @brief Insert or update an entry in the map.

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -62,7 +62,7 @@ extern "C"
      * @brief Get properties describing the program instance.
      *
      * @param[in] program Program instance to query.
-     * @param[in] program_parameters Parameters of the program.
+     * @param[out] program_parameters Parameters of the program.
      */
     void
     ebpf_program_get_properties(ebpf_program_t* program, ebpf_program_parameters_t* program_parameters);

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -17,6 +17,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_LOAD_CODE,
     EBPF_OPERATION_MAP_FIND_ELEMENT,
     EBPF_OPERATION_MAP_UPDATE_ELEMENT,
+    EBPF_OPERATION_MAP_UPDATE_ELEMENT_WITH_HANDLE,
     EBPF_OPERATION_MAP_DELETE_ELEMENT,
     EBPF_OPERATION_MAP_GET_NEXT_KEY,
     EBPF_OPERATION_GET_NEXT_MAP,
@@ -131,6 +132,14 @@ typedef struct _ebpf_operation_map_update_element_request
     uint64_t handle;
     uint8_t data[1]; // data is key+value
 } epf_operation_map_update_element_request_t;
+
+typedef struct _ebpf_operation_map_update_element_with_handle_request
+{
+    struct _ebpf_operation_header header;
+    uintptr_t map_handle;
+    uintptr_t value_handle;
+    uint8_t data[1]; // data is key+value
+} epf_operation_map_update_element_with_handle_request_t;
 
 typedef struct _ebpf_operation_map_delete_element_request
 {

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -63,7 +63,7 @@ test_crud_operations(ebpf_map_type_t map_type)
 
     for (uint32_t key = 0; key < 10; key++) {
         uint64_t* value =
-            reinterpret_cast<uint64_t*>(ebpf_map_find_entry(map.get(), reinterpret_cast<const uint8_t*>(&key)));
+            reinterpret_cast<uint64_t*>(ebpf_map_find_entry(map.get(), reinterpret_cast<const uint8_t*>(&key), FALSE));
 
         REQUIRE(value != nullptr);
         REQUIRE(*value == key * key);

--- a/tests/client/main.cpp
+++ b/tests/client/main.cpp
@@ -24,7 +24,7 @@ _get_program_byte_code_helper(const char* file_name, const char* section_name, e
     int descriptors_count;
     ebpf_result_t result = EBPF_SUCCESS;
     const char* error_message = nullptr;
-    std::vector<ebpf_program_t*> programs;
+    ebpf_object_t object;
     ebpf_program_t* program;
 
     // Get byte code and map descriptors from ELF file.
@@ -33,7 +33,7 @@ _get_program_byte_code_helper(const char* file_name, const char* section_name, e
              file_name,
              section_name,
              true, // mock map fd
-             programs,
+             object,
              &descriptors,
              &descriptors_count,
              &error_message),
@@ -42,8 +42,8 @@ _get_program_byte_code_helper(const char* file_name, const char* section_name, e
          error_message = nullptr,
          result == EBPF_SUCCESS));
 
-    REQUIRE(programs.size() == 1);
-    program = programs[0];
+    REQUIRE(object.programs.size() == 1);
+    program = object.programs[0];
     REQUIRE(program->byte_code_size != 0);
 
     info->program_type = program->program_type;

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -63,9 +63,9 @@ typedef class _single_instance_hook
     }
 
     ebpf_result_t
-    fire(void* context, uint32_t* result)
+    fire(void* context, int* result)
     {
-        ebpf_result_t (*invoke_program)(void* link, void* context, uint32_t* result) =
+        ebpf_result_t (*invoke_program)(void* link, void* context, int* result) =
             reinterpret_cast<decltype(invoke_program)>(client_dispatch_table->function[0]);
 
         return invoke_program(client_binding_context, context, result);
@@ -115,17 +115,22 @@ typedef class _single_instance_hook
 
 static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = {
     {1,
-     "ebpf_map_lookup_element",
+     "bpf_map_lookup_elem",
      EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
     {2,
-     "ebpf_map_update_element",
+     "bpf_map_update_elem",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
     {3,
-     "ebpf_map_delete_element",
+     "bpf_map_delete_elem",
      EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}}};
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {4,
+     "bpf_tail_call",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING}},
+};
 
 static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {sizeof(xdp_md_t),
                                                                  EBPF_OFFSET_OF(xdp_md_t, data),
@@ -179,3 +184,6 @@ typedef class _program_info_provider
     ebpf_extension_data_t* provider_data;
     ebpf_extension_provider_t* provider;
 } program_info_provider_t;
+
+std::vector<uint8_t>
+prepare_udp_packet(uint16_t udp_length);

--- a/tests/sample/ebpf.h
+++ b/tests/sample/ebpf.h
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+// This file is included by sample eBPF programs.
+
 #if defined(_MSC_VER)
 typedef unsigned long long uint64_t;
 #else

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -178,6 +178,28 @@
       <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="tail_call.c">
+      <FileType>CppCode</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="tail_call_bad.c">
+      <FileType>CppCode</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/tests/sample/sample.vcxproj.filters
+++ b/tests/sample/sample.vcxproj.filters
@@ -42,5 +42,14 @@
     <CustomBuild Include="droppacket_unsafe.c">
       <Filter>Source Files</Filter>
     </CustomBuild>
+    <CustomBuild Include="test_ebpf.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="tail_call.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="tail_call_bad.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
   </ItemGroup>
 </Project>

--- a/tests/sample/tail_call.c
+++ b/tests/sample/tail_call.c
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// All of this file is cross-platform except the following
+// two includes.  TODO: make the include filename(s) also be
+// cross-platform for eBPF program portability.
+#include "ebpf_helpers.h"
+#include "ebpf_nethooks.h"
+
+__attribute__((section("maps"), used)) struct bpf_map map = {
+    sizeof(struct bpf_map), BPF_MAP_TYPE_PROG_ARRAY, sizeof(uint32_t), sizeof(uint32_t), 1};
+
+__attribute__((section("xdp_prog"), used)) int
+caller(struct xdp_md* ctx)
+{
+    bpf_tail_call(ctx, &map, 0);
+
+    // If we get to here it means bpf_tail_call failed.
+    return 6;
+}
+
+__attribute__((section("xdp_prog/0"), used)) int
+callee(struct xdp_md* ctx)
+{
+    return 42;
+}

--- a/tests/sample/tail_call_bad.c
+++ b/tests/sample/tail_call_bad.c
@@ -1,0 +1,26 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// All of this file is cross-platform except the following
+// two includes.  TODO: make the include filename(s) also be
+// cross-platform for eBPF program portability.
+#include "ebpf_helpers.h"
+#include "ebpf_nethooks.h"
+
+__attribute__((section("maps"), used)) struct bpf_map map = {
+    sizeof(struct bpf_map), BPF_MAP_TYPE_PROG_ARRAY, sizeof(uint32_t), sizeof(uint32_t), 1};
+
+__attribute__((section("xdp_prog"), used)) int
+caller(struct xdp_md* ctx)
+{
+    // This should fail since the index is past the end of the array.
+    long error = bpf_tail_call(ctx, &map, 1);
+
+    return (int)error;
+}
+
+__attribute__((section("xdp_prog/0"), used)) int
+callee(struct xdp_md* ctx)
+{
+    return 42;
+}

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
+#include "bpf.h"
 #include "catch_wrapper.hpp"
+#include "helpers.h"
 #pragma warning(push)
 #pragma warning(disable : 4200)
 #include "libbpf.h"
@@ -249,3 +251,67 @@ TEST_CASE("libbpf map pinning", "[libbpf]")
 
     bpf_object__close(object);
 }
+
+static void
+_ebpf_test_tail_call(_In_z_ const char* filename, int expected_result)
+{
+    _test_helper_end_to_end test_helper;
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
+
+    struct bpf_object* object;
+    int program_fd;
+    int error = bpf_prog_load(filename, BPF_PROG_TYPE_XDP, &object, &program_fd);
+    REQUIRE(error == 0);
+    REQUIRE(object != nullptr);
+
+    struct bpf_program* caller = bpf_object__find_program_by_name(object, "caller");
+    REQUIRE(caller != nullptr);
+
+    struct bpf_program* callee = bpf_object__find_program_by_name(object, "callee");
+    REQUIRE(callee != nullptr);
+
+    struct bpf_map* map = bpf_map__next(nullptr, object);
+    REQUIRE(map != nullptr);
+
+    int callee_fd = bpf_program__fd(callee);
+    REQUIRE(callee_fd >= 0);
+
+    int map_fd = bpf_map__fd(map);
+    REQUIRE(map_fd >= 0);
+
+    // First do some negative tests.
+    int index = 1;
+    int err = bpf_map_update_elem(map_fd, (uint8_t*)&index, (uint8_t*)&callee_fd, 0);
+    REQUIRE(err != 0);
+    index = 0;
+    int bad_fd = 0;
+    err = bpf_map_update_elem(map_fd, (uint8_t*)&index, (uint8_t*)&bad_fd, 0);
+    REQUIRE(err != 0);
+
+    // Finally store the correct program fd.
+    err = bpf_map_update_elem(map_fd, (uint8_t*)&index, (uint8_t*)&callee_fd, 0);
+    REQUIRE(err == 0);
+
+    bpf_link* link = bpf_program__attach_xdp(caller, 1);
+    REQUIRE(link != nullptr);
+
+    auto packet = prepare_udp_packet(0);
+    xdp_md_t ctx{packet.data(), packet.data() + packet.size()};
+    int result;
+    REQUIRE(hook.fire(&ctx, &result) == EBPF_SUCCESS);
+    REQUIRE(result == expected_result);
+
+    result = bpf_link__destroy(link);
+    REQUIRE(result == 0);
+    bpf_object__close(object);
+}
+
+TEST_CASE("good tail_call", "[libbpf]")
+{
+    // Verify that 42 is returned, which is done by the callee.
+    // TODO(issue #344): change the 6 below to 42 once tail call is done correctly.
+    _ebpf_test_tail_call("tail_call.o", 6);
+}
+
+TEST_CASE("bad tail_call", "[libbpf]") { _ebpf_test_tail_call("tail_call_bad.o", -1); }

--- a/tools/encode_program_info/encode_program_info.cpp
+++ b/tools/encode_program_info/encode_program_info.cpp
@@ -43,7 +43,11 @@ static ebpf_helper_function_prototype_t _ebpf_helper_function_prototype[] = {
     {3,
      "bpf_map_delete_elem",
      EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}}};
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {4,
+     "bpf_tail_call",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING}}};
 
 static ebpf_result_t
 _encode_bind()


### PR DESCRIPTION
This also fixes a bug where bpf_object__find_program_by_name
could only find the first program because program->object
was always null.

Also fixes tests to correctly use a signed int for what hooks return,
instead of an unsigned int.

Not done in this PR, but will be in a separate PR:
* make tail call replace stack frame instead of simply calling into the callee
* limit number of tail calls to 32
* require the same program type for caller and callee
* test with load from a byte array instead of from a file

Addresses part of #344

Signed-off-by: Dave Thaler <dthaler@microsoft.com>