### PR TITLE
add sample_ebpf_ext.sys to built_files array in scripts/deploy-ebpf.ps1

### DIFF
--- a/scripts/deploy-ebpf.ps1
+++ b/scripts/deploy-ebpf.ps1
@@ -5,7 +5,7 @@
 ## Initialize parameters
 ##
 $build_directory=".\x64\Debug"
-[System.Collections.ArrayList]$built_files=@( "EbpfCore.sys", "EbpfApi.dll", "ebpfnetsh.dll", "ebpfsvc.exe", "NetEbpfExt.sys" )
+[System.Collections.ArrayList]$built_files=@( "EbpfCore.sys", "EbpfApi.dll", "ebpfnetsh.dll", "ebpfsvc.exe", "NetEbpfExt.sys", "sample_ebpf_ext.sys" )
 $destination_directory="C:\Temp"
 $error.clear()
 $vm="Windows 10 dev environment"


### PR DESCRIPTION
Fix for issue [#489](https://github.com/microsoft/ebpf-for-windows/issues/489).

Add missing `"sample_ebpf_ext.sys"` to `built_files` array in scripts/deploy-ebpf.ps1.