### PR TITLE
Update netsh commands to use more standard libbpf apis

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -109,9 +109,9 @@ On the attacker machine, do the following:
 6. Show that the verifier checks the code ```netsh ebpf show verification droppacket.o xdp```
 7. Launch netsh ```netsh```
 8. Switch to ebpf context ```ebpf```
-9. Load eBPF program ```add program droppacket.o xdp```
+9. Load eBPF program ```add program droppacket.o xdp``` and note the ID.
 10. Show UDP datagrams received drop to under 10 per second
-11. Unload program ```delete program droppacket.o xdp```
+11. Unload program ```delete program <id>``` where <id> is the ID noted above.
 12. Show UDP datagrams received drop to back up to ~200K per second
 13. Modify droppacket.c to be unsafe - Comment out line 20 & 21
 14. Compile droppacket.c ```clang -target bpf -O2 -Wall -c droppacket.c -o droppacket.o```
@@ -166,6 +166,6 @@ Other useful options include:
 This application tests various XDP functionalities. It has the following tests:
 1. Reflection Test: This tests the XDP_TX functionality. The following steps show how to run the test:
    1. On the system under test, install eBPF binaries (install-ebpf.bat).
-   2. Load the test eBPF program by running the following commands: `netsh`, `ebpf`, `add program reflect_packet.o xdp`.
+   2. Load the test eBPF program by running the following commands: `netsh`, `ebpf`, `add program reflect_packet.o xdp` and note the ID.
    3. From a remote host, run xdp_tests.exe and in `--remote-ip` parameter pass an IPv4 or IPv6 address of an Ethernet-like interface on the system under test in string format.
-   4. Unload the program from system under test by running `delete program reflect_packet.o xdp` on the netsh prompt.
+   4. Unload the program from system under test by running `delete program <id>` on the netsh prompt, where <id> is the ID noted above.

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -31,11 +31,13 @@ EXPORTS
     bpf_map_lookup_elem
     bpf_map_update_elem
     bpf_obj_get_info_by_fd
+    bpf_obj_pin
     bpf_object__close
     bpf_object__find_map_by_name
     bpf_object__find_map_fd_by_name
     bpf_object__find_program_by_name
     bpf_object__name
+    bpf_object__next
     bpf_object__pin
     bpf_object__pin_maps
     bpf_object__pin_programs
@@ -57,13 +59,11 @@ EXPORTS
     bpf_program__unpin
     ebpf_api_initiate
     ebpf_api_terminate
-    ebpf_api_load_program
     ebpf_api_create_map
     ebpf_api_elf_enumerate_sections
     ebpf_api_elf_disassemble_section
     ebpf_api_elf_verify_section
     ebpf_api_elf_free
-    ebpf_api_pin_object
     ebpf_api_link_program
     ebpf_api_close_handle
     ebpf_api_get_pinned_map_info
@@ -76,7 +76,6 @@ EXPORTS
     ebpf_link_close
     ebpf_map_pin
     ebpf_object_get
-    ebpf_object_pin
     ebpf_object_unpin
     ebpf_program_attach
     ebpf_program_attach_by_fd

--- a/include/bpf.h
+++ b/include/bpf.h
@@ -205,6 +205,19 @@ bpf_map_update_elem(int fd, const void* key, const void* value, __u64 flags);
 int
 bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len);
 
+/**
+ * @brief Pin an eBPF program or map referred to by fd to the
+ * provided pathname.
+ *
+ * @param[in] fd File descriptor referring to the program or map to pin.
+ * @param[in] pathname Path name to pin the object to.
+ *
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
+ */
+int
+bpf_obj_pin(int fd, const char* pathname);
+
 /** @} */
 
 /**

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -312,16 +312,6 @@ extern "C"
     ebpf_api_unpin_object(const uint8_t* name, uint32_t name_length);
 
     /**
-     * @brief Pin an object to the specified path.
-     * @param[in] fd File descriptor to the object.
-     * @param[in] path Path to pin the object to.
-     *
-     * @retval EBPF_SUCCESS The operation was successful.
-     */
-    ebpf_result_t
-    ebpf_object_pin(fd_t fd, _In_z_ const char* path);
-
-    /**
      * @brief Unpin the object from the specified path.
      * @param[in] path Path from which to unpin.
      *
@@ -427,7 +417,7 @@ extern "C"
      *  ebpf_object_close() to close this (and other) file descriptors.
      * @param[out] log_buffer Returns a pointer to a null-terminated log buffer.
      *  The caller is responsible for freeing the returned log_buffer pointer
-     *  by calling ebpf_api_free_string().
+     *  by calling ebpf_free_string().
      *
      * @retval EBPF_SUCCESS The programs are loaded and maps are created successfully.
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -85,28 +85,6 @@ extern "C"
     ebpf_api_terminate();
 
     /**
-     * @brief Load an eBFP program into the kernel execution context.
-     * @param[in] file An ELF file containing one or more eBPF programs.
-     * @param[in] section_name Name of the section in the ELF file to load.
-     * @param[in] execution_type How this program should be run in the execution
-     * context.
-     * @param[out] handle Handle to eBPF program.
-     * @param[in,out] count_of_map_handles On input, contains the maximum number of map_handles to return.
-     * On output, contains the actual number of map_handles returned.
-     * @param[out] map_handles Array of map handles to be filled in.
-     * @param[out] error_message Error message describing what failed.
-     */
-    ebpf_result_t
-    ebpf_api_load_program(
-        const char* file,
-        const char* section_name,
-        ebpf_execution_type_t execution_type,
-        ebpf_handle_t* handle,
-        uint32_t* count_of_map_handles,
-        ebpf_handle_t* map_handles,
-        const char** error_message);
-
-    /**
      * @brief Create an eBPF map with input parameters.
      * @param[in] type Map type.
      * @param[in] key_size Key size.
@@ -199,16 +177,6 @@ extern "C"
      */
     ebpf_result_t
     ebpf_get_next_program(fd_t previous_fd, _Out_ fd_t* next_fd);
-
-    /**
-     * @brief Get the next eBPF program.
-     * @param[in] previous_handle Handle to previous eBPF program or
-     *  ebpf_handle_invalid to start enumeration.
-     * @param[out] next_handle The next eBPF program or ebpf_handle_invalid if this
-     *  is the last map.
-     */
-    uint32_t
-    ebpf_api_get_next_program(ebpf_handle_t previous_handle, ebpf_handle_t* next_handle);
 
     /**
      * @brief Query properties of an eBPF map.
@@ -334,15 +302,6 @@ extern "C"
      */
     void
     ebpf_free_string(_In_opt_ _Post_invalid_ const char* string);
-
-    /**
-     * @brief Associate a name with an object handle.
-     * @param[in] handle Handle to object.
-     * @param[in] name Name to associate with handle.
-     * @param[in] name_length Length in bytes of the name.
-     */
-    uint32_t
-    ebpf_api_pin_object(ebpf_handle_t handle, const uint8_t* name, uint32_t name_length);
 
     /**
      * @brief Dissociate a name with an object handle.

--- a/include/libbpf.h
+++ b/include/libbpf.h
@@ -216,7 +216,7 @@ bpf_map__value_size(const struct bpf_map* map);
 /** @} */
 
 /**
- * @name File object-related functions
+ * @name Object-related functions
  * @{
  */
 
@@ -276,6 +276,16 @@ bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
  */
 const char*
 bpf_object__name(const struct bpf_object* obj);
+
+/**
+ * @brief Get the next eBPF object opened by the calling process.
+ *
+ * @param[in] prev Previous object, or NULL to get the first object.
+ *
+ * @returns Next object, or NULL if none.
+ */
+struct bpf_object*
+bpf_object__next(struct bpf_object* prev);
 
 /**
  * @brief Pin an eBPF object to a specified path.

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -20,14 +20,14 @@ typedef uint32_t pid_t;
 
 enum bpf_prog_type
 {
-    BPF_PROG_TYPE_UNKNOWN,
+    BPF_PROG_TYPE_UNSPEC,
     BPF_PROG_TYPE_XDP,
     BPF_PROG_TYPE_BIND, // TODO(#333): replace with cross-platform program type
 };
 
 enum bpf_attach_type
 {
-    BPF_ATTACH_TYPE_UNKNOWN,
+    BPF_ATTACH_TYPE_UNSPEC,
     BPF_ATTACH_TYPE_XDP,
 };
 

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -93,6 +93,15 @@ void
 clean_up_ebpf_maps(_Inout_ std::vector<ebpf_map_t*>& maps);
 
 /**
+ * @brief Get next eBPF object.
+ *
+ * @param[in] previous Pointer to previous eBPF object, or NULL to get the first one.
+ * @return Pointer to the next object, or NULL if none.
+ */
+_Ret_maybenull_ struct bpf_object*
+ebpf_object_next(_In_opt_ const struct bpf_object* previous);
+
+/**
  * @brief Get next program in ebpf_object object.
  *
  * @param[in] previous Pointer to previous eBPF program, or NULL to get the first one.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -359,3 +359,13 @@ ebpf_get_next_program_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
 ebpf_result_t
 ebpf_object_get_info_by_fd(
     fd_t bpf_fd, _Out_writes_bytes_to_(*info_size, *info_size) void* info, _Inout_ uint32_t* info_size);
+
+/**
+ * @brief Pin an object to the specified path.
+ * @param[in] fd File descriptor to the object.
+ * @param[in] path Path to pin the object to.
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ */
+ebpf_result_t
+ebpf_object_pin(fd_t fd, _In_z_ const char* path);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1050,8 +1050,8 @@ _link_ebpf_program(
             goto Exit;
         }
 
-        new_link->handle = reinterpret_cast<ebpf_handle_t>(reply.link_handle);
-        new_link->fd = _get_next_file_descriptor(new_link->handle);
+        new_link->handle = reply.link_handle;
+        new_link->fd = _create_file_descriptor_for_handle(new_link->handle);
         if (new_link->fd == ebpf_fd_invalid) {
             result = EBPF_NO_MEMORY;
         } else {
@@ -1150,13 +1150,12 @@ ebpf_program_attach_by_fd(
     _In_ size_t attach_parameters_size,
     _Outptr_ struct bpf_link** link)
 {
-    ebpf_program_t* program = _get_ebpf_program_from_handle(_get_handle_from_file_descriptor(program_fd));
-    if (program == nullptr || link == nullptr) {
+    if (link == nullptr) {
         return EBPF_INVALID_ARGUMENT;
     }
     *link = nullptr;
 
-    ebpf_handle_t program_handle = _get_handle_from_fd(program_fd);
+    ebpf_handle_t program_handle = _get_handle_from_file_descriptor(program_fd);
     if (program_handle == ebpf_handle_invalid) {
         return EBPF_INVALID_FD;
     }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -687,162 +687,10 @@ Done:
     return result;
 }
 
-ebpf_result_t
-ebpf_api_load_program(
-    const char* file_name,
-    const char* section_name,
-    ebpf_execution_type_t execution_type,
-    ebpf_handle_t* handle,
-    uint32_t* count_of_map_handles,
-    ebpf_handle_t* map_handles,
-    const char** error_message)
-{
-    ebpf_handle_t program_handle = ebpf_handle_invalid;
-    ebpf_protocol_buffer_t request_buffer;
-    uint32_t error_message_size = 0;
-    std::vector<ebpf_handle_t> handles;
-    ebpf_result_t result = EBPF_SUCCESS;
-    ebpf_program_load_info load_info = {0};
-    std::vector<original_fd_handle_map_t> handle_map;
-    std::vector<ebpf_program_t*> programs;
-    std::vector<ebpf_map_t*> maps;
-    ebpf_program_t* program = nullptr;
-
-    *handle = 0;
-    *error_message = nullptr;
-
-    clear_map_descriptors();
-
-    try {
-        ebpf_verifier_options_t verifier_options{false, false, false, false, false};
-        result = load_byte_code(file_name, section_name, &verifier_options, programs, maps, error_message);
-        if (result != EBPF_SUCCESS) {
-            goto Done;
-        }
-
-        if (programs.size() != 1) {
-            result = EBPF_ELF_PARSING_FAILED;
-            goto Done;
-        }
-        program = programs[0];
-
-        // Create all the maps.
-        for (auto& map : maps) {
-            ebpf_handle_t inner_map_handle = (map->inner_map) ? map->inner_map->map_handle : ebpf_handle_invalid;
-            result = _create_map(map->name, &map->map_definition, inner_map_handle, &map->map_handle);
-            if (result != EBPF_SUCCESS) {
-                goto Done;
-            }
-            map->map_fd = _create_file_descriptor_for_handle(map->map_handle);
-            if (map->map_fd == ebpf_fd_invalid) {
-                result = EBPF_FAILED;
-                goto Done;
-            }
-        }
-
-        // TODO: (issue #169): Should switch this to more idiomatic C++
-        // Note: This leaks the program handle on some errors.
-        result = _create_program(program->program_type, file_name, section_name, std::string(), &program_handle);
-        if (result != EBPF_SUCCESS) {
-            goto Done;
-        }
-
-        if (get_map_descriptor_size() > *count_of_map_handles) {
-            result = EBPF_INSUFFICIENT_BUFFER;
-            goto Done;
-        }
-
-        // populate load_info.
-        load_info.file_name = const_cast<char*>(file_name);
-        load_info.section_name = const_cast<char*>(section_name);
-        load_info.program_name = nullptr;
-        load_info.program_type = program->program_type;
-        load_info.program_handle = reinterpret_cast<file_handle_t>(program_handle);
-        load_info.execution_type = execution_type;
-        load_info.byte_code = program->byte_code;
-        load_info.byte_code_size = program->byte_code_size;
-        load_info.execution_context = execution_context_kernel_mode;
-        load_info.map_count = (uint32_t)get_map_descriptor_size();
-
-        if (load_info.map_count > 0) {
-            for (auto& map : maps) {
-                fd_t inner_map_original_fd = (map->inner_map) ? map->inner_map->original_fd : ebpf_fd_invalid;
-                handle_map.emplace_back(
-                    map->original_fd, inner_map_original_fd, reinterpret_cast<file_handle_t>(map->map_handle));
-            }
-
-            load_info.handle_map = handle_map.data();
-        }
-
-        result = ebpf_rpc_load_program(&load_info, error_message, &error_message_size);
-        if (result != EBPF_SUCCESS) {
-            goto Done;
-        }
-
-        // Program is verified and loaded.
-        *count_of_map_handles = 0;
-        for (auto& map : maps) {
-            map_handles[*count_of_map_handles] = map->map_handle;
-            (*count_of_map_handles)++;
-        }
-
-        *handle = program_handle;
-        program_handle = ebpf_handle_invalid;
-    } catch (const std::bad_alloc&) {
-        result = EBPF_NO_MEMORY;
-        goto Done;
-    } catch (...) {
-        result = EBPF_FAILED;
-        goto Done;
-    }
-
-Done:
-    if (result != EBPF_SUCCESS) {
-        handles = get_all_map_handles();
-        for (const auto& map_handle : handles) {
-            ebpf_api_close_handle((ebpf_handle_t)map_handle);
-        }
-
-        clean_up_ebpf_programs(programs);
-    } else {
-        // Clean up ebpf_program_t structures without closing the handle.
-        for (auto& program_it : programs) {
-            program_it->handle = ebpf_handle_invalid;
-            clean_up_ebpf_program(program_it);
-        }
-    }
-    clear_map_descriptors();
-
-    // Clean up ebpf_map_t structures without closing the handle.
-    for (auto& map : maps) {
-        map->map_handle = ebpf_handle_invalid;
-        clean_up_ebpf_map(map);
-    }
-
-    if (program_handle != ebpf_handle_invalid) {
-        ebpf_api_close_handle(program_handle);
-    }
-
-    return result;
-}
-
 void
 ebpf_free_string(_In_opt_ _Post_invalid_ const char* error_message)
 {
     return free(const_cast<char*>(error_message));
-}
-
-uint32_t
-ebpf_api_pin_object(ebpf_handle_t handle, const uint8_t* name, uint32_t name_length)
-{
-    ebpf_protocol_buffer_t request_buffer(offsetof(ebpf_operation_update_pinning_request_t, name) + name_length);
-    auto request = reinterpret_cast<ebpf_operation_update_pinning_request_t*>(request_buffer.data());
-
-    request->header.id = EBPF_OPERATION_UPDATE_PINNING;
-    request->header.length = static_cast<uint16_t>(request_buffer.size());
-    request->handle = handle;
-    std::copy(name, name + name_length, request->name);
-    return invoke_ioctl(request_buffer);
 }
 
 ebpf_result_t
@@ -1163,7 +1011,7 @@ static ebpf_result_t
 _link_ebpf_program(
     ebpf_handle_t program_handle,
     _In_ const ebpf_attach_type_t* attach_type,
-    _Out_ ebpf_handle_t* link_handle,
+    _Out_ ebpf_link_t** link,
     _In_reads_bytes_opt_(attach_parameter_size) uint8_t* attach_parameter,
     size_t attach_parameter_size) noexcept
 {
@@ -1171,7 +1019,13 @@ _link_ebpf_program(
     ebpf_operation_link_program_request_t* request;
     ebpf_operation_link_program_reply_t reply;
     ebpf_result_t result = EBPF_SUCCESS;
-    *link_handle = ebpf_handle_invalid;
+
+    *link = nullptr;
+    ebpf_link_t* new_link = (ebpf_link_t*)calloc(1, sizeof(ebpf_link_t));
+    if (new_link == nullptr) {
+        return EBPF_NO_MEMORY;
+    }
+    new_link->handle = ebpf_handle_invalid;
 
     try {
         size_t buffer_size = offsetof(ebpf_operation_link_program_request_t, data) + attach_parameter_size;
@@ -1196,7 +1050,15 @@ _link_ebpf_program(
             goto Exit;
         }
 
-        *link_handle = reply.link_handle;
+        new_link->handle = reinterpret_cast<ebpf_handle_t>(reply.link_handle);
+        new_link->fd = _get_next_file_descriptor(new_link->handle);
+        if (new_link->fd == ebpf_fd_invalid) {
+            result = EBPF_NO_MEMORY;
+            ebpf_link_detach(new_link);
+            ebpf_link_close(new_link);
+        } else {
+            *link = new_link;
+        }
     } catch (const std::bad_alloc&) {
         result = EBPF_NO_MEMORY;
         goto Exit;
@@ -1252,7 +1114,6 @@ ebpf_program_attach(
 {
     ebpf_result_t result = EBPF_SUCCESS;
     const ebpf_attach_type_t* program_attach_type;
-    ebpf_link_t* new_link = nullptr;
 
     if (program == nullptr || link == nullptr || (attach_params_size != 0 && attach_parameters == nullptr) ||
         (attach_parameters != nullptr && attach_params_size == 0)) {
@@ -1271,32 +1132,10 @@ ebpf_program_attach(
     }
     assert(program->handle != ebpf_handle_invalid);
 
-    *link = nullptr;
-    new_link = (ebpf_link_t*)calloc(1, sizeof(ebpf_link_t));
-    if (new_link == nullptr) {
-        result = EBPF_NO_MEMORY;
-        goto Exit;
-    }
-
-    result = _link_ebpf_program(
-        program->handle, program_attach_type, &new_link->handle, (uint8_t*)attach_parameters, attach_params_size);
-    if (result != EBPF_SUCCESS) {
-        goto Exit;
-    }
-    new_link->fd = _create_file_descriptor_for_handle(new_link->handle);
-    if (new_link->fd == ebpf_fd_invalid) {
-        result = EBPF_NO_MEMORY;
-        goto Exit;
-    }
-    *link = new_link;
+    result =
+        _link_ebpf_program(program->handle, program_attach_type, link, (uint8_t*)attach_parameters, attach_params_size);
 
 Exit:
-    if (result != EBPF_SUCCESS) {
-        if (new_link != nullptr && new_link->handle != ebpf_handle_invalid) {
-            ebpf_link_detach(new_link);
-        }
-        _clean_up_ebpf_link(new_link);
-    }
     return result;
 }
 
@@ -1304,8 +1143,8 @@ ebpf_result_t
 ebpf_program_attach_by_fd(
     fd_t program_fd,
     _In_opt_ const ebpf_attach_type_t* attach_type,
-    _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
-    _In_ size_t attach_params_size,
+    _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
+    _In_ size_t attach_parameters_size,
     _Outptr_ struct bpf_link** link)
 {
     ebpf_program_t* program = _get_ebpf_program_from_handle(_get_handle_from_file_descriptor(program_fd));
@@ -1314,7 +1153,22 @@ ebpf_program_attach_by_fd(
     }
     *link = nullptr;
 
-    return ebpf_program_attach(program, attach_type, attach_parameters, attach_params_size, link);
+    ebpf_handle_t program_handle = _get_handle_from_fd(program_fd);
+    if (program_handle == ebpf_handle_invalid) {
+        return EBPF_INVALID_FD;
+    }
+
+    if (attach_type == nullptr) {
+        // We can only use an unspecified attach_type if we can find an ebpf_program_t.
+        ebpf_program_t* program = _get_ebpf_program_from_handle(program_handle);
+        if (program == nullptr || link == nullptr) {
+            return EBPF_INVALID_ARGUMENT;
+        }
+
+        return ebpf_program_attach(program, attach_type, attach_parameters, attach_parameters_size, link);
+    }
+
+    return _link_ebpf_program(program_handle, attach_type, link, (uint8_t*)attach_parameters, attach_parameters_size);
 }
 
 uint32_t
@@ -1776,6 +1630,26 @@ Done:
     }
     clear_map_descriptors();
     return result;
+}
+
+_Ret_maybenull_ struct bpf_object*
+ebpf_object_next(_In_opt_ const struct bpf_object* previous)
+{
+    if (previous == nullptr) {
+        // Return first object.
+        return (!_ebpf_objects.empty()) ? _ebpf_objects[0] : nullptr;
+    }
+    auto it = std::find(_ebpf_objects.begin(), _ebpf_objects.end(), previous);
+    if (it == _ebpf_objects.end()) {
+        // Previous object not found.
+        return nullptr;
+    }
+    it++;
+    if (it == _ebpf_objects.end()) {
+        // No more objects.
+        return nullptr;
+    }
+    return *(it++);
 }
 
 _Ret_maybenull_ struct bpf_program*

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -58,8 +58,22 @@ bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
     return nullptr;
 }
 
+struct bpf_object*
+bpf_object__next(struct bpf_object* prev)
+{
+    return ebpf_object_next(prev);
+}
+
+// APIs from libbpf's bpf.h.
+
 int
 bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len)
 {
     return libbpf_result_err(ebpf_object_get_info_by_fd((fd_t)bpf_fd, info, info_len));
+}
+
+int
+bpf_obj_pin(int fd, const char* pathname)
+{
+    return libbpf_result_err(ebpf_object_pin((fd_t)fd, pathname));
 }

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -45,7 +45,7 @@ _get_bpf_attach_type(const ebpf_attach_type_t* type)
     if (memcmp(type, &EBPF_ATTACH_TYPE_XDP, sizeof(*type)) == 0) {
         return BPF_ATTACH_TYPE_XDP;
     }
-    return BPF_ATTACH_TYPE_UNKNOWN;
+    return BPF_ATTACH_TYPE_UNSPEC;
 }
 
 int

--- a/libs/api_common/windows_helpers.cpp
+++ b/libs/api_common/windows_helpers.cpp
@@ -163,7 +163,7 @@ _get_helper_function_prototype(const ebpf_program_info_t* info, unsigned int n)
 
 // Check whether a given integer is a valid helper ID.
 bool
-is_helper_usable_windows(int n)
+is_helper_usable_windows(int32_t n)
 {
     const ebpf_program_info_t* info;
     ebpf_result_t result = get_program_type_info(&info);
@@ -175,7 +175,7 @@ is_helper_usable_windows(int n)
 
 // Get the prototype for the helper with a given ID.
 EbpfHelperPrototype
-get_helper_prototype_windows(int n)
+get_helper_prototype_windows(int32_t n)
 {
     const ebpf_program_info_t* info;
     ebpf_result_t result = get_program_type_info(&info);

--- a/libs/api_common/windows_platform_common.hpp
+++ b/libs/api_common/windows_platform_common.hpp
@@ -4,10 +4,10 @@
 #pragma once
 
 EbpfHelperPrototype
-get_helper_prototype_windows(int n);
+get_helper_prototype_windows(int32_t n);
 
 bool
-is_helper_usable_windows(int n);
+is_helper_usable_windows(int32_t n);
 
 EbpfProgramType
 get_program_type_windows(const GUID& program_type);

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -197,7 +197,7 @@ handle_ebpf_delete_program(
         PreprocessCommand(nullptr, argv, current_index, argc, tags, _countof(tags), 0, _countof(tags), tag_type);
 
     ebpf_id_t id = EBPF_ID_NONE;
-    for (int i = 0; (status == NO_ERROR) && ((i + current_index) < argc); i++) {
+    for (int i = 0; (status == NO_ERROR) && ((i + current_index) < argc) && (i < _countof(tag_type)); i++) {
         switch (tag_type[i]) {
         case 0: // ID
         {

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -1,75 +1,36 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include <iostream>
+#include <iomanip>
 #include <string>
 #include <vector>
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <combaseapi.h>
 #include <netsh.h>
+#include "bpf.h"
+#include "ebpf_api.h"
 #include "ebpf_windows.h"
+#include "libbpf.h"
 #include "platform.h"
 #include "programs.h"
 #include "tokens.h"
 
-#include "ebpf_api.h"
-#include <iostream>
-#include <iomanip>
-
-class program_state_t final
-{
-  public:
-    std::string program_filename;
-    std::string program_section;
-    ebpf_handle_t program_handle;
-    ebpf_handle_t link_handle;
-    ebpf_handle_t map_handles[10];
-
-    program_state_t(std::string filename, std::string section)
-        : program_filename(filename), program_section(section), program_handle(ebpf_handle_invalid),
-          link_handle(ebpf_handle_invalid)
-    {
-        for (int i = 0; i < _countof(map_handles); i++) {
-            map_handles[i] = ebpf_handle_invalid;
-        }
-    }
-
-    void
-    clean(void)
-    {
-        close_handle(&link_handle);
-        close_handle(&program_handle);
-        for (int i = 0; i < _countof(map_handles); i++) {
-            close_handle(&map_handles[i]);
-        }
-    }
-
-  private:
-    void
-    close_handle(ebpf_handle_t* handle)
-    {
-        if (*handle != ebpf_handle_invalid) {
-            ebpf_api_close_handle(*handle);
-            *handle = ebpf_handle_invalid;
-        }
-    }
-};
-
-static std::vector<program_state_t> _programs;
-
 typedef enum
 {
-    PINNED_ANY = 0,
-    PINNED_YES = 1,
-    PINNED_NO = 2,
-} PINNED_CONSTRAINT;
+    BC_ANY = 0,
+    BC_YES = 1,
+    BC_NO = 2,
+} BOOLEAN_CONSTRAINT;
 
-static TOKEN_VALUE _pinned_enum[] = {
-    {L"any", PINNED_ANY},
-    {L"yes", PINNED_YES},
-    {L"no", PINNED_NO},
+static TOKEN_VALUE _boolean_constraint_enum[] = {
+    {L"any", BC_ANY},
+    {L"yes", BC_YES},
+    {L"no", BC_NO},
 };
 
-// TODO: ebpf_attach_type_index_t, _ebpf_attach_type_enum, and
+// TODO:(issue #223) ebpf_attach_type_index_t, _ebpf_attach_type_enum, and
 // _ebpf_attach_type_guids should all be replaced as soon as we
 // can query the information from ebpfapi.
 
@@ -87,6 +48,12 @@ static TOKEN_VALUE _ebpf_attach_type_enum[] = {
     {L"xdp", EBPF_ATTACH_TYPE_XDP_INDEX},
     {L"bind", EBPF_ATTACH_TYPE_BIND_INDEX},
 
+};
+
+GUID _ebpf_program_type_guids[] = {
+    EBPF_PROGRAM_TYPE_UNSPECIFIED,
+    EBPF_PROGRAM_TYPE_XDP,
+    EBPF_PROGRAM_TYPE_BIND,
 };
 
 GUID _ebpf_attach_type_guids[] = {
@@ -115,7 +82,6 @@ handle_ebpf_add_program(
 
     TAG_TYPE tags[] = {
         {TOKEN_FILENAME, NS_REQ_PRESENT, FALSE},
-        {TOKEN_SECTION, NS_REQ_PRESENT, FALSE},
         {TOKEN_TYPE, NS_REQ_ZERO, FALSE},
         {TOKEN_PINNED, NS_REQ_ZERO, FALSE},
         {TOKEN_EXECUTION, NS_REQ_ZERO, FALSE}};
@@ -126,8 +92,8 @@ handle_ebpf_add_program(
 
     std::string filename;
     std::string pinned;
-    std::string section = ""; // Use the first code section by default.
-    ebpf_attach_type_t attach_type = EBPF_ATTACH_TYPE_XDP;
+    ebpf_program_type_t* program_type = nullptr;
+    ebpf_attach_type_t* attach_type = nullptr;
     ebpf_execution_type_t execution = EBPF_EXECUTION_JIT;
     for (int i = 0; (status == NO_ERROR) && ((i + current_index) < argc); i++) {
         switch (tag_type[i]) {
@@ -136,12 +102,7 @@ handle_ebpf_add_program(
             filename = down_cast_from_wstring(std::wstring(argv[current_index + i]));
             break;
         }
-        case 1: // SECTION
-        {
-            section = down_cast_from_wstring(std::wstring(argv[current_index + i]));
-            break;
-        }
-        case 2: // TYPE
+        case 1: // TYPE
         {
             ebpf_attach_type_index_t attach_type_index;
             status = MatchEnumTag(
@@ -153,14 +114,15 @@ handle_ebpf_add_program(
             if (status != NO_ERROR) {
                 status = ERROR_INVALID_PARAMETER;
             } else {
-                attach_type = _ebpf_attach_type_guids[attach_type_index];
+                program_type = &_ebpf_program_type_guids[attach_type_index];
+                attach_type = &_ebpf_attach_type_guids[attach_type_index];
             }
             break;
         }
-        case 3: // PINNED
+        case 2: // PINNED
             pinned = down_cast_from_wstring(std::wstring(argv[current_index + i]));
             break;
-        case 4: // EXECUTION
+        case 3: // EXECUTION
             status = MatchEnumTag(
                 NULL,
                 argv[current_index + i],
@@ -177,93 +139,44 @@ handle_ebpf_add_program(
         return status;
     }
 
-    const char* error_message = nullptr;
-    program_state_t program(filename, section);
-    uint32_t count_of_map_handles = _countof(program.map_handles);
-    status = ebpf_api_load_program(
-        filename.c_str(),
-        section.c_str(),
-        execution,
-        &program.program_handle,
-        &count_of_map_handles,
-        program.map_handles,
-        &error_message);
-    if (status != ERROR_SUCCESS) {
-        if (error_message != nullptr) {
-            std::cerr << error_message << std::endl;
-        } else {
-            std::cerr << "error " << status << ": could not load program" << std::endl;
-        }
-        ebpf_free_string(error_message);
-        program.clean();
+    struct bpf_object* object;
+    int program_fd;
+    PCSTR error_message;
+    ebpf_result_t result = ebpf_program_load(
+        filename.c_str(), program_type, attach_type, EBPF_EXECUTION_ANY, &object, &program_fd, &error_message);
+    if (result != EBPF_SUCCESS) {
+        std::cerr << "error " << result << ": could not load program" << std::endl;
+        std::cerr << error_message << std::endl;
         return ERROR_SUPPRESS_OUTPUT;
     }
 
-    status = ebpf_api_link_program(program.program_handle, attach_type, &program.link_handle);
-    if (status != ERROR_SUCCESS) {
-        std::cerr << "error " << status << ": could not attach program, unloading it" << std::endl;
-        program.clean();
+    struct bpf_program* program = bpf_program__next(nullptr, object);
+    struct bpf_link* link;
+    result = ebpf_program_attach(program, attach_type, nullptr, 0, &link);
+    if (result != EBPF_SUCCESS) {
+        std::cerr << "error " << result << ": could not attach program" << std::endl;
         return ERROR_SUPPRESS_OUTPUT;
     }
 
     if (!pinned.empty()) {
-        // TODO (issue #83) replace ebpf_api_pin_object with ebpf_program_pin (aka bpf_program__pin)
-        // once it exists.
-        status = ebpf_api_pin_object(
-            program.program_handle, reinterpret_cast<const uint8_t*>(pinned.c_str()), (uint32_t)pinned.length());
-        if (status != ERROR_SUCCESS) {
-            std::cerr << "error " << status << ": could not pin program, unloading it" << std::endl;
-            program.clean();
+        if (bpf_program__pin(program, pinned.c_str()) < 0) {
+            std::cerr << "error " << errno << ": could not pin program" << std::endl;
             return ERROR_SUPPRESS_OUTPUT;
         }
     }
 
-    _programs.push_back(program);
+    // Get the ID and display it.
+    struct bpf_prog_info info;
+    uint32_t info_size = sizeof(info);
+    if (bpf_obj_get_info_by_fd(program_fd, &info, &info_size) < 0) {
+        std::cerr << "error " << errno << ": loaded program but could not get ID" << std::endl;
+        return ERROR_SUPPRESS_OUTPUT;
+    }
+    std::cout << "Loaded with ID " << info.id << std::endl;
+
+    ebpf_link_close(link);
+
     return ERROR_SUCCESS;
-}
-
-static fd_t
-_find_program_fd(const char* filename, const char* section)
-{
-    fd_t program_fd = ebpf_fd_invalid;
-    for (;;) {
-        fd_t next_program_fd;
-        ebpf_result_t status = ebpf_get_next_program(program_fd, &next_program_fd);
-        if (status != EBPF_SUCCESS) {
-            break;
-        }
-        if (program_fd != ebpf_fd_invalid) {
-            Platform::_close(program_fd);
-        }
-
-        program_fd = next_program_fd;
-        if (program_fd == ebpf_fd_invalid) {
-            break;
-        }
-
-        const char* program_file_name;
-        const char* program_section_name;
-        ebpf_execution_type_t program_execution_type;
-        status =
-            ebpf_program_query_info(program_fd, &program_execution_type, &program_file_name, &program_section_name);
-        if (status != ERROR_SUCCESS) {
-            break;
-        }
-
-        bool found = (strcmp(program_file_name, filename) == 0 && strcmp(program_section_name, section) == 0);
-
-        ebpf_free_string(program_file_name);
-        ebpf_free_string(program_section_name);
-
-        if (found) {
-            return program_fd;
-        }
-    }
-
-    if (program_fd != ebpf_fd_invalid) {
-        Platform::_close(program_fd);
-    }
-    return ebpf_fd_invalid;
 }
 
 DWORD
@@ -276,26 +189,19 @@ handle_ebpf_delete_program(
     UNREFERENCED_PARAMETER(done);
 
     TAG_TYPE tags[] = {
-        {TOKEN_FILENAME, NS_REQ_PRESENT, FALSE},
-        {TOKEN_SECTION, NS_REQ_ZERO, FALSE},
+        {TOKEN_ID, NS_REQ_PRESENT, FALSE},
     };
     ULONG tag_type[_countof(tags)] = {0};
 
     ULONG status =
         PreprocessCommand(nullptr, argv, current_index, argc, tags, _countof(tags), 0, _countof(tags), tag_type);
 
-    std::string filename;
-    std::string section = ""; // Use the first code section by default.
+    ebpf_id_t id = EBPF_ID_NONE;
     for (int i = 0; (status == NO_ERROR) && ((i + current_index) < argc); i++) {
         switch (tag_type[i]) {
-        case 0: // FILENAME
+        case 0: // ID
         {
-            filename = down_cast_from_wstring(std::wstring(argv[current_index + i]));
-            break;
-        }
-        case 1: // SECTION
-        {
-            section = down_cast_from_wstring(std::wstring(argv[current_index + i]));
+            id = (uint32_t)_wtoi(argv[current_index + i]);
             break;
         }
         default:
@@ -307,28 +213,80 @@ handle_ebpf_delete_program(
         return status;
     }
 
-    // TODO: If the program is pinned, unpin the specified program.
-    // TODO (issue #83): call ebpf_program_unpin() once it exists.
+    // TODO(issue #190): If the program is pinned, unpin the specified program.
     // The temporary API ebpf_api_unpin_object requires knowing the name a priori
     // and we have no way to get it yet.
 
     // Remove from our list of programs to release our own reference if we took one.
     // If there are no other references to the program, it will be unloaded.
-    auto found = std::find_if(_programs.begin(), _programs.end(), [filename, section](program_state_t& program) {
-        return program.program_filename == filename && program.program_section == section;
-    });
-    if (found != _programs.end()) {
-        found->clean();
-        _programs.erase(found);
-    } else {
-        std::cout << "Program not found\n";
-        return ERROR_SUPPRESS_OUTPUT;
+    bpf_object* object;
+    bpf_object* next_object;
+    bpf_object__for_each_safe(object, next_object)
+    {
+        bpf_program* program;
+        bpf_object__for_each_program(program, object)
+        {
+            int program_fd = bpf_program__fd(program);
+            struct bpf_prog_info info;
+            uint32_t info_size = sizeof(info);
+            if (bpf_obj_get_info_by_fd(program_fd, &info, &info_size) < 0) {
+                continue;
+            }
+            if (info.id == id) {
+                bpf_object__close(object);
+
+                // TODO: see if the program is still loaded, in which case some other process holds
+                // a reference. Get the PID of that process and display it.
+
+                return ERROR_OKAY;
+            }
+        }
     }
 
-    // TODO: see if the program is still loaded, in which case some other process holds
-    // a reference. Get the PID of that process and display it.
+    std::cout << "Program not found\n";
+    return ERROR_SUPPRESS_OUTPUT;
+}
 
-    return ERROR_SUCCESS;
+ebpf_result_t
+ebpf_program_attach_by_id(ebpf_id_t program_id, ebpf_attach_type_t attach_type)
+{
+    fd_t program_fd = bpf_prog_get_fd_by_id(program_id);
+    if (program_fd < 0) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    struct bpf_link* link;
+    ebpf_result_t result = ebpf_program_attach_by_fd(program_fd, &attach_type, nullptr, 0, &link);
+
+    ebpf_close_fd(program_fd); // TODO(issue #287): _close
+    return result;
+}
+
+int // errno value
+ebpf_program_detach_by_id(ebpf_id_t program_id)
+{
+    // Use the same APIs as bpftool.
+    uint32_t link_id = 0;
+    while (bpf_link_get_next_id(link_id, &link_id) == 0) {
+        fd_t link_fd = bpf_link_get_fd_by_id(link_id);
+        if (link_fd < 0) {
+            continue;
+        }
+
+        struct bpf_link_info link_info;
+        uint32_t info_len = sizeof(link_info);
+        if (bpf_obj_get_info_by_fd(link_fd, &link_info, &info_len) == 0) {
+            if (link_info.prog_id == program_id) {
+                if (bpf_link_detach(link_fd) < 0) {
+                    return errno;
+                }
+                ebpf_close_fd(link_fd); // TODO(#287): _close
+                return NO_ERROR;
+            }
+        }
+        ebpf_close_fd(link_fd); // TODO(#287): _close
+    }
+    return ERROR_NOT_FOUND;
 }
 
 DWORD
@@ -341,8 +299,8 @@ handle_ebpf_set_program(
     UNREFERENCED_PARAMETER(done);
 
     TAG_TYPE tags[] = {
-        {TOKEN_FILENAME, NS_REQ_PRESENT, FALSE},
-        {TOKEN_SECTION, NS_REQ_PRESENT, FALSE},
+        {TOKEN_ID, NS_REQ_PRESENT, FALSE},
+        {TOKEN_ATTACHED, NS_REQ_ZERO, FALSE},
         {TOKEN_PINNED, NS_REQ_ZERO, FALSE},
     };
     ULONG tag_type[_countof(tags)] = {0};
@@ -358,19 +316,22 @@ handle_ebpf_set_program(
         3, // Two required tags plus at least one optional tag.
         tag_type);
 
-    std::string filename;
-    std::string section = ""; // Use the first code section by default.
+    uint32_t id;
     std::string pinned;
+    ebpf_attach_type_t attach_type = EBPF_ATTACH_TYPE_UNSPECIFIED;
     for (int i = 0; (status == NO_ERROR) && ((i + current_index) < argc); i++) {
         switch (tag_type[i]) {
-        case 0: // FILENAME
+        case 0: // ID
         {
-            filename = down_cast_from_wstring(std::wstring(argv[current_index + i]));
+            id = (uint32_t)_wtoi(argv[current_index + i]);
             break;
         }
-        case 1: // SECTION
+        case 1: // ATTACHED
         {
-            section = down_cast_from_wstring(std::wstring(argv[current_index + i]));
+            if ((argv[current_index + i][0] != 0) &&
+                (UuidFromStringW((RPC_WSTR)argv[current_index + i], &attach_type))) {
+                status = ERROR_INVALID_SYNTAX;
+            }
             break;
         }
         case 2: // PINNED
@@ -385,31 +346,47 @@ handle_ebpf_set_program(
         return status;
     }
 
-    if (pinned.empty()) {
-        // TODO (issue #190): call ebpf_program_unpin() once it exists.
-        // The temporary API ebpf_api_unpin_object requires knowing the name a priori
-        // and we have no way to get it.
-        return ERROR_CALL_NOT_IMPLEMENTED;
-    } else {
-        // Try to find the program with the specified filename and section.
-        fd_t program_fd = _find_program_fd(filename.c_str(), section.c_str());
-        if (program_fd == ebpf_fd_invalid) {
-            std::cerr << "Program not found." << std::endl;
-            return ERROR_SUPPRESS_OUTPUT;
+    if (tags[1].bPresent) {
+        if (memcmp(&attach_type, &EBPF_ATTACH_TYPE_UNSPECIFIED, sizeof(ebpf_attach_type_t)) != 0) {
+            ebpf_result_t result = ebpf_program_attach_by_id(id, attach_type);
+            if (result != NO_ERROR) {
+                std::cerr << "error " << result << ": could not detach program" << std::endl;
+                return ERROR_SUPPRESS_OUTPUT;
+            }
+        } else {
+            int error = ebpf_program_detach_by_id(id);
+            if (error != NO_ERROR) {
+                std::cerr << "error " << error << ": could not detach program" << std::endl;
+                return ERROR_SUPPRESS_OUTPUT;
+            }
         }
-
-        // TODO (issue #83) replace ebpf_api_pin_object with ebpf_program_pin (aka bpf_program__pin)
-        // once it exists.
-        status = ebpf_object_pin(program_fd, pinned.c_str());
-        if (status != EBPF_SUCCESS) {
-            std::cerr << "error " << status << ": could not pin program" << std::endl;
-            return ERROR_SUPPRESS_OUTPUT;
-        }
-
-        Platform::_close(program_fd);
     }
 
-    return ERROR_CALL_NOT_IMPLEMENTED;
+    if (tags[2].bPresent) {
+        if (pinned.empty()) {
+            // TODO (issue #190): call ebpf_program_unpin() once it exists.
+            // The temporary API ebpf_api_unpin_object requires knowing the name a priori
+            // and we have no way to get it.
+            return ERROR_CALL_NOT_IMPLEMENTED;
+        } else {
+            // Try to find the program with the specified ID.
+            fd_t program_fd = bpf_prog_get_fd_by_id(id);
+            if (program_fd == ebpf_fd_invalid) {
+                std::cerr << "Program not found." << std::endl;
+                return ERROR_SUPPRESS_OUTPUT;
+            }
+
+            status = bpf_obj_pin(program_fd, pinned.c_str());
+            if (status != EBPF_SUCCESS) {
+                std::cerr << "error " << status << ": could not pin program" << std::endl;
+                return ERROR_SUPPRESS_OUTPUT;
+            }
+
+            Platform::_close(program_fd);
+        }
+    }
+
+    return ERROR_OKAY;
 }
 
 DWORD
@@ -423,10 +400,12 @@ handle_ebpf_show_programs(
 
     TAG_TYPE tags[] = {
         {TOKEN_TYPE, NS_REQ_ZERO, FALSE},
+        {TOKEN_ATTACHED, NS_REQ_ZERO, FALSE},
         {TOKEN_PINNED, NS_REQ_ZERO, FALSE},
         {TOKEN_LEVEL, NS_REQ_ZERO, FALSE},
         {TOKEN_FILENAME, NS_REQ_ZERO, FALSE},
         {TOKEN_SECTION, NS_REQ_ZERO, FALSE},
+        {TOKEN_ID, NS_REQ_ZERO, FALSE},
     };
     ULONG tag_type[_countof(tags)] = {0};
 
@@ -434,10 +413,12 @@ handle_ebpf_show_programs(
         PreprocessCommand(nullptr, argv, current_index, argc, tags, _countof(tags), 0, _countof(tags), tag_type);
 
     ebpf_attach_type_t attach_type = EBPF_ATTACH_TYPE_XDP;
-    PINNED_CONSTRAINT pinned = PINNED_ANY;
+    BOOLEAN_CONSTRAINT attached = BC_ANY;
+    BOOLEAN_CONSTRAINT pinned = BC_ANY;
     VERBOSITY_LEVEL level = VL_NORMAL;
     std::string filename;
     std::string section;
+    ebpf_id_t id = 0;
     for (int i = 0; (status == NO_ERROR) && ((i + current_index) < argc); i++) {
         switch (tag_type[i]) {
         case 0: // TYPE
@@ -456,26 +437,47 @@ handle_ebpf_show_programs(
             }
             break;
         }
-        case 1: // PINNED
-            status = MatchEnumTag(NULL, argv[current_index + i], _countof(_pinned_enum), _pinned_enum, (PULONG)&pinned);
+        case 1: // ATTACHED
+            status = MatchEnumTag(
+                NULL,
+                argv[current_index + i],
+                _countof(_boolean_constraint_enum),
+                _boolean_constraint_enum,
+                (PULONG)&attached);
             if (status != NO_ERROR) {
                 status = ERROR_INVALID_PARAMETER;
             }
             break;
-        case 2: // LEVEL
+        case 2: // PINNED
+            status = MatchEnumTag(
+                NULL,
+                argv[current_index + i],
+                _countof(_boolean_constraint_enum),
+                _boolean_constraint_enum,
+                (PULONG)&pinned);
+            if (status != NO_ERROR) {
+                status = ERROR_INVALID_PARAMETER;
+            }
+            break;
+        case 3: // LEVEL
             status = MatchEnumTag(NULL, argv[current_index + i], _countof(g_LevelEnum), g_LevelEnum, (PULONG)&level);
             if (status != NO_ERROR) {
                 status = ERROR_INVALID_PARAMETER;
             }
             break;
-        case 3: // FILENAME
+        case 4: // FILENAME
         {
             filename = down_cast_from_wstring(std::wstring(argv[current_index + i]));
             break;
         }
-        case 4: // SECTION
+        case 5: // SECTION
         {
             section = down_cast_from_wstring(std::wstring(argv[current_index + i]));
+            break;
+        }
+        case 6: // ID
+        {
+            id = (uint32_t)_wtoi(argv[current_index + i]);
             break;
         }
         default:
@@ -492,11 +494,11 @@ handle_ebpf_show_programs(
         level = VL_VERBOSE;
     }
 
-    // TODO(issue #83): We need to implement level, other columns, and implement filtering by pinned.
+    // TODO: We need to implement level, other columns, and implement filtering by attached and pinned.
 
     std::cout << "\n";
-    std::cout << "           File Name          Section  Requested Execution Type\n";
-    std::cout << "====================  ===============  ========================\n";
+    std::cout << "    ID            File Name         Section             Name      Mode\n";
+    std::cout << "====== ==================== =============== ================ =========\n";
 
     fd_t program_fd = ebpf_fd_invalid;
     for (;;) {
@@ -519,10 +521,20 @@ handle_ebpf_show_programs(
             break;
         }
 
-        // TODO(issue #83): we also need the program type so we can filter on it.
+        // TODO: we also need the program type so we can filter on it.
+        struct bpf_prog_info info;
+        uint32_t info_size = (uint32_t)sizeof(info);
+        int error = bpf_obj_get_info_by_fd(program_fd, &info, &info_size);
+        if (error < 0) {
+            break;
+        }
+
+        if ((id != 0) && (info.id != id)) {
+            continue;
+        }
+
         status =
             ebpf_program_query_info(program_fd, &program_execution_type, &program_file_name, &program_section_name);
-
         if (status != ERROR_SUCCESS) {
             break;
         }
@@ -530,8 +542,13 @@ handle_ebpf_show_programs(
         if (filename.empty() || strcmp(program_file_name, filename.c_str()) == 0) {
             if (section.empty() || strcmp(program_section_name, section.c_str()) == 0) {
                 program_type_name = program_execution_type == EBPF_EXECUTION_JIT ? "JIT" : "INTERPRET";
-                std::cout << std::setw(20) << std::right << program_file_name << "  " << std::setw(15) << std::right
-                          << program_section_name << "  " << std::setw(24) << std::right << program_type_name << "\n";
+                printf(
+                    "%6u %20s %15s %16s %9s\n",
+                    info.id,
+                    program_file_name,
+                    program_section_name,
+                    info.name,
+                    program_type_name);
             }
         }
 

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -494,7 +494,7 @@ handle_ebpf_show_programs(
         level = VL_VERBOSE;
     }
 
-    // TODO: We need to implement level, other columns, and implement filtering by attached and pinned.
+    // TODO(#190): We need to implement level, other columns, and implement filtering by attached and pinned.
 
     std::cout << "\n";
     std::cout << "    ID            File Name         Section             Name      Mode\n";
@@ -521,7 +521,7 @@ handle_ebpf_show_programs(
             break;
         }
 
-        // TODO: we also need the program type so we can filter on it.
+        // TODO(#190): we also need the program type so we can filter on it.
         struct bpf_prog_info info;
         uint32_t info_size = (uint32_t)sizeof(info);
         int error = bpf_obj_get_info_by_fd(program_fd, &info, &info_size);

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -262,7 +262,7 @@ ebpf_program_attach_by_id(ebpf_id_t program_id, ebpf_attach_type_t attach_type)
     struct bpf_link* link;
     ebpf_result_t result = ebpf_program_attach_by_fd(program_fd, &attach_type, nullptr, 0, &link);
 
-    ebpf_close_fd(program_fd); // TODO(issue #287): _close
+    Platform::_close(program_fd);
     ebpf_link_close(link);
     return result;
 }
@@ -285,11 +285,11 @@ ebpf_program_detach_by_id(ebpf_id_t program_id)
                 if (bpf_link_detach(link_fd) < 0) {
                     return errno;
                 }
-                ebpf_close_fd(link_fd); // TODO(#287): _close
+                Platform::_close(link_fd);
                 return NO_ERROR;
             }
         }
-        ebpf_close_fd(link_fd); // TODO(#287): _close
+        Platform::_close(link_fd);
     }
     return ERROR_NOT_FOUND;
 }

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -147,6 +147,7 @@ handle_ebpf_add_program(
     if (result != EBPF_SUCCESS) {
         std::cerr << "error " << result << ": could not load program" << std::endl;
         std::cerr << error_message << std::endl;
+        ebpf_free_string(error_message);
         return ERROR_SUPPRESS_OUTPUT;
     }
 
@@ -243,6 +244,9 @@ handle_ebpf_delete_program(
         }
     }
 
+    // TODO: see if the program is still loaded, in which case some other process holds
+    // a reference. Get the PID of that process and display it.
+
     std::cout << "Program not found\n";
     return ERROR_SUPPRESS_OUTPUT;
 }
@@ -259,6 +263,7 @@ ebpf_program_attach_by_id(ebpf_id_t program_id, ebpf_attach_type_t attach_type)
     ebpf_result_t result = ebpf_program_attach_by_fd(program_fd, &attach_type, nullptr, 0, &link);
 
     ebpf_close_fd(program_fd); // TODO(issue #287): _close
+    ebpf_link_close(link);
     return result;
 }
 

--- a/libs/ebpfnetsh/tokens.h
+++ b/libs/ebpfnetsh/tokens.h
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
-#define TOKEN_FILENAME L"filename"
-#define TOKEN_LEVEL L"level"
-#define TOKEN_SECTION L"section"
-#define TOKEN_PINNED L"pinned"
-#define TOKEN_TYPE L"type"
+#define TOKEN_ATTACHED L"attached"
 #define TOKEN_EXECUTION L"execution"
+#define TOKEN_FILENAME L"filename"
+#define TOKEN_ID L"id"
+#define TOKEN_LEVEL L"level"
+#define TOKEN_PINNED L"pinned"
+#define TOKEN_SECTION L"section"
+#define TOKEN_TYPE L"type"
 
 typedef enum
 {

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -186,7 +186,7 @@ ebpf_link_get_info(
     }
 
     info->id = link->object.id;
-    info->prog_id = ((ebpf_object_t*)link->program)->id;
+    info->prog_id = (link->program) ? ((ebpf_object_t*)link->program)->id : EBPF_ID_NONE;
 
     *info_size = sizeof(*info);
     return EBPF_SUCCESS;

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -292,7 +292,7 @@ TEST_CASE("set program", "[netsh][programs]")
     RPC_WSTR attach_type_string;
     REQUIRE(UuidToStringW(&EBPF_ATTACH_TYPE_XDP, &attach_type_string) == 0);
 
-    // Attach the program to its default attach type.
+    // Attach the program.
     output = _run_netsh_command(handle_ebpf_set_program, L"196609", (PCWSTR)attach_type_string, nullptr, &result);
     REQUIRE(output == "");
     REQUIRE(result == ERROR_OKAY);

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -263,7 +263,7 @@ TEST_CASE("show programs", "[netsh][programs]")
                   "    ID            File Name         Section             Name      Mode\n"
                   "====== ==================== =============== ================ =========\n"
                   "196609          tail_call.o        xdp_prog           caller       JIT\n"
-                  "262146          tail_call.o      xdp_prog/0           callee       JIT\n");
+                  "262145          tail_call.o      xdp_prog/0           callee       JIT\n");
 
     bpf_object__close(object);
 }

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -28,7 +28,8 @@ ebpf_test_pinned_map_enum()
 
     for (int i = 0; i < pinned_map_count; i++) {
         std::string pin_path = pin_path_prefix + std::to_string(i);
-        REQUIRE((error = bpf_obj_pin(map_fd, pin_path.c_str())) == 0);
+        error = bpf_obj_pin(map_fd, pin_path.c_str());
+        REQUIRE(error == 0);
         if (error != 0)
             goto Exit;
     }

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -6,6 +6,7 @@
 #include <map>
 #include "catch_wrapper.hpp"
 #include "common_tests.h"
+#include "platform.h"
 #include "sample_test_common.h"
 
 void
@@ -64,7 +65,7 @@ ebpf_test_pinned_map_enum()
     }
 
 Exit:
-    ebpf_close_fd(map_fd); // TODO(issue #287): change to _close(map_fd);
+    Platform::_close(map_fd);
     ebpf_api_map_info_free(map_count, map_info);
     map_count = 0;
     map_info = nullptr;

--- a/tests/libs/common/common_tests.vcxproj
+++ b/tests/libs/common/common_tests.vcxproj
@@ -123,7 +123,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(SolutionDir)tests\sample;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\thunk;$(SolutionDir)tests\util;$(SolutionDir)tests\sample;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>
@@ -142,7 +142,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\util;$(SolutionDir)tests\sample;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libs\util;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\thunk;$(SolutionDir)tests\util;$(SolutionDir)tests\sample;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
@@ -156,6 +156,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\..\libs\thunk\windows\platform.cpp" />
     <ClCompile Include="common_tests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -136,7 +136,7 @@ TEST_CASE("libbpf program attach", "[libbpf]")
     // TODO: it is not currently set.  Update this
     // test once it is set correctly.
     enum bpf_attach_type type = bpf_program__get_expected_attach_type(program);
-    REQUIRE(type == BPF_ATTACH_TYPE_UNKNOWN);
+    REQUIRE(type == BPF_ATTACH_TYPE_UNSPEC);
 
     bpf_program__set_expected_attach_type(program, BPF_ATTACH_TYPE_XDP);
 

--- a/tools/netsh/ebpfnetsh.rc
+++ b/tools/netsh/ebpfnetsh.rc
@@ -55,7 +55,6 @@ BEGIN
     HLP_EBPF_ADD_PROGRAM    "Loads an eBPF program.\n"
     HLP_EBPF_ADD_PROGRAM_EX "\
 \nUsage: %1!s! [filename=]<string>\
-\n                   [section=]<string>\
 \n                   [[type=]xdp]\
 \n                   [[pinned=]<string>]\
 \n                   [[execution=]jit|interpret]\
@@ -65,7 +64,6 @@ BEGIN
 \n      Tag         Value\
 \n      filename  - Filename or path to ELF file containing the\
 \n                  program.\
-\n      section   - The name of the section containing the program.\
 \n      type      - One of the following values:\
 \n                   xdp: The program is meant to hook into XDP.\
 \n                        This is the default value.\
@@ -80,18 +78,12 @@ BEGIN
 \n"
     HLP_EBPF_DELETE_PROGRAM "Deletes an eBPF program.\n"
     HLP_EBPF_DELETE_PROGRAM_EX "\
-\nUsage: %1!s! [filename=]<string> [[section=]<string>]\
+\nUsage: %1!s! [id=]<integer>\
 \n\
 \nParameters:\
 \n\
 \n      Tag         Value\
-\n      filename  - Filename or path to ELF file containing the\
-\n                  program.  The ELF file itself is not used, but\
-\n                  the filename is used as an identifier to match\
-\n                  a pinned program.\
-\n      section   - Optionally the name of the section containing the\
-\n                  program.  If not specified, the default is to use the\
-\n                  first code section.\
+\n      id        - ID of the program to delete.\
 \n\
 \nRemarks: If the program is pinned, this unpins the specified\
 \n         program.  If an unpinned process was loaded by the same\
@@ -103,23 +95,21 @@ BEGIN
 \n"
     HLP_EBPF_SET_PROGRAM    "Updates an eBPF program.\n"
     HLP_EBPF_SET_PROGRAM_EX "\
-\nUsage: %1!s! [filename=]<string>\
-\n                   [section=]<string>\
+\nUsage: %1!s! [id=]<integer>\
+\n                   [[attached=]yes|no]\
 \n                   [[pinned=]<string>]\
 \n\
 \nParameters:\
 \n\
 \n      Tag         Value\
-\n      filename  - Filename or path to ELF file containing the\
-\n                  program.  The ELF file itself is not used, but\
-\n                  the filename is used as an identifier to match\
-\n                  a pinned program.\
-\n      section   - The name of the section containing the program.\
+\n      id        - Program ID as shown via ""show programs"".\
+\n      attached  - Yes to attach a detached program using its\
+\n                  default attach type, or no to detach it.\
 \n      pinned    - The name to pin the program to, or if not\
-\n                  specified or empty, unpin the program.\
+\n                  empty, unpin the program.\
 \n\
-\nRemarks: Pins or unpins the specified program which must already\
-\n         be loaded.\
+\nRemarks: Pins, unpins, attaches, or detaches the specified\
+\n         program which must already be loaded.\
 \n"
     HLP_EBPF_SHOW_PROGRAMS  "Shows eBPF programs.\n"
     HLP_EBPF_SHOW_PROGRAMS_EX "\
@@ -128,6 +118,7 @@ BEGIN
 \n                     [[level=]normal|verbose]\
 \n                     [[filename=]<string>\
 \n                     [[section=]<string>]]\
+\n                     [[id=]<integer>]]\
 \n\
 \nParameters:\
 \n\
@@ -152,8 +143,10 @@ BEGIN
 \n      section   - Optionally the name of the section containing the\
 \n                  program.  If not specified, the default is to use the\
 \n                  first code section.\
+\n      id        - ID of a program to show.\
 \n\
-\nRemarks: Shows all loaded programs.\
+\nRemarks: Shows all loaded programs, or those matching specified\
+\n         criteria.\
 \n"
 
     HLP_EBPF_SHOW_DISASSEMBLY "Shows disassembly of an eBPF program.\n"

--- a/tools/netsh/ebpfnetsh.vcxproj
+++ b/tools/netsh/ebpfnetsh.vcxproj
@@ -69,7 +69,7 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>netsh.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>netsh.lib;rpcrt4.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>
@@ -96,7 +96,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <AdditionalDependencies>netsh.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>netsh.lib;rpcrt4.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <ModuleDefinitionFile>
       </ModuleDefinitionFile>
       <AdditionalLibraryDirectories>$(OutDir)</AdditionalLibraryDirectories>

--- a/tools/port_quota/port_quota.cpp
+++ b/tools/port_quota/port_quota.cpp
@@ -24,7 +24,6 @@ load(int argc, char** argv)
 {
     const char* error_message = NULL;
     ebpf_result_t result;
-    int error;
     bpf_object* object = nullptr;
     bpf_program* program = nullptr;
     bpf_link* link = nullptr;
@@ -51,14 +50,12 @@ load(int argc, char** argv)
         fprintf(stderr, "Failed to find eBPF map : %s\n", limits_map);
         return 1;
     }
-    result = ebpf_object_pin(process_map_fd, process_map);
-    if (result != EBPF_SUCCESS) {
-        fprintf(stderr, "Failed to pin eBPF program: %d\n", result);
+    if (bpf_obj_pin(process_map_fd, process_map) < 0) {
+        fprintf(stderr, "Failed to pin eBPF program: %d\n", errno);
         return 1;
     }
-    result = ebpf_object_pin(limits_map_fd, limits_map);
-    if (result != EBPF_SUCCESS) {
-        fprintf(stderr, "Failed to pin eBPF program: %d\n", result);
+    if (bpf_obj_pin(limits_map_fd, limits_map) < 0) {
+        fprintf(stderr, "Failed to pin eBPF program: %d\n", errno);
         return 1;
     }
 
@@ -73,15 +70,13 @@ load(int argc, char** argv)
         return 1;
     }
 
-    error = bpf_link__pin(link, program_link);
-    if (error != ERROR_SUCCESS) {
-        fprintf(stderr, "Failed to pin eBPF link: %d\n", error);
+    if (bpf_link__pin(link, program_link) < 0) {
+        fprintf(stderr, "Failed to pin eBPF link: %d\n", errno);
         return 1;
     }
 
-    error = bpf_program__pin(program, program_path);
-    if (error != ERROR_SUCCESS) {
-        fprintf(stderr, "Failed to pin eBPF program: %d\n", error);
+    if (bpf_program__pin(program, program_path) < 0) {
+        fprintf(stderr, "Failed to pin eBPF program: %d\n", errno);
         return 1;
     }
 


### PR DESCRIPTION
* Add support for libbpf bpf_obj_pin() API
* Add support for libbpf bpf_object__next() API
* Rename BPF_{PROG,ATTACH}_TYPE_UNKNOWN to ...UNSPEC for libbpf compat
* Remove now-unused handle APIs ebpf_api_load_program and ebpf_api_pin_object, which addresses part of issue #383 
* netsh set/delete program now uses the ID to identify the program, like bpftool does, so that it can work even if the program wasn't loaded from an ELF file

Fixes #191 

Signed-off-by: Dave Thaler <dthaler@microsoft.com>