### PR TITLE
Add support for libbpf bpf_obj_get_info_by_fd API

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -30,6 +30,7 @@ EXPORTS
     bpf_map_get_next_key
     bpf_map_lookup_elem
     bpf_map_update_elem
+    bpf_obj_get_info_by_fd
     bpf_object__close
     bpf_object__find_map_by_name
     bpf_object__find_map_fd_by_name

--- a/include/bpf.h
+++ b/include/bpf.h
@@ -179,6 +179,35 @@ bpf_map_update_elem(int fd, const void* key, const void* value, __u64 flags);
 /** @} */
 
 /**
+ * @name Object-related functions
+ * @{
+ */
+
+/**
+ * @brief Obtain information about the eBPF object referred to by bpf_fd.
+ * This function populates up to info_len bytes of info, which will
+ * be in one of the following formats depending on the eBPF object type of
+ * bpf_fd:
+ *
+ * * struct bpf_link_info
+ * * struct bpf_map_info
+ * * struct bpf_prog_info
+ *
+ *
+ * @param[in] bpf_fd File descriptor referring to an eBPF object.
+ * @param[out] info Pointer to memory in which to write the info obtained.
+ * @param[in,out] info_len On input, contains the maximum number of bytes to
+ * write into the info.  On output, contains the actual number of bytes written.
+ *
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
+ */
+int
+bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len);
+
+/** @} */
+
+/**
  * @name Program-related functions
  * @{
  */

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -77,3 +77,29 @@ typedef enum
     BPF_FUNC_get_smp_processor_id = 7,
     BPF_FUNC_ktime_get_ns = 8,
 } ebpf_helper_id_t;
+
+// Libbpf itself requires the following structs to be defined, but doesn't
+// care what fields they have.  Applications such as bpftool on the other
+// hand depend on fields of specific names and types.
+
+struct bpf_link_info
+{
+    ebpf_id_t id;      ///< Link ID.
+    ebpf_id_t prog_id; ///< Program ID.
+};
+
+struct bpf_map_info
+{
+    ebpf_id_t id;         ///< Map ID.
+    ebpf_map_type_t type; ///< Type of map.
+    uint32_t key_size;    ///< Size in bytes of a map key.
+    uint32_t value_size;  ///< Size in bytes of a map value.
+    uint32_t max_entries; ///< Maximum number of entries allowed in the map.
+};
+
+struct bpf_prog_info
+{
+    ebpf_id_t id;        ///< Program ID.
+    uint32_t nr_map_ids; ///< Number of maps associated with this program.
+    char name[16];       ///< Program name.
+};

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -97,7 +97,7 @@ struct bpf_map_info
     uint32_t max_entries; ///< Maximum number of entries allowed in the map.
 };
 
-#define BPF_OBJ_NAME_LEN 16
+#define BPF_OBJ_NAME_LEN 64
 
 struct bpf_prog_info
 {

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -97,9 +97,11 @@ struct bpf_map_info
     uint32_t max_entries; ///< Maximum number of entries allowed in the map.
 };
 
+#define BPF_OBJ_NAME_LEN 16
+
 struct bpf_prog_info
 {
-    ebpf_id_t id;        ///< Program ID.
-    uint32_t nr_map_ids; ///< Number of maps associated with this program.
-    char name[16];       ///< Program name.
+    ebpf_id_t id;                ///< Program ID.
+    uint32_t nr_map_ids;         ///< Number of maps associated with this program.
+    char name[BPF_OBJ_NAME_LEN]; ///< Null-terminated program name.
 };

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -88,16 +88,17 @@ struct bpf_link_info
     ebpf_id_t prog_id; ///< Program ID.
 };
 
+#define BPF_OBJ_NAME_LEN 64
+
 struct bpf_map_info
 {
-    ebpf_id_t id;         ///< Map ID.
-    ebpf_map_type_t type; ///< Type of map.
-    uint32_t key_size;    ///< Size in bytes of a map key.
-    uint32_t value_size;  ///< Size in bytes of a map value.
-    uint32_t max_entries; ///< Maximum number of entries allowed in the map.
+    ebpf_id_t id;                ///< Map ID.
+    ebpf_map_type_t type;        ///< Type of map.
+    uint32_t key_size;           ///< Size in bytes of a map key.
+    uint32_t value_size;         ///< Size in bytes of a map value.
+    uint32_t max_entries;        ///< Maximum number of entries allowed in the map.
+    char name[BPF_OBJ_NAME_LEN]; ///< Null-terminated map name.
 };
-
-#define BPF_OBJ_NAME_LEN 64
 
 struct bpf_prog_info
 {

--- a/include/libbpf.h
+++ b/include/libbpf.h
@@ -474,7 +474,7 @@ bpf_program__name(const struct bpf_program* prog);
 /**
  * @brief Get the next program for a given eBPF object.
  *
- * @param[in] prog Previous program.
+ * @param[in] prog Previous program, or NULL to get the first program.
  * @param[in] obj Object with programs.
  *
  * @returns Next program, or NULL if none.

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -7,6 +7,7 @@
 
 #include "ebpf_program_types.h"
 #include "ebpf_api.h"
+#include "ebpf_structs.h"
 #define LIBBPF_API
 #include "libbpf_common.h"
 #undef LIBBPF_DEPRECATED
@@ -38,9 +39,4 @@ enum bpf_func_id
 enum bpf_stats_type
 {
     BPF_STATS_TYPE_UNKNOWN
-};
-
-struct bpf_prog_info
-{
-    int data;
 };

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -339,14 +339,14 @@ ebpf_get_next_program_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
  * * struct bpf_map_info
  * * struct bpf_prog_info
  *
- *
  * @param[in] bpf_fd File descriptor referring to an eBPF object.
  * @param[out] info Pointer to memory in which to write the info obtained.
- * @param[in,out] info_len On input, contains the maximum number of bytes to
+ * @param[in,out] info_size On input, contains the maximum number of bytes to
  * write into the info.  On output, contains the actual number of bytes written.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  */
 ebpf_result_t
-ebpf_object_get_info_by_fd(fd_t bpf_fd, void* info, uint32_t* info_len);
+ebpf_object_get_info_by_fd(
+    fd_t bpf_fd, _Out_writes_bytes_to_(*info_size, *info_size) void* info, _Inout_ uint32_t* info_size);

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -328,3 +328,25 @@ ebpf_get_next_map_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
  */
 ebpf_result_t
 ebpf_get_next_program_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
+
+/**
+ * @brief Obtain information about the eBPF object referred to by bpf_fd.
+ * This function populates up to info_len bytes of info, which will
+ * be in one of the following formats depending on the eBPF object type of
+ * bpf_fd:
+ *
+ * * struct bpf_link_info
+ * * struct bpf_map_info
+ * * struct bpf_prog_info
+ *
+ *
+ * @param[in] bpf_fd File descriptor referring to an eBPF object.
+ * @param[out] info Pointer to memory in which to write the info obtained.
+ * @param[in,out] info_len On input, contains the maximum number of bytes to
+ * write into the info.  On output, contains the actual number of bytes written.
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
+ */
+ebpf_result_t
+ebpf_object_get_info_by_fd(fd_t bpf_fd, void* info, uint32_t* info_len);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2016,9 +2016,10 @@ ebpf_get_next_program_id(ebpf_id_t start_id, _Out_ ebpf_id_t* next_id) noexcept
 }
 
 ebpf_result_t
-ebpf_object_get_info_by_fd(fd_t bpf_fd, void* info, uint32_t* info_len)
+ebpf_object_get_info_by_fd(
+    fd_t bpf_fd, _Out_writes_bytes_to_(*info_size, *info_size) void* info, _Inout_ uint32_t* info_size)
 {
-    if (info == nullptr || info_len == nullptr) {
+    if (info == nullptr || info_size == nullptr) {
         return EBPF_INVALID_ARGUMENT;
     }
 
@@ -2028,7 +2029,7 @@ ebpf_object_get_info_by_fd(fd_t bpf_fd, void* info, uint32_t* info_len)
     }
 
     ebpf_protocol_buffer_t request_buffer(sizeof(ebpf_operation_get_object_info_request_t));
-    ebpf_protocol_buffer_t reply_buffer(EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info) + *info_len);
+    ebpf_protocol_buffer_t reply_buffer(EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info) + *info_size);
     auto request = reinterpret_cast<ebpf_operation_get_object_info_request_t*>(request_buffer.data());
     auto reply = reinterpret_cast<ebpf_operation_get_object_info_reply_t*>(reply_buffer.data());
 
@@ -2038,8 +2039,8 @@ ebpf_object_get_info_by_fd(fd_t bpf_fd, void* info, uint32_t* info_len)
 
     ebpf_result_t result = windows_error_to_ebpf_result(invoke_ioctl(request_buffer, reply_buffer));
     if (result == EBPF_SUCCESS) {
-        *info_len = reply->header.length - EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info);
-        memcpy(info, reply->info, *info_len);
+        *info_size = reply->header.length - EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info);
+        memcpy(info, reply->info, *info_size);
     }
 
     return result;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2014,3 +2014,33 @@ ebpf_get_next_program_id(ebpf_id_t start_id, _Out_ ebpf_id_t* next_id) noexcept
 {
     return _get_next_id(ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM_ID, start_id, next_id);
 }
+
+ebpf_result_t
+ebpf_object_get_info_by_fd(fd_t bpf_fd, void* info, uint32_t* info_len)
+{
+    if (info == nullptr || info_len == nullptr) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    ebpf_handle_t handle = _get_handle_from_fd(bpf_fd);
+    if (handle == ebpf_handle_invalid) {
+        return EBPF_INVALID_FD;
+    }
+
+    ebpf_protocol_buffer_t request_buffer(sizeof(ebpf_operation_get_object_info_request_t));
+    ebpf_protocol_buffer_t reply_buffer(EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info) + *info_len);
+    auto request = reinterpret_cast<ebpf_operation_get_object_info_request_t*>(request_buffer.data());
+    auto reply = reinterpret_cast<ebpf_operation_get_object_info_reply_t*>(reply_buffer.data());
+
+    request->header.length = static_cast<uint16_t>(request_buffer.size());
+    request->header.id = ebpf_operation_id_t::EBPF_OPERATION_GET_OBJECT_INFO;
+    request->handle = reinterpret_cast<uint64_t>(handle);
+
+    ebpf_result_t result = windows_error_to_ebpf_result(invoke_ioctl(request_buffer, reply_buffer));
+    if (result == EBPF_SUCCESS) {
+        *info_len = reply->header.length - EBPF_OFFSET_OF(ebpf_operation_get_object_info_reply_t, info);
+        memcpy(info, reply->info, *info_len);
+    }
+
+    return result;
+}

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "api_internal.h"
+#include "bpf.h"
 #pragma warning(push)
 #pragma warning(disable : 4200)
 #include "libbpf.h"
@@ -55,4 +56,10 @@ bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
     }
     errno = ENOENT;
     return nullptr;
+}
+
+int
+bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len)
+{
+    return libbpf_result_err(ebpf_object_get_info_by_fd((fd_t)bpf_fd, info, info_len));
 }

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -296,7 +296,7 @@ _ebpf_core_protocol_create_map(
     UNREFERENCED_PARAMETER(reply_length);
     ebpf_utf8_string_t map_name = {0};
 
-    if (request->header.length > sizeof(ebpf_operation_create_map_request_t)) {
+    if (request->header.length > EBPF_OFFSET_OF(ebpf_operation_create_map_request_t, data)) {
         map_name.value = (uint8_t*)request->data;
         map_name.length = ((uint8_t*)request) + request->header.length - ((uint8_t*)request->data);
     }

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -245,11 +245,12 @@ _ebpf_core_protocol_resolve_map(
     uint16_t reply_length)
 {
     ebpf_program_t* program = NULL;
-    size_t count_of_maps = (request->header.length - EBPF_OFFSET_OF(ebpf_operation_resolve_map_request_t, map_handle)) /
-                           sizeof(request->map_handle[0]);
+    uint32_t count_of_maps =
+        (request->header.length - EBPF_OFFSET_OF(ebpf_operation_resolve_map_request_t, map_handle)) /
+        sizeof(request->map_handle[0]);
     size_t required_reply_length =
         EBPF_OFFSET_OF(ebpf_operation_resolve_map_reply_t, address) + count_of_maps * sizeof(reply->address[0]);
-    size_t map_index;
+    uint32_t map_index;
     ebpf_result_t return_value;
 
     if (reply_length < required_reply_length) {
@@ -794,6 +795,9 @@ _ebpf_core_protocol_get_ec_function(
     return EBPF_SUCCESS;
 }
 
+// Get helper info for a program or program type.  This is used by the jitter/verifier,
+// not by libbpf which instead uses _ebpf_core_protocol_get_program_object_info
+// to get standard cross-platform info.
 static ebpf_result_t
 _ebpf_core_protocol_get_program_info(
     _In_ const ebpf_operation_get_program_info_request_t* request,
@@ -931,6 +935,8 @@ _ebpf_core_protocol_serialize_map_info_reply(
     return result;
 }
 
+// Get map pinning info, as opposed to _ebpf_core_protocol_get_program_object_info
+// which is used by libbpf to get standard cross-platform bpf_map_info.
 static ebpf_result_t
 _ebpf_core_protocol_get_map_info(
     _In_ const ebpf_operation_get_map_info_request_t* request,
@@ -1063,6 +1069,89 @@ _ebpf_core_protocol_get_next_program_id(
     uint16_t reply_length)
 {
     return _get_next_id(EBPF_OBJECT_PROGRAM, request, reply, reply_length);
+}
+
+// Get standard cross-platform bpf_link_info for a link object.
+static ebpf_result_t
+_ebpf_core_protocol_get_link_object_info(
+    ebpf_handle_t handle, _Out_writes_to_(*info_size, *info_size) uint8_t* buffer, _Inout_ uint16_t* info_size)
+{
+    ebpf_link_t* link;
+    ebpf_result_t result = ebpf_reference_object_by_handle(handle, EBPF_OBJECT_LINK, (ebpf_object_t**)&link);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
+    result = ebpf_link_get_info(link, buffer, info_size);
+    ebpf_object_release_reference((ebpf_object_t*)link);
+    return result;
+}
+
+// Get standard cross-platform bpf_map_info for a map object.
+// Compare _ebpf_core_protocol_get_map_info which is used to get
+// map pinning info.
+static ebpf_result_t
+_ebpf_core_protocol_get_map_object_info(
+    ebpf_handle_t handle, _Out_writes_to_(*info_size, *info_size) uint8_t* buffer, _Inout_ uint16_t* info_size)
+{
+    ebpf_map_t* map;
+    ebpf_result_t result = ebpf_reference_object_by_handle(handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
+    result = ebpf_map_get_info(map, buffer, info_size);
+    ebpf_object_release_reference((ebpf_object_t*)map);
+    return result;
+}
+
+// Get standard cross-platform bpf_prog_info for a program object.
+// Compare _ebpf_core_protocol_get_program_info which is used
+// by the verifier/jitter to get helper info for a program or
+// program type.
+static ebpf_result_t
+_ebpf_core_protocol_get_program_object_info(
+    ebpf_handle_t handle, _Out_writes_to_(*info_size, *info_size) uint8_t* buffer, _Inout_ uint16_t* info_size)
+{
+    ebpf_program_t* program;
+    ebpf_result_t result = ebpf_reference_object_by_handle(handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+    if (result != EBPF_SUCCESS) {
+        return result;
+    }
+    result = ebpf_program_get_info(program, buffer, info_size);
+    ebpf_object_release_reference((ebpf_object_t*)program);
+    return result;
+}
+
+static ebpf_result_t
+_ebpf_core_protocol_get_object_info(
+    _In_ const ebpf_operation_get_object_info_request_t* request,
+    _Out_ ebpf_operation_get_object_info_reply_t* reply,
+    uint16_t reply_length)
+{
+    uint16_t info_size = reply_length - FIELD_OFFSET(ebpf_operation_get_object_info_reply_t, info);
+    ebpf_result_t result;
+
+    // Try a link handle.
+    result = _ebpf_core_protocol_get_link_object_info(request->handle, reply->info, &info_size);
+    if (result == EBPF_SUCCESS) {
+        reply->header.length = FIELD_OFFSET(ebpf_operation_get_object_info_reply_t, info) + info_size;
+        return EBPF_SUCCESS;
+    }
+
+    // Try a map handle.
+    result = _ebpf_core_protocol_get_map_object_info(request->handle, reply->info, &info_size);
+    if (result == EBPF_SUCCESS) {
+        reply->header.length = FIELD_OFFSET(ebpf_operation_get_object_info_reply_t, info) + info_size;
+        return EBPF_SUCCESS;
+    }
+
+    // Try a program handle.
+    result = _ebpf_core_protocol_get_program_object_info(request->handle, reply->info, &info_size);
+    if (result == EBPF_SUCCESS) {
+        reply->header.length = FIELD_OFFSET(ebpf_operation_get_object_info_reply_t, info) + info_size;
+        return EBPF_SUCCESS;
+    }
+
+    return EBPF_INVALID_ARGUMENT;
 }
 
 static void*
@@ -1278,6 +1367,11 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_get_next_program_id,
      sizeof(ebpf_operation_get_next_id_request_t),
      sizeof(ebpf_operation_get_next_id_reply_t)},
+
+    // EBPF_OPERATION_GET_OBJECT_INFO
+    {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_get_object_info,
+     sizeof(ebpf_operation_get_object_info_request_t),
+     sizeof(ebpf_operation_get_object_info_reply_t)},
 };
 
 ebpf_result_t

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "ebpf_epoch.h"
+#include "ebpf_handle.h"
 #include "ebpf_link.h"
 #include "ebpf_object.h"
 #include "ebpf_platform.h"
@@ -172,4 +173,21 @@ _ebpf_link_instance_invoke(
 
 Exit:
     return return_value;
+}
+
+ebpf_result_t
+ebpf_link_get_info(
+    _In_ const ebpf_link_t* link, _Out_writes_to_(*info_size, *info_size) uint8_t* buffer, _Inout_ uint16_t* info_size)
+{
+    struct bpf_link_info* info = (struct bpf_link_info*)buffer;
+
+    if (*info_size < sizeof(*info)) {
+        return EBPF_INSUFFICIENT_BUFFER;
+    }
+
+    info->id = link->object.id;
+    info->prog_id = ((ebpf_object_t*)link->program)->id;
+
+    *info_size = sizeof(*info);
+    return EBPF_SUCCESS;
 }

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -61,6 +61,22 @@ extern "C"
     void
     ebpf_link_detach_program(ebpf_link_t* link);
 
+    /**
+     * @brief Get bpf_link_info about a link.
+     *
+     * @param[in] link The link object to get info about.
+     * @param[out] buffer Buffer to write bpf_link_info into.
+     * @param[in,out] info_size On input, the size in bytes of the buffer.
+     * On output, the number of bytes actually written.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     */
+    ebpf_result_t
+    ebpf_link_get_info(
+        _In_ const ebpf_link_t* link,
+        _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,
+        _Inout_ uint16_t* info_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -70,6 +70,7 @@ extern "C"
      * On output, the number of bytes actually written.
      *
      * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_link_info.
      */
     ebpf_result_t
     ebpf_link_get_info(

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1076,3 +1076,23 @@ ebpf_map_next_key(
     }
     return ebpf_map_function_tables[map->ebpf_map_definition.type].next_key(map, previous_key, next_key);
 }
+
+ebpf_result_t
+ebpf_map_get_info(
+    _In_ const ebpf_map_t* map, _Out_writes_to_(*info_size, *info_size) uint8_t* buffer, _Inout_ uint16_t* info_size)
+{
+    struct bpf_map_info* info = (struct bpf_map_info*)buffer;
+
+    if (*info_size < sizeof(*info)) {
+        return EBPF_INSUFFICIENT_BUFFER;
+    }
+
+    info->id = map->object.id;
+    info->type = map->ebpf_map_definition.type;
+    info->key_size = map->ebpf_map_definition.key_size;
+    info->value_size = map->original_value_size;
+    info->max_entries = map->ebpf_map_definition.max_entries;
+
+    *info_size = sizeof(*info);
+    return EBPF_SUCCESS;
+}

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1092,6 +1092,7 @@ ebpf_map_get_info(
     info->key_size = map->ebpf_map_definition.key_size;
     info->value_size = map->original_value_size;
     info->max_entries = map->ebpf_map_definition.max_entries;
+    strncpy_s(info->name, sizeof(info->name), (char*)map->name.value, map->name.length);
 
     *info_size = sizeof(*info);
     return EBPF_SUCCESS;

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -871,7 +871,7 @@ ebpf_map_create(
         break;
     }
 
-    if (type >= EBPF_COUNT_OF(ebpf_map_function_tables)) {
+    if ((type >= EBPF_COUNT_OF(ebpf_map_function_tables)) || (map_name->length >= BPF_OBJ_NAME_LEN)) {
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -168,6 +168,22 @@ extern "C"
     ebpf_result_t
     ebpf_map_associate_program(_In_ ebpf_map_t* map, _In_ const struct _ebpf_program* program);
 
+    /**
+     * @brief Get bpf_map_info about a map.
+     *
+     * @param[in] map The map to get info about.
+     * @param[out] buffer Buffer to write bpf_map_info into.
+     * @param[in,out] info_size On input, the size in bytes of the buffer.
+     * On output, the number of bytes actually written.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     */
+    ebpf_result_t
+    ebpf_map_get_info(
+        _In_ const ebpf_map_t* map,
+        _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,
+        _Inout_ uint16_t* info_size);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -177,6 +177,7 @@ extern "C"
      * On output, the number of bytes actually written.
      *
      * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_map_info.
      */
     ebpf_result_t
     ebpf_map_get_info(

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -341,7 +341,8 @@ ebpf_program_initialize(ebpf_program_t* program, const ebpf_program_parameters_t
     ebpf_utf8_string_t local_section_name = {NULL, 0};
     ebpf_utf8_string_t local_file_name = {NULL, 0};
 
-    if (program->parameters.code_type != EBPF_CODE_NONE) {
+    if ((program->parameters.code_type != EBPF_CODE_NONE) ||
+        (program_parameters->program_name.length >= BPF_OBJ_NAME_LEN)) {
         return_value = EBPF_INVALID_ARGUMENT;
         goto Done;
     }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -4,6 +4,7 @@
 #include "bpf_helpers.h"
 #include "ebpf_core.h"
 #include "ebpf_epoch.h"
+#include "ebpf_handle.h"
 #include "ebpf_link.h"
 #include "ebpf_object.h"
 #include "ebpf_program.h"
@@ -40,7 +41,7 @@ typedef struct _ebpf_program
     ebpf_extension_dispatch_table_t* general_helper_provider_dispatch_table;
 
     ebpf_map_t** maps;
-    size_t count_of_maps;
+    uint32_t count_of_maps;
 
     ebpf_extension_client_t* program_info_client;
     const void* program_info_binding_context;
@@ -395,7 +396,7 @@ ebpf_program_type(_In_ const ebpf_program_t* program)
 }
 
 ebpf_result_t
-ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, size_t maps_count)
+ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t maps_count)
 {
     size_t index;
     ebpf_map_t** program_maps = ebpf_allocate(maps_count * sizeof(ebpf_map_t*));
@@ -847,4 +848,27 @@ ebpf_program_detach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* l
 
     // Release the "attach" reference.
     ebpf_object_release_reference((ebpf_object_t*)link);
+}
+
+ebpf_result_t
+ebpf_program_get_info(
+    _In_ const ebpf_program_t* program,
+    _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,
+    _Inout_ uint16_t* info_size)
+{
+    struct bpf_prog_info* info = (struct bpf_prog_info*)buffer;
+    if (*info_size < sizeof(*info)) {
+        return EBPF_INSUFFICIENT_BUFFER;
+    }
+
+    info->id = program->object.id;
+    strncpy_s(
+        info->name,
+        sizeof(info->name),
+        (char*)program->parameters.program_name.value,
+        program->parameters.program_name.length);
+    info->nr_map_ids = program->count_of_maps;
+
+    *info_size = sizeof(*info);
+    return EBPF_SUCCESS;
 }

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -224,6 +224,7 @@ extern "C"
      * On output, the number of bytes actually written.
      *
      * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_prog_info.
      */
     ebpf_result_t
     ebpf_program_get_info(

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -123,7 +123,7 @@ extern "C"
      *  program instance.
      */
     ebpf_result_t
-    ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, size_t maps_count);
+    ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t maps_count);
 
     /**
      * @brief Load a block of eBPF code into the program instance.
@@ -214,6 +214,22 @@ extern "C"
      */
     ebpf_result_t
     ebpf_program_set_tail_call(_In_ const ebpf_program_t* next_program);
+
+    /**
+     * @brief Get bpf_prog_info about a program.
+     *
+     * @param[in] program The program to get info about.
+     * @param[out] buffer Buffer to write bpf_prog_info into.
+     * @param[in,out] info_size On input, the size in bytes of the buffer.
+     * On output, the number of bytes actually written.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     */
+    ebpf_result_t
+    ebpf_program_get_info(
+        _In_ const ebpf_program_t* program,
+        _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,
+        _Inout_ uint16_t* info_size);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -38,6 +38,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_GET_NEXT_LINK_ID,
     EBPF_OPERATION_GET_NEXT_MAP_ID,
     EBPF_OPERATION_GET_NEXT_PROGRAM_ID,
+    EBPF_OPERATION_GET_OBJECT_INFO,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -332,3 +333,15 @@ typedef struct _ebpf_operation_get_next_id_reply
     struct _ebpf_operation_header header;
     ebpf_id_t next_id;
 } ebpf_operation_get_next_id_reply_t;
+
+typedef struct _ebpf_operation_get_object_info_request
+{
+    struct _ebpf_operation_header header;
+    uint64_t handle;
+} ebpf_operation_get_object_info_request_t;
+
+typedef struct _ebpf_operation_get_object_info_reply
+{
+    struct _ebpf_operation_header header;
+    uint8_t info[1];
+} ebpf_operation_get_object_info_reply_t;

--- a/libs/platform/ebpf_serialize.h
+++ b/libs/platform/ebpf_serialize.h
@@ -88,7 +88,7 @@ extern "C"
     /**
      * @brief Serialize ebpf_program_info_t onto output buffer.
      *
-     * @param[in]  program_info Pointer to program_map_info_t to serialize.
+     * @param[in]  program_info Pointer to ebpf_program_info_t to serialize.
      * @param[out] output_buffer Caller specified output buffer to write serialized data into.
      * @param[in]  output_buffer_length Output buffer length.
      * @param[out] serialized_data_length Length of successfully serialized data.
@@ -107,7 +107,7 @@ extern "C"
         _Out_ size_t* required_length);
 
     /**
-     * @brief Deserialize input buffer to an array of ebpf_map_info_t.
+     * @brief Deserialize input buffer to an array of ebpf_program_info_t.
      *
      * @param[in] input_buffer_length Input buffer length.
      * @param[in] input_buffer Input buffer that will be de-serialized.

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -753,7 +753,7 @@ TEST_CASE("enumerate link IDs", "[libbpf]")
     REQUIRE(errno == ENOENT);
 }
 
-TEST_CASE("get prog and link info", "[libbpf]")
+TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
 {
     _test_helper_end_to_end test_helper;
     program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -768,13 +768,16 @@ TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
     REQUIRE(program != nullptr);
 
     const char* program_name = bpf_program__name(program);
-    REQUIRE(program != nullptr);
+    REQUIRE(program_name != nullptr);
 
     int program_fd = bpf_program__fd(program);
     REQUIRE(program_fd > 0);
 
     struct bpf_map* map = bpf_map__next(nullptr, object);
     REQUIRE(map != nullptr);
+
+    const char* map_name = bpf_map__name(map);
+    REQUIRE(map_name != nullptr);
 
     int map_fd = bpf_map__fd(map);
     REQUIRE(map_fd > 0);
@@ -788,6 +791,7 @@ TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
     REQUIRE(map_info.key_size == sizeof(uint32_t));
     REQUIRE(map_info.value_size == sizeof(uint64_t));
     REQUIRE(map_info.max_entries == 1);
+    REQUIRE(strcmp(map_info.name, map_name) == 0);
 
     // Fetch info about the program and verify it matches what we'd expect.
     bpf_prog_info program_info;


### PR DESCRIPTION
This is the last libbpf api needed to enable the bpftool flow to detach an already loaded program.

There's already GET_MAP_INFO and GET_PROGRAM_INFO ioctls but they do different things than libbpf requires.
There's comments about this in ebpf_core.c.  In the future we may want to see what can be either combined or renamed for clarity, but for this PR I tried to minimize impact on other paths.

This also fixes a bug in ebpf_core.c where the map name was never being set in the kernel.

Fixes #372

Signed-off-by: Dave Thaler <dthaler@microsoft.com>