### PR TITLE
Stop searching once key is matched

### DIFF
--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -256,6 +256,7 @@ _ebpf_hash_table_replace_bucket(
                     // If old_data exists, remove it.
                     old_data = entry->data;
                     old_data_index = index;
+                    break;
                 }
             }
         }
@@ -435,6 +436,7 @@ ebpf_hash_table_find(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key
         ebpf_hash_bucket_entry_t* entry = _ebpf_hash_table_bucket_entry(hash_table->key_size, bucket, index);
         if (_ebpf_hash_table_compare(hash_table, key, entry->key) == 0) {
             data = entry->data;
+            break;
         }
     }
 


### PR DESCRIPTION
Stop searching once key is matched

Minor efficiency improvement in hash-table.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>