### PR TITLE
All per-CPU structures should be allocated on EBPF_CACHE_LINE_SIZE boundaries

### DIFF
--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -65,7 +65,7 @@ typedef struct _ebpf_epoch_cpu_entry
 
 C_ASSERT(sizeof(ebpf_epoch_cpu_entry_t) % EBPF_CACHE_LINE_SIZE == 0);
 
-EBPF_DECLARE_ALIGNED_POINTER(_Writable_elements_(_ebpf_epoch_cpu_count) ebpf_epoch_cpu_entry_t, _ebpf_epoch_cpu_table)
+EBPF_DECLARE_STATIC_ALIGNED_POINTER(_Writable_elements_(_ebpf_epoch_cpu_count) ebpf_epoch_cpu_entry_t, _ebpf_epoch_cpu_table)
 static uint32_t _ebpf_epoch_cpu_count = 0;
 
 /**

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -3,8 +3,6 @@
 
 #include "ebpf_epoch.h"
 
-#define EBPF_CACHE_LINE_SIZE 64
-
 // Brief summary of how epoch tracking works.
 // Each free operation increments the _ebpf_current_epoch, the freed memory is stamped with that epoch, and the
 // memory is inserted into a per-CPU free list.
@@ -67,7 +65,7 @@ typedef struct _ebpf_epoch_cpu_entry
 
 C_ASSERT(sizeof(ebpf_epoch_cpu_entry_t) % EBPF_CACHE_LINE_SIZE == 0);
 
-static _Writable_elements_(_ebpf_epoch_cpu_count) ebpf_epoch_cpu_entry_t* _ebpf_epoch_cpu_table = NULL;
+EBPF_DECLARE_ALIGNED_POINTER(_Writable_elements_(_ebpf_epoch_cpu_count) ebpf_epoch_cpu_entry_t, _ebpf_epoch_cpu_table)
 static uint32_t _ebpf_epoch_cpu_count = 0;
 
 /**
@@ -145,7 +143,8 @@ ebpf_epoch_initiate()
     _ebpf_release_epoch = 0;
     _ebpf_epoch_cpu_count = cpu_count;
 
-    _ebpf_epoch_cpu_table = ebpf_allocate(_ebpf_epoch_cpu_count * sizeof(ebpf_epoch_cpu_entry_t));
+    EBPF_ALLOCATE_ALIGNED_POINTER(ebpf_epoch_cpu_entry_t, _ebpf_epoch_cpu_table, cpu_count)
+
     if (!_ebpf_epoch_cpu_table) {
         return_value = EBPF_NO_MEMORY;
         goto Error;
@@ -201,8 +200,7 @@ ebpf_epoch_terminate()
     }
     _ebpf_epoch_cpu_count = 0;
 
-    ebpf_free(_ebpf_epoch_cpu_table);
-    _ebpf_epoch_cpu_table = NULL;
+    EBPF_FREE_ALIGNED_PONTER(_ebpf_epoch_cpu_table);
 }
 
 ebpf_result_t

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -29,20 +29,6 @@ extern "C"
 #define EBPF_CACHE_LINE_SIZE 64
 #define EBPF_CACHE_ALIGN_POINTER(P) (void*)(((uintptr_t)P + EBPF_CACHE_LINE_SIZE - 1) & ~(EBPF_CACHE_LINE_SIZE - 1))
 
-#define EBPF_DECLARE_STATIC_ALIGNED_POINTER(TYPE, NAME)        \
-    C_ASSERT(sizeof(TYPE) % EBPF_CACHE_LINE_SIZE == 0); \
-    static TYPE* NAME = NULL;                           \
-    static void* NAME##_unaligned = NULL;
-
-#define EBPF_ALLOCATE_ALIGNED_POINTER(TYPE, NAME, COUNT)                           \
-    NAME##_unaligned = ebpf_allocate(sizeof(TYPE) * COUNT + EBPF_CACHE_LINE_SIZE); \
-    NAME = NAME##_unaligned != NULL ? NAME = EBPF_CACHE_ALIGN_POINTER(NAME##_unaligned) : NULL;
-
-#define EBPF_FREE_ALIGNED_PONTER(NAME) \
-    ebpf_free(NAME##_unaligned);       \
-    NAME##_unaligned = NULL;           \
-    NAME = NULL;
-
     /**
      * @brief A UTF-8 encoded string.
      * Notes:
@@ -136,6 +122,21 @@ extern "C"
      */
     void
     ebpf_free(_Frees_ptr_opt_ void* memory);
+
+    /**
+     * @brief Allocate memory that has a starting address that is cache aligned.
+     * @param[in] size Size of memory to allocate
+     * @returns Pointer to memory block allocated, or null on failure.
+     */
+    __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
+        _Post_writable_byte_size_(size) void* ebpf_allocate_cache_aligned(size_t size);
+
+    /**
+     * @brief Free memory that has a starting address that is cache aligned.
+     * @param[in] memory Allocation to be freed.
+     */
+    void
+    ebpf_free_cache_aligned(_Frees_ptr_opt_ void* memory);
 
     typedef enum _ebpf_page_protection
     {

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -26,10 +26,10 @@ extern "C"
         ((uint8_t*)(x)), sizeof((x)) - 1      \
     }
 
-#define EBPF_CACHE_LINE_SIZE (64)
+#define EBPF_CACHE_LINE_SIZE 64
 #define EBPF_CACHE_ALIGN_POINTER(P) (void*)(((uintptr_t)P + EBPF_CACHE_LINE_SIZE - 1) & ~(EBPF_CACHE_LINE_SIZE - 1))
 
-#define EBPF_DECLARE_ALIGNED_POINTER(TYPE, NAME)        \
+#define EBPF_DECLARE_STATIC_ALIGNED_POINTER(TYPE, NAME)        \
     C_ASSERT(sizeof(TYPE) % EBPF_CACHE_LINE_SIZE == 0); \
     static TYPE* NAME = NULL;                           \
     static void* NAME##_unaligned = NULL;

--- a/libs/platform/ebpf_state.c
+++ b/libs/platform/ebpf_state.c
@@ -17,7 +17,7 @@ typedef struct _ebpf_state_entry
     uintptr_t state[EBPF_MAX_STATE_ENTRIES];
 } ebpf_state_entry_t;
 
-EBPF_DECLARE_STATIC_ALIGNED_POINTER(_Writable_elements_(_ebpf_state_cpu_table_size) ebpf_state_entry_t, _ebpf_state_cpu_table)
+static _Writable_elements_(_ebpf_state_cpu_table_size) ebpf_state_entry_t* _ebpf_state_cpu_table = NULL;
 static uint32_t _ebpf_state_cpu_table_size = 0;
 
 ebpf_result_t
@@ -29,7 +29,7 @@ ebpf_state_initiate()
         _ebpf_state_cpu_table_size = ebpf_get_cpu_count();
         _Analysis_assume_(_ebpf_state_cpu_table_size >= 1);
 
-        EBPF_ALLOCATE_ALIGNED_POINTER(ebpf_state_entry_t, _ebpf_state_cpu_table, _ebpf_state_cpu_table_size);
+        _ebpf_state_cpu_table = ebpf_allocate_cache_aligned(sizeof(ebpf_state_entry_t) * _ebpf_state_cpu_table_size);
         if (!_ebpf_state_cpu_table) {
             return_value = EBPF_NO_MEMORY;
             goto Error;
@@ -63,7 +63,7 @@ void
 ebpf_state_terminate()
 {
     ebpf_hash_table_destroy(_ebpf_state_thread_table);
-    EBPF_FREE_ALIGNED_PONTER(_ebpf_state_cpu_table);
+    ebpf_free_cache_aligned(_ebpf_state_cpu_table);
 }
 
 ebpf_result_t

--- a/libs/platform/ebpf_state.c
+++ b/libs/platform/ebpf_state.c
@@ -17,7 +17,7 @@ typedef struct _ebpf_state_entry
     uintptr_t state[EBPF_MAX_STATE_ENTRIES];
 } ebpf_state_entry_t;
 
-static _Writable_elements_(_ebpf_state_cpu_table_size) ebpf_state_entry_t* _ebpf_state_cpu_table = NULL;
+EBPF_DECLARE_ALIGNED_POINTER(_Writable_elements_(_ebpf_state_cpu_table_size) ebpf_state_entry_t, _ebpf_state_cpu_table)
 static uint32_t _ebpf_state_cpu_table_size = 0;
 
 ebpf_result_t
@@ -29,7 +29,7 @@ ebpf_state_initiate()
         _ebpf_state_cpu_table_size = ebpf_get_cpu_count();
         _Analysis_assume_(_ebpf_state_cpu_table_size >= 1);
 
-        _ebpf_state_cpu_table = ebpf_allocate(_ebpf_state_cpu_table_size * sizeof(ebpf_state_entry_t));
+        EBPF_ALLOCATE_ALIGNED_POINTER(ebpf_state_entry_t, _ebpf_state_cpu_table, _ebpf_state_cpu_table_size);
         if (!_ebpf_state_cpu_table) {
             return_value = EBPF_NO_MEMORY;
             goto Error;
@@ -63,7 +63,7 @@ void
 ebpf_state_terminate()
 {
     ebpf_hash_table_destroy(_ebpf_state_thread_table);
-    ebpf_free(_ebpf_state_cpu_table);
+    EBPF_FREE_ALIGNED_PONTER(_ebpf_state_cpu_table);
 }
 
 ebpf_result_t

--- a/libs/platform/ebpf_state.c
+++ b/libs/platform/ebpf_state.c
@@ -17,7 +17,7 @@ typedef struct _ebpf_state_entry
     uintptr_t state[EBPF_MAX_STATE_ENTRIES];
 } ebpf_state_entry_t;
 
-EBPF_DECLARE_ALIGNED_POINTER(_Writable_elements_(_ebpf_state_cpu_table_size) ebpf_state_entry_t, _ebpf_state_cpu_table)
+EBPF_DECLARE_STATIC_ALIGNED_POINTER(_Writable_elements_(_ebpf_state_cpu_table_size) ebpf_state_entry_t, _ebpf_state_cpu_table)
 static uint32_t _ebpf_state_cpu_table_size = 0;
 
 ebpf_result_t

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -47,6 +47,19 @@ ebpf_free(_Frees_ptr_opt_ void* memory)
         ExFreePool(memory);
 }
 
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
+    _Post_writable_byte_size_(size) void* ebpf_allocate_cache_aligned(size_t size)
+{
+    return ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED, size, EBPF_POOL_TAG);
+}
+
+void
+ebpf_free_cache_aligned(_Frees_ptr_opt_ void* memory)
+{
+    if (memory)
+        ExFreePool(memory);
+}
+
 ebpf_memory_descriptor_t*
 ebpf_map_memory(size_t length)
 {

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -55,6 +55,18 @@ ebpf_free(_Frees_ptr_opt_ void* memory)
     free(memory);
 }
 
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
+    _Post_writable_byte_size_(size) void* ebpf_allocate_cache_aligned(size_t size)
+{
+    return _aligned_malloc(size, EBPF_CACHE_LINE_SIZE);
+}
+
+void
+ebpf_free_cache_aligned(_Frees_ptr_opt_ void* memory)
+{
+    _aligned_free(memory);
+}
+
 struct _ebpf_memory_descriptor
 {
     void* base;


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>