### PR TITLE
Fix bugs in ebpf_state and ebpf_object

### DIFF
--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -51,6 +51,10 @@ static _Requires_lock_held_(&_ebpf_object_tracking_list_lock) ebpf_id_entry_t _e
 static inline ebpf_id_t
 _get_id_from_index(uint32_t index)
 {
+    if (index >= EBPF_COUNT_OF(_ebpf_id_table)) {
+        return EBPF_ID_NONE;
+    }
+
     // Put the index in the high 2 bytes and the counter in the low 2 bytes.
     // This allows us to more easily detect stale IDs while
     // still keeping IDs in order by index.

--- a/libs/platform/ebpf_state.c
+++ b/libs/platform/ebpf_state.c
@@ -9,7 +9,7 @@
 // Table to track what state for each thread.
 static ebpf_hash_table_t* _ebpf_state_thread_table = NULL;
 
-static int64_t _ebpf_state_next_index = 0;
+static int64_t _ebpf_state_next_index;
 
 // Table to track what state for each CPU.
 typedef struct _ebpf_state_entry
@@ -24,6 +24,8 @@ ebpf_result_t
 ebpf_state_initiate()
 {
     ebpf_result_t return_value = EBPF_SUCCESS;
+
+    _ebpf_state_next_index = 0;
 
     if (ebpf_is_non_preemptible_work_item_supported()) {
         _ebpf_state_cpu_table_size = ebpf_get_cpu_count();


### PR DESCRIPTION
* Fix bug where getting the next ID failed to check for index beyond array size.

* Fix bug in ebpf_state.c where after enough tests ran it would start returning EBPF_NO_MEMORY because _ebpf_state_next_index was never reset.

The tests in PR #553 cover both of these bugs.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>