### PR TITLE
Switch to memory allocation API's supported on older versions of Windows.

### DIFF
--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -37,7 +37,10 @@ ebpf_platform_terminate()
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
     _Post_writable_byte_size_(size) void* ebpf_allocate(size_t size)
 {
-    return ExAllocatePool2(POOL_FLAG_NON_PAGED, size, EBPF_POOL_TAG);
+    void* p = ExAllocatePoolUninitialized(NonPagedPoolNx, size, EBPF_POOL_TAG);
+    if (p)
+        memset(p, 0, size);
+    return p;
 }
 
 void
@@ -50,7 +53,10 @@ ebpf_free(_Frees_ptr_opt_ void* memory)
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
     _Post_writable_byte_size_(size) void* ebpf_allocate_cache_aligned(size_t size)
 {
-    return ExAllocatePool2(POOL_FLAG_NON_PAGED | POOL_FLAG_CACHE_ALIGNED, size, EBPF_POOL_TAG);
+    void* p = ExAllocatePoolUninitialized(NonPagedPoolNxCacheAligned, size, EBPF_POOL_TAG);
+    if (p)
+        memset(p, 0, size);
+    return p;
 }
 
 void


### PR DESCRIPTION
ExAllocatePool2 isn't present in Windows Server 2019, switch to ExAllocatePoolUninitialized and zero memory.

Resolves: #506

Signed-off-by: Alan Jowett <alanjo@microsoft.com>