### PR TITLE
Add tests for libbpf bpf_map_*_elem APIs

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -408,10 +408,10 @@ extern "C"
      * @brief Close an eBPF handle.
      *
      * @param[in] handle Handle to close.
-     * @retval ERROR_SUCCESS Handle was closed.
-     * @retval ERROR_INVALID_HANDLE Handle is not valid.
+     * @retval EBPF_SUCCESS Handle was closed.
+     * @retval EBPF_INVALID_OBJECT Handle is not valid.
      */
-    uint32_t
+    ebpf_result_t
     ebpf_api_close_handle(ebpf_handle_t handle);
 
     /**

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -921,7 +921,9 @@ ebpf_map_pin(_In_ struct bpf_map* map, _In_opt_z_ const char* path)
         return EBPF_INVALID_ARGUMENT;
     }
     if (map->pinned) {
-        return (strcmp(path, map->pin_path) == 0) ? EBPF_OBJECT_ALREADY_EXISTS : EBPF_ALREADY_PINNED;
+        return (map->pin_path != nullptr && path != nullptr && strcmp(path, map->pin_path) == 0)
+                   ? EBPF_OBJECT_ALREADY_EXISTS
+                   : EBPF_ALREADY_PINNED;
     }
     if (path != nullptr) {
         // If pin path is already set, the pin path provided now should be same
@@ -1064,9 +1066,10 @@ ebpf_get_next_program(fd_t previous_fd, _Out_ fd_t* next_fd)
     *next_fd = ebpf_fd_invalid;
 
     ebpf_handle_t previous_handle = _get_handle_from_fd(local_fd);
-    ebpf_operation_get_next_program_request_t request{sizeof(request),
-                                                      ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM,
-                                                      reinterpret_cast<uint64_t>(previous_handle)};
+    ebpf_operation_get_next_program_request_t request{
+        sizeof(request),
+        ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM,
+        reinterpret_cast<uint64_t>(previous_handle)};
 
     ebpf_operation_get_next_program_reply_t reply;
 
@@ -1162,10 +1165,11 @@ ebpf_program_query_info(
 uint32_t
 ebpf_api_link_program(ebpf_handle_t program_handle, ebpf_attach_type_t attach_type, ebpf_handle_t* link_handle)
 {
-    ebpf_operation_link_program_request_t request = {EBPF_OFFSET_OF(ebpf_operation_link_program_request_t, data),
-                                                     EBPF_OPERATION_LINK_PROGRAM,
-                                                     reinterpret_cast<uint64_t>(program_handle),
-                                                     attach_type};
+    ebpf_operation_link_program_request_t request = {
+        EBPF_OFFSET_OF(ebpf_operation_link_program_request_t, data),
+        EBPF_OPERATION_LINK_PROGRAM,
+        reinterpret_cast<uint64_t>(program_handle),
+        attach_type};
     ebpf_operation_link_program_reply_t reply;
 
     uint32_t retval = invoke_ioctl(request, reply);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -921,7 +921,7 @@ ebpf_map_pin(_In_ struct bpf_map* map, _In_opt_z_ const char* path)
         return EBPF_INVALID_ARGUMENT;
     }
     if (map->pinned) {
-        return EBPF_ALREADY_PINNED;
+        return (strcmp(path, map->pin_path) == 0) ? EBPF_OBJECT_ALREADY_EXISTS : EBPF_ALREADY_PINNED;
     }
     if (path != nullptr) {
         // If pin path is already set, the pin path provided now should be same
@@ -1064,10 +1064,9 @@ ebpf_get_next_program(fd_t previous_fd, _Out_ fd_t* next_fd)
     *next_fd = ebpf_fd_invalid;
 
     ebpf_handle_t previous_handle = _get_handle_from_fd(local_fd);
-    ebpf_operation_get_next_program_request_t request{
-        sizeof(request),
-        ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM,
-        reinterpret_cast<uint64_t>(previous_handle)};
+    ebpf_operation_get_next_program_request_t request{sizeof(request),
+                                                      ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM,
+                                                      reinterpret_cast<uint64_t>(previous_handle)};
 
     ebpf_operation_get_next_program_reply_t reply;
 
@@ -1163,11 +1162,10 @@ ebpf_program_query_info(
 uint32_t
 ebpf_api_link_program(ebpf_handle_t program_handle, ebpf_attach_type_t attach_type, ebpf_handle_t* link_handle)
 {
-    ebpf_operation_link_program_request_t request = {
-        EBPF_OFFSET_OF(ebpf_operation_link_program_request_t, data),
-        EBPF_OPERATION_LINK_PROGRAM,
-        reinterpret_cast<uint64_t>(program_handle),
-        attach_type};
+    ebpf_operation_link_program_request_t request = {EBPF_OFFSET_OF(ebpf_operation_link_program_request_t, data),
+                                                     EBPF_OPERATION_LINK_PROGRAM,
+                                                     reinterpret_cast<uint64_t>(program_handle),
+                                                     attach_type};
     ebpf_operation_link_program_reply_t reply;
 
     uint32_t retval = invoke_ioctl(request, reply);
@@ -1356,13 +1354,13 @@ ebpf_link_close(_In_ struct bpf_link* link)
     return EBPF_SUCCESS;
 }
 
-uint32_t
+ebpf_result_t
 ebpf_api_close_handle(ebpf_handle_t handle)
 {
     ebpf_operation_close_handle_request_t request = {
         sizeof(request), EBPF_OPERATION_CLOSE_HANDLE, reinterpret_cast<uint64_t>(handle)};
 
-    return invoke_ioctl(request);
+    return windows_error_to_ebpf_result(invoke_ioctl(request));
 }
 
 ebpf_result_t

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -267,7 +267,7 @@ bpf_link__destroy(struct bpf_link* link)
     // TODO(issue #81): get handle from ebpf_link_t, and
     // detach before closing the handle.
     ebpf_handle_t link_handle = (ebpf_handle_t)link;
-    uint32_t result = ebpf_api_close_handle(link_handle);
+    ebpf_result_t result = ebpf_api_close_handle(link_handle);
     return libbpf_err(-(int)result);
 }
 

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -124,6 +124,10 @@ windows_error_to_ebpf_result(uint32_t error)
         result = EBPF_ALREADY_INITIALIZED;
         break;
 
+    case ERROR_OBJECT_ALREADY_EXISTS:
+        result = EBPF_OBJECT_ALREADY_EXISTS;
+        break;
+
     default:
         result = EBPF_FAILED;
         break;

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -165,7 +165,7 @@ _delete_array_map_entry_with_reference(_In_ ebpf_core_map_t* map, _In_ const uin
     key_value = *(uint32_t*)key;
 
     if (key_value > map->ebpf_map_definition.max_entries)
-        return EBPF_KEY_NOT_FOUND;
+        return EBPF_INVALID_ARGUMENT;
 
     uint8_t* entry = &map->data[key_value * map->ebpf_map_definition.value_size];
     if (with_reference) {

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -291,7 +291,7 @@ _ebpf_hash_table_replace_bucket(
         // Permit it if this is an insert or insert_or_update.
         case EBPF_HASH_BUCKET_OPERATION_INSERT:
             if (old_data_index != MAXSIZE_T) {
-                result = EBPF_KEY_NOT_FOUND;
+                result = EBPF_OBJECT_ALREADY_EXISTS;
                 goto Done;
             } else {
                 new_bucket_count++;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -128,6 +128,9 @@ Fail:
         case EBPF_INSUFFICIENT_BUFFER:
             SetLastError(ERROR_MORE_DATA);
             break;
+        case EBPF_OBJECT_ALREADY_EXISTS:
+            SetLastError(ERROR_OBJECT_ALREADY_EXISTS);
+            break;
         default:
             SetLastError(ERROR_INVALID_PARAMETER);
             break;


### PR DESCRIPTION
* Return correct error between EBPF_OBJECT_ALREADY_EXISTS (A program or
map is already pinned with the *same* path) vs
EBPF_ALREADY_PINNED (The program or map already pinned to a *different*
path).

* Update vs lookup elem were inconsistent in whether returning
  EBPF_KEY_NOT_FOUND vs EBPF_INVALID_ARGUMENT when passing an array
  index >= max_entries.  Made them be consistent in using
  EBPF_INVALID_ARGUMENT.

Fixes #376

Signed-off-by: Dave Thaler <dthaler@microsoft.com>