### PR TITLE
Update more UM map APIs for libbpf compatibility

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -19,6 +19,10 @@ EXPORTS
     bpf_map__type
     bpf_map__unpin
     bpf_map__value_size
+    bpf_map_delete_elem
+    bpf_map_get_next_key
+    bpf_map_lookup_elem
+    bpf_map_update_elem
     bpf_object__close
     bpf_object__find_map_by_name
     bpf_object__find_map_fd_by_name
@@ -60,11 +64,7 @@ EXPORTS
     ebpf_free_string
     ebpf_get_next_map
     ebpf_get_next_program
-    ebpf_map_delete_element
-    ebpf_map_get_next_key
-    ebpf_map_lookup_element
     ebpf_map_pin
-    ebpf_map_update_element
     ebpf_object_get
     ebpf_object_pin
     ebpf_object_unpin

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -190,58 +190,6 @@ extern "C"
         _Out_ fd_t* map_fd);
 
     /**
-     * @brief Look up an element in an eBPF map.
-     *  For a singleton map, return the value for the given key.
-     *  For a per-cpu map, return aggregate value across all CPUs.
-     *
-     * @param[in] map_fd File descriptor for the eBPF map.
-     * @param[in] key Pointer to buffer containing key.
-     * @param[out] value Pointer to buffer that contains value on success.
-     *
-     * @retval EBPF_SUCCESS The operation was successful.
-     */
-    ebpf_result_t
-    ebpf_map_lookup_element(fd_t map_fd, _In_ const void* key, _Out_ void* value);
-
-    /**
-     * @brief Update value for the specified key in an eBPF map.
-     *
-     * @param[in] map_fd File descriptor for the eBPF map.
-     * @param[in] key Pointer to buffer containing key.
-     * @param[out] value Pointer to buffer containing value.
-     *
-     * @retval EBPF_SUCCESS The operation was successful.
-     */
-    ebpf_result_t
-    ebpf_map_update_element(fd_t map_fd, _In_ const void* key, _In_ const void* value, uint64_t flags);
-
-    /**
-     * @brief Delete an element in an eBPF map.
-     *
-     * @param[in] map_fd File descriptor for the eBPF map.
-     * @param[in] key Pointer to buffer containing key.
-     *
-     * @retval EBPF_SUCCESS The operation was successful.
-     */
-    ebpf_result_t
-    ebpf_map_delete_element(fd_t map_fd, _In_ const void* key);
-
-    /**
-     * @brief Return the next key in an eBPF map.
-     *
-     * @param[in] map_fd File descriptor for the eBPF map.
-     * @param[in] previous_key Pointer to buffer containing
-        previous key or NULL to restart enumeration.
-     * @param[out] next_key Pointer to buffer that contains next
-     *  key on success.
-     *
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MORE_KEYS previous_key was the last key.
-     */
-    ebpf_result_t
-    ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_ void* next_key);
-
-    /**
      * @brief Get file descriptor to the next eBPF map.
      * @param[in] previous_fd FD to previous eBPF map or ebpf_fd_invalid to
      *  start enumeration.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -178,3 +178,55 @@ ebpf_map_unpin(_In_ struct bpf_map* map, _In_opt_z_ const char* path);
  */
 ebpf_result_t
 ebpf_map_set_pin_path(_In_ struct bpf_map* map, _In_ const char* path);
+
+/**
+ * @brief Update value for the specified key in an eBPF map.
+ *
+ * @param[in] map_fd File descriptor for the eBPF map.
+ * @param[in] key Pointer to buffer containing key.
+ * @param[out] value Pointer to buffer containing value.
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ */
+ebpf_result_t
+ebpf_map_update_element(fd_t map_fd, _In_ const void* key, _In_ const void* value, uint64_t flags);
+
+/**
+ * @brief Delete an element in an eBPF map.
+ *
+ * @param[in] map_fd File descriptor for the eBPF map.
+ * @param[in] key Pointer to buffer containing key.
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ */
+ebpf_result_t
+ebpf_map_delete_element(fd_t map_fd, _In_ const void* key);
+
+/**
+ * @brief Look up an element in an eBPF map.
+ *  For a singleton map, return the value for the given key.
+ *  For a per-cpu map, return aggregate value across all CPUs.
+ *
+ * @param[in] map_fd File descriptor for the eBPF map.
+ * @param[in] key Pointer to buffer containing key.
+ * @param[out] value Pointer to buffer that contains value on success.
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ */
+ebpf_result_t
+ebpf_map_lookup_element(fd_t map_fd, _In_ const void* key, _Out_ void* value);
+
+/**
+ * @brief Return the next key in an eBPF map.
+ *
+ * @param[in] map_fd File descriptor for the eBPF map.
+ * @param[in] previous_key Pointer to buffer containing
+    previous key or NULL to restart enumeration.
+ * @param[out] next_key Pointer to buffer that contains next
+ *  key on success.
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_NO_MORE_KEYS previous_key was the last key.
+ */
+ebpf_result_t
+ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_ void* next_key);

--- a/libs/api/libbpf_map.cpp
+++ b/libs/api/libbpf_map.cpp
@@ -204,3 +204,21 @@ bpf_map_update_elem(int fd, const void* key, const void* value, uint64_t flags)
 {
     return libbpf_err(-ebpf_map_update_element(fd, key, value, flags));
 }
+
+int
+bpf_map_delete_elem(int fd, const void* key)
+{
+    return libbpf_err(-ebpf_map_delete_element(fd, key));
+}
+
+int
+bpf_map_lookup_elem(int fd, const void* key, void* value)
+{
+    return libbpf_err(-ebpf_map_lookup_element(fd, key, value));
+}
+
+int
+bpf_map_get_next_key(int fd, const void* key, void* next_key)
+{
+    return libbpf_err(-ebpf_map_get_next_key(fd, key, next_key));
+}

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -182,7 +182,7 @@ droppacket_test(ebpf_execution_type_t execution_type)
 
     uint32_t key = 0;
     uint64_t value = 1000;
-    REQUIRE(ebpf_map_update_element(port_map_fd, &key, &value, EBPF_ANY) == EBPF_SUCCESS);
+    REQUIRE(bpf_map_update_elem(port_map_fd, &key, &value, EBPF_ANY) == EBPF_SUCCESS);
 
     // Test that we drop the packet and increment the map
     xdp_md_t ctx{packet.data(), packet.data() + packet.size()};
@@ -191,12 +191,12 @@ droppacket_test(ebpf_execution_type_t execution_type)
     REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 2);
 
-    REQUIRE(ebpf_map_lookup_element(port_map_fd, &key, &value) == EBPF_SUCCESS);
+    REQUIRE(bpf_map_lookup_elem(port_map_fd, &key, &value) == EBPF_SUCCESS);
     REQUIRE(value == 1001);
 
-    REQUIRE(ebpf_map_delete_element(port_map_fd, &key) == EBPF_SUCCESS);
+    REQUIRE(bpf_map_delete_elem(port_map_fd, &key) == EBPF_SUCCESS);
 
-    REQUIRE(ebpf_map_lookup_element(port_map_fd, &key, &value) == EBPF_SUCCESS);
+    REQUIRE(bpf_map_lookup_elem(port_map_fd, &key, &value) == EBPF_SUCCESS);
     REQUIRE(value == 0);
 
     packet = prepare_udp_packet(10);
@@ -205,7 +205,7 @@ droppacket_test(ebpf_execution_type_t execution_type)
     REQUIRE(hook.fire(&ctx2, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 1);
 
-    REQUIRE(ebpf_map_lookup_element(port_map_fd, &key, &value) == EBPF_SUCCESS);
+    REQUIRE(bpf_map_lookup_elem(port_map_fd, &key, &value) == EBPF_SUCCESS);
     REQUIRE(value == 0);
 
     hook.detach_link(link);
@@ -266,7 +266,7 @@ uint32_t
 get_bind_count_for_pid(fd_t map_fd, uint64_t pid)
 {
     process_entry_t entry{};
-    ebpf_map_lookup_element(map_fd, &pid, &entry);
+    bpf_map_lookup_elem(map_fd, &pid, &entry);
 
     return entry.count;
 }
@@ -300,7 +300,7 @@ void
 set_bind_limit(fd_t map_fd, uint32_t limit)
 {
     uint32_t limit_key = 0;
-    REQUIRE(ebpf_map_update_element(map_fd, &limit_key, &limit, EBPF_ANY) == EBPF_SUCCESS);
+    REQUIRE(bpf_map_update_elem(map_fd, &limit_key, &limit, EBPF_ANY) == EBPF_SUCCESS);
 }
 
 void
@@ -367,11 +367,11 @@ bindmonitor_test(ebpf_execution_type_t execution_type)
     REQUIRE(get_bind_count_for_pid(process_map_fd, fake_pid) == 1);
 
     uint64_t pid;
-    REQUIRE(ebpf_map_get_next_key(process_map_fd, NULL, &pid) == EBPF_SUCCESS);
+    REQUIRE(bpf_map_get_next_key(process_map_fd, NULL, &pid) == EBPF_SUCCESS);
     REQUIRE(pid != 0);
-    REQUIRE(ebpf_map_get_next_key(process_map_fd, &pid, &pid) == EBPF_SUCCESS);
+    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == EBPF_SUCCESS);
     REQUIRE(pid != 0);
-    REQUIRE(ebpf_map_get_next_key(process_map_fd, &pid, &pid) == EBPF_NO_MORE_KEYS);
+    REQUIRE(bpf_map_get_next_key(process_map_fd, &pid, &pid) == -EBPF_NO_MORE_KEYS);
 
     hook.detach_link(link);
     hook.close_link(link);
@@ -786,8 +786,7 @@ TEST_CASE("create_map", "[end_to_end]")
     REQUIRE(map_fd > 0);
 
     for (int i = 0; i < element_count; i++) {
-        result = ebpf_map_update_element(map_fd, &key, &value, EBPF_ANY);
-        REQUIRE(result == EBPF_SUCCESS);
+        REQUIRE(bpf_map_update_elem(map_fd, &key, &value, EBPF_ANY) == EBPF_SUCCESS);
         key++;
         value++;
     }
@@ -796,8 +795,7 @@ TEST_CASE("create_map", "[end_to_end]")
     value = 10;
     for (int i = 0; i < element_count; i++) {
         uint64_t read_value;
-        result = ebpf_map_lookup_element(map_fd, &key, &read_value);
-        REQUIRE(result == EBPF_SUCCESS);
+        REQUIRE(bpf_map_lookup_elem(map_fd, &key, &read_value) == EBPF_SUCCESS);
         REQUIRE(read_value == value);
         key++;
         value++;
@@ -820,8 +818,7 @@ TEST_CASE("create_map_name", "[end_to_end]")
     REQUIRE(map_fd > 0);
 
     for (int i = 0; i < element_count; i++) {
-        result = ebpf_map_update_element(map_fd, &key, &value, EBPF_ANY);
-        REQUIRE(result == EBPF_SUCCESS);
+        REQUIRE(bpf_map_update_elem(map_fd, &key, &value, EBPF_ANY) == EBPF_SUCCESS);
         key++;
         value++;
     }
@@ -830,8 +827,7 @@ TEST_CASE("create_map_name", "[end_to_end]")
     value = 10;
     for (int i = 0; i < element_count; i++) {
         uint64_t read_value;
-        result = ebpf_map_lookup_element(map_fd, &key, &read_value);
-        REQUIRE(result == EBPF_SUCCESS);
+        REQUIRE(bpf_map_lookup_elem(map_fd, &key, &read_value) == EBPF_SUCCESS);
         REQUIRE(read_value == value);
         key++;
         value++;

--- a/tests/sample/divide_by_zero.c
+++ b/tests/sample/divide_by_zero.c
@@ -7,6 +7,7 @@
 // this passes the checker
 
 #include "ebpf.h"
+#include "ebpf_helpers.h"
 
 #pragma clang section data = "maps"
 ebpf_map_definition_t test_map = {.size = sizeof(ebpf_map_definition_t),

--- a/tests/sample/droppacket.c
+++ b/tests/sample/droppacket.c
@@ -7,6 +7,7 @@
 // this passes the checker
 
 #include "ebpf.h"
+#include "ebpf_helpers.h"
 
 #pragma clang section data = "maps"
 ebpf_map_definition_t port_map = {.size = sizeof(ebpf_map_definition_t),

--- a/tests/sample/droppacket_unsafe.c
+++ b/tests/sample/droppacket_unsafe.c
@@ -7,6 +7,7 @@
 // this passes the checker
 
 #include "ebpf.h"
+#include "ebpf_helpers.h"
 
 #pragma clang section data = "maps"
 ebpf_map_definition_t port_map = {.size = sizeof(ebpf_map_definition_t),

--- a/tests/sample/ebpf.h
+++ b/tests/sample/ebpf.h
@@ -13,7 +13,6 @@ typedef unsigned int uint32_t;
 typedef unsigned short uint16_t;
 typedef unsigned char uint8_t;
 
-#include "ebpf_helpers.h"
 #include "ebpf_nethooks.h"
 
 #if defined(_MSC_VER)

--- a/tests/sample/ext/app/sample_ext_app.cpp
+++ b/tests/sample/ext/app/sample_ext_app.cpp
@@ -7,6 +7,7 @@
 #include <mutex>
 #include <thread>
 
+#include "bpf.h"
 #include "catch_wrapper.hpp"
 #include "libbpf.h"
 #include "service_helper.h"
@@ -88,7 +89,7 @@ TEST_CASE("test_test", "[test_test]")
 
     for (uint32_t key = 0; key < map_entry_buffers.size(); key++) {
         std::copy(strings[key], strings[key] + strlen(strings[key]), map_entry_buffers[key].begin());
-        REQUIRE(ebpf_map_update_element(map_fd, &key, map_entry_buffers[key].data(), EBPF_ANY) == EBPF_SUCCESS);
+        REQUIRE(bpf_map_update_elem(map_fd, &key, map_entry_buffers[key].data(), EBPF_ANY) == EBPF_SUCCESS);
     }
 
     // Attach to link.

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -366,7 +366,7 @@ TEST_CASE("disallow setting bind fd in xdp prog array", "[libbpf]")
     // associated with an XDP program.
     int index = 0;
     error = bpf_map_update_elem(map_fd, (uint8_t*)&index, (uint8_t*)&callee_fd, 0);
-    REQUIRE(error < 0);
+    REQUIRE(error == -EBPF_INVALID_ARGUMENT);
     REQUIRE(errno == -error);
 
     bpf_object__close(bind_object);
@@ -403,7 +403,7 @@ TEST_CASE("disallow prog_array mixed program type values", "[libbpf]")
 
     // Adding an entry with a different program type should fail.
     error = bpf_map_update_elem(map_fd, (uint8_t*)&index, (uint8_t*)&bind_object_fd, 0);
-    REQUIRE(error < 0);
+    REQUIRE(error == -EBPF_INVALID_ARGUMENT);
     REQUIRE(errno == -error);
 
     bpf_object__close(bind_object);

--- a/tools/port_quota/port_quota.cpp
+++ b/tools/port_quota/port_quota.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <string>
 #include <windows.h>
+#include "bpf.h"
 #include "ebpf_api.h"
 #include "libbpf.h"
 
@@ -95,7 +96,7 @@ int
 stats(int argc, char** argv)
 {
     fd_t map_fd;
-    ebpf_result_t result;
+    int result;
     uint64_t pid;
     process_entry_t process_entry;
 
@@ -108,16 +109,16 @@ stats(int argc, char** argv)
     }
 
     printf("Pid\tCount\tAppId\n");
-    result = ebpf_map_get_next_key(map_fd, nullptr, &pid);
+    result = bpf_map_get_next_key(map_fd, nullptr, &pid);
     while (result == EBPF_SUCCESS) {
         memset(&process_entry, 0, sizeof(process_entry));
-        result = ebpf_map_lookup_element(map_fd, &pid, &process_entry);
+        result = bpf_map_lookup_elem(map_fd, &pid, &process_entry);
         if (result != EBPF_SUCCESS) {
             fprintf(stderr, "Failed to look up eBPF map entry: %d\n", result);
             return 1;
         }
         printf("%lld\t%d\t%S\n", pid, process_entry.count, process_entry.name);
-        result = ebpf_map_get_next_key(map_fd, &pid, &pid);
+        result = bpf_map_get_next_key(map_fd, &pid, &pid);
     };
     return 0;
 }
@@ -142,7 +143,7 @@ limit(int argc, char** argv)
         return 1;
     }
 
-    result = ebpf_map_update_element(map_fd, &key, &value, EBPF_ANY);
+    result = bpf_map_update_elem(map_fd, &key, &value, EBPF_ANY);
     if (result != EBPF_SUCCESS) {
         fprintf(stderr, "Failed to update eBPF map element: %d\n", result);
         return 1;


### PR DESCRIPTION
Since there is a name conflict between KM helpers and UM libbpf APIs, the end-to-end tests need to _not_ include the KM helper prototypes, so removed ebpf_helpers.h from ebpf.h and made samples include it directly.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>