### PR TITLE
Add map-in-map support

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -219,7 +219,9 @@ extern "C"
      * @param[out] key_size Size of keys in the eBPF map.
      * @param[out] value_size Size of values in the eBPF map.
      * @param[out] max_entries Maximum number of entries in the map.
-     * @param[out] inner_map_idx Index in the object of an inner map template.
+     * @param[out] inner_map_idx For maps of type BPF_TYPE_ARRAY_OF_MAPS or BPF_TYPE_HASH_OF_MAPS created from an ELF
+     * file, this is the index in the maps section of another map that any inner maps must match.  Otherwise, the value
+     * is 0.
      * @retval EBPF_SUCCESS The operation was successful.
      */
     ebpf_result_t

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -219,6 +219,7 @@ extern "C"
      * @param[out] key_size Size of keys in the eBPF map.
      * @param[out] value_size Size of values in the eBPF map.
      * @param[out] max_entries Maximum number of entries in the map.
+     * @param[out] inner_map_idx Index in the object of an inner map template.
      * @retval EBPF_SUCCESS The operation was successful.
      */
     ebpf_result_t
@@ -228,7 +229,8 @@ extern "C"
         _Out_ uint32_t* type,
         _Out_ uint32_t* key_size,
         _Out_ uint32_t* value_size,
-        _Out_ uint32_t* max_entries);
+        _Out_ uint32_t* max_entries,
+        _Out_ uint32_t* inner_map_idx);
 
     /**
      * @brief Query info about an eBPF program.

--- a/include/ebpf_helpers.h
+++ b/include/ebpf_helpers.h
@@ -74,3 +74,5 @@ EBPF_HELPER(int64_t, bpf_tail_call, (void* ctx, struct bpf_map* prog_array_map, 
 #ifndef __doxygen
 #define bpf_tail_call ((bpf_tail_call_t)4)
 #endif
+
+#define SEC(name) __attribute__((section(name), used))

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -18,6 +18,8 @@ typedef enum bpf_map_type
         3, ///< Array of program fds usable with bpf_tail_call, where the map key is the array index.
     BPF_MAP_TYPE_PERCPU_HASH = 4,
     BPF_MAP_TYPE_PERCPU_ARRAY = 5,
+    BPF_MAP_TYPE_HASH_OF_MAPS = 6,
+    BPF_MAP_TYPE_ARRAY_OF_MAPS = 7,
 } ebpf_map_type_t;
 
 typedef enum ebpf_map_option
@@ -40,4 +42,5 @@ typedef struct _ebpf_map_definition
     uint32_t key_size;
     uint32_t value_size;
     uint32_t max_entries;
+    uint32_t inner_map_idx;
 } ebpf_map_definition_t;

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -19,6 +19,7 @@ create_map_internal(
     uint32_t key_size,
     uint32_t value_size,
     uint32_t max_entries,
+    uint32_t inner_map_fd,
     size_t section_offset,
     ebpf_verifier_options_t options);
 
@@ -28,6 +29,7 @@ create_map_windows(
     uint32_t key_size,
     uint32_t value_size,
     uint32_t max_entries,
+    uint32_t inner_map_fd,
     size_t section_offset,
     ebpf_verifier_options_t options)
 {
@@ -35,11 +37,11 @@ create_map_windows(
     if (options.mock_map_fds) {
         EbpfMapType type = get_map_type_windows(map_type);
         fd = create_map_crab(type, key_size, value_size, max_entries, options);
-        cache_map_file_descriptor(map_type, key_size, value_size, max_entries, fd);
+        cache_map_file_descriptor(map_type, key_size, value_size, max_entries, inner_map_fd, fd);
         return fd;
     }
 
-    return create_map_internal(map_type, key_size, value_size, max_entries, section_offset, options);
+    return create_map_internal(map_type, key_size, value_size, max_entries, inner_map_fd, section_offset, options);
 }
 
 void
@@ -60,13 +62,25 @@ parse_maps_section_windows(
         std::vector<ebpf_map_definition_t>((ebpf_map_definition_t*)data, (ebpf_map_definition_t*)(data + size));
     for (int i = 0; i < mapdefs.size(); i++) {
         auto& s = mapdefs[i];
-        map_descriptors.emplace_back(EbpfMapDescriptor{
-            .original_fd = create_map_windows(
-                s.type, s.key_size, s.value_size, s.max_entries, (i * sizeof(ebpf_map_definition_t)), options),
-            .type = (uint32_t)s.type,
-            .key_size = s.key_size,
-            .value_size = s.value_size,
-        });
+        map_descriptors.emplace_back(EbpfMapDescriptor{.original_fd = create_map_windows(
+                                                           s.type,
+                                                           s.key_size,
+                                                           s.value_size,
+                                                           s.max_entries,
+                                                           s.inner_map_idx,
+                                                           (i * sizeof(ebpf_map_definition_t)),
+                                                           options),
+                                                       .type = (uint32_t)s.type,
+                                                       .key_size = s.key_size,
+                                                       .value_size = s.value_size,
+                                                       .inner_map_fd = s.inner_map_idx});
+    }
+    for (size_t i = 0; i < mapdefs.size(); i++) {
+        unsigned int inner = mapdefs[i].inner_map_idx;
+        if (inner >= map_descriptors.size())
+            throw std::runtime_error(
+                std::string("bad inner map index ") + std::to_string(inner) + " for map " + std::to_string(i));
+        map_descriptors[i].inner_map_fd = map_descriptors.at(inner).original_fd;
     }
 }
 

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -56,27 +56,29 @@ get_file_size(const char* filename, size_t* byte_code_size) noexcept
 ebpf_result_t
 query_map_definition(
     ebpf_handle_t handle,
-    uint32_t* size,
-    uint32_t* type,
-    uint32_t* key_size,
-    uint32_t* value_size,
-    uint32_t* max_entries) noexcept
+    _Out_ uint32_t* size,
+    _Out_ uint32_t* type,
+    _Out_ uint32_t* key_size,
+    _Out_ uint32_t* value_size,
+    _Out_ uint32_t* max_entries,
+    _Out_ uint32_t* inner_map_idx) noexcept
 {
     _ebpf_operation_query_map_definition_request request{
         sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_QUERY_MAP_DEFINITION, reinterpret_cast<uint64_t>(handle)};
 
     _ebpf_operation_query_map_definition_reply reply;
 
-    uint32_t result = invoke_ioctl(request, reply);
-    if (result == ERROR_SUCCESS) {
+    uint32_t error = invoke_ioctl(request, reply);
+    ebpf_result_t result = windows_error_to_ebpf_result(error);
+    if (result == EBPF_SUCCESS) {
         *size = reply.map_definition.size;
         *type = reply.map_definition.type;
         *key_size = reply.map_definition.key_size;
         *value_size = reply.map_definition.value_size;
         *max_entries = reply.map_definition.max_entries;
+        *inner_map_idx = reply.map_definition.inner_map_idx;
     }
-
-    return windows_error_to_ebpf_result(result);
+    return result;
 }
 
 void

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -31,7 +31,7 @@ typedef struct _map_cache
         unsigned int key_size,
         unsigned int value_size,
         unsigned int max_entries,
-        unsigned int inner_map_fd,
+        unsigned int inner_map_idx,
         size_t section_offset)
         : handle(handle), section_offset(section_offset)
     {
@@ -40,7 +40,7 @@ typedef struct _map_cache
         ebpf_map_descriptor.key_size = key_size;
         ebpf_map_descriptor.value_size = value_size;
         ebpf_map_descriptor.max_entries = max_entries;
-        ebpf_map_descriptor.inner_map_fd = inner_map_fd;
+        ebpf_map_descriptor.inner_map_fd = inner_map_idx;
     }
 } map_cache_t;
 
@@ -63,6 +63,7 @@ cache_map_handle(
     uint32_t key_size,
     uint32_t value_size,
     uint32_t max_entries,
+    uint32_t inner_map_fd,
     size_t section_offset);
 
 size_t
@@ -135,11 +136,12 @@ windows_error_to_ebpf_result(uint32_t error)
 ebpf_result_t
 query_map_definition(
     ebpf_handle_t handle,
-    uint32_t* size,
-    uint32_t* type,
-    uint32_t* key_size,
-    uint32_t* value_size,
-    uint32_t* max_entries) noexcept;
+    _Out_ uint32_t* size,
+    _Out_ uint32_t* type,
+    _Out_ uint32_t* key_size,
+    _Out_ uint32_t* value_size,
+    _Out_ uint32_t* max_entries,
+    _Out_ uint32_t* inner_map_idx) noexcept;
 
 void
 set_global_program_and_attach_type(const ebpf_program_type_t* program_type, const ebpf_attach_type_t* attach_type);

--- a/libs/api_common/map_descriptors.cpp
+++ b/libs/api_common/map_descriptors.cpp
@@ -108,8 +108,6 @@ cache_map_handle(
     uint32_t inner_map_fd,
     size_t section_offset)
 {
-    // TODO(issue #287): Replace this with the CRT helper to create FD from handle once we
-    // have real handles.
     int fd = static_cast<int>(_map_file_descriptors.size() + 1);
     _map_file_descriptors.emplace_back(
         handle, fd, type, key_size, value_size, max_entries, inner_map_fd, section_offset);

--- a/libs/api_common/map_descriptors.cpp
+++ b/libs/api_common/map_descriptors.cpp
@@ -77,9 +77,10 @@ get_all_map_descriptors()
 }
 
 void
-cache_map_file_descriptor(uint32_t type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, int fd)
+cache_map_file_descriptor(
+    uint32_t type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, uint32_t inner_map_fd, int fd)
 {
-    _map_file_descriptors.emplace_back((uintptr_t)fd, fd, type, key_size, value_size, max_entries, 0, 0);
+    _map_file_descriptors.emplace_back((uintptr_t)fd, fd, type, key_size, value_size, max_entries, inner_map_fd, 0);
 }
 
 void
@@ -88,21 +89,30 @@ cache_map_file_descriptor_with_handle(
     uint32_t key_size,
     uint32_t value_size,
     uint32_t max_entries,
+    uint32_t inner_map_fd,
     int fd,
     uintptr_t handle,
     size_t section_offset)
 {
-    _map_file_descriptors.emplace_back(handle, fd, type, key_size, value_size, max_entries, 0, section_offset);
+    _map_file_descriptors.emplace_back(
+        handle, fd, type, key_size, value_size, max_entries, inner_map_fd, section_offset);
 }
 
 int
 cache_map_handle(
-    uint64_t handle, uint32_t type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, size_t section_offset)
+    uint64_t handle,
+    uint32_t type,
+    uint32_t key_size,
+    uint32_t value_size,
+    uint32_t max_entries,
+    uint32_t inner_map_fd,
+    size_t section_offset)
 {
-    // TODO: Replace this with the CRT helper to create FD from handle once we
+    // TODO(issue #287): Replace this with the CRT helper to create FD from handle once we
     // have real handles.
     int fd = static_cast<int>(_map_file_descriptors.size() + 1);
-    _map_file_descriptors.emplace_back(handle, fd, type, key_size, value_size, max_entries, 0, section_offset);
+    _map_file_descriptors.emplace_back(
+        handle, fd, type, key_size, value_size, max_entries, inner_map_fd, section_offset);
     return static_cast<int>(_map_file_descriptors.size());
 }
 

--- a/libs/api_common/map_descriptors.hpp
+++ b/libs/api_common/map_descriptors.hpp
@@ -12,7 +12,8 @@ void
 cache_map_file_descriptors(const EbpfMapDescriptor* map_descriptors, uint32_t map_descriptors_count);
 
 void
-cache_map_file_descriptor(uint32_t type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, int fd);
+cache_map_file_descriptor(
+    uint32_t type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, uint32_t inner_map_fd, int fd);
 
 void
 cache_map_file_descriptor_with_handle(
@@ -20,6 +21,7 @@ cache_map_file_descriptor_with_handle(
     uint32_t key_size,
     uint32_t value_size,
     uint32_t max_entries,
+    uint32_t inner_map_fd,
     int fd,
     uintptr_t handle,
     size_t section_offset);

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -113,6 +113,8 @@ static const EbpfMapType windows_map_types[] = {
     {BPF_MAP_TYPE(PROG_ARRAY), true, EbpfMapValueType::PROGRAM},
     {BPF_MAP_TYPE(PERCPU_HASH)},
     {BPF_MAP_TYPE(PERCPU_ARRAY), true},
+    {BPF_MAP_TYPE(HASH_OF_MAPS), false, EbpfMapValueType::MAP},
+    {BPF_MAP_TYPE(ARRAY_OF_MAPS), true, EbpfMapValueType::MAP},
 };
 
 EbpfMapType

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -474,7 +474,13 @@ _ebpf_core_protocol_map_update_element_with_handle(
     key_length = map_definition->key_size;
 
     retval = ebpf_map_update_entry_with_handle(
-        map, key_length, request->data, value_length, request->data + map_definition->key_size, request->value_handle);
+        map,
+        key_length,
+        request->data,
+        value_length,
+        request->data + map_definition->key_size,
+        request->value_handle,
+        request->option);
 
 Done:
     ebpf_object_release_reference((ebpf_object_t*)map);

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -48,7 +48,7 @@ ebpf_link_create(ebpf_link_t** link)
 
     memset(*link, 0, sizeof(ebpf_link_t));
 
-    ebpf_object_initialize(&(*link)->object, EBPF_OBJECT_LINK, _ebpf_link_free);
+    ebpf_object_initialize(&(*link)->object, EBPF_OBJECT_LINK, _ebpf_link_free, NULL);
     ebpf_lock_create(&(*link)->attach_lock);
     return EBPF_SUCCESS;
 }

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -19,12 +19,19 @@ typedef struct _ebpf_core_map
     uint8_t* data;
 } ebpf_core_map_t;
 
-typedef struct _ebpf_program_array_map
+typedef struct _ebpf_core_object_map
 {
     ebpf_core_map_t core_map;
     bool is_program_type_set;
     ebpf_program_type_t program_type;
-} ebpf_program_array_map_t;
+} ebpf_core_object_map_t;
+
+_Ret_notnull_ static const ebpf_program_type_t*
+_get_map_program_type(_In_ const ebpf_object_t* object)
+{
+    const ebpf_core_object_map_t* map = (const ebpf_core_object_map_t*)object;
+    return &map->program_type;
+}
 
 typedef struct _ebpf_map_function_table
 {
@@ -168,12 +175,14 @@ _delete_array_map_entry_with_reference(_In_ ebpf_core_map_t* map, _In_ const uin
         return EBPF_KEY_NOT_FOUND;
 
     uint8_t* entry = &map->data[key_value * map->ebpf_map_definition.value_size];
+    ebpf_lock_state_t lock_state = ebpf_lock_lock(&map->lock);
     if (with_reference) {
         ebpf_object_t** object_pointer = (ebpf_object_t**)(entry + map->ebpf_map_definition.value_size);
         ebpf_object_release_reference(*object_pointer);
         *object_pointer = NULL;
     }
     memset(entry, 0, map->ebpf_map_definition.value_size);
+    ebpf_lock_unlock(&map->lock, lock_state);
     return EBPF_SUCCESS;
 }
 
@@ -205,14 +214,13 @@ _next_array_map_key(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key,
 }
 
 static ebpf_core_map_t*
-_create_prog_array_map(_In_ const ebpf_map_definition_t* map_definition)
+_create_object_array_map(_In_ const ebpf_map_definition_t* map_definition)
 {
-    return _create_array_map_with_extra_value_size(
-        sizeof(ebpf_program_array_map_t), map_definition, sizeof(struct _ebpf_program*));
+    return _create_array_map_with_extra_value_size(sizeof(ebpf_core_object_map_t), map_definition, sizeof(void*));
 }
 
 static void
-_delete_array_map_with_references(_In_ ebpf_core_map_t* map)
+_delete_object_array_map(_In_ ebpf_core_map_t* map)
 {
     // The following addition is safe since it was checked during map creation.
     size_t actual_value_size = ((size_t)map->ebpf_map_definition.value_size) + sizeof(ebpf_object_t*);
@@ -224,14 +232,14 @@ _delete_array_map_with_references(_In_ ebpf_core_map_t* map)
         ebpf_object_release_reference(object);
     }
 
-    ebpf_free(map);
+    _delete_array_map(map);
 }
 
 static ebpf_result_t
 _associate_program_with_prog_array_map(_In_ ebpf_core_map_t* map, _In_ const ebpf_program_t* program)
 {
     ebpf_assert(map->ebpf_map_definition.type == BPF_MAP_TYPE_PROG_ARRAY);
-    ebpf_program_array_map_t* program_array = (ebpf_program_array_map_t*)map;
+    ebpf_core_object_map_t* program_array = (ebpf_core_object_map_t*)map;
 
     // Validate that the program type is
     // not in conflict with the map's program type.
@@ -253,8 +261,12 @@ _associate_program_with_prog_array_map(_In_ ebpf_core_map_t* map, _In_ const ebp
 }
 
 static ebpf_result_t
-_update_prog_array_map_entry_with_handle(
-    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_opt_ const uint8_t* value, uintptr_t value_handle)
+_update_array_map_entry_with_handle(
+    _In_ ebpf_core_map_t* map,
+    _In_ const uint8_t* key,
+    ebpf_object_type_t value_type,
+    _In_ const uint8_t* value,
+    uintptr_t value_handle)
 {
     if (!map || !key || !value)
         return EBPF_INVALID_ARGUMENT;
@@ -264,30 +276,33 @@ _update_prog_array_map_entry_with_handle(
     if (index >= map->ebpf_map_definition.max_entries)
         return EBPF_INVALID_ARGUMENT;
 
-    // Convert value handle to a program pointer.
-    struct _ebpf_program* program;
-    int return_value = ebpf_reference_object_by_handle(value_handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+    // Convert value handle to an object pointer.
+    struct _ebpf_object* object;
+    int return_value = ebpf_reference_object_by_handle(value_handle, value_type, &object);
     if (return_value != EBPF_SUCCESS)
         return return_value;
 
     // The following addition is safe since it was checked during map creation.
-    size_t actual_value_size = ((size_t)map->ebpf_map_definition.value_size) + sizeof(struct _ebpf_program*);
+    size_t actual_value_size = ((size_t)map->ebpf_map_definition.value_size) + sizeof(struct _ebpf_object*);
 
-    // Validate that the program type is
+    // Validate that the value's program type (if any) is
     // not in conflict with the map's program type.
-    const ebpf_program_type_t* program_type = ebpf_program_type(program);
-    ebpf_program_array_map_t* program_array = (ebpf_program_array_map_t*)map;
+    const ebpf_program_type_t* value_program_type =
+        (object->get_program_type) ? object->get_program_type(object) : NULL;
+    ebpf_core_object_map_t* object_map = (ebpf_core_object_map_t*)map;
     ebpf_result_t result = EBPF_SUCCESS;
 
     ebpf_lock_state_t lock_state = ebpf_lock_lock(&map->lock);
 
-    if (!program_array->is_program_type_set) {
-        program_array->is_program_type_set = TRUE;
-        program_array->program_type = *program_type;
-    } else if (memcmp(&program_array->program_type, program_type, sizeof(*program_type)) != 0) {
-        ebpf_object_release_reference((ebpf_object_t*)program);
-        result = EBPF_INVALID_FD;
-        goto Done;
+    if (value_program_type) {
+        if (!object_map->is_program_type_set) {
+            object_map->is_program_type_set = TRUE;
+            object_map->program_type = *value_program_type;
+        } else if (memcmp(&object_map->program_type, value_program_type, sizeof(*value_program_type)) != 0) {
+            ebpf_object_release_reference((ebpf_object_t*)object);
+            result = EBPF_INVALID_FD;
+            goto Done;
+        }
     }
 
     // Store the literal value.
@@ -298,8 +313,8 @@ _update_prog_array_map_entry_with_handle(
         memset(entry, 0, map->ebpf_map_definition.value_size);
     }
 
-    // Store program pointer after the value.
-    memcpy(entry + map->ebpf_map_definition.value_size, &program, sizeof(void*));
+    // Store object pointer after the value.
+    memcpy(entry + map->ebpf_map_definition.value_size, &object, sizeof(void*));
 
 Done:
     ebpf_lock_unlock(&map->lock, lock_state);
@@ -308,14 +323,28 @@ Done:
 }
 
 static ebpf_result_t
-_delete_prog_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+_update_prog_array_map_entry_with_handle(
+    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, uintptr_t value_handle)
+{
+    return _update_array_map_entry_with_handle(map, key, EBPF_OBJECT_PROGRAM, value, value_handle);
+}
+
+static ebpf_result_t
+_update_map_array_map_entry_with_handle(
+    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, uintptr_t value_handle)
+{
+    return _update_array_map_entry_with_handle(map, key, EBPF_OBJECT_MAP, value, value_handle);
+}
+
+static ebpf_result_t
+_delete_object_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
     return _delete_array_map_entry_with_reference(map, key, TRUE);
 }
 
 /**
  * @brief Get an object from a map entry that holds objects, such
- * as a program array or map of maps.  The object returned holds a
+ * as a program array or array of maps.  The object returned holds a
  * reference that the caller is responsible for releasing.
  *
  * @param[in] map Array map to search.
@@ -348,13 +377,19 @@ _get_object_from_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* 
 }
 
 static ebpf_core_map_t*
-_create_hash_map(_In_ const ebpf_map_definition_t* map_definition)
+_create_hash_map_with_extra_value_size(
+    size_t map_struct_size, _In_ const ebpf_map_definition_t* map_definition, size_t extra_value_size)
 {
     ebpf_result_t retval;
-    size_t map_size = sizeof(ebpf_core_map_t);
     ebpf_core_map_t* map = NULL;
 
-    map = ebpf_allocate(map_size);
+    size_t actual_value_size;
+    retval = ebpf_safe_size_t_add(map_definition->value_size, extra_value_size, &actual_value_size);
+    if (retval != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    map = ebpf_allocate(map_struct_size);
     if (map == NULL) {
         retval = EBPF_NO_MEMORY;
         goto Done;
@@ -371,7 +406,7 @@ _create_hash_map(_In_ const ebpf_map_definition_t* map_definition)
         ebpf_epoch_allocate,
         ebpf_epoch_free,
         map->ebpf_map_definition.key_size,
-        map->ebpf_map_definition.value_size,
+        actual_value_size,
         map->ebpf_map_definition.max_entries,
         NULL);
     if (retval != EBPF_SUCCESS) {
@@ -391,11 +426,42 @@ Done:
     return map;
 }
 
+static ebpf_core_map_t*
+_create_hash_map(_In_ const ebpf_map_definition_t* map_definition)
+{
+    return _create_hash_map_with_extra_value_size(sizeof(ebpf_core_map_t), map_definition, 0);
+}
+
+static ebpf_core_map_t*
+_create_object_hash_map(_In_ const ebpf_map_definition_t* map_definition)
+{
+    return _create_hash_map_with_extra_value_size(sizeof(ebpf_core_object_map_t), map_definition, sizeof(void*));
+}
+
 static void
 _delete_hash_map(_In_ ebpf_core_map_t* map)
 {
     ebpf_hash_table_destroy((ebpf_hash_table_t*)map->data);
     ebpf_free(map);
+}
+
+static void
+_delete_object_hash_map(_In_ ebpf_core_map_t* map)
+{
+    // Release all entry references.
+    uint8_t* next_key;
+    for (uint8_t* previous_key = NULL;; previous_key = next_key) {
+        uint8_t* value;
+        ebpf_result_t result =
+            ebpf_hash_table_next_key_pointer_and_value((ebpf_hash_table_t*)map->data, NULL, &next_key, &value);
+        if (result != EBPF_SUCCESS) {
+            break;
+        }
+        ebpf_object_t* object = *(ebpf_object_t**)(value + map->ebpf_map_definition.value_size);
+        ebpf_object_release_reference(object);
+    }
+
+    _delete_hash_map(map);
 }
 
 static uint8_t*
@@ -410,6 +476,38 @@ _find_hash_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
     }
 
     return value;
+}
+
+/**
+ * @brief Get an object from a map entry that holds objects, such
+ * as a hash of maps.  The object returned holds a
+ * reference that the caller is responsible for releasing.
+ *
+ * @param[in] map Hash map to search.
+ * @param[in] key Pointer to the key to search for.
+ * @returns Object pointer, or NULL if none.
+ */
+static _Ret_maybenull_ ebpf_object_t*
+_get_object_from_hash_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+{
+    // We need to take a lock here to make sure we can
+    // safely reference the object when another thread
+    // might be trying to delete the entry we find.
+    ebpf_lock_state_t lock_state = ebpf_lock_lock(&map->lock);
+
+    ebpf_object_t* object = NULL;
+    uint8_t* value = _find_hash_map_entry(map, key);
+    if (value != NULL) {
+        // The object pointer is stored after the fd integer value.
+        object = *(ebpf_object_t**)(value + sizeof(uint32_t));
+        if (object) {
+            ebpf_object_acquire_reference(object);
+        }
+    }
+
+    ebpf_lock_unlock(&map->lock, lock_state);
+
+    return object;
 }
 
 static ebpf_result_t
@@ -444,20 +542,100 @@ _update_hash_map_entry(
         (ebpf_hash_table_find((ebpf_hash_table_t*)map->data, key, &value) != EBPF_SUCCESS))
         result = EBPF_INVALID_ARGUMENT;
     else
-        result = ebpf_hash_table_update((ebpf_hash_table_t*)map->data, key, data, hash_table_operation);
+        result = ebpf_hash_table_update((ebpf_hash_table_t*)map->data, key, data, NULL, hash_table_operation);
 
+    return result;
+}
+
+static ebpf_result_t
+_update_hash_map_entry_with_handle(
+    _In_ ebpf_core_map_t* map,
+    _In_ const uint8_t* key,
+    ebpf_object_type_t value_type,
+    _In_ const uint8_t* new_value,
+    uintptr_t value_handle)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_lock_state_t lock_state;
+    size_t entry_count = 0;
+    if (!map || !key || !new_value)
+        return EBPF_INVALID_ARGUMENT;
+
+    // Convert value handle to an object pointer.
+    struct _ebpf_object* object;
+    int return_value = ebpf_reference_object_by_handle(value_handle, value_type, &object);
+    if (return_value != EBPF_SUCCESS)
+        return return_value;
+
+    // Validate that the object's program type is
+    // not in conflict with the map's program type.
+    const ebpf_program_type_t* program_type = (object->get_program_type) ? object->get_program_type(object) : NULL;
+    ebpf_core_object_map_t* object_map = (ebpf_core_object_map_t*)map;
+
+    lock_state = ebpf_lock_lock(&map->lock);
+    entry_count = ebpf_hash_table_key_count((ebpf_hash_table_t*)map->data);
+
+    uint8_t* old_value;
+    if ((entry_count == map->ebpf_map_definition.max_entries) &&
+        (ebpf_hash_table_find((ebpf_hash_table_t*)map->data, key, &old_value) != EBPF_SUCCESS))
+        result = EBPF_INVALID_ARGUMENT;
+    else {
+        if (program_type != NULL) {
+            if (!object_map->is_program_type_set) {
+                object_map->is_program_type_set = TRUE;
+                object_map->program_type = *program_type;
+            } else if (memcmp(&object_map->program_type, program_type, sizeof(*program_type)) != 0) {
+                ebpf_object_release_reference((ebpf_object_t*)object);
+                result = EBPF_INVALID_FD;
+                goto Done;
+            }
+        }
+
+        // Store the literal value and the object pointer.
+        result = ebpf_hash_table_update((ebpf_hash_table_t*)map->data, key, new_value, (uint8_t*)&object);
+    }
+
+Done:
+    ebpf_lock_unlock(&map->lock, lock_state);
+    return result;
+}
+
+static ebpf_result_t
+_update_map_hash_map_entry_with_handle(
+    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, uintptr_t value_handle)
+{
+    return _update_hash_map_entry_with_handle(map, key, EBPF_OBJECT_MAP, value, value_handle);
+}
+
+static ebpf_result_t
+_delete_hash_map_entry_with_reference(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key, bool with_reference)
+{
+    ebpf_result_t result;
+    if (!map || !key)
+        return EBPF_INVALID_ARGUMENT;
+
+    if (with_reference) {
+        uint8_t* value = NULL;
+        if (ebpf_hash_table_find((ebpf_hash_table_t*)map->data, key, &value) == EBPF_SUCCESS) {
+            ebpf_object_t** object_pointer = (ebpf_object_t**)(value + map->ebpf_map_definition.value_size);
+            ebpf_object_release_reference(*object_pointer);
+            *object_pointer = NULL;
+        }
+    }
+    result = ebpf_hash_table_delete((ebpf_hash_table_t*)map->data, key);
     return result;
 }
 
 static ebpf_result_t
 _delete_hash_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
-    ebpf_result_t result;
-    if (!map || !key)
-        return EBPF_INVALID_ARGUMENT;
+    return _delete_hash_map_entry_with_reference(map, key, FALSE);
+}
 
-    result = ebpf_hash_table_delete((ebpf_hash_table_t*)map->data, key);
-    return result;
+static ebpf_result_t
+_delete_object_hash_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+{
+    return _delete_hash_map_entry_with_reference(map, key, TRUE);
 }
 
 static ebpf_result_t
@@ -557,15 +735,15 @@ ebpf_map_function_table_t ebpf_map_function_tables[] = {
      _delete_array_map_entry,
      _next_array_map_key},
     {// BPF_MAP_TYPE_PROG_ARRAY
-     _create_prog_array_map,
-     _delete_array_map_with_references,
+     _create_object_array_map,
+     _delete_object_array_map,
      _associate_program_with_prog_array_map,
      _find_array_map_entry,
      _get_object_from_array_map_entry,
      NULL,
      _update_prog_array_map_entry_with_handle,
      NULL,
-     _delete_prog_array_map_entry,
+     _delete_object_array_map_entry,
      _next_array_map_key},
     {// BPF_MAP_TYPE_PERCPU_HASH
      _create_hash_map,
@@ -588,6 +766,28 @@ ebpf_map_function_table_t ebpf_map_function_tables[] = {
      NULL,
      _update_entry_per_cpu,
      _delete_array_map_entry,
+     _next_array_map_key},
+    {// BPF_MAP_TYPE_HASH_OF_MAPS
+     _create_object_hash_map,
+     _delete_object_hash_map,
+     NULL,
+     _find_hash_map_entry,
+     _get_object_from_hash_map_entry,
+     NULL,
+     _update_map_hash_map_entry_with_handle,
+     NULL,
+     _delete_object_hash_map_entry,
+     _next_array_map_key},
+    {// BPF_MAP_TYPE_ARRAY_OF_MAPS
+     _create_object_array_map,
+     _delete_object_array_map,
+     NULL,
+     _find_array_map_entry,
+     _get_object_from_array_map_entry,
+     NULL,
+     _update_map_array_map_entry_with_handle,
+     NULL,
+     _delete_object_array_map_entry,
      _next_array_map_key},
 };
 
@@ -631,6 +831,11 @@ ebpf_map_create(
         goto Exit;
     }
 
+    if (local_map_definition.size != sizeof(local_map_definition)) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
     local_map = ebpf_map_function_tables[type].create_map(&local_map_definition);
     if (!local_map) {
         result = EBPF_NO_MEMORY;
@@ -644,7 +849,9 @@ ebpf_map_create(
         goto Exit;
     }
 
-    ebpf_object_initialize(&local_map->object, EBPF_OBJECT_MAP, _ebpf_map_delete);
+    ebpf_map_function_table_t* table = &ebpf_map_function_tables[local_map->ebpf_map_definition.type];
+    ebpf_object_get_program_type_t get_program_type = (table->get_object_from_entry) ? _get_map_program_type : NULL;
+    ebpf_object_initialize(&local_map->object, EBPF_OBJECT_MAP, _ebpf_map_delete, get_program_type);
 
     *ebpf_map = local_map;
 
@@ -667,7 +874,7 @@ ebpf_map_find_entry(
     _Out_writes_(value_size) uint8_t* value,
     int flags)
 {
-    uint8_t* return_value;
+    uint8_t* return_value = NULL;
     if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_size != map->ebpf_map_definition.key_size)) {
         return EBPF_INVALID_ARGUMENT;
     }
@@ -676,11 +883,25 @@ ebpf_map_find_entry(
         return EBPF_INVALID_ARGUMENT;
     }
 
-    // Disallow reads to prog array maps from this helper call for now.
-    if ((flags & EBPF_MAP_FLAG_HELPER) && map->ebpf_map_definition.type == BPF_MAP_TYPE_PROG_ARRAY) {
-        return EBPF_INVALID_ARGUMENT;
+    ebpf_map_type_t type = map->ebpf_map_definition.type;
+    if ((flags & EBPF_MAP_FLAG_HELPER) && (ebpf_map_function_tables[type].get_object_from_entry != NULL)) {
+
+        // Disallow reads to prog array maps from this helper call for now.
+        if (type == BPF_MAP_TYPE_PROG_ARRAY) {
+            return EBPF_INVALID_ARGUMENT;
+        }
+
+        ebpf_object_t* object = ebpf_map_function_tables[type].get_object_from_entry(map, key);
+
+        // Release the extra reference obtained.
+        // REVIEW: is this safe?
+        if (object) {
+            ebpf_object_release_reference(object);
+            return_value = (uint8_t*)object;
+        }
+    } else {
+        return_value = ebpf_map_function_tables[map->ebpf_map_definition.type].find_entry(map, key);
     }
-    return_value = ebpf_map_function_tables[map->ebpf_map_definition.type].find_entry(map, key);
     if (return_value == NULL) {
         return EBPF_OBJECT_NOT_FOUND;
     }

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -97,6 +97,7 @@ extern "C"
      * @param[in] key Key to use when searching and updating the map.
      * @param[in] value Value to insert into the map.
      * @param[in] value_handle Handle associated with the value.
+     * @param[in] option One of ebpf_map_option_t options.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  entry.
@@ -108,7 +109,8 @@ extern "C"
         _In_reads_(key_size) const uint8_t* key,
         size_t value_size,
         _In_reads_(value_size) const uint8_t* value,
-        uintptr_t value_handle);
+        uintptr_t value_handle,
+        ebpf_map_option_t option);
 
     /**
      * @brief Remove an entry from the map.

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -189,6 +189,12 @@ _ebpf_program_free(ebpf_object_t* object)
     ebpf_epoch_schedule_work_item(program->cleanup_work_item);
 }
 
+static const ebpf_program_type_t*
+_ebpf_program_get_program_type(_In_ const ebpf_object_t* object)
+{
+    return ebpf_program_type((const ebpf_program_t*)object);
+}
+
 /**
  * @brief Free invoked when the current epoch ends. Scheduled by
  * _ebpf_program_free.
@@ -309,7 +315,8 @@ ebpf_program_create(ebpf_program_t** program)
     ebpf_list_initialize(&local_program->links);
     ebpf_lock_create(&local_program->links_lock);
 
-    ebpf_object_initialize(&local_program->object, EBPF_OBJECT_PROGRAM, _ebpf_program_free);
+    ebpf_object_initialize(
+        &local_program->object, EBPF_OBJECT_PROGRAM, _ebpf_program_free, _ebpf_program_get_program_type);
 
     *program = local_program;
     local_program = NULL;

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -140,6 +140,7 @@ typedef struct _ebpf_operation_map_update_element_with_handle_request
     struct _ebpf_operation_header header;
     uintptr_t map_handle;
     uintptr_t value_handle;
+    ebpf_map_option_t option;
     uint8_t data[1]; // data is key+value
 } ebpf_operation_map_update_element_with_handle_request_t;
 

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -214,6 +214,7 @@ ebpf_epoch_enter()
             _ebpf_epoch_thread_table,
             (const uint8_t*)&current_thread_id,
             (const uint8_t*)&current_epoch,
+            NULL,
             EBPF_HASH_TABLE_OPERATION_ANY);
         ebpf_lock_unlock(&_ebpf_epoch_thread_table_lock, lock_state);
         return return_value;
@@ -241,6 +242,7 @@ ebpf_epoch_exit()
             _ebpf_epoch_thread_table,
             (const uint8_t*)&current_thread_id,
             (const uint8_t*)&current_epoch,
+            NULL,
             EBPF_HASH_TABLE_OPERATION_REPLACE);
         ebpf_assert(result == EBPF_SUCCESS);
         ebpf_lock_unlock(&_ebpf_epoch_thread_table_lock, lock_state);

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -232,6 +232,7 @@ _ebpf_hash_table_replace_bucket(
         }
         delete_data = new_data;
         if (value) {
+            // TODO(issue #396): remove extra_value logic once we store ids in the value.
             if (extra_value) {
                 // The value is in two input buffers: value and extra_value,
                 // which is always of size sizeof(void*).

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -193,17 +193,19 @@ _ebpf_hash_table_bucket_entry(size_t key_size, _In_ ebpf_hash_bucket_header_t* b
  *
  * @param[in] hash_table Hash table to update.
  * @param[in] key Key to operate on.
- * @param[in] data Value to be inserted or NULL.
+ * @param[in] value Value to be inserted or NULL.
+ * @param[in] extra_value Extra value to be associated, or NULL.
  * @param[in] operation Operation to perform.
  * @retval EBPF_SUCCESS The operation succeeded.
  * @retval EBPF_KEY_NOT_FOUND The specified key is not present in the bucket.
  * @retval EBPF_NO_MEMORY Insufficient memory to construct new bucket or value.
  */
-ebpf_result_t
+static ebpf_result_t
 _ebpf_hash_table_replace_bucket(
     _In_ ebpf_hash_table_t* hash_table,
     _In_ const uint8_t* key,
-    _In_opt_ const uint8_t* data,
+    _In_opt_ const uint8_t* value,
+    _In_opt_ const uint8_t* extra_value,
     ebpf_hash_bucket_operation_t operation)
 {
     ebpf_result_t result;
@@ -229,8 +231,17 @@ _ebpf_hash_table_replace_bucket(
             goto Done;
         }
         delete_data = new_data;
-        if (data) {
-            memcpy(new_data, data, hash_table->value_size);
+        if (value) {
+            if (extra_value) {
+                // The value is in two input buffers: value and extra_value,
+                // which is always of size sizeof(void*).
+                size_t extra_value_offset = hash_table->value_size - sizeof(void*);
+                memcpy(new_data, value, extra_value_offset);
+                memcpy(new_data + extra_value_offset, extra_value, sizeof(void*));
+            } else {
+                // The full value is contiguous.
+                memcpy(new_data, value, hash_table->value_size);
+            }
         }
         break;
     case EBPF_HASH_BUCKET_OPERATION_DELETE:
@@ -490,6 +501,7 @@ ebpf_hash_table_update(
     _In_ ebpf_hash_table_t* hash_table,
     _In_ const uint8_t* key,
     _In_opt_ const uint8_t* value,
+    _In_opt_ const uint8_t* extra_value,
     ebpf_hash_table_operations_t operation)
 {
     ebpf_result_t retval;
@@ -515,7 +527,7 @@ ebpf_hash_table_update(
         goto Done;
     }
 
-    retval = _ebpf_hash_table_replace_bucket(hash_table, key, value, bucket_operation);
+    retval = _ebpf_hash_table_replace_bucket(hash_table, key, value, extra_value, bucket_operation);
 Done:
     return retval;
 }
@@ -530,18 +542,18 @@ ebpf_hash_table_delete(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* k
         goto Done;
     }
 
-    retval = _ebpf_hash_table_replace_bucket(hash_table, key, NULL, EBPF_HASH_BUCKET_OPERATION_DELETE);
+    retval = _ebpf_hash_table_replace_bucket(hash_table, key, NULL, NULL, EBPF_HASH_BUCKET_OPERATION_DELETE);
 
 Done:
     return retval;
 }
 
 ebpf_result_t
-ebpf_hash_table_next_key_and_value(
+ebpf_hash_table_next_key_pointer_and_value(
     _In_ ebpf_hash_table_t* hash_table,
     _In_opt_ const uint8_t* previous_key,
-    _Out_ uint8_t* next_key,
-    _Inout_opt_ uint8_t** value)
+    _Outptr_ uint8_t** next_key_pointer,
+    _Outptr_opt_ uint8_t** value)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     uint32_t hash;
@@ -550,7 +562,7 @@ ebpf_hash_table_next_key_and_value(
     size_t data_index;
     bool found_entry = false;
 
-    if (!hash_table || !next_key) {
+    if (!hash_table || !next_key_pointer) {
         result = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
@@ -603,10 +615,26 @@ ebpf_hash_table_next_key_and_value(
     if (value)
         *value = next_entry->data;
 
-    memcpy(next_key, next_entry->key, hash_table->key_size);
+    *next_key_pointer = next_entry->key;
 
 Done:
 
+    return result;
+}
+
+ebpf_result_t
+ebpf_hash_table_next_key_and_value(
+    _In_ ebpf_hash_table_t* hash_table,
+    _In_opt_ const uint8_t* previous_key,
+    _Out_ uint8_t* next_key,
+    _Inout_opt_ uint8_t** next_value)
+{
+    uint8_t* next_key_pointer;
+    ebpf_result_t result =
+        ebpf_hash_table_next_key_pointer_and_value(hash_table, previous_key, &next_key_pointer, next_value);
+    if (result == EBPF_SUCCESS) {
+        memcpy(next_key, next_key_pointer, hash_table->key_size);
+    }
     return result;
 }
 

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -61,12 +61,17 @@ ebpf_object_tracking_terminate()
 }
 
 void
-ebpf_object_initialize(ebpf_object_t* object, ebpf_object_type_t object_type, ebpf_free_object_t free_function)
+ebpf_object_initialize(
+    ebpf_object_t* object,
+    ebpf_object_type_t object_type,
+    ebpf_free_object_t free_function,
+    ebpf_object_get_program_type_t get_program_type_function)
 {
     object->marker = _ebpf_object_marker;
     object->reference_count = 1;
     object->type = object_type;
     object->free_function = free_function;
+    object->get_program_type = get_program_type_function;
     ebpf_list_initialize(&object->global_list_entry);
     ebpf_list_initialize(&object->object_list_entry);
     _ebpf_object_tracking_list_insert(object);

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -58,7 +58,9 @@ extern "C"
      * @param[in,out] object ebpf_object_t structure to initialize.
      * @param[in] object_type The type of the object.
      * @param[in] free_function The function used to free the object.
-     * @param[in] get_program_type_function The function used to get a program type, or NULL.
+     * @param[in] get_program_type_function The function used to get a program type, or NULL.  Each program
+     * has a problem type, and hence so do maps that can contain programs, whether directly (like
+     * BPF_MAP_TYPE_PROG_ARRAY) or indirectly (like BPF_MAP_TYPE_ARRAY_OF_MAPS containing a BPF_MAP_TYPE_PROG_ARRAY).
      */
     void
     ebpf_object_initialize(

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -21,6 +21,7 @@ extern "C"
 
     typedef struct _ebpf_object ebpf_object_t;
     typedef void (*ebpf_free_object_t)(ebpf_object_t* object);
+    typedef const ebpf_program_type_t* (*ebpf_object_get_program_type_t)(_In_ const ebpf_object_t* object);
 
     // This type probably ought to be renamed to avoid confusion with
     // ebpf_object_t in libs\api\api_internal.h
@@ -30,6 +31,7 @@ extern "C"
         volatile int32_t reference_count;
         ebpf_object_type_t type;
         ebpf_free_object_t free_function;
+        ebpf_object_get_program_type_t get_program_type;
         // Used to insert object in the global tracking list.
         ebpf_list_entry_t global_list_entry;
         // Used to insert object in an object specific list.
@@ -56,9 +58,14 @@ extern "C"
      * @param[in,out] object ebpf_object_t structure to initialize.
      * @param[in] object_type The type of the object.
      * @param[in] free_function The function used to free the object.
+     * @param[in] get_program_type_function The function used to get a program type, or NULL.
      */
     void
-    ebpf_object_initialize(ebpf_object_t* object, ebpf_object_type_t object_type, ebpf_free_object_t free_function);
+    ebpf_object_initialize(
+        ebpf_object_t* object,
+        ebpf_object_type_t object_type,
+        ebpf_free_object_t free_function,
+        ebpf_object_get_program_type_t get_program_type_function);
 
     /**
      * @brief Acquire a reference to this object.

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -59,7 +59,7 @@ extern "C"
      * @param[in] object_type The type of the object.
      * @param[in] free_function The function used to free the object.
      * @param[in] get_program_type_function The function used to get a program type, or NULL.  Each program
-     * has a problem type, and hence so do maps that can contain programs, whether directly (like
+     * has a program type, and hence so do maps that can contain programs, whether directly (like
      * BPF_MAP_TYPE_PROG_ARRAY) or indirectly (like BPF_MAP_TYPE_ARRAY_OF_MAPS containing a BPF_MAP_TYPE_PROG_ARRAY).
      */
     void

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -116,11 +116,13 @@ ebpf_pinning_table_insert(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_s
         pinning_table->hash_table,
         (const uint8_t*)&new_key,
         (const uint8_t*)&new_pinning_entry,
+        NULL,
         EBPF_HASH_TABLE_OPERATION_INSERT);
     if (return_value == EBPF_KEY_ALREADY_EXISTS) {
         return_value = EBPF_OBJECT_ALREADY_EXISTS;
     } else if (return_value == EBPF_SUCCESS)
         new_pinning_entry = NULL;
+    }
 
     ebpf_lock_unlock(&pinning_table->lock, state);
 

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -122,7 +122,6 @@ ebpf_pinning_table_insert(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_s
         return_value = EBPF_OBJECT_ALREADY_EXISTS;
     } else if (return_value == EBPF_SUCCESS)
         new_pinning_entry = NULL;
-    }
 
     ebpf_lock_unlock(&pinning_table->lock, state);
 

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -432,6 +432,7 @@ extern "C"
      * @param[in] hash_table Hash-table to update.
      * @param[in] key Key to find and insert or update.
      * @param[in] value Value to insert into hash table or NULL to insert zero entry.
+     * @param[in] extra_value Extra value to insert into hash table.
      * @param[in] operation One of ebpf_hash_table_operations_t operations.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate memory for this
@@ -442,6 +443,7 @@ extern "C"
         _In_ ebpf_hash_table_t* hash_table,
         _In_ const uint8_t* key,
         _In_opt_ const uint8_t* value,
+        _In_opt_ const uint8_t* extra_value,
         ebpf_hash_table_operations_t operation);
 
     /**
@@ -486,6 +488,24 @@ extern "C"
         _In_opt_ const uint8_t* previous_key,
         _Out_ uint8_t* next_key,
         _Inout_opt_ uint8_t** next_value);
+
+    /**
+     * @brief Returns the next (key, value) pair in the hash table.
+     *
+     * @param[in] hash_table Hash-table to query.
+     * @param[in] previous_key Previous key or NULL to restart.
+     * @param[out] next_key_pointer Pointer to next key if one exists.
+     * @param[out] next_value If non-NULL, returns the next value if it exists.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MORE_KEYS No keys exist in the hash table that
+     * are lexicographically after the specified key.
+     */
+    ebpf_result_t
+    ebpf_hash_table_next_key_pointer_and_value(
+        _In_ ebpf_hash_table_t* hash_table,
+        _In_opt_ const uint8_t* previous_key,
+        _Outptr_ uint8_t** next_key_pointer,
+        _Outptr_opt_ uint8_t** next_value);
 
     /**
      * @brief Get the number of keys in the hash table

--- a/libs/platform/ebpf_state.c
+++ b/libs/platform/ebpf_state.c
@@ -96,6 +96,7 @@ _ebpf_state_get_entry(_Out_ ebpf_state_entry_t** entry)
                 _ebpf_state_thread_table,
                 (const uint8_t*)&current_thread_id,
                 (const uint8_t*)&new_entry,
+                NULL,
                 EBPF_HASH_TABLE_OPERATION_INSERT);
 
             if (return_value != EBPF_SUCCESS) {

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -74,10 +74,10 @@ TEST_CASE("hash_table_test", "[platform]")
 
     // Insert first
     REQUIRE(
-        ebpf_hash_table_update(table, key_1.data(), data_1.data(), EBPF_HASH_TABLE_OPERATION_INSERT) == EBPF_SUCCESS);
+        ebpf_hash_table_update(table, key_1.data(), data_1.data(), nullptr, EBPF_HASH_TABLE_OPERATION_INSERT) == EBPF_SUCCESS);
 
     // Insert second
-    REQUIRE(ebpf_hash_table_update(table, key_2.data(), data_2.data(), EBPF_HASH_TABLE_OPERATION_ANY) == EBPF_SUCCESS);
+    REQUIRE(ebpf_hash_table_update(table, key_2.data(), data_2.data(), nullptr, EBPF_HASH_TABLE_OPERATION_ANY) == EBPF_SUCCESS);
 
     // Find the first
     REQUIRE(ebpf_hash_table_find(table, key_1.data(), &returned_value) == EBPF_SUCCESS);
@@ -90,7 +90,7 @@ TEST_CASE("hash_table_test", "[platform]")
     // Replace
     memset(data_1.data(), '0x55', data_1.size());
     REQUIRE(
-        ebpf_hash_table_update(table, key_1.data(), data_1.data(), EBPF_HASH_TABLE_OPERATION_REPLACE) == EBPF_SUCCESS);
+        ebpf_hash_table_update(table, key_1.data(), data_1.data(), nullptr, EBPF_HASH_TABLE_OPERATION_REPLACE) == EBPF_SUCCESS);
 
     // Find the first
     REQUIRE(ebpf_hash_table_find(table, key_1.data(), &returned_value) == EBPF_SUCCESS);
@@ -153,6 +153,7 @@ TEST_CASE("hash_table_stress_test", "[platform]")
                         table,
                         reinterpret_cast<const uint8_t*>(&key),
                         reinterpret_cast<const uint8_t*>(&value),
+                        nullptr,
                         EBPF_HASH_TABLE_OPERATION_ANY);
                 });
             }
@@ -200,8 +201,10 @@ TEST_CASE("pinning_test", "[platform]")
     ebpf_utf8_string_t foo = EBPF_UTF8_STRING_FROM_CONST_STRING("foo");
     ebpf_utf8_string_t bar = EBPF_UTF8_STRING_FROM_CONST_STRING("bar");
 
-    ebpf_object_initialize(&an_object.object, EBPF_OBJECT_MAP, [](ebpf_object_t*) {});
-    ebpf_object_initialize(&another_object.object, EBPF_OBJECT_MAP, [](ebpf_object_t*) {});
+    ebpf_object_initialize(
+        &an_object.object, EBPF_OBJECT_MAP, [](ebpf_object_t*) {}, NULL);
+    ebpf_object_initialize(
+        &another_object.object, EBPF_OBJECT_MAP, [](ebpf_object_t*) {}, NULL);
 
     ebpf_pinning_table_t* pinning_table = nullptr;
     REQUIRE(ebpf_pinning_table_allocate(&pinning_table) == EBPF_SUCCESS);
@@ -343,8 +346,8 @@ TEST_CASE("trampoline_test", "[platform]")
     auto provider_function2 = []() { return EBPF_OBJECT_ALREADY_EXISTS; };
     ebpf_result_t (*function_pointer2)() = provider_function2;
     const void* helper_functions2[] = {(void*)function_pointer2};
-    ebpf_helper_function_addresses_t helper_function_addresses2 = {
-        EBPF_COUNT_OF(helper_functions1), (uint64_t*)helper_functions2};
+    ebpf_helper_function_addresses_t helper_function_addresses2 = {EBPF_COUNT_OF(helper_functions1),
+                                                                   (uint64_t*)helper_functions2};
 
     REQUIRE(ebpf_allocate_trampoline_table(1, &table) == EBPF_SUCCESS);
     REQUIRE(

--- a/libs/platform/user/ebpf_extension_user.c
+++ b/libs/platform/user/ebpf_extension_user.c
@@ -87,6 +87,7 @@ ebpf_extension_load(
         local_extension_provider->client_table,
         (const uint8_t*)&local_extension_client->client_id,
         (const uint8_t*)&local_extension_client,
+        NULL,
         EBPF_HASH_TABLE_OPERATION_INSERT);
     if (return_value != EBPF_SUCCESS) {
         goto Done;
@@ -239,6 +240,7 @@ ebpf_provider_load(
         _ebpf_provider_table,
         (const uint8_t*)interface_id,
         (const uint8_t*)&local_extension_provider,
+        NULL,
         EBPF_HASH_TABLE_OPERATION_INSERT);
     if (return_value != EBPF_SUCCESS)
         goto Done;

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -218,8 +218,10 @@ _query_and_cache_map_descriptors(_In_reads_(handle_map_count) fd_handle_map* han
                 return result;
             }
 
-            // Convert inner_map_idx to descriptor.inner_map_fd.
-            descriptor.inner_map_fd = handle_map[inner_map_idx].file_descriptor;
+            if (descriptor.type == BPF_MAP_TYPE_ARRAY_OF_MAPS || descriptor.type == BPF_MAP_TYPE_HASH_OF_MAPS) {
+                // Convert inner_map_idx to descriptor.inner_map_fd.
+                descriptor.inner_map_fd = handle_map[inner_map_idx].file_descriptor;
+            }
 
             cache_map_file_descriptor_with_handle(
                 descriptor.type,

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -196,7 +196,7 @@ _resolve_maps_in_byte_code(ebpf_handle_t program_handle, ebpf_code_buffer_t& byt
 }
 
 static ebpf_result_t
-_query_and_cache_map_descriptors(fd_handle_map* handle_map, uint32_t handle_map_count)
+_query_and_cache_map_descriptors(_In_reads_(handle_map_count) fd_handle_map* handle_map, uint32_t handle_map_count)
 {
     ebpf_result_t result;
     EbpfMapDescriptor descriptor;
@@ -205,22 +205,28 @@ _query_and_cache_map_descriptors(fd_handle_map* handle_map, uint32_t handle_map_
         for (uint32_t i = 0; i < handle_map_count; i++) {
             uint32_t size;
             descriptor = {0};
+            uint32_t inner_map_idx;
             result = query_map_definition(
                 handle_map[i].handle,
                 &size,
                 &descriptor.type,
                 &descriptor.key_size,
                 &descriptor.value_size,
-                &descriptor.max_entries);
+                &descriptor.max_entries,
+                &inner_map_idx);
             if (result != EBPF_SUCCESS) {
                 return result;
             }
+
+            // Convert inner_map_idx to descriptor.inner_map_fd.
+            descriptor.inner_map_fd = handle_map[inner_map_idx].file_descriptor;
 
             cache_map_file_descriptor_with_handle(
                 descriptor.type,
                 descriptor.key_size,
                 descriptor.value_size,
                 descriptor.max_entries,
+                descriptor.inner_map_fd,
                 handle_map[i].file_descriptor,
                 (uintptr_t)handle_map[i].handle,
                 0);

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -547,7 +547,8 @@ TEST_CASE("enumerate_and_query_maps", "[end_to_end]")
                 reinterpret_cast<uint32_t*>(&map_definitions[index].type),
                 &map_definitions[index].key_size,
                 &map_definitions[index].value_size,
-                &map_definitions[index].max_entries) == EBPF_SUCCESS);
+                &map_definitions[index].max_entries,
+                &map_definitions[index].inner_map_idx) == EBPF_SUCCESS);
         if (index % 2 == 0) {
             REQUIRE(memcmp(&process_map, &map_definitions[index], sizeof(process_map)) == 0);
         } else {

--- a/tests/sample/bpf_call.c
+++ b/tests/sample/bpf_call.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // All of this file is cross-platform except the following
-// two includes.  TODO: make the include filename(s) also be
+// two includes.  TODO(issue #426): make the include filename(s) also be
 // cross-platform for eBPF program portability.
 #include "ebpf_helpers.h"
 #include "ebpf_nethooks.h"

--- a/tests/sample/map_in_map.c
+++ b/tests/sample/map_in_map.c
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "ebpf_helpers.h"
+#include "ebpf_nethooks.h"
+typedef unsigned int uint32_t;
+typedef unsigned long uint64_t;
+
+SEC("maps")
+struct bpf_map outer_map = {.type = BPF_MAP_TYPE_ARRAY_OF_MAPS,
+                            .key_size = sizeof(uint32_t),
+                            .value_size = sizeof(uint32_t),
+                            .max_entries = 1,
+                            // inner_map_idx refers to the map index in the same ELF object.
+                            .inner_map_idx = 1}; // (uint32_t)&inner_map
+
+SEC("maps")
+struct bpf_map inner_map = {
+    .type = BPF_MAP_TYPE_ARRAY, .key_size = sizeof(uint32_t), .value_size = sizeof(uint32_t), .max_entries = 1};
+
+SEC("xdp_prog") int caller(struct xdp_md* ctx)
+{
+    uint32_t outer_key = 0;
+    void* nolocal_lru_map = bpf_map_lookup_elem(&outer_map, &outer_key);
+    if (nolocal_lru_map) {
+        uint32_t inner_key = 0;
+        uint32_t* value = (uint32_t*)bpf_map_lookup_elem(nolocal_lru_map, &inner_key);
+        if (value) {
+            return *(uint32_t*)value;
+        }
+    }
+    return 0;
+}

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -96,8 +96,6 @@
       <Outputs>%(Filename).o;%(Outputs)</Outputs>
       <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
       <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
@@ -108,8 +106,6 @@
       <Command>clang -target bpf -O2 -Wall -c %(Filename).c -o %(Filename).o</Command>
       <Outputs>%(Filename).o;%(Outputs)</Outputs>
       <TreatOutputAsContent>true</TreatOutputAsContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
@@ -120,8 +116,6 @@
       <Command>clang -target bpf -O2 -Wall -c %(Filename).c -o %(Filename).o</Command>
       <Outputs>%(Filename).o;%(Outputs)</Outputs>
       <TreatOutputAsContent>true</TreatOutputAsContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
@@ -132,8 +126,6 @@
       <Command>clang -target bpf -O2 -Wall -c %(Filename).c -o %(Filename).o</Command>
       <Outputs>%(Filename).o;%(Outputs)</Outputs>
       <TreatOutputAsContent>true</TreatOutputAsContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -I./ext/inc -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -I./ext/inc -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
@@ -144,8 +136,6 @@
       <Command>clang -target bpf -O2 -Wall -c %(Filename).c -o %(Filename).o</Command>
       <Outputs>%(Filename).o;%(Outputs)</Outputs>
       <TreatOutputAsContent>true</TreatOutputAsContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
@@ -168,7 +158,6 @@
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="droppacket_unsafe.c">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
       <FileType>CppCode</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
@@ -191,6 +180,26 @@
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="tail_call_bad.c">
+      <FileType>CppCode</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
+  </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="map_in_map.c">
+      <FileType>CppCode</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
+    <CustomBuild Include="tail_call_map.c">
       <FileType>CppCode</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>

--- a/tests/sample/sample.vcxproj.filters
+++ b/tests/sample/sample.vcxproj.filters
@@ -42,13 +42,19 @@
     <CustomBuild Include="droppacket_unsafe.c">
       <Filter>Source Files</Filter>
     </CustomBuild>
-    <CustomBuild Include="test_ebpf.c">
-      <Filter>Source Files</Filter>
-    </CustomBuild>
     <CustomBuild Include="tail_call.c">
       <Filter>Source Files</Filter>
     </CustomBuild>
     <CustomBuild Include="tail_call_bad.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="map_in_map.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="tail_call_map.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="test_sample_ebpf.c">
       <Filter>Source Files</Filter>
     </CustomBuild>
   </ItemGroup>

--- a/tests/sample/tail_call.c
+++ b/tests/sample/tail_call.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // All of this file is cross-platform except the following
-// two includes.  TODO: make the include filename(s) also be
+// two includes.  TODO(issue #426): make the include filename(s) also be
 // cross-platform for eBPF program portability.
 #include "ebpf_helpers.h"
 #include "ebpf_nethooks.h"

--- a/tests/sample/tail_call_bad.c
+++ b/tests/sample/tail_call_bad.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // All of this file is cross-platform except the following
-// two includes.  TODO: make the include filename(s) also be
+// two includes.  TODO(issue #426): make the include filename(s) also be
 // cross-platform for eBPF program portability.
 #include "ebpf_helpers.h"
 #include "ebpf_nethooks.h"

--- a/tests/sample/tail_call_map.c
+++ b/tests/sample/tail_call_map.c
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// All of this file is cross-platform except the following
+// two includes.  TODO: make the include filename(s) also be
+// cross-platform for eBPF program portability.
+#include "ebpf_helpers.h"
+#include "ebpf_nethooks.h"
+
+__attribute__((section("maps"), used)) struct bpf_map outer_map = {.size = sizeof(struct bpf_map),
+                                                                   .type = BPF_MAP_TYPE_ARRAY_OF_MAPS,
+                                                                   .key_size = sizeof(uint32_t),
+                                                                   .value_size = sizeof(uint32_t),
+                                                                   .max_entries = 1};
+
+__attribute__((section("xdp_prog"), used)) int
+caller(struct xdp_md* ctx)
+{
+    uint32_t index = 0;
+    struct bpf_map* inner_map = (struct bpf_map*)bpf_map_lookup_elem(&outer_map, &index);
+
+    bpf_tail_call(ctx, inner_map, 0);
+
+    // If we get to here it means bpf_tail_call failed.
+    return 6;
+}
+
+__attribute__((section("xdp_prog/0"), used)) int
+callee(struct xdp_md* ctx)
+{
+    return 42;
+}

--- a/tests/sample/tail_call_map.c
+++ b/tests/sample/tail_call_map.c
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // All of this file is cross-platform except the following
-// two includes.  TODO: make the include filename(s) also be
+// two includes.  TODO(issue #426): make the include filename(s) also be
 // cross-platform for eBPF program portability.
 #include "ebpf_helpers.h"
 #include "ebpf_nethooks.h"

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -424,7 +424,7 @@ TEST_CASE("disallow prog_array mixed program type values", "[libbpf]")
     REQUIRE(error == -EBPF_INVALID_ARGUMENT);
     REQUIRE(errno == -error);
 
-    // TODO(issue #287): _close(map_fd);
+    ebpf_close_fd(map_fd); // TODO(issue #287): change to _close(map_fd);
     bpf_object__close(bind_object);
     bpf_object__close(xdp_object);
 }
@@ -462,8 +462,8 @@ TEST_CASE("simple hash of maps", "[libbpf]")
     error = bpf_map_delete_elem(outer_map_fd, &outer_key);
     REQUIRE(error == 0);
 
-    // TODO(issue #287): _close(inner_map_fd);
-    // TODO(issue #287): _close(outer_map_fd);
+    ebpf_close_fd(inner_map_fd); // TODO(issue #287): change to _close(inner_map_fd);
+    ebpf_close_fd(outer_map_fd); // TODO(issue #287): change to _close(outer_map_fd);
 }
 
 // Verify an app can communicate with an eBPF program via an array of maps.
@@ -515,6 +515,6 @@ TEST_CASE("array of maps", "[libbpf]")
     // Verify the return value is what we saved in the inner map.
     REQUIRE(result == inner_value);
 
-    // TODO(issue #287): _close(inner_map_fd);
+    ebpf_close_fd(inner_map_fd); // TODO(issue #287): change to _close(inner_map_fd);
     bpf_object__close(xdp_object);
 }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1,5 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
+#include <io.h>
 #include "bpf.h"
 #include "catch_wrapper.hpp"
 #include "helpers.h"
@@ -423,6 +424,97 @@ TEST_CASE("disallow prog_array mixed program type values", "[libbpf]")
     REQUIRE(error == -EBPF_INVALID_ARGUMENT);
     REQUIRE(errno == -error);
 
+    // TODO(issue #287): _close(map_fd);
     bpf_object__close(bind_object);
+    bpf_object__close(xdp_object);
+}
+
+// Verify libbpf can create and update arrays of maps.
+TEST_CASE("simple hash of maps", "[libbpf]")
+{
+    _test_helper_end_to_end test_helper;
+
+    int outer_map_fd = bpf_create_map(BPF_MAP_TYPE_HASH_OF_MAPS, sizeof(__u32), sizeof(__u32), 2, 0);
+    REQUIRE(outer_map_fd > 0);
+
+    int inner_map_fd = bpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(__u32), sizeof(__u32), 1, 0);
+    REQUIRE(inner_map_fd > 0);
+
+    // Verify we can insert the inner map into the outer map.
+    __u32 outer_key = 0;
+    int error = bpf_map_update_elem(outer_map_fd, &outer_key, &inner_map_fd, 0);
+    REQUIRE(error == 0);
+
+    // Verify we can't insert an integer into the outer map.
+    __u32 bad_value = 12345678;
+    outer_key = 1;
+    error = bpf_map_update_elem(outer_map_fd, &outer_key, &bad_value, 0);
+    REQUIRE(error == -EBPF_INVALID_FD);
+    REQUIRE(errno == -error);
+
+    // Try deleting outer key that doesn't exist
+    error = bpf_map_delete_elem(outer_map_fd, &outer_key);
+    REQUIRE(error == -EBPF_KEY_NOT_FOUND);
+    REQUIRE(errno == -error);
+
+    // Try deleting outer key that does exist.
+    outer_key = 0;
+    error = bpf_map_delete_elem(outer_map_fd, &outer_key);
+    REQUIRE(error == 0);
+
+    // TODO(issue #287): _close(inner_map_fd);
+    // TODO(issue #287): _close(outer_map_fd);
+}
+
+// Verify an app can communicate with an eBPF program via an array of maps.
+TEST_CASE("array of maps", "[libbpf]")
+{
+    _test_helper_end_to_end test_helper;
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
+
+    struct bpf_object* xdp_object;
+    int xdp_object_fd;
+    int error = bpf_prog_load("map_in_map.o", BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
+    REQUIRE(error == 0);
+    REQUIRE(xdp_object != nullptr);
+
+    struct bpf_program* caller = bpf_object__find_program_by_name(xdp_object, "caller");
+    REQUIRE(caller != nullptr);
+
+    struct bpf_map* outer_map = bpf_object__find_map_by_name(xdp_object, "outer_map");
+    REQUIRE(outer_map != nullptr);
+
+    int outer_map_fd = bpf_map__fd(outer_map);
+    REQUIRE(outer_map_fd > 0);
+
+    // Create an inner map.
+    int inner_map_fd = bpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(__u32), sizeof(__u32), 1, 0);
+    REQUIRE(inner_map_fd > 0);
+
+    // Add a value to the inner map.
+    int inner_value = 42;
+    uint32_t inner_key = 0;
+    error = bpf_map_update_elem(inner_map_fd, &inner_key, &inner_value, 0);
+    REQUIRE(error == 0);
+
+    // Add inner map to outer map.
+    __u32 outer_key = 0;
+    error = bpf_map_update_elem(outer_map_fd, &outer_key, &inner_map_fd, 0);
+    REQUIRE(error == 0);
+
+    bpf_link* link = bpf_program__attach_xdp(caller, 1);
+    REQUIRE(link != nullptr);
+
+    // Now run the ebpf program.
+    auto packet = prepare_udp_packet(0);
+    xdp_md_t ctx{packet.data(), packet.data() + packet.size()};
+    int result;
+    REQUIRE(hook.fire(&ctx, &result) == EBPF_SUCCESS);
+
+    // Verify the return value is what we saved in the inner map.
+    REQUIRE(result == inner_value);
+
+    // TODO(issue #287): _close(inner_map_fd);
     bpf_object__close(xdp_object);
 }


### PR DESCRIPTION
Replace UM ebpf_map_update/delete_element with libbpf-compliant bpf_map_update/delete_elem

This adds the basic functionality needed for #375 (for an intro on map-in-map support, see [this article](https://hechao.li/2019/03/19/Use-Map-in-Map-in-BPF-programs-via-Libbpf/))

Not in this PR, but in a subsequent PR:
* ensure that all inner maps match the one specified by inner_map_idx, much like prog_types have to match in a `BPF_MAP_TYPE_PROG_ARRAY`.
* ensure that putting a prog_array in an array of maps adheres to the prog_array contract that any associated progs have to match the type of the calling program.
* read a map id not fd when UM reads the value (will be done together with issue #396 since also affects prog_arrays). There may be a bit of confusion reading this PR as a result since it's not yet separated.  This will become clearer once this item is done.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>