### PR TITLE
fix unit tests

### DIFF
--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -181,15 +181,11 @@ static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = 
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS, EBPF_ARGUMENT_TYPE_ANYTHING}},
 };
 
-static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {
-    sizeof(xdp_md_t),
-    EBPF_OFFSET_OF(xdp_md_t, data),
-    EBPF_OFFSET_OF(xdp_md_t, data_end),
-    EBPF_OFFSET_OF(xdp_md_t, data_meta)};
-static ebpf_program_info_t _ebpf_xdp_program_info = {
-    {"xdp", &_ebpf_xdp_context_descriptor, {0}},
-    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-    _ebpf_map_helper_function_prototype};
+static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {sizeof(xdp_md_t),
+                                                                 EBPF_OFFSET_OF(xdp_md_t, data),
+                                                                 EBPF_OFFSET_OF(xdp_md_t, data_end),
+                                                                 EBPF_OFFSET_OF(xdp_md_t, data_meta)};
+static ebpf_program_info_t _ebpf_xdp_program_info = {{"xdp", &_ebpf_xdp_context_descriptor, {0}}, 0, NULL};
 
 static ebpf_program_data_t _ebpf_xdp_program_data = {&_ebpf_xdp_program_info, NULL};
 
@@ -198,10 +194,7 @@ static ebpf_extension_data_t _ebpf_xdp_program_info_provider_data = {
 
 static ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
     sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
-static ebpf_program_info_t _ebpf_bind_program_info = {
-    {"bind", &_ebpf_bind_context_descriptor, {0}},
-    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_bind_program_info = {{"bind", &_ebpf_bind_context_descriptor, {0}}, 0, NULL};
 
 static ebpf_program_data_t _ebpf_bind_program_data = {&_ebpf_bind_program_info, NULL};
 

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -6,6 +6,7 @@
 #include "capture_helper.hpp"
 #include "catch_wrapper.hpp"
 #include "elf.h"
+#include "helpers.h"
 #include "programs.h"
 #include "test_helper.hpp"
 
@@ -194,6 +195,7 @@ TEST_CASE("show verification bpf.o", "[netsh][verification]")
 TEST_CASE("show verification droppacket.o", "[netsh][verification]")
 {
     int result;
+    program_info_provider_t program_info_provider(EBPF_PROGRAM_TYPE_XDP);
     std::string output = _run_netsh_command(handle_ebpf_show_verification, L"droppacket.o", L"xdp", &result);
     REQUIRE(result == NO_ERROR);
     REQUIRE(
@@ -207,6 +209,7 @@ TEST_CASE("show verification droppacket.o", "[netsh][verification]")
 TEST_CASE("show verification droppacket_unsafe.o", "[netsh][verification]")
 {
     int result;
+    program_info_provider_t program_info_provider(EBPF_PROGRAM_TYPE_XDP);
     std::string output = _run_netsh_command(handle_ebpf_show_verification, L"droppacket_unsafe.o", L"xdp", &result);
     REQUIRE(result == ERROR_SUPPRESS_OUTPUT);
     REQUIRE(


### PR DESCRIPTION
The reason #381  masked break in netsh unit tests is because the program info was cached in TLS. With #403 the cache was cleared and the tests started failing. This PR adds program_info_provider helper objects to netsh tests to make them work without having to rely on the fallback path that #381  eliminated.

Now the RPC marshaling code can be removed (when a suitable alternative is decided on) without impacting the unit tests.

The unit tests also incorrectly included global helper function in xdp/bind program data - which is removed.