### PR TITLE
Switch to hash table from AVL. Lock free in the presence of epoch allocator.

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -249,9 +249,6 @@ ebpf_program_create(ebpf_program_t** program)
         goto Done;
     }
 
-    ebpf_list_initialize(&local_program->links);
-    ebpf_lock_create(&local_program->links_lock);
-
     ebpf_object_initialize(&local_program->object, EBPF_OBJECT_PROGRAM, _ebpf_program_free);
 
     *program = local_program;
@@ -305,6 +302,9 @@ ebpf_program_initialize(ebpf_program_t* program, const ebpf_program_parameters_t
     if (return_value != EBPF_SUCCESS) {
         goto Done;
     }
+
+    ebpf_list_initialize(&program->links);
+    ebpf_lock_create(&program->links_lock);
 
     return_value = EBPF_SUCCESS;
 

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -249,6 +249,9 @@ ebpf_program_create(ebpf_program_t** program)
         goto Done;
     }
 
+    ebpf_list_initialize(&local_program->links);
+    ebpf_lock_create(&local_program->links_lock);
+
     ebpf_object_initialize(&local_program->object, EBPF_OBJECT_PROGRAM, _ebpf_program_free);
 
     *program = local_program;
@@ -302,9 +305,6 @@ ebpf_program_initialize(ebpf_program_t* program, const ebpf_program_parameters_t
     if (return_value != EBPF_SUCCESS) {
         goto Done;
     }
-
-    ebpf_list_initialize(&program->links);
-    ebpf_lock_create(&program->links_lock);
 
     return_value = EBPF_SUCCESS;
 

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include <set>
+
 #include "catch_wrapper.hpp"
 #include "ebpf_core.h"
 #include "ebpf_maps.h"
@@ -76,6 +78,7 @@ test_crud_operations(ebpf_map_type_t map_type)
 
     uint32_t previous_key;
     uint32_t next_key;
+    std::set<uint32_t> keys;
     for (uint32_t key = 0; key < 10; key++) {
         REQUIRE(
             ebpf_map_next_key(
@@ -85,8 +88,9 @@ test_crud_operations(ebpf_map_type_t map_type)
                 reinterpret_cast<uint8_t*>(&next_key)) == EBPF_SUCCESS);
 
         previous_key = next_key;
-        REQUIRE(previous_key == key);
+        keys.insert(previous_key);
     }
+    REQUIRE(keys.size() == 10);
     REQUIRE(
         ebpf_map_next_key(
             map.get(),

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -111,7 +111,9 @@ ebpf_epoch_initiate()
 {
     ebpf_result_t return_value = EBPF_SUCCESS;
     uint32_t cpu_id;
+    uint32_t cpu_count;
 
+    ebpf_get_cpu_count(&cpu_count);
     _ebpf_epoch_initiated = true;
 
     _ebpf_current_epoch = 1;
@@ -121,7 +123,7 @@ ebpf_epoch_initiate()
     ebpf_lock_create(&_ebpf_epoch_free_list_lock);
 
     if (ebpf_is_non_preemptible_work_item_supported()) {
-        ebpf_get_cpu_count(&_ebpf_epoch_cpu_table_size);
+        _ebpf_epoch_cpu_table_size = cpu_count;
         _Analysis_assume_(_ebpf_epoch_cpu_table_size >= 1);
 
         _ebpf_epoch_cpu_table = ebpf_allocate(_ebpf_epoch_cpu_table_size * sizeof(ebpf_epoch_cpu_entry_t));
@@ -154,7 +156,7 @@ ebpf_epoch_initiate()
     }
 
     return_value = ebpf_hash_table_create(
-        &_ebpf_epoch_thread_table, ebpf_allocate, ebpf_free, sizeof(uint64_t), sizeof(int64_t), NULL);
+        &_ebpf_epoch_thread_table, ebpf_allocate, ebpf_free, sizeof(uint64_t), sizeof(int64_t), cpu_count, NULL);
     if (return_value != EBPF_SUCCESS) {
         goto Error;
     }
@@ -239,7 +241,7 @@ ebpf_epoch_exit()
     }
 
     if (!ebpf_list_is_empty(&_ebpf_epoch_free_list) &&
-        (ebpf_interlocked_compare_exchange_int32(&_ebpf_flush_timer_set, 0, 1) != 0)) {
+        (ebpf_interlocked_compare_exchange_int32(&_ebpf_flush_timer_set, 1, 0) != 0)) {
         ebpf_schedule_timer_work_item(_ebpf_flush_timer, EBPF_EPOCH_FLUSH_DELAY_IN_MICROSECONDS);
     }
 }
@@ -291,6 +293,7 @@ ebpf_epoch_free(void* memory)
         return;
 
     header--;
+    ebpf_assert(header->freed_epoch == 0);
     header->entry_type = EBPF_EPOCH_ALLOCATION_MEMORY;
 
     // Items are inserted into the free list in increasing epoch order.
@@ -400,7 +403,7 @@ _ebpf_flush_worker(void* context)
 {
     UNREFERENCED_PARAMETER(context);
 
-    if (ebpf_interlocked_compare_exchange_int32(&_ebpf_flush_timer_set, 1, 0) != 1) {
+    if (ebpf_interlocked_compare_exchange_int32(&_ebpf_flush_timer_set, 0, 1) != 1) {
         return;
     }
     ebpf_epoch_flush();

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -3,52 +3,344 @@
 
 #include "ebpf_platform.h"
 
+// Buckets contain an array of pointers to value and keys.
+// Buckets are immutable once inserted in to the hash-table and replaced when
+// modified.
+
+// Layout is:
+// ebpf_hash_table_t.buckets->ebpf_hash_bucket_header_t.entries->data
+// Keys are stored contiguously in ebpf_hash_bucket_header_t for fast
+// searching, data is stored separately to prevent RCU from causing loss of
+// updates.
+
+typedef struct _ebpf_hash_bucket_entry
+{
+    uint8_t* data;
+    uint8_t key[1];
+} ebpf_hash_bucket_entry_t;
+
+typedef struct _ebpf_hash_bucket_header
+{
+    size_t count;
+    ebpf_hash_bucket_entry_t entries[1];
+} ebpf_hash_bucket_header_t;
+
 struct _ebpf_hash_table
 {
-    struct _RTL_AVL_TABLE avl_table;
-    ebpf_hash_table_compare_result_t (*compare_function)(const uint8_t* key1, const uint8_t* key2);
+    uint32_t bucket_count;
+    volatile int32_t entry_count;
+    uint32_t seed;
     size_t key_size;
     size_t value_size;
     void* (*allocate)(size_t size);
     void (*free)(void* memory);
+    void (*extract)(const uint8_t* value, const uint8_t** data, size_t* num);
+    ebpf_hash_bucket_header_t* volatile buckets[1];
 };
 
-// NOTE:
-// AVL tree gives a single struct containing both key and value.
-// Compare can be called with a partial struct only containing the key.
-// Do not access beyond map->ebpf_map_definition.key_size bytes.
-static RTL_GENERIC_COMPARE_RESULTS
-_ebpf_hash_map_compare(_In_ struct _RTL_AVL_TABLE* avl_table, _In_ void* first_struct, _In_ void* second_struct)
+typedef enum _ebpf_hash_bucket_operation
 {
-    ebpf_hash_table_t* table = (ebpf_hash_table_t*)avl_table;
+    EBPF_HASH_BUCKET_OPERATION_INSERT,
+    EBPF_HASH_BUCKET_OPERATION_DELETE,
+} ebpf_hash_bucket_operation_t;
 
-    if (table->compare_function) {
-        return (RTL_GENERIC_COMPARE_RESULTS)table->compare_function(
-            (const uint8_t*)first_struct, (const uint8_t*)second_struct);
+/**
+ * @brief Perform a rotate left on a value.
+ *
+ * @param[in] value Value to be rotated.
+ * @param[in] count Count of bits to rotate.
+ * @return Rotated value.
+ */
+static inline unsigned long
+_ebpf_rol(uint32_t value, size_t count)
+{
+    return (value << count) | (value >> (32 - count));
+}
+
+// Ported from https://github.com/aappleby/smhasher
+// Quote from https://github.com/aappleby/smhasher/blob/61a0530f28277f2e850bfc39600ce61d02b518de/src/MurmurHash3.cpp#L2
+// "MurmurHash3 was written by Austin Appleby, and is placed in the public domain."
+
+/**
+ * @brief An implementation of the murmur3_32 hash function. This is a high
+ * performance non-cryptographic hash function.
+ *
+ * @param[in] key Pointer to key to hash.
+ * @param[in] length Length of key to hash.
+ * @param[in] seed Seed to randomize hash.
+ * @return Hash of key.
+ */
+unsigned long
+_ebpf_murmur3_32(_In_ const uint8_t* key, size_t length, uint32_t seed)
+{
+    uint32_t c1 = 0xcc9e2d51;
+    uint32_t c2 = 0x1b873593;
+    uint32_t r1 = 15;
+    uint32_t r2 = 13;
+    uint32_t m = 5;
+    uint32_t n = 0xe6546b64;
+    uint32_t hash = seed;
+
+    for (size_t index = 0; (length - index) > 3; index += 4) {
+        uint32_t k = *(uint32_t*)(key + index);
+        k *= c1;
+        k = _ebpf_rol(k, r1);
+        k *= c2;
+
+        hash ^= k;
+        hash = _ebpf_rol(hash, r2);
+        hash *= m;
+        hash += n;
+    }
+    unsigned long remainder = 0;
+    for (size_t index = length & (~3); index < length; index++) {
+        remainder <<= 8;
+        remainder |= key[index];
+    }
+    remainder *= c1;
+    remainder = _ebpf_rol(remainder, r1);
+    remainder *= c2;
+
+    hash ^= remainder;
+    hash ^= (uint32_t)length;
+    hash *= 0x85ebca6b;
+    hash ^= (hash >> r2);
+    hash *= 0xc2b2ae35;
+    hash ^= (hash >> 16);
+    return hash;
+}
+
+/**
+ * @brief Given two potentially non-comparable key values, extract the key and
+ * compare them.
+ *
+ * @param[in] hash_table Hash table the keys belong to.
+ * @param[in] key_a First key
+ * @param[in] key_b Second key
+ * @retval -1 if key_a < key_b
+ * @retval 0 if key_a == key_b
+ * @retval 1 if key_a > key_b
+ */
+static int
+_ebpf_hash_table_compare(ebpf_hash_table_t* hash_table, _In_ const uint8_t* key_a, _In_ const uint8_t* key_b)
+{
+    size_t length_a;
+    size_t length_b;
+    const uint8_t* data_a;
+    const uint8_t* data_b;
+    if (hash_table->extract) {
+        hash_table->extract(key_a, &data_a, &length_a);
+        hash_table->extract(key_b, &data_b, &length_b);
     } else {
-        int result = memcmp(first_struct, second_struct, table->key_size);
-        if (result < 0) {
-            return GenericLessThan;
-        } else if (result > 0) {
-            return GenericGreaterThan;
-        } else {
-            return GenericEqual;
+        length_a = hash_table->key_size;
+        data_a = key_a;
+        length_b = hash_table->key_size;
+        data_b = key_b;
+    }
+    if (length_a < length_b) {
+        return -1;
+    }
+    if (length_a > length_b) {
+        return 1;
+    }
+    return memcmp(data_a, data_b, length_a);
+}
+
+/**
+ * @brief Given a potentially non-comparable key value, extract the key and
+ * compute the hash.
+ *
+ * @param[in] hash_table Hash table the keys belong to.
+ * @param[in] key_a First key
+ * @retval Hash of key
+ */
+static uint32_t
+_ebpf_hash_table_compute_hash(ebpf_hash_table_t* hash_table, _In_ const uint8_t* key)
+{
+    size_t length;
+    const uint8_t* data;
+    if (hash_table->extract) {
+        hash_table->extract(key, &data, &length);
+    } else {
+        length = hash_table->key_size;
+        data = key;
+    }
+    return _ebpf_murmur3_32(data, length, hash_table->seed);
+}
+
+/**
+ * @brief Given a pointer to a bucket, compute the offset of a bucket entry.
+ *
+ * @param [in] key_size Size
+ * @param [in] bucket Pointer to start of the bucket.
+ * @param [in] index Index into the bucket
+ * @return Pointer to the ebpf_hash_bucket_entry_t
+ */
+ebpf_hash_bucket_entry_t*
+_ebpf_hash_table_bucket_entry(size_t key_size, _In_ ebpf_hash_bucket_header_t* bucket, size_t index)
+{
+    uint8_t* offset = (uint8_t*)bucket->entries;
+    size_t entry_size = EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key) + key_size;
+
+    return (ebpf_hash_bucket_entry_t*)(offset + (size_t)index * entry_size);
+}
+
+/**
+ * @brief Perform an atomic replacement of a bucket in the hash table.
+ * Operations include insert and delete of elements.
+ *
+ * @param[in] hash_table Hash table to update.
+ * @param[in] key Key to operate on.
+ * @param[in] data Value to be inserted or NULL.
+ * @param[in] operation Operation to perform
+ * @retval EBPF_SUCCESS The operation succeeded.
+ * @retval EBPF_KEY_NOT_FOUND The specified key is not present in the bucket.
+ * @retval EBPF_NO_MEMORY Insufficient memory to construct new bucket or value.
+ */
+ebpf_result_t
+_ebpf_hash_table_replace_bucket(
+    _In_ ebpf_hash_table_t* hash_table,
+    _In_ const uint8_t* key,
+    _In_opt_ const uint8_t* data,
+    ebpf_hash_bucket_operation_t operation)
+{
+    ebpf_result_t result;
+    size_t index;
+    size_t old_data_index = MAXSIZE_T;
+    size_t entry_size = EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key) + hash_table->key_size;
+    uint8_t* old_data = NULL;
+    uint8_t* new_data = NULL;
+    uint8_t* delete_data = NULL;
+    uint32_t hash;
+    ebpf_hash_bucket_header_t* old_bucket = NULL;
+    ebpf_hash_bucket_header_t* new_bucket = NULL;
+    ebpf_hash_bucket_header_t* delete_bucket = NULL;
+    hash = _ebpf_hash_table_compute_hash(hash_table, key);
+
+    if (operation == EBPF_HASH_BUCKET_OPERATION_INSERT) {
+        new_data = hash_table->allocate(hash_table->value_size);
+        if (!new_data) {
+            result = EBPF_NO_MEMORY;
+            goto Done;
+        }
+        delete_data = new_data;
+        if (data) {
+            memcpy(new_data, data, hash_table->value_size);
         }
     }
-}
 
-static void*
-_ebpf_hash_table_allocate(struct _RTL_AVL_TABLE* avl_table, unsigned long byte_size)
-{
-    ebpf_hash_table_t* table = (ebpf_hash_table_t*)avl_table;
-    return table->allocate(byte_size);
-}
+    for (;;) {
+        size_t old_bucket_count = 0;
+        size_t new_bucket_count = 0;
 
-static void
-_ebpf_hash_table_free(struct _RTL_AVL_TABLE* avl_table, void* buffer)
-{
-    ebpf_hash_table_t* table = (ebpf_hash_table_t*)avl_table;
-    table->free(buffer);
+        new_bucket = NULL;
+        old_data = NULL;
+        delete_bucket = new_bucket;
+        delete_data = new_data;
+
+        // Capture current bucket pointer
+        old_bucket = hash_table->buckets[hash % hash_table->bucket_count];
+
+        // If the old_bucket exists, capture it's count.
+        if (old_bucket) {
+            old_bucket_count = old_bucket->count;
+        }
+
+        // Find the old key index if it exists.
+        if (old_bucket) {
+            for (index = 0; index < old_bucket_count; index++) {
+                ebpf_hash_bucket_entry_t* entry =
+                    _ebpf_hash_table_bucket_entry(hash_table->key_size, old_bucket, index);
+                ebpf_assert(entry);
+                if (_ebpf_hash_table_compare(hash_table, key, entry->key) == 0) {
+                    // If old_data exists, remove it.
+                    old_data = entry->data;
+                    old_data_index = index;
+                }
+            }
+        }
+
+        // If this is a delete, but the key isn't present, return key not found.
+        if (operation == EBPF_HASH_BUCKET_OPERATION_DELETE && old_data_index == MAXSIZE_T) {
+            result = EBPF_KEY_NOT_FOUND;
+            goto Done;
+        }
+
+        // new_bucket_count is either old_bucket_count +1 or -1.
+        new_bucket_count = old_bucket_count;
+
+        if (operation == EBPF_HASH_BUCKET_OPERATION_INSERT && old_data_index == MAXSIZE_T) {
+            new_bucket_count++;
+        }
+
+        if (operation == EBPF_HASH_BUCKET_OPERATION_DELETE) {
+            new_bucket_count--;
+        }
+
+        ebpf_assert(new_bucket_count < MAXUINT32);
+
+        if (new_bucket_count) {
+            new_bucket = hash_table->allocate(entry_size * new_bucket_count + sizeof(ebpf_hash_bucket_header_t));
+            if (!new_bucket) {
+                result = EBPF_NO_MEMORY;
+                goto Done;
+            }
+            delete_bucket = new_bucket;
+
+            // Copy everything except old entry over.
+            for (index = 0; index < old_bucket_count; index++) {
+                ebpf_hash_bucket_entry_t* old_entry =
+                    _ebpf_hash_table_bucket_entry(hash_table->key_size, old_bucket, index);
+                ebpf_hash_bucket_entry_t* new_entry =
+                    _ebpf_hash_table_bucket_entry(hash_table->key_size, new_bucket, new_bucket->count);
+
+                if (index == old_data_index) {
+                    continue;
+                }
+                memcpy(new_entry, old_entry, entry_size);
+                new_bucket->count++;
+            }
+
+            // If new_data exists, add it to the end.
+            if (new_data) {
+                ebpf_assert(new_bucket_count > new_bucket->count);
+                ebpf_hash_bucket_entry_t* new_entry =
+                    _ebpf_hash_table_bucket_entry(hash_table->key_size, new_bucket, new_bucket->count);
+                new_entry->data = new_data;
+                memcpy(new_entry->key, key, hash_table->key_size);
+                new_bucket->count++;
+            }
+        }
+
+        ebpf_assert(
+            (new_bucket == NULL && new_bucket_count == 0) || // No new bucket.
+            (new_bucket_count == new_bucket->count));        // New bucket is full.
+
+        if (ebpf_interlocked_compare_exchange_pointer(
+                (void* volatile*)&hash_table->buckets[hash % hash_table->bucket_count], new_bucket, old_bucket) ==
+            old_bucket) {
+            delete_bucket = old_bucket;
+            delete_data = old_data;
+            break;
+        } else {
+            // Delete new_bucket and try again.
+            hash_table->free(new_bucket);
+        }
+    }
+
+    if (operation == EBPF_HASH_BUCKET_OPERATION_INSERT) {
+        if (!old_data)
+            ebpf_interlocked_increment_int32(&hash_table->entry_count);
+    } else {
+        ebpf_interlocked_decrement_int32(&hash_table->entry_count);
+    }
+
+    result = EBPF_SUCCESS;
+
+Done:
+    hash_table->free(delete_bucket);
+    hash_table->free(delete_data);
+    return result;
 }
 
 ebpf_result_t
@@ -58,30 +350,36 @@ ebpf_hash_table_create(
     _In_ void (*free)(void* memory),
     size_t key_size,
     size_t value_size,
-    _In_opt_ ebpf_hash_table_compare_result_t (*compare_function)(const uint8_t* key1, const uint8_t* key2))
+    size_t bucket_count,
+    void (*extract)(const uint8_t* value, const uint8_t** data, size_t* num))
 {
     ebpf_result_t retval;
     ebpf_hash_table_t* table = NULL;
+    size_t table_size = 0;
+    retval = ebpf_safe_size_t_multiply(sizeof(ebpf_hash_bucket_header_t*), bucket_count, &table_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+    retval = ebpf_safe_size_t_add(table_size, EBPF_OFFSET_OF(ebpf_hash_table_t, buckets), &table_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
 
     // allocate
-    table = ebpf_allocate(sizeof(ebpf_hash_table_t));
+    table = allocate(table_size);
     if (table == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;
     }
 
-    table->compare_function = compare_function;
-
-#pragma warning(push)
-#pragma warning(disable : 28023) // Function not marked with _Function_class_ annotation
-    RtlInitializeGenericTableAvl(
-        &table->avl_table, _ebpf_hash_map_compare, _ebpf_hash_table_allocate, _ebpf_hash_table_free, NULL);
-#pragma warning(pop)
-
     table->key_size = key_size;
     table->value_size = value_size;
     table->allocate = allocate;
     table->free = free;
+    table->bucket_count = (uint32_t)bucket_count;
+    table->entry_count = 0;
+    table->seed = ebpf_random_uint32();
+    table->extract = extract;
 
     *hash_table = table;
     retval = EBPF_SUCCESS;
@@ -92,36 +390,63 @@ Done:
 void
 ebpf_hash_table_destroy(_In_opt_ _Post_ptr_invalid_ ebpf_hash_table_t* hash_table)
 {
-    RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
+    size_t index;
     if (!hash_table) {
         return;
     }
 
-    for (;;) {
-        uint8_t* entry;
-        entry = RtlEnumerateGenericTableAvl(table, TRUE);
-        if (!entry)
-            break;
-        RtlDeleteElementGenericTableAvl(table, entry);
+    for (index = 0; index < hash_table->bucket_count; index++) {
+        ebpf_hash_bucket_header_t* bucket = (ebpf_hash_bucket_header_t*)hash_table->buckets[index];
+        if (bucket) {
+            size_t inner_index;
+            for (inner_index = 0; inner_index < bucket->count; inner_index++) {
+                ebpf_hash_bucket_entry_t* entry =
+                    _ebpf_hash_table_bucket_entry(hash_table->key_size, bucket, inner_index);
+                hash_table->free(entry->data);
+            }
+            hash_table->free(bucket);
+            hash_table->buckets[index] = NULL;
+        }
     }
-    ebpf_free(hash_table);
+    hash_table->free(hash_table);
 }
 
 ebpf_result_t
 ebpf_hash_table_find(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _Outptr_ uint8_t** value)
 {
     ebpf_result_t retval;
-    RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
-    uint8_t* entry;
+    uint32_t hash;
+    uint8_t* data = NULL;
+    size_t index;
+    ebpf_hash_bucket_header_t* bucket;
 
-    entry = RtlLookupElementGenericTableAvl(table, (uint8_t*)key);
-
-    if (entry) {
-        *value = entry + hash_table->key_size;
-        retval = EBPF_SUCCESS;
-    } else {
-        retval = EBPF_KEY_NOT_FOUND;
+    if (!hash_table || !key) {
+        retval = EBPF_INVALID_ARGUMENT;
+        goto Done;
     }
+
+    hash = _ebpf_hash_table_compute_hash(hash_table, key);
+    bucket = hash_table->buckets[hash % hash_table->bucket_count];
+    if (!bucket) {
+        retval = EBPF_KEY_NOT_FOUND;
+        goto Done;
+    }
+
+    for (index = 0; index < bucket->count; index++) {
+        ebpf_hash_bucket_entry_t* entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, bucket, index);
+        if (_ebpf_hash_table_compare(hash_table, key, entry->key) == 0) {
+            data = entry->data;
+        }
+    }
+
+    if (!data) {
+        retval = EBPF_KEY_NOT_FOUND;
+        goto Done;
+    }
+
+    *value = data;
+    retval = EBPF_SUCCESS;
+Done:
     return retval;
 }
 
@@ -129,53 +454,31 @@ ebpf_result_t
 ebpf_hash_table_update(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _In_opt_ const uint8_t* value)
 {
     ebpf_result_t retval;
-    RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
-    uint8_t* entry;
-    uint8_t* temp = NULL;
-    size_t temp_size = hash_table->key_size + hash_table->value_size;
-    BOOLEAN new_entry;
 
     if (!hash_table || !key) {
         retval = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
 
-    temp = ebpf_allocate(temp_size);
-    if (!temp) {
-        retval = EBPF_NO_MEMORY;
-        goto Done;
-    }
-
-    memcpy(temp, key, hash_table->key_size);
-    if (value)
-        memcpy(temp + hash_table->key_size, value, hash_table->value_size);
-
-    entry = RtlInsertElementGenericTableAvl(table, temp, (uint32_t)temp_size, &new_entry);
-    if (!entry) {
-        retval = EBPF_NO_MEMORY;
-        goto Done;
-    }
-
-    // Update existing entry
-    if (value)
-        memcpy(entry + hash_table->key_size, value, hash_table->value_size);
-
-    retval = EBPF_SUCCESS;
-
+    retval = _ebpf_hash_table_replace_bucket(hash_table, key, value, EBPF_HASH_BUCKET_OPERATION_INSERT);
 Done:
-    ebpf_free(temp);
-
     return retval;
 }
 
 ebpf_result_t
 ebpf_hash_table_delete(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key)
 {
-    BOOLEAN result;
-    RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
+    ebpf_result_t retval;
 
-    result = RtlDeleteElementGenericTableAvl(table, (uint8_t*)key);
-    return result ? EBPF_SUCCESS : EBPF_KEY_NOT_FOUND;
+    if (!hash_table || !key) {
+        retval = EBPF_INVALID_ARGUMENT;
+        goto Done;
+    }
+
+    retval = _ebpf_hash_table_replace_bucket(hash_table, key, NULL, EBPF_HASH_BUCKET_OPERATION_DELETE);
+
+Done:
+    return retval;
 }
 
 ebpf_result_t
@@ -183,53 +486,72 @@ ebpf_hash_table_next_key_and_value(
     _In_ ebpf_hash_table_t* hash_table,
     _In_opt_ const uint8_t* previous_key,
     _Out_ uint8_t* next_key,
-    _Outptr_opt_ uint8_t** value)
+    _Inout_opt_ uint8_t** value)
 {
     ebpf_result_t result = EBPF_SUCCESS;
-    RTL_AVL_TABLE* table = (RTL_AVL_TABLE*)hash_table;
-    uint8_t* entry;
-    void* restart_key;
+    uint32_t hash;
+    ebpf_hash_bucket_entry_t* next_entry = NULL;
+    size_t bucket_index;
+    size_t data_index;
+    bool found_entry = false;
 
-    if (value != NULL)
-        *value = NULL;
+    if (!hash_table || !next_key) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Done;
+    }
 
-    if (!previous_key) {
-        entry = RtlEnumerateGenericTableAvl(table, TRUE);
-    } else {
-        // Note - We need a better option to resume the search when the element was
-        // deleted.
-        entry = RtlLookupFirstMatchingElementGenericTableAvl(table, (void*)previous_key, &restart_key);
-        if (!entry) {
-            // Entry deleted.
+    hash = (previous_key != NULL) ? _ebpf_hash_table_compute_hash(hash_table, previous_key) : 0;
 
-            // Start at the beginning of the table.
-            entry = RtlEnumerateGenericTableAvl(table, TRUE);
-            if (entry == NULL) {
-                return EBPF_NO_MORE_KEYS;
+    for (bucket_index = hash % hash_table->bucket_count; bucket_index < hash_table->bucket_count; bucket_index++) {
+        ebpf_hash_bucket_header_t* bucket = hash_table->buckets[bucket_index];
+        // Skip empty buckets.
+        if (!bucket) {
+            continue;
+        }
+
+        // Pick first entry if no previous key.
+        if (!previous_key) {
+            next_entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, bucket, 0);
+            break;
+        }
+
+        for (data_index = 0; data_index < bucket->count; data_index++) {
+            ebpf_hash_bucket_entry_t* entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, bucket, data_index);
+            if (!entry) {
+                result = EBPF_INVALID_ARGUMENT;
+                goto Done;
+            }
+            // Do we have the previous key?
+            if (found_entry) {
+                // Yes, then this is the next key.
+                next_entry = entry;
+                break;
             }
 
-            // Advance the cursor until we reach the first entry that is greater than
-            // the key.
-            while (!(_ebpf_hash_map_compare(table, (uint8_t*)previous_key, entry) == GenericGreaterThan)) {
-                entry = RtlEnumerateGenericTableAvl(table, FALSE);
-                if (!entry) {
-                    break;
-                }
+            // Is this the previous key?
+            if (_ebpf_hash_table_compare(hash_table, previous_key, entry->key) == 0) {
+                // Yes, record it's location.
+                found_entry = true;
             }
-        } else {
-            entry = RtlEnumerateGenericTableAvl(table, FALSE);
+        }
+        if (next_entry) {
+            break;
         }
     }
-    if (entry == NULL) {
+    if (!next_entry) {
         result = EBPF_NO_MORE_KEYS;
-        goto Exit;
-    } else {
-        memcpy(next_key, entry, hash_table->key_size);
-        if (value != NULL)
-            *value = entry + hash_table->key_size;
+        goto Done;
     }
 
-Exit:
+    result = EBPF_SUCCESS;
+
+    if (value)
+        *value = next_entry->data;
+
+    memcpy(next_key, next_entry->key, hash_table->key_size);
+
+Done:
+
     return result;
 }
 
@@ -243,5 +565,5 @@ ebpf_hash_table_next_key(
 size_t
 ebpf_hash_table_key_count(_In_ ebpf_hash_table_t* hash_table)
 {
-    return hash_table->avl_table.NumberGenericTableElements;
+    return hash_table->entry_count;
 }

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -351,7 +351,7 @@ ebpf_hash_table_create(
     size_t key_size,
     size_t value_size,
     size_t bucket_count,
-    _In_ void (*extract)(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* num))
+    _In_opt_ void (*extract)(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* num))
 {
     ebpf_result_t retval;
     ebpf_hash_table_t* table = NULL;

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -351,7 +351,7 @@ ebpf_hash_table_create(
     size_t key_size,
     size_t value_size,
     size_t bucket_count,
-    void (*extract)(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* num))
+    _In_ void (*extract)(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* num))
 {
     ebpf_result_t retval;
     ebpf_hash_table_t* table = NULL;

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -5,31 +5,20 @@
 
 #include "ebpf_object.h"
 
+#define EBPF_PINNING_TABLE_BUCKET_COUNT 64
+
 typedef struct _ebpf_pinning_table
 {
     _Requires_lock_held_(&lock) ebpf_hash_table_t* hash_table;
     ebpf_lock_t lock;
 } ebpf_pinning_table_t;
 
-static ebpf_hash_table_compare_result_t
-_ebpf_pining_table_compare_function(const uint8_t* key1, const uint8_t* key2)
+static void
+_ebpf_pining_table_extract(const uint8_t* value, const uint8_t** data, size_t* length)
 {
-    const ebpf_utf8_string_t* first_key = *(ebpf_utf8_string_t**)key1;
-    const ebpf_utf8_string_t* second_key = *(ebpf_utf8_string_t**)key2;
-    size_t min_length = min(first_key->length, second_key->length);
-
-    // Note: This is not a lexicographical sort order.
-    int compare_result = memcmp(first_key->value, second_key->value, min_length);
-    if (compare_result < 0)
-        return EBPF_HASH_TABLE_LESS_THAN;
-    else if (compare_result > 0)
-        return EBPF_HASH_TABLE_GREATER_THAN;
-    else if (first_key->length < second_key->length)
-        return EBPF_HASH_TABLE_LESS_THAN;
-    else if (first_key->length > second_key->length)
-        return EBPF_HASH_TABLE_GREATER_THAN;
-    else
-        return EBPF_HASH_TABLE_EQUAL;
+    const ebpf_utf8_string_t* key = *(ebpf_utf8_string_t**)value;
+    *data = key->value;
+    *length = key->length;
 }
 
 static void
@@ -63,7 +52,8 @@ ebpf_pinning_table_allocate(ebpf_pinning_table_t** pinning_table)
         ebpf_free,
         sizeof(ebpf_utf8_string_t*),
         sizeof(ebpf_pinning_entry_t*),
-        _ebpf_pining_table_compare_function);
+        EBPF_PINNING_TABLE_BUCKET_COUNT,
+        _ebpf_pining_table_extract);
 
     if (return_value != EBPF_SUCCESS)
         goto Done;
@@ -84,7 +74,7 @@ void
 ebpf_pinning_table_free(ebpf_pinning_table_t* pinning_table)
 {
     ebpf_result_t return_value;
-    ebpf_utf8_string_t* key;
+    ebpf_utf8_string_t* key = NULL;
 
     for (;;) {
         return_value = ebpf_hash_table_next_key(pinning_table->hash_table, NULL, (uint8_t*)&key);
@@ -178,9 +168,9 @@ ebpf_pinning_table_delete(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_s
         pinning_table->hash_table, (const uint8_t*)&existing_key, (uint8_t**)&existing_pinning_entry);
     if (return_value == EBPF_SUCCESS) {
         ebpf_pinning_entry_t* entry = *existing_pinning_entry;
-        // Note: Can't fail because we first checked the entry exists.
-        ebpf_hash_table_delete(pinning_table->hash_table, (const uint8_t*)&existing_key);
-        _ebpf_pinning_entry_free(entry);
+        return_value = ebpf_hash_table_delete(pinning_table->hash_table, (const uint8_t*)&existing_key);
+        if (return_value == EBPF_SUCCESS)
+            _ebpf_pinning_entry_free(entry);
     }
     ebpf_lock_unlock(&pinning_table->lock, state);
 

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -14,7 +14,7 @@ typedef struct _ebpf_pinning_table
 } ebpf_pinning_table_t;
 
 static void
-_ebpf_pining_table_extract(const uint8_t* value, const uint8_t** data, size_t* length)
+_ebpf_pinning_table_extract(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* length)
 {
     const ebpf_utf8_string_t* key = *(ebpf_utf8_string_t**)value;
     *data = key->value;
@@ -53,7 +53,7 @@ ebpf_pinning_table_allocate(ebpf_pinning_table_t** pinning_table)
         sizeof(ebpf_utf8_string_t*),
         sizeof(ebpf_pinning_entry_t*),
         EBPF_PINNING_TABLE_BUCKET_COUNT,
-        _ebpf_pining_table_extract);
+        _ebpf_pinning_table_extract);
 
     if (return_value != EBPF_SUCCESS)
         goto Done;

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -398,7 +398,7 @@ extern "C"
         size_t key_size,
         size_t value_size,
         size_t bucket_count,
-        void (*extract_function)(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* length));
+        _In_ void (*extract_function)(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* length));
 
     /**
      * @brief Remove all items from the hash table and release memory.

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -398,7 +398,8 @@ extern "C"
         size_t key_size,
         size_t value_size,
         size_t bucket_count,
-        _In_ void (*extract_function)(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* length));
+        _In_opt_ void (*extract_function)(
+            _In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* length));
 
     /**
      * @brief Remove all items from the hash table and release memory.
@@ -560,7 +561,7 @@ extern "C"
      */
     void*
     ebpf_interlocked_compare_exchange_pointer(
-        _Inout_ void* volatile* destination, _In_ const void* exchange, _In_ const void* comperand);
+        _Inout_ void* volatile* destination, _In_opt_ const void* exchange, _In_opt_ const void* comperand);
 
     typedef void (*ebpf_extension_change_callback_t)(
         _In_ void* client_binding_context,

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -398,7 +398,7 @@ extern "C"
         size_t key_size,
         size_t value_size,
         size_t bucket_count,
-        void (*extract_function)(_In_ const uint8_t* value, _Out_ const uint8_t** data, _Out_ size_t* length));
+        void (*extract_function)(_In_ const uint8_t* value, _Outptr_ const uint8_t** data, _Out_ size_t* length));
 
     /**
      * @brief Remove all items from the hash table and release memory.
@@ -560,7 +560,7 @@ extern "C"
      */
     void*
     ebpf_interlocked_compare_exchange_pointer(
-        _Inout_ void* volatile* destination, const void* exchange, const void* comperand);
+        _Inout_ void* volatile* destination, _In_ const void* exchange, _In_ const void* comperand);
 
     typedef void (*ebpf_extension_change_callback_t)(
         _In_ void* client_binding_context,

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -372,13 +372,6 @@ extern "C"
 
     typedef struct _ebpf_hash_table ebpf_hash_table_t;
 
-    typedef enum _ebpf_hash_table_compare_result
-    {
-        EBPF_HASH_TABLE_LESS_THAN = 0,
-        EBPF_HASH_TABLE_GREATER_THAN = 1,
-        EBPF_HASH_TABLE_EQUAL = 2,
-    } ebpf_hash_table_compare_result_t;
-
     /**
      * @brief Allocate and initialize a hash table.
      *
@@ -389,8 +382,10 @@ extern "C"
      * @param[in] free Function to use when freeing elements in the hash table.
      * @param[in] key_size Size of the keys used in the hash table.
      * @param[in] value_size Size of the values used in the hash table.
-     * @param[in] compare_function Function used to lexicographically order
-     * keys. If NULL, memcmp is used instead.
+     * @param[in] bucket_count Count of buckets to use.
+     * @param[in] extract_function Function used to convert a key into a value
+     * that can be hashed and compared. If NULL, key is assumes to be
+     * comparable.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  hash table.
@@ -402,7 +397,8 @@ extern "C"
         _In_ void (*free)(void* memory),
         size_t key_size,
         size_t value_size,
-        _In_opt_ ebpf_hash_table_compare_result_t (*compare_function)(const uint8_t* key1, const uint8_t* key2));
+        size_t bucket_count,
+        void (*extract_function)(_In_ const uint8_t* value, _Out_ const uint8_t** data, _Out_ size_t* length));
 
     /**
      * @brief Remove all items from the hash table and release memory.
@@ -478,7 +474,7 @@ extern "C"
         _In_ ebpf_hash_table_t* hash_table,
         _In_opt_ const uint8_t* previous_key,
         _Out_ uint8_t* next_key,
-        _Outptr_opt_ uint8_t** next_value);
+        _Inout_opt_ uint8_t** next_value);
 
     /**
      * @brief Get the number of keys in the hash table
@@ -546,6 +542,25 @@ extern "C"
      */
     int32_t
     ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, int32_t exchange, int32_t comperand);
+
+    /**
+     * @brief Performs an atomic operation that compares the input value pointed
+     *  to by destination with the value of comperand and replaces it with
+     *  exchange.
+     *
+     * @param[in,out] destination A pointer to the input value that is compared
+     *  with the value of comperand.
+     * @param[in] exchange Specifies the output value pointed to by destination
+     *  if the input value pointed to by destination equals the value of
+     *  comperand.
+     * @param[in] comperand Specifies the value that is compared with the input
+     *  value pointed to by destination.
+     * @return Returns the original value of memory pointed to by
+     *  destination.
+     */
+    void*
+    ebpf_interlocked_compare_exchange_pointer(
+        _Inout_ void* volatile* destination, const void* exchange, const void* comperand);
 
     typedef void (*ebpf_extension_change_callback_t)(
         _In_ void* client_binding_context,
@@ -775,6 +790,14 @@ extern "C"
     ebpf_result_t
     ebpf_validate_security_descriptor(
         _In_ ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length);
+
+    /**
+     * @brief Return a pseudorandom number.
+     *
+     * @return A pseudorandom number.
+     */
+    uint32_t
+    ebpf_random_uint32();
 
 #ifdef __cplusplus
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -231,7 +231,7 @@ ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, i
 
 void*
 ebpf_interlocked_compare_exchange_pointer(
-    _Inout_ void* volatile* destination, const void* exchange, const void* comperand)
+    _Inout_ void* volatile* destination, _In_ const void* exchange, _In_ const void* comperand)
 {
     return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -30,7 +30,9 @@ ebpf_platform_initiate()
 
 void
 ebpf_platform_terminate()
-{}
+{
+    KeFlushQueuedDpcs();
+}
 
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
     _Post_writable_byte_size_(size) void* ebpf_allocate(size_t size)
@@ -227,6 +229,13 @@ ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, i
     return InterlockedCompareExchange((long volatile*)destination, exchange, comperand);
 }
 
+void*
+ebpf_interlocked_compare_exchange_pointer(
+    _Inout_ void* volatile* destination, const void* exchange, const void* comperand)
+{
+    return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
+}
+
 void
 ebpf_get_cpu_count(_Out_ uint32_t* cpu_count)
 {
@@ -311,8 +320,8 @@ ebpf_queue_non_preemptible_work_item(_In_ ebpf_non_preemptible_work_item_t* work
 
 typedef struct _ebpf_timer_work_item
 {
-    KTIMER timer;
     KDPC deferred_procedure_call;
+    KTIMER timer;
     void (*work_item_routine)(void* work_item_context);
     void* work_item_context;
 } ebpf_timer_work_item_t;
@@ -443,4 +452,12 @@ ebpf_validate_security_descriptor(
 
 Done:
     return result;
+}
+
+uint32_t
+ebpf_random_uint32()
+{
+    LARGE_INTEGER p = KeQueryPerformanceCounter(NULL);
+    ULONG seed = p.LowPart ^ (DWORD)p.HighPart;
+    return RtlRandomEx(&seed);
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -231,7 +231,7 @@ ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, i
 
 void*
 ebpf_interlocked_compare_exchange_pointer(
-    _Inout_ void* volatile* destination, _In_ const void* exchange, _In_ const void* comperand)
+    _Inout_ void* volatile* destination, _In_opt_ const void* exchange, _In_opt_ const void* comperand)
 {
     return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
 }

--- a/libs/platform/user/ebpf_extension_user.c
+++ b/libs/platform/user/ebpf_extension_user.c
@@ -3,6 +3,8 @@
 
 #include "ebpf_platform.h"
 
+#define EBPF_EXTENSION_TABLE_BUCKET_COUNT 64
+
 typedef struct _ebpf_extension_client
 {
     GUID client_id;
@@ -185,8 +187,14 @@ ebpf_provider_load(
     state = ebpf_lock_lock(&_ebpf_provider_table_lock);
 
     if (!_ebpf_provider_table) {
-        return_value =
-            ebpf_hash_table_create(&_ebpf_provider_table, ebpf_allocate, ebpf_free, sizeof(GUID), sizeof(void*), NULL);
+        return_value = ebpf_hash_table_create(
+            &_ebpf_provider_table,
+            ebpf_allocate,
+            ebpf_free,
+            sizeof(GUID),
+            sizeof(void*),
+            EBPF_EXTENSION_TABLE_BUCKET_COUNT,
+            NULL);
         if (return_value != EBPF_SUCCESS)
             goto Done;
     }
@@ -215,7 +223,13 @@ ebpf_provider_load(
     local_extension_provider->client_detach_callback = client_detach_callback;
 
     return_value = ebpf_hash_table_create(
-        &local_extension_provider->client_table, ebpf_allocate, ebpf_free, sizeof(GUID), sizeof(void*), NULL);
+        &local_extension_provider->client_table,
+        ebpf_allocate,
+        ebpf_free,
+        sizeof(GUID),
+        sizeof(void*),
+        EBPF_EXTENSION_TABLE_BUCKET_COUNT,
+        NULL);
     if (return_value != EBPF_SUCCESS) {
         goto Done;
     }

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -17,74 +17,9 @@ bool _ebpf_platform_code_integrity_enabled = false;
 // Permit the test to simulate non-preemptible execution.
 bool _ebpf_platform_is_preemptible = true;
 
-void (*RtlInitializeGenericTableAvl)(
-    _Out_ PRTL_AVL_TABLE Table,
-    _In_ PRTL_AVL_COMPARE_ROUTINE CompareRoutine,
-    _In_ PRTL_AVL_ALLOCATE_ROUTINE AllocateRoutine,
-    _In_ PRTL_AVL_FREE_ROUTINE FreeRoutine,
-    _In_opt_ PVOID TableContext);
-
-void* (*RtlEnumerateGenericTableAvl)(_In_ PRTL_AVL_TABLE Table, _In_ BOOLEAN Restart);
-
-BOOLEAN (*RtlDeleteElementGenericTableAvl)(_In_ PRTL_AVL_TABLE Table, _In_ PVOID Buffer);
-
-void* (*RtlLookupElementGenericTableAvl)(_In_ PRTL_AVL_TABLE Table, _In_ PVOID Buffer);
-
-void* (*RtlInsertElementGenericTableAvl)(
-    _In_ PRTL_AVL_TABLE Table,
-    _In_reads_bytes_(BufferSize) PVOID Buffer,
-    _In_ const uint32_t BufferSize,
-    _Out_opt_ PBOOLEAN NewElement);
-
-PVOID(*RtlLookupFirstMatchingElementGenericTableAvl)
-(_In_ PRTL_AVL_TABLE Table, _In_ PVOID Buffer, _Out_ PVOID* RestartKey);
-
-template <typename fn>
-bool
-resolve_function(HMODULE module_handle, fn& function, const char* function_name)
-{
-    function = reinterpret_cast<fn>(GetProcAddress(module_handle, function_name));
-    return (function != nullptr);
-}
-
 ebpf_result_t
 ebpf_platform_initiate()
 {
-    HMODULE ntdll_module = nullptr;
-
-    ntdll_module = LoadLibrary(L"ntdll.dll");
-    if (ntdll_module == nullptr) {
-        return EBPF_OPERATION_NOT_SUPPORTED;
-    }
-
-    if (!resolve_function(ntdll_module, RtlInitializeGenericTableAvl, "RtlInitializeGenericTableAvl")) {
-        return EBPF_OPERATION_NOT_SUPPORTED;
-    }
-    if (!resolve_function(ntdll_module, RtlEnumerateGenericTableAvl, "RtlEnumerateGenericTableAvl")) {
-        return EBPF_OPERATION_NOT_SUPPORTED;
-    }
-    if (!resolve_function(ntdll_module, RtlDeleteElementGenericTableAvl, "RtlDeleteElementGenericTableAvl")) {
-        return EBPF_OPERATION_NOT_SUPPORTED;
-    }
-    if (!resolve_function(ntdll_module, RtlLookupElementGenericTableAvl, "RtlLookupElementGenericTableAvl")) {
-        return EBPF_OPERATION_NOT_SUPPORTED;
-    }
-    if (!resolve_function(ntdll_module, RtlEnumerateGenericTableAvl, "RtlEnumerateGenericTableAvl")) {
-        return EBPF_OPERATION_NOT_SUPPORTED;
-    }
-    if (!resolve_function(
-            ntdll_module,
-            RtlLookupFirstMatchingElementGenericTableAvl,
-            "RtlLookupFirstMatchingElementGenericTableAvl")) {
-        return EBPF_OPERATION_NOT_SUPPORTED;
-    }
-    if (!resolve_function(ntdll_module, RtlInsertElementGenericTableAvl, "RtlInsertElementGenericTableAvl")) {
-        return EBPF_OPERATION_NOT_SUPPORTED;
-    }
-
-    // Note: This is safe because ntdll is never unloaded becuase
-    // ntdll.dll houses the module loader, which cannot unload itself.
-    FreeLibrary(ntdll_module);
     return EBPF_SUCCESS;
 }
 
@@ -261,6 +196,21 @@ int32_t
 ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, int32_t exchange, int32_t comperand)
 {
     return InterlockedCompareExchange((long volatile*)destination, exchange, comperand);
+}
+
+void*
+ebpf_interlocked_compare_exchange_pointer(
+    _Inout_ void* volatile* destination, const void* exchange, const void* comperand)
+{
+    return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
+}
+
+uint32_t
+ebpf_random_uint32()
+{
+    std::random_device rd;
+    std::mt19937 mt(rd());
+    return mt();
 }
 
 void

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -200,7 +200,7 @@ ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, i
 
 void*
 ebpf_interlocked_compare_exchange_pointer(
-    _Inout_ void* volatile* destination, _In_ const void* exchange, _In_ const void* comperand)
+    _Inout_ void* volatile* destination, _In_opt_ const void* exchange, _In_opt_ const void* comperand)
 {
     return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
 }

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -200,7 +200,7 @@ ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, i
 
 void*
 ebpf_interlocked_compare_exchange_pointer(
-    _Inout_ void* volatile* destination, const void* exchange, const void* comperand)
+    _Inout_ void* volatile* destination, _In_ const void* exchange, _In_ const void* comperand)
 {
     return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
 }

--- a/libs/platform/user/framework.h
+++ b/libs/platform/user/framework.h
@@ -24,101 +24,10 @@
 
 // Types and functions from the ntddk duplicated here to allow user and kernel more closely align.
 
-//
-//  The results of a compare can be less than, equal, or greater than.
-//
-
-typedef enum _RTL_GENERIC_COMPARE_RESULTS
-{
-    GenericLessThan,
-    GenericGreaterThan,
-    GenericEqual
-} RTL_GENERIC_COMPARE_RESULTS;
-
-struct _RTL_AVL_TABLE;
-
-//
-//  The comparison function takes as input pointers to elements containing
-//  user defined structures and returns the results of comparing the two
-//  elements.
-//
-
-typedef _IRQL_requires_same_ _Function_class_(RTL_AVL_COMPARE_ROUTINE) RTL_GENERIC_COMPARE_RESULTS NTAPI
-    RTL_AVL_COMPARE_ROUTINE(_In_ struct _RTL_AVL_TABLE* table, _In_ void* first_struct, _In_ void* second_struct);
-typedef RTL_AVL_COMPARE_ROUTINE* PRTL_AVL_COMPARE_ROUTINE;
-
-//
-//  The allocation function is called by the generic table package whenever
-//  it needs to allocate memory for the table.
-//
-
-typedef _IRQL_requires_same_ _Function_class_(RTL_AVL_ALLOCATE_ROUTINE) __drv_allocatesMem(Mem) void* NTAPI
-    RTL_AVL_ALLOCATE_ROUTINE(_In_ struct _RTL_AVL_TABLE* table, _In_ const unsigned long byte_size);
-typedef RTL_AVL_ALLOCATE_ROUTINE* PRTL_AVL_ALLOCATE_ROUTINE;
-
-//
-//  The deallocation function is called by the generic table package whenever
-//  it needs to deallocate memory from the table that was allocated by calling
-//  the user supplied allocation function.
-//
-
-typedef _IRQL_requires_same_ _Function_class_(RTL_AVL_FREE_ROUTINE) VOID NTAPI
-    RTL_AVL_FREE_ROUTINE(_In_ struct _RTL_AVL_TABLE* table, _In_ __drv_freesMem(Mem) _Post_invalid_ void* buffer);
-typedef RTL_AVL_FREE_ROUTINE* PRTL_AVL_FREE_ROUTINE;
-
-typedef struct _RTL_BALANCED_LINKS
-{
-    struct _RTL_BALANCED_LINKS* Parent;
-    struct _RTL_BALANCED_LINKS* LeftChild;
-    struct _RTL_BALANCED_LINKS* RightChild;
-    CHAR Balance;
-    UCHAR Reserved[3];
-} RTL_BALANCED_LINKS;
-typedef RTL_BALANCED_LINKS* PRTL_BALANCED_LINKS;
-
-typedef struct _RTL_AVL_TABLE
-{
-    RTL_BALANCED_LINKS BalancedRoot;
-    PVOID OrderedPointer;
-    ULONG WhichOrderedElement;
-    ULONG NumberGenericTableElements;
-    ULONG DepthOfTree;
-    PRTL_BALANCED_LINKS RestartKey;
-    ULONG DeleteCount;
-    PRTL_AVL_COMPARE_ROUTINE CompareRoutine;
-    PRTL_AVL_ALLOCATE_ROUTINE AllocateRoutine;
-    PRTL_AVL_FREE_ROUTINE FreeRoutine;
-    PVOID TableContext;
-} RTL_AVL_TABLE;
-typedef RTL_AVL_TABLE* PRTL_AVL_TABLE;
-
 #ifdef __cplusplus
 extern "C"
 {
 #endif
-
-    extern void (*RtlInitializeGenericTableAvl)(
-        _Out_ PRTL_AVL_TABLE table,
-        _In_ PRTL_AVL_COMPARE_ROUTINE compare_routine,
-        _In_ PRTL_AVL_ALLOCATE_ROUTINE allocate_routine,
-        _In_ PRTL_AVL_FREE_ROUTINE free_routine,
-        _In_opt_ PVOID table_context);
-
-    extern void* (*RtlEnumerateGenericTableAvl)(_In_ PRTL_AVL_TABLE table, _In_ BOOLEAN restart);
-
-    extern BOOLEAN (*RtlDeleteElementGenericTableAvl)(_In_ PRTL_AVL_TABLE table, _In_ void* buffer);
-
-    extern void* (*RtlLookupElementGenericTableAvl)(_In_ PRTL_AVL_TABLE table, _In_ void* buffer);
-
-    extern void* (*RtlInsertElementGenericTableAvl)(
-        _In_ PRTL_AVL_TABLE table,
-        _In_reads_bytes_(BufferSize) void* buffer,
-        _In_ const uint32_t buffer_size,
-        _Out_opt_ PBOOLEAN new_element);
-
-    extern PVOID (*RtlLookupFirstMatchingElementGenericTableAvl)(
-        _In_ PRTL_AVL_TABLE table, _In_ void* buffer, _Out_ void** RestartKey);
-
     typedef LIST_ENTRY ebpf_list_entry_t;
 
     inline void


### PR DESCRIPTION
Switch to hash table from AVL. Lock-free in the presence of epoch allocator.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>