### PR TITLE
Require all inner map attributes to match

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -265,8 +265,10 @@ _check_value_type(_In_ const ebpf_core_map_t* outer_map, _In_ const ebpf_object_
     ebpf_core_map_t* template = outer_map->inner_map_template;
     const ebpf_map_t* value_map = (ebpf_map_t*)value_object;
 
-    // TODO(discussion #460): what other map attributes need to match?
-    bool allowed = (template != NULL) && (value_map->ebpf_map_definition.type == template->ebpf_map_definition.type);
+    bool allowed = (template != NULL) && (value_map->ebpf_map_definition.type == template->ebpf_map_definition.type) &&
+                   (value_map->ebpf_map_definition.key_size == template->ebpf_map_definition.key_size) &&
+                   (value_map->ebpf_map_definition.value_size == template->ebpf_map_definition.value_size) &&
+                   (value_map->ebpf_map_definition.max_entries == template->ebpf_map_definition.max_entries);
 
     return allowed;
 }

--- a/tests/sample/map_in_map.c
+++ b/tests/sample/map_in_map.c
@@ -14,7 +14,7 @@ struct _ebpf_map_definition_in_file outer_map = {
 
 SEC("maps")
 struct _ebpf_map_definition_in_file inner_map = {
-    .type = BPF_MAP_TYPE_ARRAY, .key_size = sizeof(uint32_t), .value_size = sizeof(uint32_t), .max_entries = 1};
+    .type = BPF_MAP_TYPE_HASH, .key_size = sizeof(uint32_t), .value_size = sizeof(uint32_t), .max_entries = 1};
 
 SEC("xdp_prog") int caller(struct xdp_md* ctx)
 {


### PR DESCRIPTION
Updated the map_in_map.c test to use HASH instead of ARRAY as the inner
map type, to make it possible to test key_size mismatch (since key_size
must be 4 for all ARRAY maps, it can't be tested with ARRAY).

Fixes #507

Signed-off-by: Dave Thaler <dthaler@microsoft.com>