### PR TITLE
Revert "Add code to propagate flags for helper functions."

### DIFF
--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -28,8 +28,6 @@ typedef struct _ebpf_program_type_descriptor
     char is_privileged;
 } ebpf_program_type_descriptor_t;
 
-#define EBPF_HELPER_FUNCTION_FLAGS_UNWIND_ON_SUCCESS 0x2
-
 typedef struct _ebpf_helper_function_prototype
 {
     uint32_t helper_id;
@@ -37,7 +35,6 @@ typedef struct _ebpf_helper_function_prototype
     const char* name;
     ebpf_return_type_t return_type;
     ebpf_argument_type_t arguments[5];
-    uint64_t flags;
 } ebpf_helper_function_prototype_t;
 
 typedef struct _ebpf_program_info

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -34,53 +34,39 @@ _ebpf_core_tail_call(void* ctx, ebpf_map_t* map, uint32_t index);
 #define EBPF_CORE_GLOBAL_HELPER_EXTENSION_VERSION 0
 
 static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = {
-    {
-        (uint32_t)(intptr_t)bpf_map_lookup_elem,
-        "bpf_map_lookup_elem",
-        EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY},
-        0,
-    },
-    {
-        (uint32_t)(intptr_t)bpf_map_update_elem,
-        "bpf_map_update_elem",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE},
-        0,
-    },
-    {
-        (uint32_t)(intptr_t)bpf_map_delete_elem,
-        "bpf_map_delete_elem",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY},
-        0,
-    },
-    {
-        (uint32_t)(intptr_t)bpf_tail_call,
-        "bpf_tail_call",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING},
-        EBPF_HELPER_FUNCTION_FLAGS_UNWIND_ON_SUCCESS,
-    },
+    {(uint32_t)(intptr_t)bpf_map_lookup_elem,
+     "bpf_map_lookup_elem",
+     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {(uint32_t)(intptr_t)bpf_map_update_elem,
+     "bpf_map_update_elem",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
+    {(uint32_t)(intptr_t)bpf_map_delete_elem,
+     "bpf_map_delete_elem",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {(uint32_t)(intptr_t)bpf_tail_call,
+     "bpf_tail_call",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING}},
 };
 
-static ebpf_program_info_t _ebpf_global_helper_program_info = {
-    {"global_helper", NULL, {0}},
-    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_global_helper_program_info = {{"global_helper", NULL, {0}},
+                                                               EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
+                                                               _ebpf_map_helper_function_prototype};
 
-static const void* _ebpf_general_helpers[] = {
-    NULL,
-    (void*)&_ebpf_core_map_find_element,
-    (void*)&_ebpf_core_map_update_element,
-    (void*)&_ebpf_core_map_delete_element,
-    (void*)&_ebpf_core_tail_call};
+static const void* _ebpf_general_helpers[] = {NULL,
+                                              (void*)&_ebpf_core_map_find_element,
+                                              (void*)&_ebpf_core_map_update_element,
+                                              (void*)&_ebpf_core_map_delete_element,
+                                              (void*)&_ebpf_core_tail_call};
 
 static ebpf_extension_provider_t* _ebpf_global_helper_function_provider_context = NULL;
 static ebpf_helper_function_addresses_t _ebpf_global_helper_function_dispatch_table = {
     EBPF_COUNT_OF(_ebpf_general_helpers), (uint64_t*)_ebpf_general_helpers};
-static ebpf_program_data_t _ebpf_global_helper_function_program_data = {
-    &_ebpf_global_helper_program_info, &_ebpf_global_helper_function_dispatch_table};
+static ebpf_program_data_t _ebpf_global_helper_function_program_data = {&_ebpf_global_helper_program_info,
+                                                                        &_ebpf_global_helper_function_dispatch_table};
 
 static ebpf_extension_data_t _ebpf_global_helper_function_extension_data = {
     EBPF_CORE_GLOBAL_HELPER_EXTENSION_VERSION,
@@ -643,9 +629,9 @@ static ebpf_result_t
 _ebpf_core_protocol_update_pinning(_In_ const struct _ebpf_operation_update_map_pinning_request* request)
 {
     ebpf_result_t retval;
-    const ebpf_utf8_string_t name = {
-        (uint8_t*)request->name,
-        request->header.length - EBPF_OFFSET_OF(ebpf_operation_update_pinning_request_t, name)};
+    const ebpf_utf8_string_t name = {(uint8_t*)request->name,
+                                     request->header.length -
+                                         EBPF_OFFSET_OF(ebpf_operation_update_pinning_request_t, name)};
     ebpf_object_t* object = NULL;
 
     if (name.length == 0) {

--- a/libs/platform/ebpf_serialize.c
+++ b/libs/platform/ebpf_serialize.c
@@ -27,7 +27,6 @@ typedef struct _ebpf_serialized_helper_function_prototype
     size_t size;
     uint32_t helper_id;
     ebpf_return_type_t return_type;
-    uint64_t flags;
     ebpf_argument_type_t arguments[5];
     size_t name_length;
     uint8_t name[1];
@@ -392,7 +391,6 @@ ebpf_serialize_program_info(
                 EBPF_OFFSET_OF(ebpf_serialized_helper_function_prototype_t, name) + helper_function_name_length;
             serialized_helper_prototype->helper_id = helper_prototype->helper_id;
             serialized_helper_prototype->return_type = helper_prototype->return_type;
-            serialized_helper_prototype->flags = helper_prototype->flags;
             for (uint16_t index = 0; index < EBPF_COUNT_OF(helper_prototype->arguments); index++) {
                 serialized_helper_prototype->arguments[index] = helper_prototype->arguments[index];
             }
@@ -559,7 +557,6 @@ ebpf_deserialize_program_info(
         // Serialize helper prototype.
         helper_prototype->helper_id = serialized_helper_prototype->helper_id;
         helper_prototype->return_type = serialized_helper_prototype->return_type;
-        helper_prototype->flags = serialized_helper_prototype->flags;
         for (int i = 0; i < EBPF_COUNT_OF(helper_prototype->arguments); i++)
             helper_prototype->arguments[i] = serialized_helper_prototype->arguments[i];
 

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -197,14 +197,14 @@ TEST_CASE("trampoline_test", "[platform]")
     auto provider_function1 = []() { return EBPF_SUCCESS; };
     ebpf_result_t (*function_pointer1)() = provider_function1;
     const void* helper_functions1[] = {(void*)function_pointer1};
-    ebpf_helper_function_addresses_t helper_function_addresses1 = {
-        EBPF_COUNT_OF(helper_functions1), (uint64_t*)helper_functions1};
+    ebpf_helper_function_addresses_t helper_function_addresses1 = {EBPF_COUNT_OF(helper_functions1),
+                                                                   (uint64_t*)helper_functions1};
 
     auto provider_function2 = []() { return EBPF_OBJECT_ALREADY_EXISTS; };
     ebpf_result_t (*function_pointer2)() = provider_function2;
     const void* helper_functions2[] = {(void*)function_pointer2};
-    ebpf_helper_function_addresses_t helper_function_addresses2 = {
-        EBPF_COUNT_OF(helper_functions1), (uint64_t*)helper_functions2};
+    ebpf_helper_function_addresses_t helper_function_addresses2 = {EBPF_COUNT_OF(helper_functions1),
+                                                                   (uint64_t*)helper_functions2};
 
     REQUIRE(ebpf_allocate_trampoline_table(1, &table) == EBPF_SUCCESS);
     REQUIRE(ebpf_update_trampoline_table(table, &helper_function_addresses1) == EBPF_SUCCESS);
@@ -221,45 +221,32 @@ TEST_CASE("trampoline_test", "[platform]")
 }
 
 static ebpf_helper_function_prototype_t _helper_functions[] = {
-    {
-        1,
-        "bpf_map_lookup_elem",
-        EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY},
-        0,
-    },
-    {
-        2,
-        "bpf_map_update_elem",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE},
-        0,
-    },
-    {
-        3,
-        "bpf_map_delete_elem",
-        EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY},
-        0,
-    },
-    {
-        4,
-        "bpf_tail_call",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING},
-        EBPF_HELPER_FUNCTION_FLAGS_UNWIND_ON_SUCCESS,
-    },
+    {1,
+     "bpf_map_lookup_elem",
+     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {2,
+     "bpf_map_update_elem",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
+    {3,
+     "bpf_map_delete_elem",
+     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {4,
+     "bpf_tail_call",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING}},
 };
 
 TEST_CASE("program_type_info", "[platform]")
 {
     _test_helper test_helper;
 
-    ebpf_context_descriptor_t context_descriptor{
-        sizeof(xdp_md_t),
-        EBPF_OFFSET_OF(xdp_md_t, data),
-        EBPF_OFFSET_OF(xdp_md_t, data_end),
-        EBPF_OFFSET_OF(xdp_md_t, data_meta)};
+    ebpf_context_descriptor_t context_descriptor{sizeof(xdp_md_t),
+                                                 EBPF_OFFSET_OF(xdp_md_t, data),
+                                                 EBPF_OFFSET_OF(xdp_md_t, data_end),
+                                                 EBPF_OFFSET_OF(xdp_md_t, data_meta)};
     ebpf_program_type_descriptor_t program_type{"xdp", &context_descriptor};
     ebpf_program_info_t program_info{program_type, _countof(_helper_functions), _helper_functions};
     ebpf_program_info_t* new_program_info = nullptr;
@@ -422,20 +409,14 @@ TEST_CASE("serialize_program_info_test", "[platform]")
     _test_helper test_helper;
 
     ebpf_helper_function_prototype_t helper_prototype[] = {
-        {
-            1000,
-            "helper_0",
-            EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-            {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY},
-            1234,
-        },
-        {
-            1001,
-            "helper_1",
-            EBPF_RETURN_TYPE_INTEGER,
-            {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE},
-            5678,
-        }};
+        {1000,
+         "helper_0",
+         EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
+         {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+        {1001,
+         "helper_1",
+         EBPF_RETURN_TYPE_INTEGER,
+         {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}}};
     // The values of the fields in the context_descriptor variable are completely arbitrary
     // and have no effect on the test.
     ebpf_context_descriptor_t context_descriptor = {32, 0, 8, -1};
@@ -490,7 +471,6 @@ TEST_CASE("serialize_program_info_test", "[platform]")
         ebpf_helper_function_prototype_t* out_prototype = &out_program_info->helper_prototype[i];
         REQUIRE(in_prototype->helper_id == out_prototype->helper_id);
         REQUIRE(in_prototype->return_type == out_prototype->return_type);
-        REQUIRE(in_prototype->flags == out_prototype->flags);
         for (int j = 0; j < _countof(in_prototype->arguments); j++)
             REQUIRE(in_prototype->arguments[j] == out_prototype->arguments[j]);
         REQUIRE(out_prototype->name != nullptr);

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -22,42 +22,32 @@
 // f788ef4a-207d-4dc3-85cf-0f2ea107213c
 DEFINE_GUID(EBPF_PROGRAM_TYPE_SAMPLE, 0xf788ef4a, 0x207d, 0x4dc3, 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c);
 
-static ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {
-    sizeof(test_program_context_t),
-    EBPF_OFFSET_OF(test_program_context_t, data_start),
-    EBPF_OFFSET_OF(test_program_context_t, data_end),
-    -1};
+static ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {sizeof(test_program_context_t),
+                                                                    EBPF_OFFSET_OF(test_program_context_t, data_start),
+                                                                    EBPF_OFFSET_OF(test_program_context_t, data_end),
+                                                                    -1};
 
 // Test Extension Helper function prototype descriptors.
 static ebpf_helper_function_prototype_t _sample_ebpf_extension_helper_function_prototype[] = {
-    {
-        EBPF_MAX_GENERAL_HELPER_FUNCTION + 1,
-        "sample_ebpf_extension_helper_function1",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_CTX},
-        0,
-    },
-    {
-        EBPF_MAX_GENERAL_HELPER_FUNCTION + 2,
-        "sample_ebpf_extension_find",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-         EBPF_ARGUMENT_TYPE_CONST_SIZE,
-         EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-         EBPF_ARGUMENT_TYPE_CONST_SIZE},
-        0,
-    },
-    {
-        EBPF_MAX_GENERAL_HELPER_FUNCTION + 3,
-        "sample_ebpf_extension_replace",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-         EBPF_ARGUMENT_TYPE_CONST_SIZE,
-         EBPF_ARGUMENT_TYPE_ANYTHING,
-         EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-         EBPF_ARGUMENT_TYPE_CONST_SIZE},
-        0,
-    }};
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 1,
+     "sample_ebpf_extension_helper_function1",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 2,
+     "sample_ebpf_extension_find",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
+      EBPF_ARGUMENT_TYPE_CONST_SIZE,
+      EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
+      EBPF_ARGUMENT_TYPE_CONST_SIZE}},
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 3,
+     "sample_ebpf_extension_replace",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
+      EBPF_ARGUMENT_TYPE_CONST_SIZE,
+      EBPF_ARGUMENT_TYPE_ANYTHING,
+      EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
+      EBPF_ARGUMENT_TYPE_CONST_SIZE}}};
 
 static ebpf_program_info_t _sample_ebpf_extension_program_info = {
     {"sample", &_sample_ebpf_context_descriptor, {0}},
@@ -73,10 +63,9 @@ static int64_t
 _sample_ebpf_extension_replace(
     _In_ const void* buffer, uint32_t size, int64_t position, _In_ const void* replace, uint32_t arg_size);
 
-static const void* _sample_ebpf_extension_helpers[] = {
-    (void*)&_sample_ebpf_extension_helper_function1,
-    (void*)&_sample_ebpf_extension_find,
-    (void*)&_sample_ebpf_extension_replace};
+static const void* _sample_ebpf_extension_helpers[] = {(void*)&_sample_ebpf_extension_helper_function1,
+                                                       (void*)&_sample_ebpf_extension_find,
+                                                       (void*)&_sample_ebpf_extension_replace};
 
 static ebpf_helper_function_addresses_t _sample_ebpf_extension_helper_function_address_table = {
     EBPF_COUNT_OF(_sample_ebpf_extension_helpers), (uint64_t*)_sample_ebpf_extension_helpers};
@@ -212,10 +201,9 @@ _sample_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_c
 // Test eBPF extension Hook NPI provider characteristics
 ebpf_attach_provider_data_t _sample_ebpf_extension_attach_provider_data;
 
-ebpf_extension_data_t _sample_ebpf_extension_hook_provider_data = {
-    EBPF_ATTACH_PROVIDER_DATA_VERSION,
-    sizeof(_sample_ebpf_extension_attach_provider_data),
-    &_sample_ebpf_extension_attach_provider_data};
+ebpf_extension_data_t _sample_ebpf_extension_hook_provider_data = {EBPF_ATTACH_PROVIDER_DATA_VERSION,
+                                                                   sizeof(_sample_ebpf_extension_attach_provider_data),
+                                                                   &_sample_ebpf_extension_attach_provider_data};
 
 const NPI_PROVIDER_CHARACTERISTICS _sample_ebpf_extension_hook_provider_characteristics = {
     0,

--- a/tools/encode_program_info/encode_program_info.cpp
+++ b/tools/encode_program_info/encode_program_info.cpp
@@ -32,34 +32,22 @@ _emit_program_info_file(const char* file_name, const char* symbol_name, uint8_t*
 }
 
 static ebpf_helper_function_prototype_t _ebpf_helper_function_prototype[] = {
-    {
-        1,
-        "bpf_map_lookup_elem",
-        EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY},
-        0,
-    },
-    {
-        2,
-        "bpf_map_update_elem",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE},
-        0,
-    },
-    {
-        3,
-        "bpf_map_delete_elem",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY},
-        0,
-    },
-    {
-        4,
-        "bpf_tail_call",
-        EBPF_RETURN_TYPE_INTEGER,
-        {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING},
-        EBPF_HELPER_FUNCTION_FLAGS_UNWIND_ON_SUCCESS,
-    }};
+    {1,
+     "bpf_map_lookup_elem",
+     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {2,
+     "bpf_map_update_elem",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
+    {3,
+     "bpf_map_delete_elem",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {4,
+     "bpf_tail_call",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_ANYTHING}}};
 
 static ebpf_result_t
 _encode_bind()
@@ -96,11 +84,10 @@ _encode_xdp()
     ebpf_result_t return_value;
     uint8_t* buffer = NULL;
     unsigned long buffer_size = 0;
-    ebpf_context_descriptor_t xdp_context_descriptor = {
-        sizeof(xdp_md_t),
-        EBPF_OFFSET_OF(xdp_md_t, data),
-        EBPF_OFFSET_OF(xdp_md_t, data_end),
-        EBPF_OFFSET_OF(xdp_md_t, data_meta)};
+    ebpf_context_descriptor_t xdp_context_descriptor = {sizeof(xdp_md_t),
+                                                        EBPF_OFFSET_OF(xdp_md_t, data),
+                                                        EBPF_OFFSET_OF(xdp_md_t, data_end),
+                                                        EBPF_OFFSET_OF(xdp_md_t, data_meta)};
     ebpf_program_type_descriptor_t xdp_program_type = {"xdp", &xdp_context_descriptor, EBPF_PROGRAM_TYPE_XDP};
     ebpf_program_info_t xdp_program_info = {
         xdp_program_type, EBPF_COUNT_OF(_ebpf_helper_function_prototype), _ebpf_helper_function_prototype};


### PR DESCRIPTION
Reverts microsoft/ebpf-for-windows#365

Not necessary now that we have clarified that the return_type provides the information necessary to tell whether stack unwind is needed.