### PR TITLE
Add support for per-cpu hash and array maps - Part 1

### DIFF
--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -16,6 +16,8 @@ typedef enum bpf_map_type
     BPF_MAP_TYPE_ARRAY = 2,       ///< Array, where the map key is the array index.
     BPF_MAP_TYPE_PROG_ARRAY =
         3, ///< Array of program fds usable with bpf_tail_call, where the map key is the array index.
+    BPF_MAP_TYPE_PERCPU_HASH = 4,
+    BPF_MAP_TYPE_PERCPU_ARRAY = 5,
 } ebpf_map_type_t;
 
 /**

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -111,6 +111,8 @@ static const EbpfMapType windows_map_types[] = {
     {BPF_MAP_TYPE(HASH)},
     {BPF_MAP_TYPE(ARRAY), true},
     {BPF_MAP_TYPE(PROG_ARRAY), true, EbpfMapValueType::PROGRAM},
+    {BPF_MAP_TYPE(PERCPU_HASH)},
+    {BPF_MAP_TYPE(PERCPU_ARRAY), true},
 };
 
 EbpfMapType

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -52,23 +52,21 @@ static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = 
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS, EBPF_ARGUMENT_TYPE_ANYTHING}},
 };
 
-static ebpf_program_info_t _ebpf_global_helper_program_info = {
-    {"global_helper", NULL, {0}},
-    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_global_helper_program_info = {{"global_helper", NULL, {0}},
+                                                               EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
+                                                               _ebpf_map_helper_function_prototype};
 
-static const void* _ebpf_general_helpers[] = {
-    NULL,
-    (void*)&_ebpf_core_map_find_element,
-    (void*)&_ebpf_core_map_update_element,
-    (void*)&_ebpf_core_map_delete_element,
-    (void*)&_ebpf_core_tail_call};
+static const void* _ebpf_general_helpers[] = {NULL,
+                                              (void*)&_ebpf_core_map_find_element,
+                                              (void*)&_ebpf_core_map_update_element,
+                                              (void*)&_ebpf_core_map_delete_element,
+                                              (void*)&_ebpf_core_tail_call};
 
 static ebpf_extension_provider_t* _ebpf_global_helper_function_provider_context = NULL;
 static ebpf_helper_function_addresses_t _ebpf_global_helper_function_dispatch_table = {
     EBPF_COUNT_OF(_ebpf_general_helpers), (uint64_t*)_ebpf_general_helpers};
-static ebpf_program_data_t _ebpf_global_helper_function_program_data = {
-    &_ebpf_global_helper_program_info, &_ebpf_global_helper_function_dispatch_table};
+static ebpf_program_data_t _ebpf_global_helper_function_program_data = {&_ebpf_global_helper_program_info,
+                                                                        &_ebpf_global_helper_function_dispatch_table};
 
 static ebpf_extension_data_t _ebpf_global_helper_function_extension_data = {
     EBPF_CORE_GLOBAL_HELPER_EXTENSION_VERSION,
@@ -367,27 +365,6 @@ Done:
     return retval;
 }
 
-static bool
-_ebpf_is_find_update_delete_operation_permitted_on_map(_In_ const ebpf_map_definition_t* map_definition)
-{
-    switch (map_definition->type) {
-    case BPF_MAP_TYPE_UNSPECIFIED:
-        return false;
-    case BPF_MAP_TYPE_HASH:
-        return true;
-    case BPF_MAP_TYPE_ARRAY:
-        return true;
-    case BPF_MAP_TYPE_PROG_ARRAY:
-        return true;
-    case BPF_MAP_TYPE_PERCPU_HASH:
-        return false;
-    case BPF_MAP_TYPE_PERCPU_ARRAY:
-        return false;
-    default:
-        return false;
-    }
-}
-
 static ebpf_result_t
 _ebpf_core_protocol_map_find_element(
     _In_ const ebpf_operation_map_find_element_request_t* request,
@@ -403,11 +380,6 @@ _ebpf_core_protocol_map_find_element(
         goto Done;
 
     const ebpf_map_definition_t* map_definition = ebpf_map_get_definition(map);
-
-    if (!_ebpf_is_find_update_delete_operation_permitted_on_map(map_definition)) {
-        retval = EBPF_INVALID_ARGUMENT;
-        goto Done;
-    }
 
     if (request->header.length <
         (EBPF_OFFSET_OF(ebpf_operation_map_find_element_request_t, key) + map_definition->key_size)) {
@@ -446,11 +418,6 @@ _ebpf_core_protocol_map_update_element(_In_ const epf_operation_map_update_eleme
 
     const ebpf_map_definition_t* map_definition = ebpf_map_get_definition(map);
 
-    if (!_ebpf_is_find_update_delete_operation_permitted_on_map(map_definition)) {
-        retval = EBPF_INVALID_ARGUMENT;
-        goto Done;
-    }
-
     if (request->header.length < (EBPF_OFFSET_OF(epf_operation_map_update_element_request_t, data) +
                                   map_definition->key_size + map_definition->value_size)) {
         retval = EBPF_INVALID_ARGUMENT;
@@ -477,11 +444,6 @@ _ebpf_core_protocol_map_update_element_with_handle(
 
     const ebpf_map_definition_t* map_definition = ebpf_map_get_definition(map);
 
-    if (!_ebpf_is_find_update_delete_operation_permitted_on_map(map_definition)) {
-        retval = EBPF_INVALID_ARGUMENT;
-        goto Done;
-    }
-
     if (request->header.length < (EBPF_OFFSET_OF(epf_operation_map_update_element_with_handle_request_t, data) +
                                   map_definition->key_size + map_definition->value_size)) {
         retval = EBPF_INVALID_ARGUMENT;
@@ -507,11 +469,6 @@ _ebpf_core_protocol_map_delete_element(_In_ const ebpf_operation_map_delete_elem
         goto Done;
 
     const ebpf_map_definition_t* map_definition = ebpf_map_get_definition(map);
-
-    if (!_ebpf_is_find_update_delete_operation_permitted_on_map(map_definition)) {
-        retval = EBPF_INVALID_ARGUMENT;
-        goto Done;
-    }
 
     if (request->header.length <
         (EBPF_OFFSET_OF(ebpf_operation_map_delete_element_request_t, key) + map_definition->key_size)) {
@@ -542,11 +499,6 @@ _ebpf_core_protocol_map_get_next_key(
         goto Done;
 
     const ebpf_map_definition_t* map_definition = ebpf_map_get_definition(map);
-
-    if (!_ebpf_is_find_update_delete_operation_permitted_on_map(map_definition)) {
-        retval = EBPF_INVALID_ARGUMENT;
-        goto Done;
-    }
 
     // If request length shows zero key, treat as restart.
     if (request->header.length == EBPF_OFFSET_OF(ebpf_operation_map_get_next_key_request_t, previous_key)) {
@@ -699,9 +651,9 @@ static ebpf_result_t
 _ebpf_core_protocol_update_pinning(_In_ const struct _ebpf_operation_update_map_pinning_request* request)
 {
     ebpf_result_t retval;
-    const ebpf_utf8_string_t name = {
-        (uint8_t*)request->name,
-        request->header.length - EBPF_OFFSET_OF(ebpf_operation_update_pinning_request_t, name)};
+    const ebpf_utf8_string_t name = {(uint8_t*)request->name,
+                                     request->header.length -
+                                         EBPF_OFFSET_OF(ebpf_operation_update_pinning_request_t, name)};
     ebpf_object_t* object = NULL;
 
     if (name.length == 0) {

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -537,6 +537,10 @@ _get_hash_table_for_cpu(_In_ ebpf_core_map_t* map)
     uint32_t current_cpu;
     ebpf_core_map_per_cpu_t* per_cpu = NULL;
     ebpf_hash_table_t** tables;
+    if (ebpf_is_preemptible()) {
+        return NULL;
+    }
+
     current_cpu = ebpf_get_current_cpu();
     per_cpu = (ebpf_core_map_per_cpu_t*)map->data;
     tables = (ebpf_hash_table_t**)&per_cpu->data;
@@ -677,6 +681,10 @@ _get_array_table_for_cpu(_In_ ebpf_core_map_t* map)
     size_t offset = (size_t)map->ebpf_map_definition.max_entries * (size_t)map->ebpf_map_definition.value_size;
     uint32_t current_cpu;
     ebpf_core_map_per_cpu_t* per_cpu = NULL;
+    if (ebpf_is_preemptible()) {
+        return NULL;
+    }
+
     current_cpu = ebpf_get_current_cpu();
     per_cpu = (ebpf_core_map_per_cpu_t*)map->data;
     if (current_cpu < per_cpu->count) {
@@ -786,6 +794,7 @@ ebpf_map_function_table_t ebpf_map_function_tables[] = {
     {// BPF_MAP_TYPE_HASH
      _create_hash_map_per_cpu,
      _delete_hash_map_per_cpu,
+     NULL,
      _find_hash_map_entry_per_cpu,
      NULL,
      _update_hash_map_entry_per_cpu,
@@ -795,6 +804,7 @@ ebpf_map_function_table_t ebpf_map_function_tables[] = {
     {// BPF_MAP_TYPE_ARRAY
      _create_array_map_per_cpu,
      _delete_array_map_per_cpu,
+     NULL,
      _find_array_map_entry_per_cpu,
      NULL,
      _update_array_map_entry_per_cpu,

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -37,6 +37,12 @@ typedef struct _ebpf_map_function_table
     ebpf_result_t (*next_key)(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
 } ebpf_map_function_table_t;
 
+typedef struct _ebpf_core_map_per_cpu
+{
+    uint32_t count;
+    uint8_t data[1];
+} ebpf_core_map_per_cpu_t;
+
 const ebpf_map_definition_t*
 ebpf_map_get_definition(_In_ const ebpf_map_t* map)
 {
@@ -439,6 +445,311 @@ _next_hash_map_key(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key, 
     return result;
 }
 
+static ebpf_core_map_t*
+_create_hash_map_per_cpu(_In_ const ebpf_map_definition_t* map_definition)
+{
+    ebpf_result_t retval;
+    size_t map_size = sizeof(ebpf_core_map_t);
+    ebpf_core_map_t* map = NULL;
+    uint32_t cpu_count;
+    uint32_t index;
+    size_t per_cpu_size = 0;
+    ebpf_core_map_per_cpu_t* per_cpu = NULL;
+
+    ebpf_get_cpu_count(&cpu_count);
+
+    retval = ebpf_safe_size_t_multiply(sizeof(ebpf_hash_table_t*), cpu_count, &per_cpu_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    retval = ebpf_safe_size_t_add(EBPF_OFFSET_OF(ebpf_core_map_per_cpu_t, data), per_cpu_size, &per_cpu_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    retval = ebpf_safe_size_t_add(per_cpu_size, map_size, &map_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    map = ebpf_allocate(map_size);
+    if (map == NULL) {
+        retval = EBPF_NO_MEMORY;
+        goto Done;
+    }
+
+    map->ebpf_map_definition = *map_definition;
+    map->data = (uint8_t*)(map + 1);
+    per_cpu = (ebpf_core_map_per_cpu_t*)map->data;
+
+    for (index = 0; index < cpu_count; index++) {
+        ebpf_hash_table_t** tables = (ebpf_hash_table_t**)&per_cpu->data;
+        retval = ebpf_hash_table_create(
+            tables + index,
+            ebpf_epoch_allocate,
+            ebpf_epoch_free,
+            map->ebpf_map_definition.key_size,
+            map->ebpf_map_definition.value_size,
+            NULL);
+        if (retval != EBPF_SUCCESS) {
+            goto Done;
+        }
+    }
+
+    map->data = (uint8_t*)per_cpu;
+    per_cpu->count = cpu_count;
+
+    ebpf_lock_create(&map->lock);
+    retval = EBPF_SUCCESS;
+
+Done:
+    if (retval != EBPF_SUCCESS) {
+        if (per_cpu) {
+            for (index = 0; index < per_cpu->count; index++) {
+                ebpf_hash_table_t** tables = (ebpf_hash_table_t**)&per_cpu->data;
+                ebpf_hash_table_destroy(tables[index]);
+            }
+        }
+        ebpf_free(map);
+        map = NULL;
+    }
+    return map;
+}
+
+static void
+_delete_hash_map_per_cpu(_In_ ebpf_core_map_t* map)
+{
+    uint32_t index;
+    ebpf_core_map_per_cpu_t* per_cpu = NULL;
+    ebpf_lock_destroy(&map->lock);
+    per_cpu = (ebpf_core_map_per_cpu_t*)map->data;
+    for (index = 0; index < per_cpu->count; index++) {
+        ebpf_hash_table_t** tables = (ebpf_hash_table_t**)&per_cpu->data;
+        ebpf_hash_table_destroy(tables[index]);
+    }
+    ebpf_free(map);
+}
+
+static ebpf_hash_table_t*
+_get_hash_table_for_cpu(_In_ ebpf_core_map_t* map)
+{
+    uint32_t current_cpu;
+    ebpf_core_map_per_cpu_t* per_cpu = NULL;
+    ebpf_hash_table_t** tables;
+    current_cpu = ebpf_get_current_cpu();
+    per_cpu = (ebpf_core_map_per_cpu_t*)map->data;
+    tables = (ebpf_hash_table_t**)&per_cpu->data;
+    if (current_cpu < per_cpu->count) {
+        return tables[current_cpu];
+    } else {
+        return NULL;
+    }
+}
+
+static uint8_t*
+_find_hash_map_entry_per_cpu(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+{
+    uint8_t* value = NULL;
+    ebpf_hash_table_t* table;
+    if (!map || !key)
+        return NULL;
+
+    table = _get_hash_table_for_cpu(map);
+    if (!table)
+        return NULL;
+
+    if (ebpf_hash_table_find(table, key, &value) != EBPF_SUCCESS) {
+        value = NULL;
+    }
+
+    return value;
+}
+
+static ebpf_result_t
+_update_hash_map_entry_per_cpu(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* data)
+{
+    ebpf_result_t result;
+    ebpf_hash_table_t* table;
+    size_t entry_count = 0;
+    uint8_t* value;
+    if (!map || !key || !data)
+        return EBPF_INVALID_ARGUMENT;
+
+    table = _get_hash_table_for_cpu(map);
+    if (!table)
+        return EBPF_INVALID_ARGUMENT;
+
+    entry_count = ebpf_hash_table_key_count(table);
+
+    if ((entry_count == map->ebpf_map_definition.max_entries) &&
+        (ebpf_hash_table_find(table, key, &value) != EBPF_SUCCESS))
+        result = EBPF_INVALID_ARGUMENT;
+    else
+        result = ebpf_hash_table_update(table, key, data);
+
+    return result;
+}
+
+static ebpf_result_t
+_delete_hash_map_entry_per_cpu(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+{
+    ebpf_result_t result;
+    ebpf_hash_table_t* table;
+    if (!map || !key)
+        return EBPF_INVALID_ARGUMENT;
+
+    table = _get_hash_table_for_cpu(map);
+    if (!table)
+        return EBPF_INVALID_ARGUMENT;
+
+    result = ebpf_hash_table_delete(_get_hash_table_for_cpu(map), key);
+    return result;
+}
+
+static ebpf_result_t
+_next_hash_map_key_per_cpu(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
+{
+    ebpf_result_t result;
+    if (!map || !next_key)
+        return EBPF_INVALID_ARGUMENT;
+
+    result = ebpf_hash_table_next_key(_get_hash_table_for_cpu(map), previous_key, next_key);
+    return result;
+}
+
+static ebpf_core_map_t*
+_create_array_map_per_cpu(_In_ const ebpf_map_definition_t* map_definition)
+{
+    ebpf_result_t retval;
+    uint32_t cpu_count;
+    size_t map_entry_size = sizeof(ebpf_core_map_t);
+    size_t map_data_size = 0;
+    ebpf_core_map_t* map = NULL;
+    ebpf_core_map_per_cpu_t* per_cpu = NULL;
+    ebpf_get_cpu_count(&cpu_count);
+
+    retval = ebpf_safe_size_t_multiply(map_definition->max_entries, map_definition->value_size, &map_data_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    retval = ebpf_safe_size_t_multiply(map_data_size, cpu_count, &map_data_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    retval = ebpf_safe_size_t_add(map_data_size, EBPF_OFFSET_OF(ebpf_core_map_per_cpu_t, data), &map_data_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    retval = ebpf_safe_size_t_add(map_data_size, map_entry_size, &map_entry_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    // allocate
+    map = ebpf_allocate(map_entry_size);
+    if (map == NULL) {
+        goto Done;
+    }
+
+    map->ebpf_map_definition = *map_definition;
+    map->data = (uint8_t*)(map + 1);
+
+    per_cpu = (ebpf_core_map_per_cpu_t*)map->data;
+    per_cpu->count = cpu_count;
+
+Done:
+    return map;
+}
+
+static void
+_delete_array_map_per_cpu(_In_ ebpf_core_map_t* map)
+{
+    ebpf_free(map);
+}
+
+static uint8_t*
+_get_array_table_for_cpu(_In_ ebpf_core_map_t* map)
+{
+    size_t offset = (size_t)map->ebpf_map_definition.max_entries * (size_t)map->ebpf_map_definition.value_size;
+    uint32_t current_cpu;
+    ebpf_core_map_per_cpu_t* per_cpu = NULL;
+    current_cpu = ebpf_get_current_cpu();
+    per_cpu = (ebpf_core_map_per_cpu_t*)map->data;
+    if (current_cpu < per_cpu->count) {
+        return per_cpu->data + current_cpu * offset;
+    } else {
+        return NULL;
+    }
+}
+
+static uint8_t*
+_find_array_map_entry_per_cpu(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+{
+    uint8_t* data;
+    uint32_t key_value;
+    if (!map || !key)
+        return NULL;
+
+    key_value = *(uint32_t*)key;
+
+    if (key_value > map->ebpf_map_definition.max_entries)
+        return NULL;
+
+    data = _get_array_table_for_cpu(map);
+    if (!data) {
+        return NULL;
+    }
+
+    return &data[map->ebpf_map_definition.value_size * key_value];
+}
+
+static ebpf_result_t
+_update_array_map_entry_per_cpu(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* data)
+{
+    uint8_t* entry = _find_array_map_entry_per_cpu(map, key);
+    if (!entry)
+        return EBPF_INVALID_ARGUMENT;
+
+    memcpy(entry, data, map->ebpf_map_definition.value_size);
+    return EBPF_SUCCESS;
+}
+
+static ebpf_result_t
+_delete_array_map_entry_per_cpu(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+{
+    uint8_t* entry = _find_array_map_entry_per_cpu(map, key);
+    if (!entry)
+        return EBPF_KEY_NOT_FOUND;
+
+    memset(entry, 0, map->ebpf_map_definition.value_size);
+    return EBPF_SUCCESS;
+}
+
+static ebpf_result_t
+_next_array_map_key_per_cpu(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
+{
+    uint32_t key_value;
+    if (!map || !next_key)
+        return EBPF_INVALID_ARGUMENT;
+
+    if (previous_key) {
+        key_value = *(uint32_t*)previous_key;
+        key_value++;
+    } else
+        key_value = 0;
+
+    if (key_value >= map->ebpf_map_definition.max_entries)
+        return EBPF_NO_MORE_KEYS;
+
+    *(uint32_t*)next_key = key_value;
+
+    return EBPF_SUCCESS;
+}
+
 ebpf_map_function_table_t ebpf_map_function_tables[] = {
     {// BPF_MAP_TYPE_UNSPECIFIED
      NULL},
@@ -472,6 +783,24 @@ ebpf_map_function_table_t ebpf_map_function_tables[] = {
      _update_prog_array_map_entry_with_handle,
      _delete_prog_array_map_entry,
      _next_array_map_key},
+    {// BPF_MAP_TYPE_HASH
+     _create_hash_map_per_cpu,
+     _delete_hash_map_per_cpu,
+     _find_hash_map_entry_per_cpu,
+     NULL,
+     _update_hash_map_entry_per_cpu,
+     NULL,
+     _delete_hash_map_entry_per_cpu,
+     _next_hash_map_key_per_cpu},
+    {// BPF_MAP_TYPE_ARRAY
+     _create_array_map_per_cpu,
+     _delete_array_map_per_cpu,
+     _find_array_map_entry_per_cpu,
+     NULL,
+     _update_array_map_entry_per_cpu,
+     NULL,
+     _delete_array_map_entry_per_cpu,
+     _next_array_map_key_per_cpu},
 };
 
 ebpf_result_t

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -100,6 +100,18 @@ TEST_CASE("map_crud_operations_array", "[execution_context]") { test_crud_operat
 
 TEST_CASE("map_crud_operations_hash", "[execution_context]") { test_crud_operations(BPF_MAP_TYPE_HASH); }
 
+TEST_CASE("map_crud_operations_array_per_cpu", "[execution_context]")
+{
+    thread_affinity_helper_t tah(0);
+    test_crud_operations(BPF_MAP_TYPE_PERCPU_ARRAY);
+}
+
+TEST_CASE("map_crud_operations_hash_per_cpu", "[execution_context]")
+{
+    thread_affinity_helper_t tah(0);
+    test_crud_operations(BPF_MAP_TYPE_PERCPU_HASH);
+}
+
 #define TEST_FUNCTION_RETURN 42
 
 uint32_t
@@ -156,8 +168,8 @@ TEST_CASE("program", "[execution_context]")
     auto provider_function1 = []() { return (ebpf_result_t)TEST_FUNCTION_RETURN; };
     ebpf_result_t (*function_pointer1)() = provider_function1;
     const void* helper_functions[] = {(void*)function_pointer1};
-    ebpf_helper_function_addresses_t helper_function_addresses = {EBPF_COUNT_OF(helper_functions),
-                                                                  (uint64_t*)helper_functions};
+    ebpf_helper_function_addresses_t helper_function_addresses = {
+        EBPF_COUNT_OF(helper_functions), (uint64_t*)helper_functions};
 
     REQUIRE(ebpf_allocate_trampoline_table(1, &table) == EBPF_SUCCESS);
     REQUIRE(ebpf_update_trampoline_table(table, &helper_function_addresses) == EBPF_SUCCESS);

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -102,13 +102,13 @@ TEST_CASE("map_crud_operations_hash", "[execution_context]") { test_crud_operati
 
 TEST_CASE("map_crud_operations_array_per_cpu", "[execution_context]")
 {
-    thread_affinity_helper_t tah(0);
+    emulate_dpc_t dpc(0);
     test_crud_operations(BPF_MAP_TYPE_PERCPU_ARRAY);
 }
 
 TEST_CASE("map_crud_operations_hash_per_cpu", "[execution_context]")
 {
-    thread_affinity_helper_t tah(0);
+    emulate_dpc_t dpc(0);
     test_crud_operations(BPF_MAP_TYPE_PERCPU_HASH);
 }
 


### PR DESCRIPTION
Add support for per-cpu hash and array maps - Part 1

Create core map functionality and block it from user mode API's.

Part 2 is to create per-cpu version of CRUD API's to access map entries.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>