### PR TITLE
Remove reference to MSVC Runtime from docs as it is no longer needed

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -64,12 +64,6 @@ a kernel debugger (KD) attached and running, or test signing is enabled. (It is 
 releases of eBPF for Windows will eventually be production signed at some point in the future after
 security hardening is completed.)
 
-Ensure that the matching versions of the Microsoft C Runtime are installed on the machine. Versions of the Microsoft C Runtime are available on the developer machine, located in %ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\version, where version is updated with each patch of Visual Studio.
-
-With version 14.29.30133, the full path is:
-1) Release - ```%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\14.29.30133\vc_redist.x64.exe```
-2) Debug - ```%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\14.29.30133\debug_nonredist\x64\Microsoft.VC142.DebugCRT```
-
 For basic testing, the simplest way to install eBPF for Windows is into a Windows VM with test signing enabled.
 Follow the [VM Installation Instructions](vm-setup.md) to do so.
 

--- a/docs/SelfHostedRunnerSetup.md
+++ b/docs/SelfHostedRunnerSetup.md
@@ -14,14 +14,12 @@ Self-hosted runners are necessary as GitHub-hosted runners don't have the requis
    3) ```Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v2.281.1/actions-runner-win-x64-2.281.1.zip -OutFile actions-runner-win-x64-2.281.1.zip```
    4) ```if((Get-FileHash -Path actions-runner-win-x64-2.281.1.zip -Algorithm SHA256).Hash.ToUpper() -ne 'b8dccfef39c5d696443d98edd1ee57881075066bb62adef0a344fcb11bd19f1b'.ToUpper()){ throw 'Computed checksum did not match' }```
    5) ```Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/actions-runner-win-x64-2.281.1.zip", "$PWD")```
-6) Obtain an [authentication token](https://github.com/microsoft/ebpf-for-windows/settings/actions/runners/new). This requires administrator permissions in the project.
-7) Configure action runner.
+5) Obtain an [authentication token](https://github.com/microsoft/ebpf-for-windows/settings/actions/runners/new). This requires administrator permissions in the project.
+6) Configure action runner.
    1) ```./config.cmd --url https://github.com/microsoft/ebpf-for-windows --token <action runner token>```
 8) Change action runner service to run as "LocalSystem".
    1) Open services.msc.
    2) Locate "GitHub Action Runner ...".
    3) Right Click -> Properties -> Log On.
    4) Change "Log on as:" to "Local System Account".
-9)  Install the [Visual C++ Runtime Files](https://docs.microsoft.com/en-us/visualstudio/releases/2019/redistribution#visual-c-runtime-files)
-10)  Install the debug version of the Visual C++ Runtime files from ```"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\14.29.30133\debug_nonredist\x64\Microsoft.VC142.DebugCRT"``` on a machine with Visual Studio installed.
-11) Reboot the runner.
+8) Reboot the runner.

--- a/docs/SelfHostedRunnerSetup.md
+++ b/docs/SelfHostedRunnerSetup.md
@@ -14,12 +14,12 @@ Self-hosted runners are necessary as GitHub-hosted runners don't have the requis
    3) ```Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v2.281.1/actions-runner-win-x64-2.281.1.zip -OutFile actions-runner-win-x64-2.281.1.zip```
    4) ```if((Get-FileHash -Path actions-runner-win-x64-2.281.1.zip -Algorithm SHA256).Hash.ToUpper() -ne 'b8dccfef39c5d696443d98edd1ee57881075066bb62adef0a344fcb11bd19f1b'.ToUpper()){ throw 'Computed checksum did not match' }```
    5) ```Add-Type -AssemblyName System.IO.Compression.FileSystem ; [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/actions-runner-win-x64-2.281.1.zip", "$PWD")```
-5) Obtain an [authentication token](https://github.com/microsoft/ebpf-for-windows/settings/actions/runners/new). This requires administrator permissions in the project.
-6) Configure action runner.
+6) Obtain an [authentication token](https://github.com/microsoft/ebpf-for-windows/settings/actions/runners/new). This requires administrator permissions in the project.
+7) Configure action runner.
    1) ```./config.cmd --url https://github.com/microsoft/ebpf-for-windows --token <action runner token>```
 8) Change action runner service to run as "LocalSystem".
    1) Open services.msc.
    2) Locate "GitHub Action Runner ...".
    3) Right Click -> Properties -> Log On.
    4) Change "Log on as:" to "Local System Account".
-8) Reboot the runner.
+9) Reboot the runner.

--- a/docs/vm-setup.md
+++ b/docs/vm-setup.md
@@ -16,7 +16,7 @@
     4. When the Create Virtual Machine dialog appears, select "Windows 10 dev environment".
     5. Click the "Create Virtual Machine" button.
     6. Once that is complete click the "Edit Settings" button.
-    7. Select security, clear the "Enable Scure Boot" checkbox, and click OK. (This is a prerequisite for
+    7. Select security, clear the "Enable Secure Boot" checkbox, and click OK. (This is a prerequisite for
        enabling test signed binaries.)
     8. Click "Connect" and start the VM.
 

--- a/docs/vm-setup.md
+++ b/docs/vm-setup.md
@@ -16,7 +16,7 @@
     4. When the Create Virtual Machine dialog appears, select "Windows 10 dev environment".
     5. Click the "Create Virtual Machine" button.
     6. Once that is complete click the "Edit Settings" button.
-    7. Select security, clear the "Enable Secure Boot" checkbox, and click OK. (This is a prerequisite for
+    7. Select security, clear the "Enable Scure Boot" checkbox, and click OK. (This is a prerequisite for
        enabling test signed binaries.)
     8. Click "Connect" and start the VM.
 
@@ -25,13 +25,6 @@
     1. Start an admin command shell (cmd.exe).
     2. Do `bcdedit.exe -set TESTSIGNING ON`.
     3. Restart the VM so that the change will be applied.
-
-4. Install the matching version of the Microsoft Visual C++ Runtime:
-Versions of the Microsoft C Runtime are available on the developer machine, located in %ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\version, where version is updated with each patch of Visual Studio.
-
-With version 14.29.30133, the full path is:
-1) Release - ```%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\14.29.30133\vc_redist.x64.exe```
-2) Debug - ```%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\VC\Redist\MSVC\14.29.30133\debug_nonredist\x64\Microsoft.VC142.DebugCRT```
 
 ## Installing eBPF into a VM
 


### PR DESCRIPTION
Docs refer to installing the Visual Studio C++ Runtime, which is no longer required as we now include the runtime in the output folder.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>