### PR TITLE
Explicit key and value lengths passed to map layer

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -864,14 +864,14 @@ Exit:
 ebpf_result_t
 ebpf_map_find_entry(
     _In_ ebpf_map_t* map,
-    size_t key_length,
-    _In_reads_(key_length) const uint8_t* key,
+    size_t key_size,
+    _In_reads_(key_size) const uint8_t* key,
     size_t value_size,
     _Out_writes_(value_size) uint8_t* value,
     int flags)
 {
     uint8_t* return_value;
-    if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_length != map->ebpf_map_definition.key_size)) {
+    if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_size != map->ebpf_map_definition.key_size)) {
         return EBPF_INVALID_ARGUMENT;
     }
 
@@ -906,9 +906,9 @@ ebpf_map_associate_program(_In_ ebpf_map_t* map, _In_ const ebpf_program_t* prog
 }
 
 _Ret_maybenull_ ebpf_program_t*
-ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_length, _In_reads_(key_length) const uint8_t* key)
+ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key)
 {
-    if (key_length != map->ebpf_map_definition.key_size) {
+    if (key_size != map->ebpf_map_definition.key_size) {
         return NULL;
     }
     ebpf_map_type_t type = map->ebpf_map_definition.type;
@@ -925,17 +925,17 @@ ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_length, _In_rea
 ebpf_result_t
 ebpf_map_update_entry(
     _In_ ebpf_map_t* map,
-    size_t key_length,
-    _In_reads_(key_length) const uint8_t* key,
-    size_t value_length,
-    _In_reads_(value_length) const uint8_t* value,
+    size_t key_size,
+    _In_reads_(key_size) const uint8_t* key,
+    size_t value_size,
+    _In_reads_(value_size) const uint8_t* value,
     int flags)
 {
-    if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_length != map->ebpf_map_definition.key_size)) {
+    if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_size != map->ebpf_map_definition.key_size)) {
         return EBPF_INVALID_ARGUMENT;
     }
 
-    if (!(flags & EBPF_MAP_FLAG_HELPER) && (value_length != map->ebpf_map_definition.value_size)) {
+    if (!(flags & EBPF_MAP_FLAG_HELPER) && (value_size != map->ebpf_map_definition.value_size)) {
         return EBPF_INVALID_ARGUMENT;
     }
 
@@ -948,17 +948,17 @@ ebpf_map_update_entry(
 ebpf_result_t
 ebpf_map_update_entry_with_handle(
     _In_ ebpf_map_t* map,
-    size_t key_length,
-    _In_reads_(key_length) const uint8_t* key,
-    size_t value_length,
-    _In_reads_(value_length) const uint8_t* value,
+    size_t key_size,
+    _In_reads_(key_size) const uint8_t* key,
+    size_t value_size,
+    _In_reads_(value_size) const uint8_t* value,
     uintptr_t value_handle)
 {
-    if (key_length != map->ebpf_map_definition.key_size) {
+    if (key_size != map->ebpf_map_definition.key_size) {
         return EBPF_INVALID_ARGUMENT;
     }
 
-    if (value_length != map->ebpf_map_definition.value_size) {
+    if (value_size != map->ebpf_map_definition.value_size) {
         return EBPF_INVALID_ARGUMENT;
     }
 
@@ -970,9 +970,9 @@ ebpf_map_update_entry_with_handle(
 }
 
 ebpf_result_t
-ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_length, _In_reads_(key_length) const uint8_t* key, int flags)
+ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags)
 {
-    if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_length != map->ebpf_map_definition.key_size)) {
+    if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_size != map->ebpf_map_definition.key_size)) {
         return EBPF_INVALID_ARGUMENT;
     }
     return ebpf_map_function_tables[map->ebpf_map_definition.type].delete_entry(map, key);
@@ -981,11 +981,11 @@ ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_length, _In_reads_(key_le
 ebpf_result_t
 ebpf_map_next_key(
     _In_ ebpf_map_t* map,
-    size_t key_length,
-    _In_reads_opt_(key_length) const uint8_t* previous_key,
-    _Out_writes_(key_length) uint8_t* next_key)
+    size_t key_size,
+    _In_reads_opt_(key_size) const uint8_t* previous_key,
+    _Out_writes_(key_size) uint8_t* next_key)
 {
-    if (key_length != map->ebpf_map_definition.key_size) {
+    if (key_size != map->ebpf_map_definition.key_size) {
         return EBPF_INVALID_ARGUMENT;
     }
     return ebpf_map_function_tables[map->ebpf_map_definition.type].next_key(map, previous_key, next_key);

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -51,8 +51,8 @@ extern "C"
     ebpf_result_t
     ebpf_map_find_entry(
         _In_ ebpf_map_t* map,
-        size_t key_length,
-        _In_reads_(key_length) const uint8_t* key,
+        size_t key_size,
+        _In_reads_(key_size) const uint8_t* key,
         size_t value_size,
         _Out_writes_(value_size) uint8_t* value,
         int flags);
@@ -70,10 +70,10 @@ extern "C"
     ebpf_result_t
     ebpf_map_update_entry(
         _In_ ebpf_map_t* map,
-        size_t key_length,
-        _In_reads_(key_length) const uint8_t* key,
-        size_t value_length,
-        _In_reads_(value_length) const uint8_t* value,
+        size_t key_size,
+        _In_reads_(key_size) const uint8_t* key,
+        size_t value_size,
+        _In_reads_(value_size) const uint8_t* value,
         int flags);
 
     /**
@@ -90,10 +90,10 @@ extern "C"
     ebpf_result_t
     ebpf_map_update_entry_with_handle(
         _In_ ebpf_map_t* map,
-        size_t key_length,
-        _In_reads_(key_length) const uint8_t* key,
-        size_t value_length,
-        _In_reads_(value_length) const uint8_t* value,
+        size_t key_size,
+        _In_reads_(key_size) const uint8_t* key,
+        size_t value_size,
+        _In_reads_(value_size) const uint8_t* value,
         uintptr_t value_handle);
 
     /**
@@ -107,7 +107,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_map_delete_entry(
-        _In_ ebpf_map_t* map, size_t key_length, _In_reads_(key_length) const uint8_t* key, int flags);
+        _In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags);
 
     /**
      * @brief Retrieve the next key from the map.
@@ -124,9 +124,9 @@ extern "C"
     ebpf_result_t
     ebpf_map_next_key(
         _In_ ebpf_map_t* map,
-        size_t key_length,
-        _In_reads_opt_(key_length) const uint8_t* previous_key,
-        _Out_writes_(key_length) uint8_t* next_key);
+        size_t key_size,
+        _In_reads_opt_(key_size) const uint8_t* previous_key,
+        _Out_writes_(key_size) uint8_t* next_key);
 
     /**
      * @brief Get a program from an entry in a map that holds programs.  The
@@ -139,7 +139,7 @@ extern "C"
      * @returns Program pointer, or NULL if none.
      */
     _Ret_maybenull_ struct _ebpf_program*
-    ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_length, _In_reads_(key_length) const uint8_t* key);
+    ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key);
 
     /**
      * @brief Let a map take any actions when first

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -38,7 +38,8 @@ extern "C"
     const ebpf_map_definition_t*
     ebpf_map_get_definition(_In_ const ebpf_map_t* map);
 
-#define EBPF_MAP_FIND_ENTRY_FLAG_HELPER 0x01 /* Called by an eBPF program */
+#define EBPF_MAP_FLAG_HELPER 0x01 /* Called by an eBPF program */
+
     /**
      * @brief Get a pointer to an entry in the map.
      *
@@ -47,8 +48,14 @@ extern "C"
      * @param[in] flags Zero or more EBPF_MAP_FIND_ENTRY_FLAG_* flags.
      * @return Pointer to the value if found or NULL.
      */
-    uint8_t*
-    ebpf_map_find_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, int flags);
+    ebpf_result_t
+    ebpf_map_find_entry(
+        _In_ ebpf_map_t* map,
+        size_t key_length,
+        _In_reads_(key_length) const uint8_t* key,
+        size_t value_size,
+        _Out_writes_(value_size) uint8_t* value,
+        int flags);
 
     /**
      * @brief Insert or update an entry in the map.
@@ -61,7 +68,13 @@ extern "C"
      *  entry.
      */
     ebpf_result_t
-    ebpf_map_update_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value);
+    ebpf_map_update_entry(
+        _In_ ebpf_map_t* map,
+        size_t key_length,
+        _In_reads_(key_length) const uint8_t* key,
+        size_t value_length,
+        _In_reads_(value_length) const uint8_t* value,
+        int flags);
 
     /**
      * @brief Insert or update an entry in the map.
@@ -76,7 +89,12 @@ extern "C"
      */
     ebpf_result_t
     ebpf_map_update_entry_with_handle(
-        _In_ ebpf_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, uintptr_t value_handle);
+        _In_ ebpf_map_t* map,
+        size_t key_length,
+        _In_reads_(key_length) const uint8_t* key,
+        size_t value_length,
+        _In_reads_(value_length) const uint8_t* value,
+        uintptr_t value_handle);
 
     /**
      * @brief Remove an entry from the map.
@@ -88,7 +106,8 @@ extern "C"
      *  invalid.
      */
     ebpf_result_t
-    ebpf_map_delete_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key);
+    ebpf_map_delete_entry(
+        _In_ ebpf_map_t* map, size_t key_length, _In_reads_(key_length) const uint8_t* key, int flags);
 
     /**
      * @brief Retrieve the next key from the map.
@@ -103,7 +122,11 @@ extern "C"
      * key in lexicographically order.
      */
     ebpf_result_t
-    ebpf_map_next_key(_In_ ebpf_map_t* map, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
+    ebpf_map_next_key(
+        _In_ ebpf_map_t* map,
+        size_t key_length,
+        _In_reads_opt_(key_length) const uint8_t* previous_key,
+        _Out_writes_(key_length) uint8_t* next_key);
 
     /**
      * @brief Get a program from an entry in a map that holds programs.  The
@@ -116,7 +139,7 @@ extern "C"
      * @returns Program pointer, or NULL if none.
      */
     _Ret_maybenull_ struct _ebpf_program*
-    ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, _In_ const uint8_t* key, size_t key_size);
+    ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_length, _In_reads_(key_length) const uint8_t* key);
 
     /**
      * @brief Let a map take any actions when first

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -141,7 +141,7 @@ typedef struct _ebpf_operation_map_update_element_with_handle_request
     uintptr_t map_handle;
     uintptr_t value_handle;
     uint8_t data[1]; // data is key+value
-} epf_operation_map_update_element_with_handle_request_t;
+} ebpf_operation_map_update_element_with_handle_request_t;
 
 typedef struct _ebpf_operation_map_delete_element_request
 {
@@ -154,7 +154,7 @@ typedef struct _ebpf_operation_get_next_map_request
 {
     struct _ebpf_operation_header header;
     uint64_t previous_handle;
-} ebpf_operation_get_next_map_request;
+} ebpf_operation_get_next_map_request_t;
 
 typedef struct _ebpf_operation_get_next_map_reply
 {
@@ -166,7 +166,7 @@ typedef struct _ebpf_operation_get_next_program_request
 {
     struct _ebpf_operation_header header;
     uint64_t previous_handle;
-} ebpf_operation_get_next_program_request;
+} ebpf_operation_get_next_program_request_t;
 
 typedef struct _ebpf_operation_get_next_program_reply
 {
@@ -184,13 +184,13 @@ typedef struct _ebpf_operation_query_map_definition_reply
 {
     struct _ebpf_operation_header header;
     struct _ebpf_map_definition map_definition;
-} ebpf_operation_query_map_definition_reply;
+} ebpf_operation_query_map_definition_reply_t;
 
 typedef struct _ebpf_operation_query_program_info_request
 {
     struct _ebpf_operation_header header;
     uint64_t handle;
-} ebpf_operation_query_program_info_request;
+} ebpf_operation_query_program_info_request_t;
 
 typedef struct _ebpf_operation_query_program_info_reply
 {
@@ -199,7 +199,7 @@ typedef struct _ebpf_operation_query_program_info_reply
     uint16_t file_name_offset;
     uint16_t section_name_offset;
     uint8_t data[1];
-} ebpf_operation_query_program_info_reply;
+} ebpf_operation_query_program_info_reply_t;
 
 typedef struct _ebpf_operation_map_get_next_key_request
 {


### PR DESCRIPTION
This is a prerequisite to supporting variable-sized values being returned to user mode (when value size is a function of CPU count).

Signed-off-by: Alan Jowett <alanjo@microsoft.com>