### PR TITLE
Test utility helper functions.

### DIFF
--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -106,6 +106,7 @@ get_global_attach_type()
 void
 ebpf_clear_thread_local_storage() noexcept
 {
+    set_global_program_and_attach_type(nullptr, nullptr);
     clear_map_descriptors();
     clear_program_info_cache();
     set_program_under_verification(ebpf_handle_invalid);

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -45,9 +45,9 @@ const EbpfProgramType windows_bind_program_type =
     PTYPE("bind", &g_bind_context_descriptor, (uint64_t)&EBPF_PROGRAM_TYPE_BIND, {"bind"});
 
 const ebpf_context_descriptor_t g_sample_ext_context_descriptor = {
-    sizeof(test_program_context_t),
-    EBPF_OFFSET_OF(test_program_context_t, data_start),
-    EBPF_OFFSET_OF(test_program_context_t, data_end),
+    sizeof(sample_program_context_t),
+    EBPF_OFFSET_OF(sample_program_context_t, data_start),
+    EBPF_OFFSET_OF(sample_program_context_t, data_end),
     -1, // Offset into ctx struct for pointer to metadata, or -1 if none.
 };
 

--- a/scripts/run_tests.bat
+++ b/scripts/run_tests.bat
@@ -1,0 +1,37 @@
+@echo off
+rem Copyright (c) Microsoft Corporation
+rem SPDX-License-Identifier: MIT
+if [%1]==[] (
+    set /A install=1
+    goto :INSTALL
+)
+if "%1" == "/noinstall" (
+    set /A install=0
+) else (
+    goto :USAGE
+)
+:INSTALL
+if %install% == 1 (
+    @echo Installing eBPF components.
+    call .\install-ebpf.bat
+)
+@echo =====================
+@echo Executing Unit Tests.
+@echo =====================
+.\unit_tests.exe
+@echo ===========================
+@echo Executing RPC Client Tests.
+@echo ===========================
+.\ebpf_client.exe
+@echo ====================
+@echo Executing API Tests.
+@echo ====================
+.\api_test.exe
+@echo =================================
+@echo Executing Sample Extension Tests.
+@echo =================================
+.\sample_ext_app.exe
+goto EOF
+:USAGE
+@echo Usage: run_tests /noinstall
+:EOF

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -17,6 +17,7 @@
 #include "helpers.h"
 #include "libbpf.h"
 #include "mock.h"
+#include "program_helper.h"
 #include "sample_test_common.h"
 #include "test_helper.hpp"
 #include "tlv.h"
@@ -275,28 +276,11 @@ static void
 _utility_helper_functions_test(ebpf_execution_type_t execution_type)
 {
     _test_helper_end_to_end test_helper;
-
-    ebpf_result_t result;
-    const char* error_message = nullptr;
-    bpf_object* object = nullptr;
-    fd_t program_fd;
-    bpf_link* link;
-
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
     program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
-
-    result = ebpf_program_load(
-        SAMPLE_PATH "test_utility_helpers.o", nullptr, nullptr, execution_type, &object, &program_fd, &error_message);
-
-    if (error_message) {
-        printf("ebpf_program_load failed with %s\n", error_message);
-        ebpf_free_string(error_message);
-        error_message = nullptr;
-    }
-    REQUIRE(result == EBPF_SUCCESS);
-    fd_t utility_map_fd = bpf_object__find_map_fd_by_name(object, "utility_map");
-
-    REQUIRE(hook.attach_link(program_fd, &link) == EBPF_SUCCESS);
+    program_load_attach_helper_t program_helper(
+        SAMPLE_PATH "test_utility_helpers.o", EBPF_PROGRAM_TYPE_XDP, "test_utility_helpers", execution_type, hook);
+    bpf_object* object = program_helper.get_object();
 
     // Dummy context (not used by the eBPF program).
     xdp_md_t ctx{};
@@ -305,17 +289,7 @@ _utility_helper_functions_test(ebpf_execution_type_t execution_type)
     REQUIRE(hook.fire(&ctx, &hook_result) == EBPF_SUCCESS);
     REQUIRE(hook_result == 0);
 
-    ebpf_utility_helpers_data_t test_data[UTILITY_MAP_SIZE];
-    for (uint32_t key = 0; key < UTILITY_MAP_SIZE; key++)
-        REQUIRE(bpf_map_lookup_elem(utility_map_fd, &key, (void*)&test_data[key]) == EBPF_SUCCESS);
-
-    REQUIRE(test_data[0].random != test_data[1].random);
-    REQUIRE(test_data[0].timestamp < test_data[1].timestamp);
-
-    hook.detach_link(link);
-    hook.close_link(link);
-
-    bpf_object__close(object);
+    verify_utility_helper_results(object);
 }
 
 TEST_CASE("droppacket-jit", "[end_to_end]") { droppacket_test(EBPF_EXECUTION_JIT); }
@@ -382,6 +356,49 @@ TEST_CASE("verify section", "[end_to_end]")
         result == 0));
     REQUIRE(report != nullptr);
     ebpf_free_string(report);
+}
+
+TEST_CASE("verify_test0", "[sample_extension]")
+{
+    _test_helper_end_to_end test_helper;
+    program_info_provider_t sample_extension_program_info(EBPF_PROGRAM_TYPE_SAMPLE);
+
+    const char* error_message = nullptr;
+    const char* report = nullptr;
+    uint32_t result;
+
+    ebpf_api_verifier_stats_t stats;
+    REQUIRE(
+        (result = ebpf_api_elf_verify_section(
+             SAMPLE_PATH "test_sample_ebpf.o", "sample_ext", false, &report, &error_message, &stats),
+         ebpf_free_string(error_message),
+         error_message = nullptr,
+         result == 0));
+    REQUIRE(report != nullptr);
+    ebpf_free_string(report);
+}
+
+TEST_CASE("verify_test1", "[sample_extension]")
+{
+    _test_helper_end_to_end test_helper;
+    program_info_provider_t sample_extension_program_info(EBPF_PROGRAM_TYPE_SAMPLE);
+
+    const char* error_message = nullptr;
+    const char* report = nullptr;
+    uint32_t result;
+
+    ebpf_api_verifier_stats_t stats;
+
+    REQUIRE(
+        (result = ebpf_api_elf_verify_section(
+             SAMPLE_PATH "test_sample_ebpf.o", "sample_ext/utility", false, &report, &error_message, &stats),
+         ebpf_free_string(error_message),
+         error_message = nullptr,
+         result == 0));
+    REQUIRE(report != nullptr);
+    ebpf_free_string(report);
+
+    REQUIRE(result == 0);
 }
 
 TEST_CASE("map_pinning_test", "[end_to_end]")

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -10,6 +10,8 @@
 #include "ebpf_program_types.h"
 #include "sample_ext_program_info.h"
 
+#pragma warning(disable : 26812) // Prefer enum class.
+
 typedef struct _ebpf_free_memory
 {
     void

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -10,8 +10,6 @@
 #include "ebpf_program_types.h"
 #include "sample_ext_program_info.h"
 
-#pragma warning(disable : 26812) // Prefer enum class.
-
 typedef struct _ebpf_free_memory
 {
     void

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -58,15 +58,9 @@ typedef class _hook_helper
     _hook_helper(ebpf_attach_type_t attach_type) : _attach_type(attach_type) {}
 
     ebpf_result_t
-    attach(struct bpf_program* program)
+    attach_link(fd_t program_fd, bpf_link** link)
     {
-        // Attach program to link.
-        bpf_link* link = nullptr;
-        ebpf_result_t result = ebpf_program_attach(program, &_attach_type, nullptr, 0, &link);
-
-        REQUIRE(result == EBPF_SUCCESS);
-
-        return result;
+        return ebpf_program_attach_by_fd(program_fd, &_attach_type, nullptr, 0, link);
     }
 
   private:
@@ -100,12 +94,6 @@ typedef class _single_instance_hook : public _hook_helper
     attach(ebpf_handle_t program_handle)
     {
         return ebpf_api_link_program(program_handle, attach_type, &link_handle);
-    }
-
-    ebpf_result_t
-    attach_link(fd_t program_fd, bpf_link** link)
-    {
-        return ebpf_program_attach_by_fd(program_fd, &attach_type, nullptr, 0, link);
     }
 
     void

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include "catch_wrapper.hpp"
 #include "common_tests.h"
+#include "sample_test_common.h"
 
 void
 ebpf_test_pinned_map_enum()
@@ -71,4 +72,16 @@ Exit:
     ebpf_api_map_info_free(map_count, map_info);
     map_count = 0;
     map_info = nullptr;
+}
+
+void
+verify_utility_helper_results(_In_ const bpf_object* object)
+{
+    fd_t utility_map_fd = bpf_object__find_map_fd_by_name(object, "utility_map");
+    ebpf_utility_helpers_data_t test_data[UTILITY_MAP_SIZE];
+    for (uint32_t key = 0; key < UTILITY_MAP_SIZE; key++)
+        REQUIRE(bpf_map_lookup_elem(utility_map_fd, &key, (void*)&test_data[key]) == EBPF_SUCCESS);
+
+    REQUIRE(test_data[0].random != test_data[1].random);
+    REQUIRE(test_data[0].timestamp < test_data[1].timestamp);
 }

--- a/tests/libs/common/common_tests.h
+++ b/tests/libs/common/common_tests.h
@@ -6,8 +6,13 @@
 #pragma once
 #include <windows.h>
 
+#include "bpf.h"
 #include "ebpf_api.h"
 #include "ebpf_result.h"
+#include "libbpf.h"
 
 void
 ebpf_test_pinned_map_enum();
+
+void
+verify_utility_helper_results(_In_ const bpf_object* object);

--- a/tests/libs/common/common_tests.h
+++ b/tests/libs/common/common_tests.h
@@ -11,6 +11,8 @@
 #include "ebpf_result.h"
 #include "libbpf.h"
 
+#pragma warning(disable : 26812) // Prefer enum class.
+
 void
 ebpf_test_pinned_map_enum();
 

--- a/tests/libs/common/common_tests.h
+++ b/tests/libs/common/common_tests.h
@@ -11,8 +11,6 @@
 #include "ebpf_result.h"
 #include "libbpf.h"
 
-#pragma warning(disable : 26812) // Prefer enum class.
-
 void
 ebpf_test_pinned_map_enum();
 

--- a/tests/libs/common/common_tests.vcxproj
+++ b/tests/libs/common/common_tests.vcxproj
@@ -123,7 +123,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(SolutionDir)tests\sample;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -142,7 +142,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(SolutionDir)tests\sample;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "catch_wrapper.hpp"
+#include "program_helper.h"
+
+_program_load_attach_helper::_program_load_attach_helper(
+    _In_z_ const char* file_name,
+    _In_ const ebpf_program_type_t program_type,
+    _In_ const char* program_name,
+    ebpf_execution_type_t execution_type,
+    hook_helper_t& hook,
+    bool initiate_api)
+    : _file_name(file_name), _program_type(program_type), _program_name(program_name), _execution_type(execution_type),
+      _object(nullptr)
+{
+    ebpf_result_t result;
+    fd_t program_fd;
+    const char* log_buffer = nullptr;
+
+    if (initiate_api) {
+        REQUIRE(ebpf_api_initiate() == EBPF_SUCCESS);
+        _api_initialized = true;
+    }
+
+    // Load BPF object from ELF file.
+    result = ebpf_program_load(
+        _file_name.c_str(), &_program_type, nullptr, _execution_type, &_object, &program_fd, &log_buffer);
+    REQUIRE(result == EBPF_SUCCESS);
+    REQUIRE(program_fd > 0);
+
+    // Load program by name.
+    struct bpf_program* program = bpf_object__find_program_by_name(_object, _program_name.c_str());
+    REQUIRE(program != nullptr);
+
+    // Attach program to link.
+    REQUIRE(hook.attach(program) == EBPF_SUCCESS);
+
+    ebpf_free_string(log_buffer);
+}
+
+_program_load_attach_helper::~_program_load_attach_helper()
+{
+    bpf_object__close(_object);
+
+    if (_api_initialized)
+        ebpf_api_terminate();
+}
+
+struct bpf_object*
+_program_load_attach_helper::get_object()
+{
+    return _object;
+}

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -6,13 +6,13 @@
 
 _program_load_attach_helper::_program_load_attach_helper(
     _In_z_ const char* file_name,
-    _In_ const ebpf_program_type_t program_type,
+    ebpf_program_type_t program_type,
     _In_ const char* program_name,
     ebpf_execution_type_t execution_type,
     hook_helper_t& hook,
     bool initiate_api)
     : _file_name(file_name), _program_type(program_type), _program_name(program_name), _execution_type(execution_type),
-      _object(nullptr)
+      _object(nullptr), _api_initialized(false)
 {
     ebpf_result_t result;
     fd_t program_fd;

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -7,7 +7,7 @@
 _program_load_attach_helper::_program_load_attach_helper(
     _In_z_ const char* file_name,
     ebpf_program_type_t program_type,
-    _In_ const char* program_name,
+    _In_z_ const char* program_name,
     ebpf_execution_type_t execution_type,
     hook_helper_t& hook,
     bool initiate_api)

--- a/tests/libs/util/program_helper.h
+++ b/tests/libs/util/program_helper.h
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Utility functions for loading and attaching test eBPF programs.
+ */
+
+#include "bpf.h"
+#include "helpers.h"
+#include "libbpf.h"
+
+typedef class _program_load_attach_helper
+{
+  public:
+    _program_load_attach_helper(
+        _In_z_ const char* file_name,
+        _In_ const ebpf_program_type_t program_type,
+        _In_ const char* program_name,
+        ebpf_execution_type_t execution_type,
+        hook_helper_t& hook,
+        bool initiate_api = false);
+
+    ~_program_load_attach_helper();
+
+    struct bpf_object*
+    get_object();
+
+  private:
+    std::string _file_name;
+    ebpf_program_type_t _program_type;
+    std::string _program_name;
+    ebpf_execution_type_t _execution_type;
+    bpf_object* _object;
+    bool _api_initialized;
+} program_load_attach_helper_t;

--- a/tests/libs/util/program_helper.h
+++ b/tests/libs/util/program_helper.h
@@ -15,7 +15,7 @@ typedef class _program_load_attach_helper
     _program_load_attach_helper(
         _In_z_ const char* file_name,
         ebpf_program_type_t program_type,
-        _In_ const char* program_name,
+        _In_z_ const char* program_name,
         ebpf_execution_type_t execution_type,
         hook_helper_t& hook,
         bool initiate_api = false);

--- a/tests/libs/util/program_helper.h
+++ b/tests/libs/util/program_helper.h
@@ -30,6 +30,7 @@ typedef class _program_load_attach_helper
     ebpf_program_type_t _program_type;
     std::string _program_name;
     ebpf_execution_type_t _execution_type;
+    bpf_link* _link;
     bpf_object* _object;
     bool _api_initialized;
 } program_load_attach_helper_t;

--- a/tests/libs/util/program_helper.h
+++ b/tests/libs/util/program_helper.h
@@ -14,7 +14,7 @@ typedef class _program_load_attach_helper
   public:
     _program_load_attach_helper(
         _In_z_ const char* file_name,
-        _In_ const ebpf_program_type_t program_type,
+        ebpf_program_type_t program_type,
         _In_ const char* program_name,
         ebpf_execution_type_t execution_type,
         hook_helper_t& hook,

--- a/tests/libs/util/service_helper.h
+++ b/tests/libs/util/service_helper.h
@@ -36,4 +36,3 @@ class service_install_helper
     bool already_installed;
     bool initialized;
 };
-

--- a/tests/libs/util/test_util.vcxproj
+++ b/tests/libs/util/test_util.vcxproj
@@ -4,6 +4,7 @@
   SPDX-License-Identifier: MIT
 -->
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(SolutionDir)packages\CatchOrg.Catch.2.8.0\build\native\CatchOrg.Catch.props" Condition="Exists('$(SolutionDir)packages\CatchOrg.Catch.2.8.0\build\native\CatchOrg.Catch.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -25,6 +26,8 @@
   <ItemGroup>
     <ClCompile Include="service_helper.cpp" />
     <ClInclude Include="service_helper.h" />
+    <ClCompile Include="program_helper.cpp" />
+    <ClInclude Include="program_helper.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -127,7 +130,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)libs\execution_context;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)libs\execution_context;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample\ext\inc;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -146,7 +149,10 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)libs\execution_context;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample\ext\inc;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -159,4 +165,10 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('$(SolutionDir)packages\CatchOrg.Catch.2.8.0\build\native\CatchOrg.Catch.props')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)packages\CatchOrg.Catch.2.8.0\build\native\CatchOrg.Catch.props'))" />
+  </Target>
 </Project>

--- a/tests/performance/performance.vcxproj
+++ b/tests/performance/performance.vcxproj
@@ -125,7 +125,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -144,7 +144,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>

--- a/tests/sample/ext/app/sample_ext_app.h
+++ b/tests/sample/ext/app/sample_ext_app.h
@@ -6,3 +6,4 @@
 #include "ebpf_windows.h"
 #include "framework.h"
 #include "sample_ext_ioctls.h"
+#include "sample_test_common.h"

--- a/tests/sample/ext/app/sample_ext_app.vcxproj
+++ b/tests/sample/ext/app/sample_ext_app.vcxproj
@@ -125,7 +125,7 @@
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(SolutionDir)tests\sample\ext\inc;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\execution_context;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
@@ -142,7 +142,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(SolutionDir)tests\sample\ext\inc;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\execution_context;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -15,49 +15,16 @@
 #include "ebpf_program_types.h"
 #include "ebpf_windows.h"
 
-#include "sample_ext_helpers.h"
+#include "sample_ext_program_info.h"
 
 #define SAMPLE_EBPF_EXTENSION_NPI_PROVIDER_VERSION 0
 
 // f788ef4a-207d-4dc3-85cf-0f2ea107213c
 DEFINE_GUID(EBPF_PROGRAM_TYPE_SAMPLE, 0xf788ef4a, 0x207d, 0x4dc3, 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c);
 
-static ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {
-    sizeof(test_program_context_t),
-    EBPF_OFFSET_OF(test_program_context_t, data_start),
-    EBPF_OFFSET_OF(test_program_context_t, data_end),
-    -1};
-
-// Test Extension Helper function prototype descriptors.
-static ebpf_helper_function_prototype_t _sample_ebpf_extension_helper_function_prototype[] = {
-    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 1,
-     "sample_ebpf_extension_helper_function1",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
-    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 2,
-     "sample_ebpf_extension_find",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-      EBPF_ARGUMENT_TYPE_CONST_SIZE,
-      EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-      EBPF_ARGUMENT_TYPE_CONST_SIZE}},
-    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 3,
-     "sample_ebpf_extension_replace",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-      EBPF_ARGUMENT_TYPE_CONST_SIZE,
-      EBPF_ARGUMENT_TYPE_ANYTHING,
-      EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
-      EBPF_ARGUMENT_TYPE_CONST_SIZE}}};
-
-static ebpf_program_info_t _sample_ebpf_extension_program_info = {
-    {"sample", &_sample_ebpf_context_descriptor, {0}},
-    EBPF_COUNT_OF(_sample_ebpf_extension_helper_function_prototype),
-    _sample_ebpf_extension_helper_function_prototype};
-
 // Test Extension helper function addresses table.
 static int64_t
-_sample_ebpf_extension_helper_function1(_In_ const test_program_context_t* context);
+_sample_ebpf_extension_helper_function1(_In_ const sample_program_context_t* context);
 static int64_t
 _sample_ebpf_extension_find(_In_ const void* buffer, uint32_t size, _In_ const void* find, uint32_t arg_size);
 static int64_t
@@ -467,7 +434,7 @@ Exit:
 }
 
 ebpf_result_t
-sample_ebpf_extension_invoke_program(_In_ const test_program_context_t* context, _Out_ uint32_t* result)
+sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* context, _Out_ uint32_t* result)
 {
     ebpf_result_t return_value = EBPF_SUCCESS;
 
@@ -492,7 +459,7 @@ Exit:
 // Helper Function Definitions.
 
 static int64_t
-_sample_ebpf_extension_helper_function1(_In_ const test_program_context_t* context)
+_sample_ebpf_extension_helper_function1(_In_ const sample_program_context_t* context)
 {
     UNREFERENCED_PARAMETER(context);
     return 0;

--- a/tests/sample/ext/drv/sample_ext.h
+++ b/tests/sample/ext/drv/sample_ext.h
@@ -10,7 +10,7 @@
 #include <ntddk.h>
 #include "ebpf_platform.h"
 
-typedef struct _test_program_context test_program_context_t;
+typedef struct _sample_program_context sample_program_context_t;
 
 /**
  * @brief Register program information NPI provider.
@@ -54,4 +54,4 @@ sample_ebpf_extension_hook_provider_unregister();
  * @retval EBPF_OPERATION_NOT_SUPPORTED Operation not supported.
  */
 ebpf_result_t
-sample_ebpf_extension_invoke_program(_In_ const test_program_context_t* context, _Out_ uint32_t* result);
+sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* context, _Out_ uint32_t* result);

--- a/tests/sample/ext/drv/sample_ext_drv.c
+++ b/tests/sample/ext/drv/sample_ext_drv.c
@@ -210,7 +210,7 @@ _sample_ebpf_ext_driver_io_device_control(
     void* output_buffer = NULL;
     size_t actual_input_length = 0;
     size_t actual_output_length = 0;
-    test_program_context_t program_context = {0};
+    sample_program_context_t program_context = {0};
     uint32_t program_result = 0;
     ebpf_result_t result;
 

--- a/tests/sample/ext/inc/sample_ext_helpers.h
+++ b/tests/sample/ext/inc/sample_ext_helpers.h
@@ -8,7 +8,7 @@
 
 #include <stdint.h>
 
-// Test Extension Hook program context.
+// Sample extension program context.
 typedef struct _sample_program_context
 {
     uint8_t* data_start;

--- a/tests/sample/ext/inc/sample_ext_helpers.h
+++ b/tests/sample/ext/inc/sample_ext_helpers.h
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
+
+// This file contains program context and helper functions declarations that are
+// exposed by the sample extension.
+
 #pragma once
 
 #include <stdint.h>
 
 // Test Extension Hook program context.
-typedef struct _test_program_context
+typedef struct _sample_program_context
 {
     uint8_t* data_start;
     uint8_t* data_end;
     uint32_t uint32_data;
     uint16_t uint16_data;
-} test_program_context_t;
-
-// This file contains APIs for helper functions that are
-// exposed by the test extension.
+} sample_program_context_t;
 
 #define SAMPLE_EXT_HELPER_FN_BASE 0xFFFF
 
@@ -27,7 +28,7 @@ typedef struct _test_program_context
  * @param[in] context Pointer to program context.
  * @retval 0 The operation was successful.
  */
-EBPF_HELPER(int64_t, sample_ebpf_extension_helper_function1, (test_program_context_t * context));
+EBPF_HELPER(int64_t, sample_ebpf_extension_helper_function1, (sample_program_context_t * context));
 #ifndef __doxygen
 #define sample_ebpf_extension_helper_function1 ((sample_ebpf_extension_helper_function1_t)SAMPLE_EXT_HELPER_FN_BASE + 1)
 #endif

--- a/tests/sample/ext/inc/sample_ext_program_info.h
+++ b/tests/sample/ext/inc/sample_ext_program_info.h
@@ -11,6 +11,8 @@
 
 #include "sample_ext_helpers.h"
 
+#define SAMPLE_EXT_HELPER_FUNCTION_START EBPF_MAX_GENERAL_HELPER_FUNCTION
+
 static ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {
     sizeof(sample_program_context_t),
     EBPF_OFFSET_OF(sample_program_context_t, data_start),
@@ -19,18 +21,18 @@ static ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {
 
 // Test Extension Helper function prototype descriptors.
 static ebpf_helper_function_prototype_t _sample_ebpf_extension_helper_function_prototype[] = {
-    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 1,
+    {SAMPLE_EXT_HELPER_FUNCTION_START + 1,
      "sample_ebpf_extension_helper_function1",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
-    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 2,
+    {SAMPLE_EXT_HELPER_FUNCTION_START + 2,
      "sample_ebpf_extension_find",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
       EBPF_ARGUMENT_TYPE_CONST_SIZE,
       EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
       EBPF_ARGUMENT_TYPE_CONST_SIZE}},
-    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 3,
+    {SAMPLE_EXT_HELPER_FUNCTION_START + 3,
      "sample_ebpf_extension_replace",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,

--- a/tests/sample/ext/inc/sample_ext_program_info.h
+++ b/tests/sample/ext/inc/sample_ext_program_info.h
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Sample eBPF Extension program types.
+ */
+
+#include <stdint.h>
+
+#include "ebpf_platform.h"
+
+#include "sample_ext_helpers.h"
+
+static ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {
+    sizeof(sample_program_context_t),
+    EBPF_OFFSET_OF(sample_program_context_t, data_start),
+    EBPF_OFFSET_OF(sample_program_context_t, data_end),
+    -1};
+
+// Test Extension Helper function prototype descriptors.
+static ebpf_helper_function_prototype_t _sample_ebpf_extension_helper_function_prototype[] = {
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 1,
+     "sample_ebpf_extension_helper_function1",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 2,
+     "sample_ebpf_extension_find",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
+      EBPF_ARGUMENT_TYPE_CONST_SIZE,
+      EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
+      EBPF_ARGUMENT_TYPE_CONST_SIZE}},
+    {EBPF_MAX_GENERAL_HELPER_FUNCTION + 3,
+     "sample_ebpf_extension_replace",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
+      EBPF_ARGUMENT_TYPE_CONST_SIZE,
+      EBPF_ARGUMENT_TYPE_ANYTHING,
+      EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
+      EBPF_ARGUMENT_TYPE_CONST_SIZE}}};
+
+static ebpf_program_info_t _sample_ebpf_extension_program_info = {
+    {"sample", &_sample_ebpf_context_descriptor, {0}},
+    EBPF_COUNT_OF(_sample_ebpf_extension_helper_function_prototype),
+    _sample_ebpf_extension_helper_function_prototype};

--- a/tests/sample/sample_common_routines.h
+++ b/tests/sample/sample_common_routines.h
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Common routines that eBPF sample programs can invoke.
+
+#include "ebpf_helpers.h"
+#include "sample_test_common.h"
+
+int
+test_utility_helper_functions(struct bpf_map* utility_map)
+{
+    uint32_t keys[UTILITY_MAP_SIZE] = {0, 1};
+    ebpf_utility_helpers_data_t test_data = {0};
+
+    // get a random number.
+    test_data.random = bpf_get_prandom_u32();
+
+    // get current timestamp.
+    test_data.timestamp = bpf_ktime_get_boot_ns();
+
+    // get current cpu ID.
+    test_data.cpu_id = bpf_get_smp_processor_id();
+
+    // Write into test utility_map index 0.
+    bpf_map_update_elem(utility_map, &keys[0], &test_data, 0);
+
+    // get another random number.
+    test_data.random = bpf_get_prandom_u32();
+
+    // get current timestamp.
+    test_data.timestamp = bpf_ktime_get_boot_ns();
+
+    // Write into test utility_map index 1.
+    bpf_map_update_elem(utility_map, &keys[1], &test_data, 0);
+
+    return 0;
+}

--- a/tests/sample/sample_common_routines.h
+++ b/tests/sample/sample_common_routines.h
@@ -3,7 +3,7 @@
 
 // Common routines that eBPF sample programs can invoke.
 
-#include "ebpf_helpers.h"
+#include "bpf_helpers.h"
 #include "sample_test_common.h"
 
 int
@@ -12,22 +12,22 @@ test_utility_helper_functions(struct bpf_map* utility_map)
     uint32_t keys[UTILITY_MAP_SIZE] = {0, 1};
     ebpf_utility_helpers_data_t test_data = {0};
 
-    // get a random number.
+    // Get a random number.
     test_data.random = bpf_get_prandom_u32();
 
-    // get current timestamp.
+    // Get current timestamp.
     test_data.timestamp = bpf_ktime_get_boot_ns();
 
-    // get current cpu ID.
+    // Get current cpu ID.
     test_data.cpu_id = bpf_get_smp_processor_id();
 
     // Write into test utility_map index 0.
     bpf_map_update_elem(utility_map, &keys[0], &test_data, 0);
 
-    // get another random number.
+    // Get another random number.
     test_data.random = bpf_get_prandom_u32();
 
-    // get current timestamp.
+    // Get current timestamp.
     test_data.timestamp = bpf_ktime_get_boot_ns();
 
     // Write into test utility_map index 1.

--- a/tests/sample/test_sample_ebpf.c
+++ b/tests/sample/test_sample_ebpf.c
@@ -4,7 +4,6 @@
 // Test eBPF program for EBPF_PROGRAM_TYPE_SAMPLE implemented in
 // the Test eBPF extension.
 
-#include "bpf_helpers.h"
 #include "sample_common_routines.h"
 #include "sample_ext_helpers.h"
 #include "sample_test_common.h"
@@ -64,7 +63,7 @@ struct bpf_map utility_map = {
     .value_size = sizeof(ebpf_utility_helpers_data_t),
     .max_entries = UTILITY_MAP_SIZE};
 
-#pragma clang section text = "sample_ext/utility"
+SEC("sample_ext/utility")
 int
 test_utility_helpers(sample_program_context_t* context)
 {

--- a/tests/sample/test_sample_ebpf.c
+++ b/tests/sample/test_sample_ebpf.c
@@ -5,7 +5,9 @@
 // the Test eBPF extension.
 
 #include "bpf_helpers.h"
+#include "sample_common_routines.h"
 #include "sample_ext_helpers.h"
+#include "sample_test_common.h"
 
 #define VALUE_SIZE 32
 
@@ -19,36 +21,52 @@ ebpf_map_definition_in_file_t test_map = {
 
 SEC("sample_ext")
 int
-test_program_entry(test_program_context_t* context)
+test_program_entry(sample_program_context_t* context)
 {
     int64_t result;
     uint32_t keys[2] = {0, 1};
     uint8_t* values[2] = {0};
 
-    result = sample_ebpf_extension_helper_function1(context);
-    if (result < 0)
-        goto Exit;
-
     values[0] = bpf_map_lookup_elem(&test_map, &keys[0]);
     values[1] = bpf_map_lookup_elem(&test_map, &keys[1]);
 
     if (context->data_end > context->data_start) {
-        int64_t position;
+        int64_t position = 0;
 
-        if (values[0])
+        if (values[0]) {
             position = sample_ebpf_extension_find(
                 context->data_start, context->data_end - context->data_start, values[0], VALUE_SIZE);
-        if (values[1]) {
-            result = sample_ebpf_extension_replace(
-                context->data_start, context->data_end - context->data_start, position, values[1], VALUE_SIZE);
-            if (result < 0)
-                goto Exit;
+            if (values[1]) {
+                result = sample_ebpf_extension_replace(
+                    context->data_start, context->data_end - context->data_start, position, values[1], VALUE_SIZE);
+                if (result < 0)
+                    goto Exit;
+            }
         }
     }
+
+    result = sample_ebpf_extension_helper_function1(context);
+    if (result < 0)
+        goto Exit;
 
     // "The answer to the question of life, the universe and everything".
     //          - Douglas Adams (The Hitchhiker’s Guide to the Galaxy).
     result = 42;
 Exit:
     return result;
+}
+
+SEC("maps")
+struct bpf_map utility_map = {
+    .size = sizeof(struct bpf_map),
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(ebpf_utility_helpers_data_t),
+    .max_entries = UTILITY_MAP_SIZE};
+
+#pragma clang section text = "sample_ext/utility"
+int
+test_utility_helpers(sample_program_context_t* context)
+{
+    return test_utility_helper_functions(&utility_map);
 }

--- a/tests/sample/test_utility_helpers.c
+++ b/tests/sample/test_utility_helpers.c
@@ -5,6 +5,7 @@
 
 #include "bpf_helpers.h"
 #include "ebpf_nethooks.h"
+#include "sample_common_routines.h"
 #include "sample_test_common.h"
 
 #define VALUE_SIZE 32
@@ -19,31 +20,7 @@ struct bpf_map utility_map = {
 
 SEC("xdp")
 int
-test_program_entry(xdp_md_t* context)
+test_utility_helpers(xdp_md_t* context)
 {
-    uint32_t keys[UTILITY_MAP_SIZE] = {0, 1};
-    ebpf_utility_helpers_data_t test_data = {0};
-
-    // get a random number.
-    test_data.random = bpf_get_prandom_u32();
-
-    // get current timestamp.
-    test_data.timestamp = bpf_ktime_get_boot_ns();
-
-    // get current cpu ID.
-    test_data.cpu_id = bpf_get_smp_processor_id();
-
-    // Write into test utility_map index 0.
-    bpf_map_update_elem(&utility_map, &keys[0], &test_data, 0);
-
-    // get another random number.
-    test_data.random = bpf_get_prandom_u32();
-
-    // get current timestamp.
-    test_data.timestamp = bpf_ktime_get_boot_ns();
-
-    // Write into test utility_map index 1.
-    bpf_map_update_elem(&utility_map, &keys[1], &test_data, 0);
-
-    return 0;
+    return test_utility_helper_functions(&utility_map);
 }

--- a/tests/unit/test.vcxproj
+++ b/tests/unit/test.vcxproj
@@ -95,7 +95,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)external\libbpf\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\libbpf\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)external\libbpf\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\libbpf\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -126,7 +126,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -146,7 +146,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>


### PR DESCRIPTION
This PR is further addressing #342  by adding tests for the utility helper functions in kernel mode. The PR makes the following changes:
1. Moves sample extension helper prototypes to a separate header file such that both code duplication is not needed betweeen extension driver and unit test.
2. Refactor eBPF program so that the the helper functions are invoked from another routine that can be included by eBPF programs of XDP and sample extension program types.
3. Some refactoring in unit test code such that code duplication can be avoided.
4. one *bug fix* where global attach type in TLS was not cleared up.
5. introduce run_tests.bat for running all tests on a test machine (I think it was part of #381 , but was removed when the PR was reverted).