### PR TITLE
Register program type specific helper functions to uBPF in interpreted mode

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -41,16 +41,24 @@ typedef struct _ebpf_program
     ebpf_extension_client_t* program_info_client;
     const void* program_info_binding_context;
     const ebpf_extension_data_t* program_info_provider_data;
-    uint32_t helper_function_count;
+    // Program type specific helper function count.
+    uint32_t provider_helper_function_count;
     bool program_invalidated;
 
     ebpf_trampoline_table_t* trampoline_table;
+
+    // Array of helper function Id referred by this program.
+    size_t helper_function_count;
+    uint32_t* helper_function_ids;
 
     ebpf_epoch_work_item_t* cleanup_work_item;
 
     ebpf_list_entry_t links;
     ebpf_lock_t links_lock;
 } ebpf_program_t;
+
+static ebpf_result_t
+_ebpf_program_register_helpers(ebpf_program_t* program);
 
 static void
 _ebpf_program_detach_links(_Inout_ ebpf_program_t* program)
@@ -70,6 +78,7 @@ _ebpf_program_program_info_provider_changed(
 {
     ebpf_result_t return_value;
     ebpf_program_t* program = (ebpf_program_t*)client_binding_context;
+    uint32_t* provider_helper_function_ids = NULL;
 
     if (provider_data == NULL) {
         // Extension is detaching. Program will get invalidated.
@@ -85,31 +94,63 @@ _ebpf_program_program_info_provider_changed(
 
         helper_function_addresses = program_data->helper_function_addresses;
 
-        if ((program->helper_function_count > 0) &&
-            (helper_function_addresses->helper_function_count != program->helper_function_count))
+        if ((program->provider_helper_function_count > 0) &&
+            (helper_function_addresses->helper_function_count != program->provider_helper_function_count))
             // A program info provider cannot modify helper function count upon reload.
             goto Exit;
 
         if (helper_function_addresses != NULL) {
+            ebpf_program_info_t* program_info = program_data->program_info;
+            ebpf_helper_function_prototype_t* helper_prototypes = NULL;
+            ebpf_assert(program_info != NULL);
+            if (program_info->count_of_helpers != helper_function_addresses->helper_function_count) {
+                return_value = EBPF_INVALID_ARGUMENT;
+                goto Exit;
+            }
+            helper_prototypes = program_info->helper_prototype;
+            if (helper_prototypes == NULL) {
+                return_value = EBPF_INVALID_ARGUMENT;
+                goto Exit;
+            }
             if (!program->trampoline_table) {
                 // Program info provider is being loaded for the first time. Allocate trampoline table.
-                program->helper_function_count = helper_function_addresses->helper_function_count;
+                program->provider_helper_function_count = helper_function_addresses->helper_function_count;
                 return_value =
-                    ebpf_allocate_trampoline_table(program->helper_function_count, &program->trampoline_table);
+                    ebpf_allocate_trampoline_table(program->provider_helper_function_count, &program->trampoline_table);
                 if (return_value != EBPF_SUCCESS)
                     goto Exit;
             }
-
+            _Analysis_assume_(program->provider_helper_function_count > 0);
+            provider_helper_function_ids =
+                (uint32_t*)ebpf_allocate(sizeof(uint32_t) * program->provider_helper_function_count);
+            if (provider_helper_function_ids == NULL) {
+                return_value = EBPF_NO_MEMORY;
+                goto Exit;
+            }
+            for (uint32_t index = 0; index < program->provider_helper_function_count; index++)
+                provider_helper_function_ids[index] = helper_prototypes[index].helper_id;
             // Update trampoline table with new helper function addresses.
-            return_value = ebpf_update_trampoline_table(program->trampoline_table, helper_function_addresses);
+            return_value = ebpf_update_trampoline_table(
+                program->trampoline_table,
+                program->provider_helper_function_count,
+                provider_helper_function_ids,
+                helper_function_addresses);
             if (return_value != EBPF_SUCCESS)
                 goto Exit;
+
+            if (program->code_or_vm.vm != NULL) {
+                // Register with UBPF for interpreted mode.
+                return_value = _ebpf_program_register_helpers(program);
+                if (return_value != EBPF_SUCCESS)
+                    goto Exit;
+            }
         }
     }
 
     program->program_info_binding_context = provider_binding_context;
     program->program_info_provider_data = provider_data;
 Exit:
+    ebpf_free(provider_helper_function_ids);
     program->program_invalidated = (program->program_info_provider_data == NULL);
 }
 
@@ -173,6 +214,8 @@ _ebpf_program_epoch_free(void* context)
     ebpf_free(program->maps);
 
     ebpf_free_trampoline_table(program->trampoline_table);
+
+    ebpf_free(program->helper_function_ids);
 
     ebpf_free(program->cleanup_work_item);
     ebpf_free(program);
@@ -360,13 +403,14 @@ ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, size_t m
 }
 
 ebpf_result_t
-ebpf_program_load_machine_code(ebpf_program_t* program, uint8_t* machine_code, size_t machine_code_size)
+_ebpf_program_load_machine_code(
+    _Inout_ ebpf_program_t* program, _In_ const uint8_t* machine_code, size_t machine_code_size)
 {
     ebpf_result_t return_value;
     uint8_t* local_machine_code = NULL;
     ebpf_memory_descriptor_t* local_code_memory_descriptor = NULL;
 
-    if (program->parameters.code_type != EBPF_CODE_NONE) {
+    if (program->parameters.code_type != EBPF_CODE_NATIVE) {
         return_value = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
@@ -385,7 +429,6 @@ ebpf_program_load_machine_code(ebpf_program_t* program, uint8_t* machine_code, s
         goto Done;
     }
 
-    program->parameters.code_type = EBPF_CODE_NATIVE;
     program->code_or_vm.code.code_memory_descriptor = local_code_memory_descriptor;
     program->code_or_vm.code.code_pointer = local_machine_code;
     local_code_memory_descriptor = NULL;
@@ -401,35 +444,59 @@ Done:
 static ebpf_result_t
 _ebpf_program_register_helpers(ebpf_program_t* program)
 {
+    ebpf_result_t result = EBPF_SUCCESS;
     size_t index = 0;
     ebpf_program_data_t* general_helper_program_data =
         (ebpf_program_data_t*)program->general_helper_provider_data->data;
     ebpf_helper_function_addresses_t* general_helper_function_addresses =
         general_helper_program_data->helper_function_addresses;
-    size_t count = general_helper_function_addresses->helper_function_count;
 
-    for (index = 0; index < count; index++) {
-        const void* helper = (void*)general_helper_function_addresses->helper_function_address[index];
+    ebpf_assert(program->code_or_vm.vm != NULL);
+
+    for (index = 0; index < program->helper_function_count; index++) {
+        uint32_t helper_function_id = program->helper_function_ids[index];
+        const void* helper = NULL;
+        if (helper_function_id > EBPF_MAX_GENERAL_HELPER_FUNCTION) {
+            // Get the program-type specific helper function address from the trampoline table.
+            result = ebpf_get_trampoline_helper_address(
+                program->trampoline_table,
+                (size_t)(helper_function_id - (EBPF_MAX_GENERAL_HELPER_FUNCTION + 1)),
+                (void**)&helper);
+            if (result != EBPF_SUCCESS)
+                goto Exit;
+        } else {
+            // Get the general helper function address.
+            if (helper_function_id > general_helper_function_addresses->helper_function_count) {
+                result = EBPF_INVALID_ARGUMENT;
+                goto Exit;
+            }
+            helper = (void*)general_helper_function_addresses->helper_function_address[helper_function_id];
+        }
         if (helper == NULL)
             continue;
 
-        if (ubpf_register(program->code_or_vm.vm, (unsigned int)index, NULL, (void*)helper) < 0)
-            return EBPF_INVALID_ARGUMENT;
+        if (ubpf_register(program->code_or_vm.vm, (unsigned int)index, NULL, (void*)helper) < 0) {
+            result = EBPF_INVALID_ARGUMENT;
+            goto Exit;
+        }
     }
-    return EBPF_SUCCESS;
+
+Exit:
+    return result;
 }
 
 ebpf_result_t
-ebpf_program_load_byte_code(ebpf_program_t* program, ebpf_instruction_t* instructions, size_t instruction_count)
+_ebpf_program_load_byte_code(
+    _Inout_ ebpf_program_t* program, _In_ const ebpf_instruction_t* instructions, size_t instruction_count)
 {
     ebpf_result_t return_value;
     char* error_message = NULL;
-    if (program->parameters.code_type != EBPF_CODE_NONE) {
+
+    if (program->parameters.code_type != EBPF_CODE_EBPF) {
         return_value = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
 
-    program->parameters.code_type = EBPF_CODE_EBPF;
     program->code_or_vm.vm = ubpf_create();
     if (!program->code_or_vm.vm) {
         return_value = EBPF_NO_MEMORY;
@@ -465,6 +532,25 @@ Done:
     return return_value;
 }
 
+ebpf_result_t
+ebpf_program_load_code(
+    _Inout_ ebpf_program_t* program, ebpf_code_type_t code_type, _In_ const uint8_t* code, size_t code_size)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    program->parameters.code_type = code_type;
+    if (program->parameters.code_type == EBPF_CODE_NATIVE)
+        result = _ebpf_program_load_machine_code(program, code, code_size);
+    else if (program->parameters.code_type == EBPF_CODE_EBPF)
+        result = _ebpf_program_load_byte_code(
+            program, (const ebpf_instruction_t*)code, code_size / sizeof(ebpf_instruction_t));
+    else {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+Exit:
+    return result;
+}
+
 void
 ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out_ uint32_t* result)
 {
@@ -488,8 +574,8 @@ ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out
     }
 }
 
-ebpf_result_t
-ebpf_program_get_helper_function_address(
+static ebpf_result_t
+_ebpf_program_get_helper_function_address(
     _In_ const ebpf_program_t* program, const uint32_t helper_function_id, uint64_t* address)
 {
     if (helper_function_id > EBPF_MAX_GENERAL_HELPER_FUNCTION) {
@@ -518,6 +604,59 @@ ebpf_program_get_helper_function_address(
     }
 
     return EBPF_SUCCESS;
+}
+
+ebpf_result_t
+ebpf_program_get_helper_function_addresses(
+    _In_ const ebpf_program_t* program, size_t addresses_count, _Out_writes_(addresses_count) uint64_t* addresses)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+
+    if (program->helper_function_count > addresses_count) {
+        result = EBPF_INSUFFICIENT_BUFFER;
+        goto Exit;
+    }
+
+    for (uint32_t index = 0; index < program->helper_function_count; index++) {
+        result =
+            _ebpf_program_get_helper_function_address(program, program->helper_function_ids[index], &addresses[index]);
+        if (result != EBPF_SUCCESS)
+            break;
+    }
+
+Exit:
+    return result;
+}
+
+ebpf_result_t
+ebpf_program_set_helper_function_ids(
+    _Inout_ ebpf_program_t* program,
+    const size_t helper_function_count,
+    _In_reads_(helper_function_count) const uint32_t* helper_function_ids)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+
+    if (program->helper_function_ids != NULL) {
+        // Helper function IDs already set.
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
+    if (helper_function_count == 0)
+        goto Exit;
+
+    program->helper_function_count = helper_function_count;
+    program->helper_function_ids = ebpf_allocate(sizeof(uint32_t) * helper_function_count);
+    if (program->helper_function_ids == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    for (size_t index = 0; index < helper_function_count; index++)
+        program->helper_function_ids[index] = helper_function_ids[index];
+
+Exit:
+    return result;
 }
 
 ebpf_result_t

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -402,7 +402,7 @@ ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, size_t m
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+static ebpf_result_t
 _ebpf_program_load_machine_code(
     _Inout_ ebpf_program_t* program, _In_ const uint8_t* machine_code, size_t machine_code_size)
 {
@@ -485,7 +485,7 @@ Exit:
     return result;
 }
 
-ebpf_result_t
+static ebpf_result_t
 _ebpf_program_load_byte_code(
     _Inout_ ebpf_program_t* program, _In_ const ebpf_instruction_t* instructions, size_t instruction_count)
 {

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -47,7 +47,7 @@ typedef struct _ebpf_program
 
     ebpf_trampoline_table_t* trampoline_table;
 
-    // Array of helper function Id referred by this program.
+    // Array of helper function ids referred by this program.
     size_t helper_function_count;
     uint32_t* helper_function_ids;
 
@@ -139,7 +139,7 @@ _ebpf_program_program_info_provider_changed(
                 goto Exit;
 
             if (program->code_or_vm.vm != NULL) {
-                // Register with UBPF for interpreted mode.
+                // Register with uBPF for interpreted mode.
                 return_value = _ebpf_program_register_helpers(program);
                 if (return_value != EBPF_SUCCESS)
                     goto Exit;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -543,11 +543,8 @@ ebpf_program_load_code(
     else if (program->parameters.code_type == EBPF_CODE_EBPF)
         result = _ebpf_program_load_byte_code(
             program, (const ebpf_instruction_t*)code, code_size / sizeof(ebpf_instruction_t));
-    else {
+    else
         result = EBPF_INVALID_ARGUMENT;
-        goto Exit;
-    }
-Exit:
     return result;
 }
 

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -109,31 +109,20 @@ extern "C"
     ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, size_t maps_count);
 
     /**
-     * @brief Load a block of machine code into the program instance.
+     * @brief Load a block of eBPF code into the program instance.
      *
-     * @param[in] program Program instance to load the machine code into.
-     * @param[in] machine_code Pointer to memory containing the machine code.
-     * @param[in] machine_code_size Size of the memory block containing the machine
+     * @param[in, out] program Program instance to load the eBPF code into.
+     * @param[in] code_type Specifies whether eBPF code is JIT compiled or byte code.
+     * @param[in] code Pointer to memory containing the eBPF code.
+     * @param[in] machine_size Size of the memory block containing the eBPF
      *  code.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
     ebpf_result_t
-    ebpf_program_load_machine_code(ebpf_program_t* program, uint8_t* machine_code, size_t machine_code_size);
-
-    /**
-     * @brief Load a block of eBPF instructions into the program instance.
-     *
-     * @param[in] program Program instance to load the byte code into.
-     * @param[in] instructions Pointer to array of eBPF instructions.
-     * @param[in] instruction_count Count of eBPF instructions to load.
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
-     *  program instance.
-     */
-    ebpf_result_t
-    ebpf_program_load_byte_code(ebpf_program_t* program, ebpf_instruction_t* instructions, size_t instruction_count);
+    ebpf_program_load_code(
+        _Inout_ ebpf_program_t* program, ebpf_code_type_t code_type, _In_ const uint8_t* code, size_t code_size);
 
     /**
      * @brief Invoke an ebpf_program_t instance.
@@ -146,17 +135,38 @@ extern "C"
     ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out_ uint32_t* result);
 
     /**
-     * @brief Get the address of a helper function.
+     * @brief Store the helper function IDs that are used by the eBPF program in an array inside the program object. The
+     array index is the helper function ID to be used by uBPF whereas the array value is the actual helper ID.
      *
-     * @param[in] program Program object to query this on.
-     * @param[in] helper_function_id Helper function ID to look up.
-     * @param[out] address Address of the helper function.
+     * @param[in, out] program Program object to query this on.
+     * @param[in] helper_function_count Count of helper functions.
+     * @param[in] helper_function_ids Array of helper function IDs to store.
      * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_INVALID_ARGUMENT The helper_function_id is not valid.
+     * @retval EBPF_INVALID_ARGUMENT The helper function IDs array is already populated.
+     * @retval EBPF_NO_MEMORY Could not allocate array of helper function IDs.
      */
     ebpf_result_t
-    ebpf_program_get_helper_function_address(
-        _In_ const ebpf_program_t* program, const uint32_t helper_function_id, uint64_t* address);
+    ebpf_program_set_helper_function_ids(
+        _Inout_ ebpf_program_t* program,
+        const size_t helper_function_count,
+        _In_reads_(helper_function_count) const uint32_t* helper_function_ids);
+
+    /**
+     * @brief Get the address of a helper functions referred to by the program. Assumes
+     * ebpf_program_set_helper_function_ids has already been invoked on the program object.
+     *
+     * @param[in] program Program object to query this on.
+     * @param[in] addresses_count Length of caller supplied output array.
+     * @param[out] address Caller supplied output array where the addresses of the helper functions are written to.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INSUFFICIENT_BUFFER Output array is insufficient.
+     * @retval EBPF_INVALID_ARGUMENT At least one helper function id is not valid.
+     */
+    ebpf_result_t
+    ebpf_program_get_helper_function_addresses(
+        _In_ const ebpf_program_t* program,
+        const size_t addresses_count,
+        _Out_writes_(addresses_count) uint64_t* addresses);
 
     /**
      * @brief Attach a link object to an eBPF program.

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -135,8 +135,9 @@ extern "C"
     ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out_ uint32_t* result);
 
     /**
-     * @brief Store the helper function IDs that are used by the eBPF program in an array inside the program object. The
-     array index is the helper function ID to be used by uBPF whereas the array value is the actual helper ID.
+     * @brief Store the helper function IDs that are used by the eBPF program in an array
+     *  inside the program object. The array index is the helper function ID to be used by
+     *  uBPF whereas the array value is the actual helper ID.
      *
      * @param[in, out] program Program object to query this on.
      * @param[in] helper_function_count Count of helper functions.

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -698,14 +698,19 @@ extern "C"
      * @brief Populate the function pointers in a trampoline table.
      *
      * @param[in] trampoline_table Trampoline table to populate.
+     * @param[in] helper_function_count Count of helper functions.
+     * @param[in] helper_function_ids Array of helper function IDs.
      * @param[in] dispatch_table Dispatch table to populate from.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
+     * @retval EBPF_INVALID_ARGUMENT An invalid argument was supplied.
      */
     ebpf_result_t
     ebpf_update_trampoline_table(
         _Inout_ ebpf_trampoline_table_t* trampoline_table,
+        uint32_t helper_function_count,
+        _In_reads_(helper_function_count) const uint32_t* helper_function_ids,
         _In_ const ebpf_helper_function_addresses_t* helper_function_addresses);
 
     /**
@@ -722,6 +727,21 @@ extern "C"
     ebpf_result_t
     ebpf_get_trampoline_function(
         _In_ const ebpf_trampoline_table_t* trampoline_table, size_t index, _Out_ void** function);
+
+    /**
+     * @brief Get the address of the helper function from the trampoline table entry.
+     *
+     * @param[in] trampoline_table Trampoline table to query.
+     * @param[in] index Index of trampoline table entry.
+     * @param[out] helper_address Pointer to memory that contains the address to helper function on success.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  operation.
+     * @retval EBPF_INVALID_ARGUMENT An invalid argument was supplied.
+     */
+    ebpf_result_t
+    ebpf_get_trampoline_helper_address(
+        _In_ const ebpf_trampoline_table_t* trampoline_table, size_t index, _Out_ void** helper_address);
 
     typedef struct _ebpf_program_info ebpf_program_info_t;
 

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -334,11 +334,12 @@ ebpf_verify_and_load_program(
             goto Exit;
         }
 
+        std::vector<uint64_t> helper_id_adddress;
+        result = _build_helper_id_to_address_map(program_handle, byte_code_buffer, helper_id_adddress);
+        if (result != EBPF_SUCCESS)
+            goto Exit;
+
         if (execution_type == EBPF_EXECUTION_JIT) {
-            std::vector<uint64_t> helper_id_adddress;
-            result = _build_helper_id_to_address_map(program_handle, byte_code_buffer, helper_id_adddress);
-            if (result != EBPF_SUCCESS)
-                goto Exit;
 
             ebpf_code_buffer_t machine_code(MAX_CODE_SIZE_IN_BYTES);
             size_t machine_code_size = machine_code.size();

--- a/tests/sample/ext/app/sample_ext_app.cpp
+++ b/tests/sample/ext/app/sample_ext_app.cpp
@@ -49,7 +49,8 @@ _program_load_helper(
     return result;
 }
 
-TEST_CASE("test_test", "[test_test]")
+void
+sample_ebpf_ext_test(ebpf_execution_type_t execution_type)
 {
     ebpf_result_t result;
     struct bpf_object* object = nullptr;
@@ -70,7 +71,7 @@ TEST_CASE("test_test", "[test_test]")
     REQUIRE(ebpf_api_initiate() == EBPF_SUCCESS);
 
     result =
-        _program_load_helper("test_sample_ebpf.o", &EBPF_PROGRAM_TYPE_SAMPLE, EBPF_EXECUTION_JIT, &object, &program_fd);
+        _program_load_helper("test_sample_ebpf.o", &EBPF_PROGRAM_TYPE_SAMPLE, execution_type, &object, &program_fd);
 
     REQUIRE(result == EBPF_SUCCESS);
     REQUIRE(program_fd > 0);
@@ -129,3 +130,7 @@ TEST_CASE("test_test", "[test_test]")
 
     ebpf_api_terminate();
 }
+
+TEST_CASE("jit_test", "[test_test]") { sample_ebpf_ext_test(EBPF_EXECUTION_JIT); }
+
+TEST_CASE("interpret_test", "[test_test]") { sample_ebpf_ext_test(EBPF_EXECUTION_INTERPRET); }


### PR DESCRIPTION
This PR addresses #370 and second issue of #291 .

This PR adds support for program type specific helper functions in interpret mode. Here are the changes:

1. The program object now maintains an array of helper function IDs that are used by the program. Due to limitations in uBPF code, the helper function IDs have to be moved to a (0 - 63) range. The array indices are the "modified" helper IDs to be used by uBPF whereas the real helper IDs are stored in the array values.
2. When a program info provider (re)attaches the helper addresses are stored in the trampoline table. The index of the trampoline entry is chosen such that it can be easily derived from the helper ID; and a full lookup of the trampoline table is not needed when trying to retrieve address of a helper function.
3. Finally, when a byte code is loaded, the addresses of program type specific helper function are retrieved from the trampoline table. The trampoline table is updated every time a provider reloads post byte code load.

I have tested this using the sample extension driver and loading the test program for sample extension loaded in interpreted mode. I have also tested after enabling HVCI.

API_Test and ebpf_client tests were ran as well.