### PR TITLE
clean up test code

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -12,6 +12,9 @@
 #include "ebpf_serialize.h"
 #include "ebpf_state.h"
 
+extern ebpf_helper_function_prototype_t* _ebpf_core_helper_function_prototype;
+extern uint32_t _ebpf_core_helper_functions_count;
+
 const ebpf_handle_t ebpf_handle_invalid = (ebpf_handle_t)-1;
 
 GUID ebpf_general_helper_function_interface_id = {/* 8d2a1d3f-9ce6-473d-b48e-17aa5c5581fe */
@@ -47,32 +50,7 @@ _ebpf_core_get_current_cpu();
 
 #define EBPF_CORE_GLOBAL_HELPER_EXTENSION_VERSION 0
 
-static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = {
-    {(uint32_t)(intptr_t)bpf_map_lookup_elem,
-     "bpf_map_lookup_elem",
-     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {(uint32_t)(intptr_t)bpf_map_update_elem,
-     "bpf_map_update_elem",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
-    {(uint32_t)(intptr_t)bpf_map_delete_elem,
-     "bpf_map_delete_elem",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {(uint32_t)(intptr_t)bpf_tail_call,
-     "bpf_tail_call",
-     EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS, EBPF_ARGUMENT_TYPE_ANYTHING}},
-    {(uint32_t)(intptr_t)bpf_get_prandom_u32, "bpf_get_prandom_u32", EBPF_RETURN_TYPE_INTEGER, {0}},
-    {(uint64_t)(intptr_t)bpf_ktime_get_boot_ns, "bpf_ktime_get_boot_ns", EBPF_RETURN_TYPE_INTEGER, {0}},
-    {(uint32_t)(intptr_t)bpf_get_smp_processor_id, "bpf_get_smp_processor_id", EBPF_RETURN_TYPE_INTEGER, {0}},
-};
-
-static ebpf_program_info_t _ebpf_global_helper_program_info = {
-    {"global_helper", NULL, {0}},
-    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_global_helper_program_info = {{"global_helper", NULL, {0}}, 0, NULL};
 
 static const void* _ebpf_general_helpers[] = {
     NULL,
@@ -126,6 +104,8 @@ ebpf_core_initiate()
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
+    _ebpf_global_helper_program_info.count_of_helpers = _ebpf_core_helper_functions_count;
+    _ebpf_global_helper_program_info.helper_prototype = _ebpf_core_helper_function_prototype;
     return_value = ebpf_provider_load(
         &_ebpf_global_helper_function_provider_context,
         &ebpf_general_helper_function_interface_id,

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -8,12 +8,8 @@
 #include "ebpf_maps.h"
 #include "ebpf_pinning_table.h"
 #include "ebpf_program.h"
-#include "ebpf_program_types.h"
 #include "ebpf_serialize.h"
 #include "ebpf_state.h"
-
-extern ebpf_helper_function_prototype_t* _ebpf_core_helper_function_prototype;
-extern uint32_t _ebpf_core_helper_functions_count;
 
 const ebpf_handle_t ebpf_handle_invalid = (ebpf_handle_t)-1;
 
@@ -104,8 +100,8 @@ ebpf_core_initiate()
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
-    _ebpf_global_helper_program_info.count_of_helpers = _ebpf_core_helper_functions_count;
-    _ebpf_global_helper_program_info.helper_prototype = _ebpf_core_helper_function_prototype;
+    _ebpf_global_helper_program_info.count_of_helpers = ebpf_core_helper_functions_count;
+    _ebpf_global_helper_program_info.helper_prototype = ebpf_core_helper_function_prototype;
     return_value = ebpf_provider_load(
         &_ebpf_global_helper_function_provider_context,
         &ebpf_general_helper_function_interface_id,

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -5,12 +5,16 @@
 
 #include "ebpf_platform.h"
 #include "ebpf_protocol.h"
+#include "ebpf_program_types.h"
 
 #ifdef __cplusplus
 extern "C"
 {
 #endif
 #include "ebpf_protocol.h"
+
+    extern ebpf_helper_function_prototype_t* ebpf_core_helper_function_prototype;
+    extern uint32_t ebpf_core_helper_functions_count;
 
     extern GUID ebpf_general_helper_function_interface_id;
 

--- a/libs/execution_context/ebpf_general_helpers.c
+++ b/libs/execution_context/ebpf_general_helpers.c
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Prototypes for general helper function implemented by eBPF core Execution Context.
+ */
+
+#include "ebpf_platform.h"
+#include "ebpf_program_types.h"
+#include "ebpf_structs.h"
+
+ebpf_helper_function_prototype_t _ebpf_core_helper_function_prototype_array[] = {
+    {BPF_FUNC_map_lookup_elem,
+     "bpf_map_lookup_elem",
+     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {BPF_FUNC_map_update_elem,
+     "bpf_map_update_elem",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
+    {BPF_FUNC_map_delete_elem,
+     "bpf_map_delete_elem",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
+    {BPF_FUNC_tail_call,
+     "bpf_tail_call",
+     EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS, EBPF_ARGUMENT_TYPE_ANYTHING}},
+    {BPF_FUNC_get_prandom_u32, "bpf_get_prandom_u32", EBPF_RETURN_TYPE_INTEGER, {0}},
+    {BPF_FUNC_ktime_get_boot_ns, "bpf_ktime_get_boot_ns", EBPF_RETURN_TYPE_INTEGER, {0}},
+    {BPF_FUNC_get_smp_processor_id, "bpf_get_smp_processor_id", EBPF_RETURN_TYPE_INTEGER, {0}},
+};
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    ebpf_helper_function_prototype_t* _ebpf_core_helper_function_prototype =
+        &_ebpf_core_helper_function_prototype_array[0];
+    uint32_t _ebpf_core_helper_functions_count = EBPF_COUNT_OF(_ebpf_core_helper_function_prototype_array);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libs/execution_context/ebpf_general_helpers.c
+++ b/libs/execution_context/ebpf_general_helpers.c
@@ -2,14 +2,14 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * @brief Prototypes for general helper function implemented by eBPF core Execution Context.
+ * @brief Prototypes for general helper functions (aka global functions) implemented by eBPF core Execution Context.
  */
 
 #include "ebpf_platform.h"
 #include "ebpf_program_types.h"
 #include "ebpf_structs.h"
 
-ebpf_helper_function_prototype_t _ebpf_core_helper_function_prototype_array[] = {
+ebpf_helper_function_prototype_t ebpf_core_helper_function_prototype_array[] = {
     {BPF_FUNC_map_lookup_elem,
      "bpf_map_lookup_elem",
      EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
@@ -36,9 +36,9 @@ extern "C"
 {
 #endif
 
-    ebpf_helper_function_prototype_t* _ebpf_core_helper_function_prototype =
-        &_ebpf_core_helper_function_prototype_array[0];
-    uint32_t _ebpf_core_helper_functions_count = EBPF_COUNT_OF(_ebpf_core_helper_function_prototype_array);
+    ebpf_helper_function_prototype_t* ebpf_core_helper_function_prototype =
+        &ebpf_core_helper_function_prototype_array[0];
+    uint32_t ebpf_core_helper_functions_count = EBPF_COUNT_OF(ebpf_core_helper_function_prototype_array);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/kernel/execution_context_kernel.vcxproj
+++ b/libs/execution_context/kernel/execution_context_kernel.vcxproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\ebpf_core.c" />
+    <ClCompile Include="..\ebpf_general_helpers.c" />
     <ClCompile Include="..\ebpf_link.c" />
     <ClCompile Include="..\ebpf_maps.c" />
     <ClCompile Include="..\ebpf_program.c" />

--- a/libs/execution_context/kernel/execution_context_kernel.vcxproj.filters
+++ b/libs/execution_context/kernel/execution_context_kernel.vcxproj.filters
@@ -22,6 +22,9 @@
     <ClCompile Include="..\ebpf_core.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ebpf_general_helpers.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\ebpf_link.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/libs/execution_context/user/execution_context_user.vcxproj
+++ b/libs/execution_context/user/execution_context_user.vcxproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\ebpf_core.c" />
+    <ClCompile Include="..\ebpf_general_helpers.c" />
     <ClCompile Include="..\ebpf_link.c" />
     <ClCompile Include="..\ebpf_maps.c" />
     <ClCompile Include="..\ebpf_program.c" />

--- a/libs/execution_context/user/execution_context_user.vcxproj.filters
+++ b/libs/execution_context/user/execution_context_user.vcxproj.filters
@@ -22,6 +22,9 @@
     <ClCompile Include="..\ebpf_core.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+      <ClCompile Include="..\ebpf_general_helpers.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="..\ebpf_link.c">
       <Filter>Source Files</Filter>
     </ClCompile>

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -21,6 +21,12 @@
 #include "ebpf_xdp_program_data.h"
 #include "ebpf_state.h"
 
+extern "C"
+{
+    extern ebpf_helper_function_prototype_t* _ebpf_core_helper_function_prototype;
+    extern uint32_t _ebpf_core_helper_functions_count;
+}
+
 class _test_helper
 {
   public:
@@ -391,28 +397,6 @@ TEST_CASE("trampoline_test", "[platform]")
     ebpf_free_trampoline_table(table);
 }
 
-static ebpf_helper_function_prototype_t _helper_functions[] = {
-    {BPF_FUNC_map_lookup_elem,
-     "bpf_map_lookup_elem",
-     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {BPF_FUNC_map_update_elem,
-     "bpf_map_update_elem",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
-    {BPF_FUNC_map_delete_elem,
-     "bpf_map_delete_elem",
-     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {BPF_FUNC_tail_call,
-     "bpf_tail_call",
-     EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS, EBPF_ARGUMENT_TYPE_ANYTHING}},
-    {BPF_FUNC_get_prandom_u32, "bpf_get_prandom_u32", EBPF_RETURN_TYPE_INTEGER, {0}},
-    {BPF_FUNC_ktime_get_boot_ns, "bpf_ktime_get_boot_ns", EBPF_RETURN_TYPE_INTEGER, {0}},
-    {BPF_FUNC_get_smp_processor_id, "bpf_get_smp_processor_id", EBPF_RETURN_TYPE_INTEGER, {0}},
-};
-
 TEST_CASE("program_type_info", "[platform]")
 {
     _test_helper test_helper;
@@ -423,7 +407,8 @@ TEST_CASE("program_type_info", "[platform]")
         EBPF_OFFSET_OF(xdp_md_t, data_end),
         EBPF_OFFSET_OF(xdp_md_t, data_meta)};
     ebpf_program_type_descriptor_t program_type{"xdp", &context_descriptor};
-    ebpf_program_info_t program_info{program_type, _countof(_helper_functions), _helper_functions};
+    ebpf_program_info_t program_info{
+        program_type, _ebpf_core_helper_functions_count, _ebpf_core_helper_function_prototype};
     ebpf_program_info_t* new_program_info = nullptr;
     uint8_t* buffer = nullptr;
     unsigned long buffer_size;
@@ -441,7 +426,7 @@ TEST_CASE("program_type_info_stored", "[platform]")
         ebpf_program_info_decode(
             &xdp_program_info, _ebpf_encoded_xdp_program_info_data, sizeof(_ebpf_encoded_xdp_program_info_data)) ==
         EBPF_SUCCESS);
-    REQUIRE(xdp_program_info->count_of_helpers == _countof(_helper_functions));
+    REQUIRE(xdp_program_info->count_of_helpers == _ebpf_core_helper_functions_count);
     REQUIRE(strcmp(xdp_program_info->program_type_descriptor.name, "xdp") == 0);
     ebpf_free(xdp_program_info);
 
@@ -450,7 +435,7 @@ TEST_CASE("program_type_info_stored", "[platform]")
             &bind_program_info, _ebpf_encoded_bind_program_info_data, sizeof(_ebpf_encoded_bind_program_info_data)) ==
         EBPF_SUCCESS);
     REQUIRE(strcmp(bind_program_info->program_type_descriptor.name, "bind") == 0);
-    REQUIRE(bind_program_info->count_of_helpers == _countof(_helper_functions));
+    REQUIRE(bind_program_info->count_of_helpers == _ebpf_core_helper_functions_count);
     ebpf_free(bind_program_info);
 }
 

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -20,12 +20,7 @@
 #include "ebpf_serialize.h"
 #include "ebpf_xdp_program_data.h"
 #include "ebpf_state.h"
-
-extern "C"
-{
-    extern ebpf_helper_function_prototype_t* _ebpf_core_helper_function_prototype;
-    extern uint32_t _ebpf_core_helper_functions_count;
-}
+#include "encode_program_info.h"
 
 class _test_helper
 {
@@ -408,7 +403,7 @@ TEST_CASE("program_type_info", "[platform]")
         EBPF_OFFSET_OF(xdp_md_t, data_meta)};
     ebpf_program_type_descriptor_t program_type{"xdp", &context_descriptor};
     ebpf_program_info_t program_info{
-        program_type, _ebpf_core_helper_functions_count, _ebpf_core_helper_function_prototype};
+        program_type, ebpf_core_helper_functions_count, ebpf_core_helper_function_prototype};
     ebpf_program_info_t* new_program_info = nullptr;
     uint8_t* buffer = nullptr;
     unsigned long buffer_size;
@@ -426,7 +421,7 @@ TEST_CASE("program_type_info_stored", "[platform]")
         ebpf_program_info_decode(
             &xdp_program_info, _ebpf_encoded_xdp_program_info_data, sizeof(_ebpf_encoded_xdp_program_info_data)) ==
         EBPF_SUCCESS);
-    REQUIRE(xdp_program_info->count_of_helpers == _ebpf_core_helper_functions_count);
+    REQUIRE(xdp_program_info->count_of_helpers == ebpf_core_helper_functions_count);
     REQUIRE(strcmp(xdp_program_info->program_type_descriptor.name, "xdp") == 0);
     ebpf_free(xdp_program_info);
 
@@ -435,7 +430,7 @@ TEST_CASE("program_type_info_stored", "[platform]")
             &bind_program_info, _ebpf_encoded_bind_program_info_data, sizeof(_ebpf_encoded_bind_program_info_data)) ==
         EBPF_SUCCESS);
     REQUIRE(strcmp(bind_program_info->program_type_descriptor.name, "bind") == 0);
-    REQUIRE(bind_program_info->count_of_helpers == _ebpf_core_helper_functions_count);
+    REQUIRE(bind_program_info->count_of_helpers == ebpf_core_helper_functions_count);
     ebpf_free(bind_program_info);
 }
 

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -172,37 +172,12 @@ typedef class _single_instance_hook : public _hook_helper
 
 #define TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION 0
 
-static ebpf_helper_function_prototype_t _ebpf_map_helper_function_prototype[] = {
-    {BPF_FUNC_map_lookup_elem,
-     "bpf_map_lookup_elem",
-     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {BPF_FUNC_map_update_elem,
-     "bpf_map_update_elem",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
-    {BPF_FUNC_map_delete_elem,
-     "bpf_map_delete_elem",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {BPF_FUNC_tail_call,
-     "bpf_tail_call",
-     EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS, EBPF_ARGUMENT_TYPE_ANYTHING}},
-    {BPF_FUNC_get_prandom_u32, "bpf_get_prandom_u32", EBPF_RETURN_TYPE_INTEGER, {0}},
-    {BPF_FUNC_ktime_get_boot_ns, "bpf_ktime_get_boot_ns", EBPF_RETURN_TYPE_INTEGER, {0}},
-    {BPF_FUNC_get_smp_processor_id, "bpf_get_smp_processor_id", EBPF_RETURN_TYPE_INTEGER, {0}},
-};
-
 static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {
     sizeof(xdp_md_t),
     EBPF_OFFSET_OF(xdp_md_t, data),
     EBPF_OFFSET_OF(xdp_md_t, data_end),
     EBPF_OFFSET_OF(xdp_md_t, data_meta)};
-static ebpf_program_info_t _ebpf_xdp_program_info = {
-    {"xdp", &_ebpf_xdp_context_descriptor, {0}},
-    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_xdp_program_info = {{"xdp", &_ebpf_xdp_context_descriptor, {0}}, 0, NULL};
 
 static ebpf_program_data_t _ebpf_xdp_program_data = {&_ebpf_xdp_program_info, NULL};
 
@@ -211,10 +186,7 @@ static ebpf_extension_data_t _ebpf_xdp_program_info_provider_data = {
 
 static ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
     sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
-static ebpf_program_info_t _ebpf_bind_program_info = {
-    {"bind", &_ebpf_bind_context_descriptor, {0}},
-    EBPF_COUNT_OF(_ebpf_map_helper_function_prototype),
-    _ebpf_map_helper_function_prototype};
+static ebpf_program_info_t _ebpf_bind_program_info = {{"bind", &_ebpf_bind_context_descriptor, {0}}, 0, NULL};
 
 static ebpf_program_data_t _ebpf_bind_program_data = {&_ebpf_bind_program_info, NULL};
 

--- a/tests/unit/test.vcxproj
+++ b/tests/unit/test.vcxproj
@@ -95,7 +95,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\libbpf\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\libbpf\src;$(SolutionDir)tools\encode_program_info;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\libbpf\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\libbpf\src;;$(SolutionDir)tools\encode_program_info;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -126,7 +126,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;;$(SolutionDir)tools\encode_program_info;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp17</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
@@ -146,7 +146,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;;$(SolutionDir)tools\encode_program_info;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <TreatWarningAsError>true</TreatWarningAsError>
       <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>

--- a/tools/encode_program_info/encode_program_info.cpp
+++ b/tools/encode_program_info/encode_program_info.cpp
@@ -8,6 +8,12 @@
 #include "ebpf_program_types.h"
 #include "ebpf_windows.h"
 
+extern "C"
+{
+    extern ebpf_helper_function_prototype_t* _ebpf_core_helper_function_prototype;
+    extern uint32_t _ebpf_core_helper_functions_count;
+}
+
 static ebpf_result_t
 _emit_program_info_file(const char* file_name, const char* symbol_name, uint8_t* buffer, unsigned long buffer_size)
 {
@@ -31,28 +37,6 @@ _emit_program_info_file(const char* file_name, const char* symbol_name, uint8_t*
     return EBPF_SUCCESS;
 }
 
-static ebpf_helper_function_prototype_t _ebpf_helper_function_prototype[] = {
-    {BPF_FUNC_map_lookup_elem,
-     "bpf_map_lookup_elem",
-     EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {BPF_FUNC_map_update_elem,
-     "bpf_map_update_elem",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_VALUE}},
-    {BPF_FUNC_map_delete_elem,
-     "bpf_map_delete_elem",
-     EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_MAP, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_KEY}},
-    {BPF_FUNC_tail_call,
-     "bpf_tail_call",
-     EBPF_RETURN_TYPE_INTEGER_OR_NO_RETURN_IF_SUCCEED,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_MAP_OF_PROGRAMS, EBPF_ARGUMENT_TYPE_ANYTHING}},
-    {BPF_FUNC_get_prandom_u32, "bpf_get_prandom_u32", EBPF_RETURN_TYPE_INTEGER, {0}},
-    {BPF_FUNC_ktime_get_boot_ns, "bpf_ktime_get_boot_ns", EBPF_RETURN_TYPE_INTEGER, {0}},
-    {BPF_FUNC_get_smp_processor_id, "bpf_get_smp_processor_id", EBPF_RETURN_TYPE_INTEGER, {0}},
-};
-
 static ebpf_result_t
 _encode_bind()
 {
@@ -62,9 +46,10 @@ _encode_bind()
     ebpf_context_descriptor_t bind_context_descriptor = {
         sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
     ebpf_program_type_descriptor_t bind_program_type = {"bind", &bind_context_descriptor, EBPF_PROGRAM_TYPE_BIND};
-    ebpf_program_info_t bind_program_info = {
-        bind_program_type, EBPF_COUNT_OF(_ebpf_helper_function_prototype), _ebpf_helper_function_prototype};
+    ebpf_program_info_t bind_program_info = {bind_program_type, 0, NULL};
 
+    bind_program_info.count_of_helpers = _ebpf_core_helper_functions_count;
+    bind_program_info.helper_prototype = _ebpf_core_helper_function_prototype;
     return_value = ebpf_program_info_encode(&bind_program_info, &buffer, &buffer_size);
     if (return_value != EBPF_SUCCESS)
         goto Done;
@@ -94,9 +79,9 @@ _encode_xdp()
         EBPF_OFFSET_OF(xdp_md_t, data_end),
         EBPF_OFFSET_OF(xdp_md_t, data_meta)};
     ebpf_program_type_descriptor_t xdp_program_type = {"xdp", &xdp_context_descriptor, EBPF_PROGRAM_TYPE_XDP};
-    ebpf_program_info_t xdp_program_info = {
-        xdp_program_type, EBPF_COUNT_OF(_ebpf_helper_function_prototype), _ebpf_helper_function_prototype};
-
+    ebpf_program_info_t xdp_program_info = {xdp_program_type, 0, NULL};
+    xdp_program_info.count_of_helpers = _ebpf_core_helper_functions_count;
+    xdp_program_info.helper_prototype = _ebpf_core_helper_function_prototype;
     return_value = ebpf_program_info_encode(&xdp_program_info, &buffer, &buffer_size);
     if (return_value != EBPF_SUCCESS)
         goto Done;

--- a/tools/encode_program_info/encode_program_info.cpp
+++ b/tools/encode_program_info/encode_program_info.cpp
@@ -4,15 +4,7 @@
 #include <stdio.h>
 #include "ebpf_api.h"
 #include "ebpf_nethooks.h"
-#include "ebpf_platform.h"
-#include "ebpf_program_types.h"
-#include "ebpf_windows.h"
-
-extern "C"
-{
-    extern ebpf_helper_function_prototype_t* _ebpf_core_helper_function_prototype;
-    extern uint32_t _ebpf_core_helper_functions_count;
-}
+#include "encode_program_info.h"
 
 static ebpf_result_t
 _emit_program_info_file(const char* file_name, const char* symbol_name, uint8_t* buffer, unsigned long buffer_size)
@@ -48,8 +40,8 @@ _encode_bind()
     ebpf_program_type_descriptor_t bind_program_type = {"bind", &bind_context_descriptor, EBPF_PROGRAM_TYPE_BIND};
     ebpf_program_info_t bind_program_info = {bind_program_type, 0, NULL};
 
-    bind_program_info.count_of_helpers = _ebpf_core_helper_functions_count;
-    bind_program_info.helper_prototype = _ebpf_core_helper_function_prototype;
+    bind_program_info.count_of_helpers = ebpf_core_helper_functions_count;
+    bind_program_info.helper_prototype = ebpf_core_helper_function_prototype;
     return_value = ebpf_program_info_encode(&bind_program_info, &buffer, &buffer_size);
     if (return_value != EBPF_SUCCESS)
         goto Done;
@@ -80,8 +72,8 @@ _encode_xdp()
         EBPF_OFFSET_OF(xdp_md_t, data_meta)};
     ebpf_program_type_descriptor_t xdp_program_type = {"xdp", &xdp_context_descriptor, EBPF_PROGRAM_TYPE_XDP};
     ebpf_program_info_t xdp_program_info = {xdp_program_type, 0, NULL};
-    xdp_program_info.count_of_helpers = _ebpf_core_helper_functions_count;
-    xdp_program_info.helper_prototype = _ebpf_core_helper_function_prototype;
+    xdp_program_info.count_of_helpers = ebpf_core_helper_functions_count;
+    xdp_program_info.helper_prototype = ebpf_core_helper_function_prototype;
     return_value = ebpf_program_info_encode(&xdp_program_info, &buffer, &buffer_size);
     if (return_value != EBPF_SUCCESS)
         goto Done;

--- a/tools/encode_program_info/encode_program_info.h
+++ b/tools/encode_program_info/encode_program_info.h
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ebpf_platform.h"
+#include "ebpf_program_types.h"
+#include "ebpf_windows.h"
+
+extern "C"
+{
+    extern ebpf_helper_function_prototype_t* ebpf_core_helper_function_prototype;
+    extern uint32_t ebpf_core_helper_functions_count;
+}

--- a/tools/encode_program_info/encode_program_info.vcxproj
+++ b/tools/encode_program_info/encode_program_info.vcxproj
@@ -180,6 +180,9 @@ $(OutputPath)encode_program_info.exe</Command>
     <ProjectReference Include="..\..\libs\platform\user\platform_user.vcxproj">
       <Project>{c26cb6a9-158c-4a9e-a243-755ddd98e5fe}</Project>
     </ProjectReference>
+    <ProjectReference Include="..\..\libs\execution_context\user\execution_context_user.vcxproj">
+      <Project>{18127b0d-8381-4afe-9a3a-cf53241992d3}</Project>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">


### PR DESCRIPTION
This PR is cleaning up some test code in preparation for #341.

- The `helpers.h` file initializes the test program info provider for xdp and bind program types to have general helper prototypes. They are not needed as they are obtained from core library. So the PR removes them.
- netsh test still uses the old program_info encode fallback path. Those modules hard coded the global helper function and they had to be duplicated in 3 places. This PR consolidates the global helper function prototype descriptors in a single file.