### PR TITLE
Store build output as artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,8 +76,9 @@ jobs:
     - name: Upload Build Output
       uses: actions/upload-artifact@v2
       with:
-        name: Build-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
-        path: ${{env.GITHUB_WORKSPACE}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        name: Build x64 ${{ matrix.configurations }}
+        path: ${{ github.workspace }}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        retention-days: 5
 
     - name: Run Unit Tests
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
@@ -93,3 +94,4 @@ jobs:
       with:
         name: Crash-Dumps-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
         path: c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        retention-days: 5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,15 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@v1
 
+    - name: Install ProcDump64
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        curl -fsSL -o Procdump.zip https://download.sysinternals.com/files/Procdump.zip
+        7z x Procdump.zip -y -o"C:/Program Files/ProcDump"
+        echo "C:\Program Files\ProcDump" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        mkdir c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        echo "test" > c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/test.txt
+
     - name: Install LLVM and Clang
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
@@ -64,10 +73,23 @@ jobs:
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:Analysis='True' ${{env.SOLUTION_FILE_PATH}}
 
+    - name: Upload Build Output
+      uses: actions/upload-artifact@v2
+      with:
+        name: Build-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
+        path: ${{env.GITHUB_WORKSPACE}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+
     - name: Run Unit Tests
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-      run: ./unit_tests.exe -s
+      run: procdump64.exe -accepteula -o -ma -e -x c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}} ./unit_tests.exe -s
 
     - name: Run RPC Client Tests
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-      run: ./ebpf_client.exe -s
+      run: procdump64.exe -accepteula -o -ma -e -x c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}} ./ebpf_client.exe -s
+
+    - name: Upload any crash dumps
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: Crash-Dumps-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
+        path: c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}


### PR DESCRIPTION
Store build output as artifacts

Prerequisite to storing crash dumps.

Resolves: #412

Signed-off-by: Alan Jowett <alanjo@microsoft.com>