### PR TITLE
Add netsh capability to unpin programs

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -30,6 +30,7 @@ EXPORTS
     bpf_map_get_next_key
     bpf_map_lookup_elem
     bpf_map_update_elem
+    bpf_obj_get
     bpf_obj_get_info_by_fd
     bpf_obj_pin
     bpf_object__close
@@ -72,6 +73,7 @@ EXPORTS
     ebpf_create_map_name
     ebpf_free_string
     ebpf_get_next_map
+    ebpf_get_next_pinned_program_name
     ebpf_get_next_program
     ebpf_get_program_type_by_name
     ebpf_link_close

--- a/include/bpf.h
+++ b/include/bpf.h
@@ -184,6 +184,15 @@ bpf_map_update_elem(int fd, const void* key, const void* value, __u64 flags);
  */
 
 /**
+ * @brief Get a file descriptor for a pinned object by pin path.
+ * @param[in] path Pin path for the object.
+ *
+ * @return file descriptor for the pinned object, or -1 if not found.
+ */
+int
+bpf_obj_get(const char* pathname);
+
+/**
  * @brief Obtain information about the eBPF object referred to by bpf_fd.
  * This function populates up to info_len bytes of info, which will
  * be in one of the following formats depending on the eBPF object type of

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -509,15 +509,6 @@ extern "C"
     ebpf_link_close(_In_ struct bpf_link* link);
 
     /**
-     * @brief Get fd for a pinned object by pin path.
-     * @param[in] path Pin path for the object.
-     *
-     * @return file descriptor for the pinned object, -1 if not found.
-     */
-    fd_t
-    ebpf_object_get(_In_z_ const char* path);
-
-    /**
      * @brief Close a file descriptor. Also close the underlying handle.
      * @param [in] fd File descriptor to be closed.
      *
@@ -542,6 +533,19 @@ extern "C"
         _In_z_ const char* name,
         _Out_ ebpf_program_type_t* program_type,
         _Out_ ebpf_attach_type_t* expected_attach_type);
+
+    /**
+     * @brief Gets the next pinned program after a given name.
+     *
+     * @param[in] start_name Name to look for an entry greater than.
+     * @param[out] next_name Returns the next name, if one exists.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MORE_KEYS No more entries found.
+     */
+    ebpf_result_t
+    ebpf_get_next_pinned_program_name(
+        _In_z_ const char* start_name, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_name);
 
 #ifdef __cplusplus
 }

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -120,3 +120,9 @@ struct bpf_prog_info
     // Windows-specific fields.
     ebpf_program_type_t type_uuid; ///< Program type UUID.
 };
+
+typedef struct _ebpf_windows_program_type_data
+{
+    ebpf_program_type_t program_type_uuid; ///< Program type UUID.
+    ebpf_attach_type_t attach_type_uuid;   ///< Attach type UUID.
+} ebpf_windows_program_type_data_t;

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -368,3 +368,12 @@ ebpf_object_get_info_by_fd(
  */
 ebpf_result_t
 ebpf_object_pin(fd_t fd, _In_z_ const char* path);
+
+/**
+ * @brief Get fd for a pinned object by pin path.
+ * @param[in] path Pin path for the object.
+ *
+ * @return file descriptor for the pinned object, -1 if not found.
+ */
+fd_t
+ebpf_object_get(_In_z_ const char* path);

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -77,3 +77,9 @@ bpf_obj_pin(int fd, const char* pathname)
 {
     return libbpf_result_err(ebpf_object_pin((fd_t)fd, pathname));
 }
+
+int
+bpf_obj_get(const char* pathname)
+{
+    return (int)ebpf_object_get(pathname);
+}

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -360,7 +360,7 @@ handle_ebpf_set_program(
         if (memcmp(&attach_type, &EBPF_ATTACH_TYPE_UNSPECIFIED, sizeof(ebpf_attach_type_t)) != 0) {
             ebpf_result_t result = ebpf_program_attach_by_id(id, attach_type);
             if (result != NO_ERROR) {
-                std::cerr << "error " << result << ": could not detach program" << std::endl;
+                std::cerr << "error " << result << ": could not attach program" << std::endl;
                 return ERROR_SUPPRESS_OUTPUT;
             }
         } else {

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -71,9 +71,7 @@ handle_ebpf_add_program(
         case 1: // TYPE
         {
             std::string type_name = down_cast_from_wstring(std::wstring(argv[current_index + i]));
-            ebpf_attach_type_t expected_attach_type;
-            ebpf_result_t result =
-                ebpf_get_program_type_by_name(type_name.c_str(), &program_type, &expected_attach_type);
+            ebpf_result_t result = ebpf_get_program_type_by_name(type_name.c_str(), &program_type, &attach_type);
             if (result != EBPF_SUCCESS) {
                 status = ERROR_INVALID_PARAMETER;
             }
@@ -117,6 +115,7 @@ handle_ebpf_add_program(
         return ERROR_SUPPRESS_OUTPUT;
     }
 
+    // TODO(#188): add option to pin all programs in the object.
     struct bpf_program* program = bpf_program__next(nullptr, object);
     struct bpf_link* link;
     result = ebpf_program_attach(program, (tags[1].bPresent ? &attach_type : nullptr), nullptr, 0, &link);
@@ -144,6 +143,40 @@ handle_ebpf_add_program(
     ebpf_link_close(link);
 
     return ERROR_SUCCESS;
+}
+
+static DWORD
+_unpin_program_by_id(ebpf_id_t id)
+{
+    ebpf_result_t result;
+    DWORD status = NO_ERROR;
+    char name[EBPF_MAX_PIN_PATH_LENGTH] = {0};
+
+    for (;;) {
+        result = ebpf_get_next_pinned_program_name(name, name);
+        if (result != EBPF_SUCCESS) {
+            break;
+        }
+        int fd = bpf_obj_get(name);
+        if (fd < 0) {
+            continue;
+        }
+        bpf_prog_info info;
+        uint32_t info_size = sizeof(info);
+        if (bpf_obj_get_info_by_fd(fd, &info, &info_size) == 0) {
+            if (id == info.id) {
+                result = ebpf_object_unpin(name);
+                if (result != EBPF_SUCCESS) {
+                    printf("Error %d unpinning %d from %s\n", result, id, name);
+                    status = ERROR_SUPPRESS_OUTPUT;
+                } else {
+                    printf("Unpinned %d from %s\n", id, name);
+                }
+            }
+        }
+        Platform::_close(fd);
+    }
+    return status;
 }
 
 DWORD
@@ -180,9 +213,11 @@ handle_ebpf_delete_program(
         return status;
     }
 
-    // TODO(issue #190): If the program is pinned, unpin the specified program.
-    // The temporary API ebpf_api_unpin_object requires knowing the name a priori
-    // and we have no way to get it yet.
+    // If the program is pinned, unpin the specified program.
+    status = _unpin_program_by_id(id);
+    if (status != NO_ERROR) {
+        return status;
+    }
 
     // Remove from our list of programs to release our own reference if we took one.
     // If there are no other references to the program, it will be unloaded.
@@ -205,7 +240,7 @@ handle_ebpf_delete_program(
                 // TODO: see if the program is still loaded, in which case some other process holds
                 // a reference. Get the PID of that process and display it.
 
-                return ERROR_OKAY;
+                return NO_ERROR;
             }
         }
     }
@@ -299,9 +334,13 @@ handle_ebpf_set_program(
         }
         case 1: // ATTACHED
         {
-            if ((argv[current_index + i][0] != 0) &&
-                (UuidFromStringW((RPC_WSTR)argv[current_index + i], &attach_type))) {
-                status = ERROR_INVALID_SYNTAX;
+            if (argv[current_index + i][0] != 0) {
+                std::string type_name = down_cast_from_wstring(std::wstring(argv[current_index + i]));
+                ebpf_program_type_t program_type;
+                ebpf_result_t result = ebpf_get_program_type_by_name(type_name.c_str(), &program_type, &attach_type);
+                if (result != EBPF_SUCCESS) {
+                    status = ERROR_INVALID_SYNTAX;
+                }
             }
             break;
         }
@@ -335,10 +374,8 @@ handle_ebpf_set_program(
 
     if (tags[2].bPresent) {
         if (pinned.empty()) {
-            // TODO (issue #190): call ebpf_program_unpin() once it exists.
-            // The temporary API ebpf_api_unpin_object requires knowing the name a priori
-            // and we have no way to get it.
-            return ERROR_CALL_NOT_IMPLEMENTED;
+            // Unpin a program from all names to which it is currently pinned.
+            return _unpin_program_by_id(id);
         } else {
             // Try to find the program with the specified ID.
             fd_t program_fd = bpf_prog_get_fd_by_id(id);
@@ -460,7 +497,7 @@ handle_ebpf_show_programs(
         level = VL_VERBOSE;
     }
 
-    // TODO(#190): We need to implement level, other columns, and implement filtering by attached and pinned.
+    // TODO(#188): We need to implement level, other columns, and implement filtering by attached and pinned.
 
     std::cout << "\n";
     std::cout << "    ID            File Name         Section             Name      Mode\n";

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1070,6 +1070,18 @@ _ebpf_core_protocol_get_next_program_id(
 }
 
 static ebpf_result_t
+_ebpf_core_protocol_get_next_pinned_program_name(
+    _In_ const ebpf_operation_get_next_pinned_name_request_t* request,
+    _Out_ ebpf_operation_get_next_pinned_name_reply_t* reply,
+    uint16_t reply_length)
+{
+    UNREFERENCED_PARAMETER(reply_length);
+
+    return ebpf_pinning_table_get_next_name(
+        _ebpf_core_map_pinning_table, EBPF_OBJECT_PROGRAM, request->start_name, reply->next_name);
+}
+
+static ebpf_result_t
 _ebpf_core_protocol_get_object_info(
     _In_ const ebpf_operation_get_object_info_request_t* request,
     _Out_ ebpf_operation_get_object_info_reply_t* reply,
@@ -1323,6 +1335,11 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_get_object_info,
      sizeof(ebpf_operation_get_object_info_request_t),
      sizeof(ebpf_operation_get_object_info_reply_t)},
+
+    // EBPF_OPERATION_GET_NEXT_PINNED_PROGRAM_NAME
+    {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_get_next_pinned_program_name,
+     sizeof(ebpf_operation_get_next_pinned_name_request_t),
+     sizeof(ebpf_operation_get_next_pinned_name_reply_t)},
 };
 
 ebpf_result_t

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -38,6 +38,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_GET_NEXT_MAP_ID,
     EBPF_OPERATION_GET_NEXT_PROGRAM_ID,
     EBPF_OPERATION_GET_OBJECT_INFO,
+    EBPF_OPERATION_GET_NEXT_PINNED_PROGRAM_NAME,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -332,6 +333,18 @@ typedef struct _ebpf_operation_get_next_id_reply
     struct _ebpf_operation_header header;
     ebpf_id_t next_id;
 } ebpf_operation_get_next_id_reply_t;
+
+typedef struct _ebpf_operation_get_next_pinned_name_request
+{
+    struct _ebpf_operation_header header;
+    char start_name[EBPF_MAX_PIN_PATH_LENGTH];
+} ebpf_operation_get_next_pinned_name_request_t;
+
+typedef struct _ebpf_operation_get_next_pinned_name_reply
+{
+    struct _ebpf_operation_header header;
+    char next_name[EBPF_MAX_PIN_PATH_LENGTH];
+} ebpf_operation_get_next_pinned_name_reply_t;
 
 typedef struct _ebpf_operation_get_object_info_request
 {

--- a/libs/platform/ebpf_pinning_table.h
+++ b/libs/platform/ebpf_pinning_table.h
@@ -102,6 +102,23 @@ extern "C"
         _Outptr_result_buffer_maybenull_(*entry_count) ebpf_pinning_entry_t** pinning_entries);
 
     /**
+     * @brief Gets the next name in the pinning table after a given name.
+     *
+     * @param[in] pinning_table Pinning table to enumerate.
+     * @param[in] object_type Object type.
+     * @param[in] start_name Name to look for an entry greater than.
+     * @param[out] next_name Returns the next name, if one exists.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MORE_KEYS No more entries found.
+     */
+    ebpf_result_t
+    ebpf_pinning_table_get_next_name(
+        _In_ ebpf_pinning_table_t* pinning_table,
+        ebpf_object_type_t object_type,
+        _In_z_ const char* start_name,
+        _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_name);
+
+    /**
      * @brief Releases entries returned by ebpf_pinning_table_enumerate_entries.
      * @param[in] entry_count Length of input array of entries.
      * @param[in] pinning_entries Array of entries to be released.

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -579,18 +579,22 @@ TEST_CASE("map_pinning_test", "[end_to_end]")
         bpf_map__pin(bpf_object__find_map_by_name(object, "process_map"), process_maps_name.c_str()) == EBPF_SUCCESS);
     REQUIRE(bpf_map__pin(bpf_object__find_map_by_name(object, "limits_map"), limit_maps_name.c_str()) == EBPF_SUCCESS);
 
-    REQUIRE(ebpf_object_get(process_maps_name.c_str()) != ebpf_fd_invalid);
+    fd_t fd = bpf_obj_get(process_maps_name.c_str());
+    REQUIRE(fd != ebpf_fd_invalid);
+    Platform::_close(fd);
 
-    REQUIRE(ebpf_object_get(limit_maps_name.c_str()) != ebpf_fd_invalid);
+    fd = bpf_obj_get(limit_maps_name.c_str());
+    REQUIRE(fd != ebpf_fd_invalid);
+    Platform::_close(fd);
 
     REQUIRE(
         bpf_map__unpin(bpf_object__find_map_by_name(object, "process_map"), process_maps_name.c_str()) == EBPF_SUCCESS);
     REQUIRE(
         bpf_map__unpin(bpf_object__find_map_by_name(object, "limits_map"), limit_maps_name.c_str()) == EBPF_SUCCESS);
 
-    REQUIRE(ebpf_object_get(limit_maps_name.c_str()) == ebpf_fd_invalid);
+    REQUIRE(bpf_obj_get(limit_maps_name.c_str()) == ebpf_fd_invalid);
 
-    REQUIRE(ebpf_object_get(process_maps_name.c_str()) == ebpf_fd_invalid);
+    REQUIRE(bpf_obj_get(process_maps_name.c_str()) == ebpf_fd_invalid);
 
     bpf_object__close(object);
 }

--- a/tools/port_quota/port_quota.cpp
+++ b/tools/port_quota/port_quota.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include <io.h>
 #include <iostream>
 #include <string>
 #include <windows.h>
@@ -106,7 +107,7 @@ stats(int argc, char** argv)
 
     UNREFERENCED_PARAMETER(argc);
     UNREFERENCED_PARAMETER(argv);
-    map_fd = ebpf_object_get((char*)process_map);
+    map_fd = bpf_obj_get((char*)process_map);
     if (map_fd == ebpf_fd_invalid) {
         fprintf(stderr, "Failed to look up eBPF map\n");
         return 1;
@@ -124,6 +125,7 @@ stats(int argc, char** argv)
         printf("%lld\t%d\t%S\n", pid, process_entry.count, process_entry.name);
         result = bpf_map_get_next_key(map_fd, &pid, &pid);
     };
+    _close(map_fd);
     return 0;
 }
 
@@ -141,7 +143,7 @@ limit(int argc, char** argv)
     uint32_t result;
     uint32_t key = 0;
 
-    map_fd = ebpf_object_get((char*)limits_map);
+    map_fd = bpf_obj_get((char*)limits_map);
     if (map_fd == ebpf_fd_invalid) {
         fprintf(stderr, "Failed to look up eBPF map.\n");
         return 1;
@@ -152,6 +154,8 @@ limit(int argc, char** argv)
         fprintf(stderr, "Failed to update eBPF map element: %d\n", result);
         return 1;
     }
+
+    _close(map_fd);
 
     return 0;
 }


### PR DESCRIPTION
* The netsh `set program id=<id> pinned=` (with no value) will now unpin a program from all paths
* The netsh `delete program <id>` will now also unpin a program from all paths before and releasing any reference held by netsh itself
* Make the `attached=<string>` argument to netsh set programs work with a section name like string
* Add libbpf api bpf_obj_get()
* Add ebpf_get_next_pinned_program_name() API to enumerate pinned programs

Fixes #190 
Fixes #373

This is required for #188 which will update the "show programs" and also add an option to "add program" to pin all programs rather than just the first one in a file, like bpftool has such an option.