### PR TITLE
Fully support BPF flags for map operations

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -73,16 +73,6 @@ extern "C"
     struct bpf_map;
     struct bpf_link;
 
-    typedef enum ebpf_map_option
-    {
-        // Create a new element or update an existing element.
-        EBPF_ANY,
-        // Create a new element only when it does not exist.
-        EBPF_NOEXIST,
-        // Update an existing element.
-        EBPF_EXIST
-    } ebpf_map_option_t;
-
     /**
      *  @brief Initialize the eBPF user mode library.
      */

--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -91,6 +91,9 @@ extern "C"
 
         /// The enumeration found no more keys.
         EBPF_NO_MORE_KEYS, // = 25
+
+        // The requested key is already present.
+        EBPF_KEY_ALREADY_EXISTS, // = 26
     } ebpf_result_t;
 
 #ifdef __cplusplus

--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -93,7 +93,7 @@ extern "C"
         EBPF_NO_MORE_KEYS, // = 25
 
         // The requested key is already present.
-        EBPF_KEY_ALREADY_EXISTS, // = 26
+        EBPF_KEY_ALREADY_EXISTS,
     } ebpf_result_t;
 
 #ifdef __cplusplus

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -20,6 +20,16 @@ typedef enum bpf_map_type
     BPF_MAP_TYPE_PERCPU_ARRAY = 5,
 } ebpf_map_type_t;
 
+typedef enum ebpf_map_option
+{
+    // Create a new element or update an existing element.
+    EBPF_ANY,
+    // Create a new element only when it does not exist.
+    EBPF_NOEXIST,
+    // Update an existing element.
+    EBPF_EXIST
+} ebpf_map_option_t;
+
 /**
  * @brief eBPF Map Definition.
  */

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -439,7 +439,16 @@ ebpf_map_update_element(fd_t map_fd, _In_ const void* key, _In_ const void* valu
     uint32_t value_size = 0;
     uint32_t type;
 
-    if (map_fd <= 0 || key == nullptr || value == nullptr || flags != 0) {
+    if (map_fd <= 0 || key == nullptr || value == nullptr) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    switch (flags) {
+    case EBPF_ANY:
+    case EBPF_NOEXIST:
+    case EBPF_EXIST:
+        break;
+    default:
         return EBPF_INVALID_ARGUMENT;
     }
 

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -390,7 +390,7 @@ _update_map_element(
         request->header.length = static_cast<uint16_t>(request_buffer.size());
         request->header.id = ebpf_operation_id_t::EBPF_OPERATION_MAP_UPDATE_ELEMENT;
         request->handle = (uint64_t)map_handle;
-        request->flags = flags;
+        request->option = static_cast<ebpf_map_option_t>(flags);
         std::copy((uint8_t*)key, (uint8_t*)key + key_size, request->data);
         std::copy((uint8_t*)value, (uint8_t*)value + value_size, request->data + key_size);
 

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -429,8 +429,8 @@ _ebpf_core_protocol_map_update_element(_In_ const epf_operation_map_update_eleme
 
     key_length = map_definition->key_size;
 
-    retval =
-        ebpf_map_update_entry(map, key_length, request->data, value_length, request->data + key_length, request->flags);
+    retval = ebpf_map_update_entry(
+        map, key_length, request->data, value_length, request->data + key_length, request->option, 0);
 
 Done:
     ebpf_object_release_reference((ebpf_object_t*)map);
@@ -977,8 +977,7 @@ _ebpf_core_map_find_element(ebpf_map_t* map, const uint8_t* key)
 static int64_t
 _ebpf_core_map_update_element(ebpf_map_t* map, const uint8_t* key, const uint8_t* value, uint64_t flags)
 {
-    UNREFERENCED_PARAMETER(flags);
-    return -ebpf_map_update_entry(map, 0, key, 0, value, EBPF_MAP_FLAG_HELPER);
+    return -ebpf_map_update_entry(map, 0, key, 0, value, flags, EBPF_MAP_FLAG_HELPER);
 }
 
 static int64_t

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -429,7 +429,8 @@ _ebpf_core_protocol_map_update_element(_In_ const epf_operation_map_update_eleme
 
     key_length = map_definition->key_size;
 
-    retval = ebpf_map_update_entry(map, key_length, request->data, value_length, request->data + key_length, 0);
+    retval =
+        ebpf_map_update_entry(map, key_length, request->data, value_length, request->data + key_length, request->flags);
 
 Done:
     ebpf_object_release_reference((ebpf_object_t*)map);

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -665,7 +665,7 @@ ebpf_map_find_entry(
     _In_reads_(key_size) const uint8_t* key,
     size_t value_size,
     _Out_writes_(value_size) uint8_t* value,
-    uint64_t flags)
+    int flags)
 {
     uint8_t* return_value;
     if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_size != map->ebpf_map_definition.key_size)) {
@@ -778,7 +778,7 @@ ebpf_map_update_entry_with_handle(
 }
 
 ebpf_result_t
-ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, uint64_t flags)
+ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags)
 {
     if (!(flags & EBPF_MAP_FLAG_HELPER) && (key_size != map->ebpf_map_definition.key_size)) {
         return EBPF_INVALID_ARGUMENT;

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -49,7 +49,7 @@ extern "C"
     uint32_t
     ebpf_map_get_effective_value_size(_In_ const ebpf_map_t* map);
 
-#define EBPF_MAP_FLAG_HELPER (((uint64_t)0x1) << 63) /* Called by an eBPF program */
+#define EBPF_MAP_FLAG_HELPER 0x01 /* Called by an eBPF program */
 
     /**
      * @brief Get a pointer to an entry in the map.
@@ -74,7 +74,8 @@ extern "C"
      * @param[in] map Map to update.
      * @param[in] key Key to use when searching and updating the map.
      * @param[in] value Value to insert into the map.
-     * @param[in] flags One of ebpf_map_option_t flags.
+     * @param[in] option One of ebpf_map_option_t options.
+     * @param[in] flags EBPF_MAP_FLAG_HELPER if called from helper function.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  entry.
@@ -86,7 +87,8 @@ extern "C"
         _In_reads_(key_size) const uint8_t* key,
         size_t value_size,
         _In_reads_(value_size) const uint8_t* value,
-        uint64_t flags);
+        ebpf_map_option_t option,
+        int flags);
 
     /**
      * @brief Insert or update an entry in the map.

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -115,14 +115,12 @@ extern "C"
      *
      * @param[in] map Map to update.
      * @param[in] key Key to use when searching and updating the map.
-     * @param[in] flags Must be zero.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are
      *  invalid.
      */
     ebpf_result_t
-    ebpf_map_delete_entry(
-        _In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags);
+    ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags);
 
     /**
      * @brief Retrieve the next key from the map.

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -66,7 +66,7 @@ extern "C"
         _In_reads_(key_size) const uint8_t* key,
         size_t value_size,
         _Out_writes_(value_size) uint8_t* value,
-        uint64_t flags);
+        int flags);
 
     /**
      * @brief Insert or update an entry in the map.
@@ -122,7 +122,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_map_delete_entry(
-        _In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, uint64_t flags);
+        _In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags);
 
     /**
      * @brief Retrieve the next key from the map.

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -49,7 +49,7 @@ extern "C"
     uint32_t
     ebpf_map_get_effective_value_size(_In_ const ebpf_map_t* map);
 
-#define EBPF_MAP_FLAG_HELPER 0x01 /* Called by an eBPF program */
+#define EBPF_MAP_FLAG_HELPER (((uint64_t)0x1) << 63) /* Called by an eBPF program */
 
     /**
      * @brief Get a pointer to an entry in the map.
@@ -66,7 +66,7 @@ extern "C"
         _In_reads_(key_size) const uint8_t* key,
         size_t value_size,
         _Out_writes_(value_size) uint8_t* value,
-        int flags);
+        uint64_t flags);
 
     /**
      * @brief Insert or update an entry in the map.
@@ -74,6 +74,7 @@ extern "C"
      * @param[in] map Map to update.
      * @param[in] key Key to use when searching and updating the map.
      * @param[in] value Value to insert into the map.
+     * @param[in] flags One of ebpf_map_option_t flags.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  entry.
@@ -85,7 +86,7 @@ extern "C"
         _In_reads_(key_size) const uint8_t* key,
         size_t value_size,
         _In_reads_(value_size) const uint8_t* value,
-        int flags);
+        uint64_t flags);
 
     /**
      * @brief Insert or update an entry in the map.
@@ -112,13 +113,14 @@ extern "C"
      *
      * @param[in] map Map to update.
      * @param[in] key Key to use when searching and updating the map.
+     * @param[in] flags Must be zero.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are
      *  invalid.
      */
     ebpf_result_t
     ebpf_map_delete_entry(
-        _In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags);
+        _In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, uint64_t flags);
 
     /**
      * @brief Retrieve the next key from the map.

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -131,7 +131,7 @@ typedef struct _ebpf_operation_map_update_element_request
 {
     struct _ebpf_operation_header header;
     uint64_t handle;
-    uint64_t flags;
+    ebpf_map_option_t option;
     uint8_t data[1]; // data is key+value
 } epf_operation_map_update_element_request_t;
 

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -51,8 +51,13 @@ test_crud_operations(ebpf_map_type_t map_type)
         *reinterpret_cast<uint64_t*>(value.data()) = static_cast<uint64_t>(key) * static_cast<uint64_t>(key);
         REQUIRE(
             ebpf_map_update_entry(
-                map.get(), sizeof(key), reinterpret_cast<const uint8_t*>(&key), value.size(), value.data(), 0) ==
-            EBPF_SUCCESS);
+                map.get(),
+                sizeof(key),
+                reinterpret_cast<const uint8_t*>(&key),
+                value.size(),
+                value.data(),
+                EBPF_ANY,
+                0) == EBPF_SUCCESS);
     }
 
     // Test for inserting max_entries + 1
@@ -60,8 +65,13 @@ test_crud_operations(ebpf_map_type_t map_type)
     *reinterpret_cast<uint64_t*>(value.data()) = 11 * 11;
     REQUIRE(
         ebpf_map_update_entry(
-            map.get(), sizeof(bad_key), reinterpret_cast<const uint8_t*>(&bad_key), value.size(), value.data(), 0) ==
-        EBPF_INVALID_ARGUMENT);
+            map.get(),
+            sizeof(bad_key),
+            reinterpret_cast<const uint8_t*>(&bad_key),
+            value.size(),
+            value.data(),
+            EBPF_ANY,
+            0) == EBPF_INVALID_ARGUMENT);
 
     REQUIRE(
         ebpf_map_delete_entry(map.get(), sizeof(bad_key), reinterpret_cast<const uint8_t*>(&bad_key), 0) ==

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -83,6 +83,13 @@ extern "C"
 
     typedef struct _ebpf_helper_function_addresses ebpf_helper_function_addresses_t;
 
+    typedef enum _ebpf_hash_table_operations
+    {
+        EBPF_HASH_TABLE_OPERATION_ANY = 0,
+        EBPF_HASH_TABLE_OPERATION_INSERT = 1,
+        EBPF_HASH_TABLE_OPERATION_REPLACE = 2,
+    } ebpf_hash_table_operations_t;
+
     /**
      * @brief Initialize the eBPF platform abstraction layer.
      * @retval EBPF_SUCCESS The operation was successful.
@@ -427,12 +434,17 @@ extern "C"
      * @param[in] hash_table Hash-table to update.
      * @param[in] key Key to find and insert or update.
      * @param[in] value Value to insert into hash table or NULL to insert zero entry.
+     * @param[in] operation One of ebpf_hash_table_operations_t operations.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate memory for this
      *  entry in the hash table.
      */
     ebpf_result_t
-    ebpf_hash_table_update(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _In_opt_ const uint8_t* value);
+    ebpf_hash_table_update(
+        _In_ ebpf_hash_table_t* hash_table,
+        _In_ const uint8_t* key,
+        _In_opt_ const uint8_t* value,
+        ebpf_hash_table_operations_t operation);
 
     /**
      * @brief Remove an entry from the hash table.

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -72,10 +72,11 @@ TEST_CASE("hash_table_test", "[platform]")
         ebpf_hash_table_create(&table, ebpf_allocate, ebpf_free, key_1.size(), data_1.size(), 1, NULL) == EBPF_SUCCESS);
 
     // Insert first
-    REQUIRE(ebpf_hash_table_update(table, key_1.data(), data_1.data()) == EBPF_SUCCESS);
+    REQUIRE(
+        ebpf_hash_table_update(table, key_1.data(), data_1.data(), EBPF_HASH_TABLE_OPERATION_INSERT) == EBPF_SUCCESS);
 
     // Insert second
-    REQUIRE(ebpf_hash_table_update(table, key_2.data(), data_2.data()) == EBPF_SUCCESS);
+    REQUIRE(ebpf_hash_table_update(table, key_2.data(), data_2.data(), EBPF_HASH_TABLE_OPERATION_ANY) == EBPF_SUCCESS);
 
     // Find the first
     REQUIRE(ebpf_hash_table_find(table, key_1.data(), &returned_value) == EBPF_SUCCESS);
@@ -87,7 +88,8 @@ TEST_CASE("hash_table_test", "[platform]")
 
     // Replace
     memset(data_1.data(), '0x55', data_1.size());
-    REQUIRE(ebpf_hash_table_update(table, key_1.data(), data_1.data()) == EBPF_SUCCESS);
+    REQUIRE(
+        ebpf_hash_table_update(table, key_1.data(), data_1.data(), EBPF_HASH_TABLE_OPERATION_REPLACE) == EBPF_SUCCESS);
 
     // Find the first
     REQUIRE(ebpf_hash_table_find(table, key_1.data(), &returned_value) == EBPF_SUCCESS);
@@ -148,7 +150,10 @@ TEST_CASE("hash_table_stress_test", "[platform]")
             for (auto& key : keys) {
                 run_in_epoch([&]() {
                     ebpf_hash_table_update(
-                        table, reinterpret_cast<const uint8_t*>(&key), reinterpret_cast<const uint8_t*>(&value));
+                        table,
+                        reinterpret_cast<const uint8_t*>(&key),
+                        reinterpret_cast<const uint8_t*>(&value),
+                        EBPF_HASH_TABLE_OPERATION_ANY);
                 });
             }
             for (auto& key : keys)

--- a/libs/platform/user/ebpf_extension_user.c
+++ b/libs/platform/user/ebpf_extension_user.c
@@ -86,7 +86,8 @@ ebpf_extension_load(
     return_value = ebpf_hash_table_update(
         local_extension_provider->client_table,
         (const uint8_t*)&local_extension_client->client_id,
-        (const uint8_t*)&local_extension_client);
+        (const uint8_t*)&local_extension_client,
+        EBPF_HASH_TABLE_OPERATION_INSERT);
     if (return_value != EBPF_SUCCESS) {
         goto Done;
     }
@@ -235,7 +236,10 @@ ebpf_provider_load(
     }
 
     return_value = ebpf_hash_table_update(
-        _ebpf_provider_table, (const uint8_t*)interface_id, (const uint8_t*)&local_extension_provider);
+        _ebpf_provider_table,
+        (const uint8_t*)interface_id,
+        (const uint8_t*)&local_extension_provider,
+        EBPF_HASH_TABLE_OPERATION_INSERT);
     if (return_value != EBPF_SUCCESS)
         goto Done;
 


### PR DESCRIPTION
Fully support BPF flags for map operations

Options include:
1) Insert if the element doesn't exist.
2) Update the existing element.
3) Insert or update an element.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>