### PR TITLE
Add libpf's libbpf_prog_type_by_name() API

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -73,6 +73,7 @@ EXPORTS
     ebpf_free_string
     ebpf_get_next_map
     ebpf_get_next_program
+    ebpf_get_program_type_by_name
     ebpf_link_close
     ebpf_map_pin
     ebpf_object_get
@@ -81,3 +82,4 @@ EXPORTS
     ebpf_program_attach_by_fd
     ebpf_program_load
     ebpf_program_query_info
+    libbpf_prog_type_by_name

--- a/ebpfapi/rpc_client.cpp
+++ b/ebpfapi/rpc_client.cpp
@@ -7,7 +7,6 @@
 #include <stdlib.h>
 #include <windows.h>
 #include "ebpf_api.h"
-#include "ebpf_windows.h"
 #include "rpc_interface_c.c"
 
 #pragma comment(lib, "Rpcrt4.lib")

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -5,11 +5,9 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include "ebpf_core_structs.h"
 #include "ebpf_execution_type.h"
 #include "ebpf_result.h"
-#include "ebpf_core_structs.h"
-#include "ebpf_result.h"
-#include "ebpf_windows.h"
 
 #ifdef __cplusplus
 extern "C"
@@ -528,6 +526,22 @@ extern "C"
      */
     ebpf_result_t
     ebpf_close_fd(fd_t fd);
+
+    /**
+     * @brief Get a program type and expected attach type by name.
+     *
+     * @param[in] name Name, as if it were a section name in an ELF file.
+     * @param[out] prog_type Program type.
+     * @param[out] expected_attach_type Expected attach type.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_KEY_NOT_FOUND No program type was found.
+     */
+    ebpf_result_t
+    ebpf_get_program_type_by_name(
+        _In_z_ const char* name,
+        _Out_ ebpf_program_type_t* program_type,
+        _Out_ ebpf_attach_type_t* expected_attach_type);
 
 #ifdef __cplusplus
 }

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -8,6 +8,7 @@
 
 #include <stdint.h>
 #include "../external/ebpf-verifier/src/ebpf_base.h"
+#include "ebpf_windows.h"
 
 typedef enum bpf_map_type
 {
@@ -78,6 +79,14 @@ typedef enum
     BPF_FUNC_ktime_get_ns = 8,
 } ebpf_helper_id_t;
 
+// Cross-platform BPF program types.
+enum bpf_prog_type
+{
+    BPF_PROG_TYPE_UNKNOWN,
+    BPF_PROG_TYPE_XDP,
+    BPF_PROG_TYPE_BIND, // TODO(#333): replace with cross-platform program type
+};
+
 // Libbpf itself requires the following structs to be defined, but doesn't
 // care what fields they have.  Applications such as bpftool on the other
 // hand depend on fields of specific names and types.
@@ -102,7 +111,12 @@ struct bpf_map_info
 
 struct bpf_prog_info
 {
+    // Cross-platform fields.
     ebpf_id_t id;                ///< Program ID.
+    enum bpf_prog_type type;     ///< Program type, if a cross-platform type..
     uint32_t nr_map_ids;         ///< Number of maps associated with this program.
     char name[BPF_OBJ_NAME_LEN]; ///< Null-terminated program name.
+
+    // Windows-specific fields.
+    ebpf_program_type_t type_uuid; ///< Program type UUID.
 };

--- a/include/ebpf_windows.h
+++ b/include/ebpf_windows.h
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#ifdef _MSC_VER
 #include <guiddef.h>
+#else
+typedef uint8_t GUID[16];
+#endif
 
 // This file contains eBPF definitions needed by eBPF programs as well as
 // the verifier and execution context.

--- a/include/libbpf.h
+++ b/include/libbpf.h
@@ -568,6 +568,19 @@ bpf_program__set_expected_attach_type(struct bpf_program* prog, enum bpf_attach_
 int
 bpf_program__unpin(struct bpf_program* prog, const char* path);
 
+/**
+ * @brief Get a program type and expected attach type by name.
+ *
+ * @param[in] name Name, as if it were a section name in an ELF file.
+ * @param[out] prog_type Program type.
+ * @param[out] expected_attach_type Expected attach type.
+ *
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
+ */
+int
+libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum bpf_attach_type* expected_attach_type);
+
 /** @} */
 
 #else

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -18,13 +18,6 @@ typedef uint32_t __u32;
 typedef uint64_t __u64;
 typedef uint32_t pid_t;
 
-enum bpf_prog_type
-{
-    BPF_PROG_TYPE_UNSPEC,
-    BPF_PROG_TYPE_XDP,
-    BPF_PROG_TYPE_BIND, // TODO(#333): replace with cross-platform program type
-};
-
 enum bpf_attach_type
 {
     BPF_ATTACH_TYPE_UNSPEC,

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -6,7 +6,6 @@
 #include "api_common.hpp"
 #include "ebpf_api.h"
 #include "ebpf_platform.h"
-#include "ebpf_windows.h"
 #include "spec_type_descriptors.hpp"
 
 struct bpf_object;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -18,6 +18,7 @@ extern "C"
 #include "ubpf.h"
 }
 #include "Verifier.h"
+#include "windows_platform_common.hpp"
 
 using namespace Platform;
 
@@ -1884,4 +1885,17 @@ ebpf_object_get_info_by_fd(
     }
 
     return result;
+}
+
+ebpf_result_t
+ebpf_get_program_type_by_name(
+    _In_ PCSTR name, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* expected_attach_type)
+{
+    EbpfProgramType type = get_program_type_windows(name, name);
+    *program_type = *(GUID*)type.platform_specific_data;
+
+    // TODO(issue #223): get expected attach type.
+    *expected_attach_type = EBPF_ATTACH_TYPE_UNSPECIFIED;
+
+    return EBPF_SUCCESS;
 }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1889,7 +1889,7 @@ ebpf_object_get_info_by_fd(
 
 ebpf_result_t
 ebpf_get_program_type_by_name(
-    _In_ PCSTR name, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* expected_attach_type)
+    _In_z_ const char* name, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* expected_attach_type)
 {
     EbpfProgramType type = get_program_type_windows(name, name);
     *program_type = *(GUID*)type.platform_specific_data;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1891,6 +1891,10 @@ ebpf_result_t
 ebpf_get_program_type_by_name(
     _In_z_ const char* name, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* expected_attach_type)
 {
+    if (name == nullptr || program_type == nullptr || expected_attach_type == nullptr) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
     EbpfProgramType type = get_program_type_windows(name, name);
     *program_type = *(GUID*)type.platform_specific_data;
 

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -63,7 +63,7 @@ bpf_prog_load(const char* file_name, enum bpf_prog_type type, struct bpf_object*
     if (result != EBPF_SUCCESS) {
         return libbpf_result_err(result);
     }
-    return EBPF_SUCCESS;
+    return 0;
 }
 
 int
@@ -291,6 +291,10 @@ bpf_prog_get_next_id(uint32_t start_id, uint32_t* next_id)
 int
 libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum bpf_attach_type* expected_attach_type)
 {
+    if (prog_type == nullptr || expected_attach_type == nullptr) {
+        return libbpf_err(-EINVAL);
+    }
+
     ebpf_program_type_t program_type_uuid;
     ebpf_attach_type_t expected_attach_type_uuid;
     ebpf_result_t result = ebpf_get_program_type_by_name(name, &program_type_uuid, &expected_attach_type_uuid);

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -869,6 +869,8 @@ ebpf_program_get_info(
         (char*)program->parameters.program_name.value,
         program->parameters.program_name.length);
     info->nr_map_ids = program->count_of_maps;
+    info->type = BPF_PROG_TYPE_UNKNOWN; // TODO(issue #223): get integer if any.
+    info->type_uuid = *ebpf_program_type(program);
 
     *info_size = sizeof(*info);
     return EBPF_SUCCESS;

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -6,7 +6,6 @@
 // This file must only include headers that are safe
 // to include in both user mode and kernel mode.
 #include "ebpf_core_structs.h"
-#include "ebpf_windows.h"
 
 typedef enum _ebpf_operation_id
 {

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -255,7 +255,7 @@ TEST_CASE("show programs", "[netsh][programs]")
     REQUIRE(object != nullptr);
     REQUIRE(program_fd != -1);
 
-    std::string output = _run_netsh_command(handle_ebpf_show_programs, nullptr, nullptr, nullptr, &result);
+    std::string output = _run_netsh_command(handle_ebpf_show_programs, L"xdp", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
 
     REQUIRE(

--- a/tests/sample/ext/app/sample_ext_app.h
+++ b/tests/sample/ext/app/sample_ext_app.h
@@ -3,7 +3,6 @@
 
 #pragma once
 #include "ebpf_result.h"
-#include "ebpf_windows.h"
 #include "framework.h"
 #include "sample_ext_ioctls.h"
 #include "sample_test_common.h"

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -13,7 +13,6 @@
 
 #include "ebpf_platform.h"
 #include "ebpf_program_types.h"
-#include "ebpf_windows.h"
 
 #include "sample_ext_program_info.h"
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -821,3 +821,24 @@ TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
 
     Platform::_close(link_fd);
 }
+
+TEST_CASE("libbpf_prog_type_by_name", "[libbpf]")
+{
+    bpf_prog_type prog_type;
+    bpf_attach_type expected_attach_type;
+
+    // Try a cross-platform type.
+    REQUIRE(libbpf_prog_type_by_name("xdp", &prog_type, &expected_attach_type) == 0);
+    REQUIRE(prog_type == BPF_PROG_TYPE_XDP);
+    REQUIRE(expected_attach_type == BPF_ATTACH_TYPE_XDP);
+
+    // Try a Windows-specific type.
+    REQUIRE(libbpf_prog_type_by_name("bind", &prog_type, &expected_attach_type) == 0);
+    REQUIRE(prog_type == BPF_PROG_TYPE_BIND);
+    REQUIRE(expected_attach_type == BPF_ATTACH_TYPE_UNSPEC);
+
+    // Try something that will fall back to the default.
+    REQUIRE(libbpf_prog_type_by_name("default", &prog_type, &expected_attach_type) == 0);
+    REQUIRE(prog_type == BPF_PROG_TYPE_XDP);
+    REQUIRE(expected_attach_type == BPF_ATTACH_TYPE_XDP);
+}

--- a/tools/encode_program_info/encode_program_info.h
+++ b/tools/encode_program_info/encode_program_info.h
@@ -5,7 +5,6 @@
 
 #include "ebpf_platform.h"
 #include "ebpf_program_types.h"
-#include "ebpf_windows.h"
 
 extern "C"
 {

--- a/tools/netsh/ebpfnetsh.rc
+++ b/tools/netsh/ebpfnetsh.rc
@@ -55,7 +55,7 @@ BEGIN
     HLP_EBPF_ADD_PROGRAM    "Loads an eBPF program.\n"
     HLP_EBPF_ADD_PROGRAM_EX "\
 \nUsage: %1!s! [filename=]<string>\
-\n                   [[type=]xdp]\
+\n                   [[type=]<string>]\
 \n                   [[pinned=]<string>]\
 \n                   [[execution=]jit|interpret]\
 \n\
@@ -64,9 +64,9 @@ BEGIN
 \n      Tag         Value\
 \n      filename  - Filename or path to ELF file containing the\
 \n                  program.\
-\n      type      - One of the following values:\
-\n                   xdp: The program is meant to hook into XDP.\
-\n                        This is the default value.\
+\n      type      - A string used as if it were a section name, to\
+\n                  determine the program type and expected attach\
+\n                  type.  If not specified, the default is xdp.\
 \n      pinned    - Optionally the name to pin the program to.  If not\
 \n                  specified, the default is to not pin the program.\
 \n      execution - One of the following values:\
@@ -113,7 +113,8 @@ BEGIN
 \n"
     HLP_EBPF_SHOW_PROGRAMS  "Shows eBPF programs.\n"
     HLP_EBPF_SHOW_PROGRAMS_EX "\
-\nUsage: %1!s! [[type=]xdp]\
+\nUsage: %1!s! [[type=]<string>]\
+\n                     [[attached=]any|yes|no]\
 \n                     [[pinned=]any|yes|no]\
 \n                     [[level=]normal|verbose]\
 \n                     [[filename=]<string>\
@@ -123,9 +124,9 @@ BEGIN
 \nParameters:\
 \n\
 \n      Tag         Value\
-\n      type      - One of the following values:\
-\n                   xdp: The program is meant to hook into XDP.\
-\n                        This is the default value.\
+\n      type      - A string used as if it were a section name, to\
+\n                  determine the program type and expected attach\
+\n                  type.  If not specified, the default is xdp.\
 \n      pinned    - One of the following values:\
 \n                   any: Show all programs, pinned or not.\
 \n                        This is the default value.\


### PR DESCRIPTION
* Add the standard libbpf_prog_type_by_name() that accepts the equivalent of an ELF section name and returns the associated program type and expected attach type as ints.
* Add ebpf_get_program_type_by_name() that returns the GUIDs instead of ints.

This also removes the hard-coding of GUIDs or ints from the netsh helper.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>