### PR TITLE
Add BPF_MAP_TYPE_LRU_HASH

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -6,11 +6,8 @@ name: "CodeQL"
 on:
   push:
     branches: [ master ]
-  pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
   schedule:
-    - cron: '00 21 * * 0'
+    - cron: '00 21 * * *'
 
 jobs:
   analyze:

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -21,6 +21,7 @@ typedef enum bpf_map_type
     BPF_MAP_TYPE_PERCPU_ARRAY = 5,
     BPF_MAP_TYPE_HASH_OF_MAPS = 6,
     BPF_MAP_TYPE_ARRAY_OF_MAPS = 7,
+    BPF_MAP_TYPE_LRU_HASH = 8,
 } ebpf_map_type_t;
 
 typedef enum ebpf_map_option

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -490,7 +490,10 @@ _create_lru_hash_map(_In_ const ebpf_map_definition_in_memory_t* map_definition)
             map = NULL;
         }
     }
-    return &map->core_map;
+    if (map)
+        return &map->core_map;
+    else
+        return NULL;
 }
 
 static void

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -33,7 +33,7 @@ typedef std::unique_ptr<ebpf_map_t, ebpf_object_deleter<ebpf_map_t>> map_ptr;
 typedef std::unique_ptr<ebpf_program_t, ebpf_object_deleter<ebpf_program_t>> program_ptr;
 
 static void
-_test_crud_operations(ebpf_map_type_t map_type, bool is_array)
+_test_crud_operations(ebpf_map_type_t map_type, bool is_array, bool replace_on_full = false)
 {
     _ebpf_core_initializer core;
 
@@ -62,8 +62,8 @@ _test_crud_operations(ebpf_map_type_t map_type, bool is_array)
     }
 
     // Test for inserting max_entries + 1
-    uint32_t bad_key = 11;
-    *reinterpret_cast<uint64_t*>(value.data()) = 11 * 11;
+    uint32_t bad_key = 10;
+    *reinterpret_cast<uint64_t*>(value.data()) = bad_key * bad_key;
     REQUIRE(
         ebpf_map_update_entry(
             map.get(),
@@ -72,20 +72,29 @@ _test_crud_operations(ebpf_map_type_t map_type, bool is_array)
             value.size(),
             value.data(),
             EBPF_ANY,
-            0) == EBPF_INVALID_ARGUMENT);
+            0) == (replace_on_full ? EBPF_SUCCESS : EBPF_INVALID_ARGUMENT));
 
-    ebpf_result_t expected_result = is_array ? EBPF_INVALID_ARGUMENT : EBPF_KEY_NOT_FOUND;
-    REQUIRE(
-        ebpf_map_delete_entry(map.get(), sizeof(bad_key), reinterpret_cast<const uint8_t*>(&bad_key), 0) ==
-        expected_result);
+    if (!replace_on_full) {
+        ebpf_result_t expected_result = is_array ? EBPF_INVALID_ARGUMENT : EBPF_KEY_NOT_FOUND;
+        REQUIRE(
+            ebpf_map_delete_entry(map.get(), sizeof(bad_key), reinterpret_cast<const uint8_t*>(&bad_key), 0) ==
+            expected_result);
+    }
 
     for (uint32_t key = 0; key < 10; key++) {
+        ebpf_result_t expected_result;
+        if (replace_on_full) {
+            expected_result = key == 0 ? EBPF_OBJECT_NOT_FOUND : EBPF_SUCCESS;
+        } else {
+            expected_result = key == 10 ? EBPF_OBJECT_NOT_FOUND : EBPF_SUCCESS;
+        }
         REQUIRE(
             ebpf_map_find_entry(
                 map.get(), sizeof(key), reinterpret_cast<const uint8_t*>(&key), value.size(), value.data(), 0) ==
-            EBPF_SUCCESS);
-
-        REQUIRE(*reinterpret_cast<uint64_t*>(value.data()) == key * key);
+            expected_result);
+        if (expected_result == EBPF_SUCCESS) {
+            REQUIRE(*reinterpret_cast<uint64_t*>(value.data()) == key * key);
+        }
     }
 
     uint32_t previous_key;
@@ -110,7 +119,7 @@ _test_crud_operations(ebpf_map_type_t map_type, bool is_array)
             reinterpret_cast<const uint8_t*>(&previous_key),
             reinterpret_cast<uint8_t*>(&next_key)) == EBPF_NO_MORE_KEYS);
 
-    for (uint32_t key = 0; key < 10; key++) {
+    for (const auto key : keys) {
         REQUIRE(
             ebpf_map_delete_entry(map.get(), sizeof(key), reinterpret_cast<const uint8_t*>(&key), 0) == EBPF_SUCCESS);
     }
@@ -123,6 +132,11 @@ _test_crud_operations(ebpf_map_type_t map_type, bool is_array)
 TEST_CASE("map_crud_operations_array", "[execution_context]") { _test_crud_operations(BPF_MAP_TYPE_ARRAY, true); }
 
 TEST_CASE("map_crud_operations_hash", "[execution_context]") { _test_crud_operations(BPF_MAP_TYPE_HASH, false); }
+
+TEST_CASE("map_crud_operations_lru_hash", "[execution_context]")
+{
+    _test_crud_operations(BPF_MAP_TYPE_LRU_HASH, false, true);
+}
 
 TEST_CASE("map_crud_operations_array_per_cpu", "[execution_context]")
 {

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -63,7 +63,7 @@ _test_crud_operations(ebpf_map_type_t map_type, bool is_array, bool replace_on_f
 
     // Test for inserting max_entries + 1
     uint32_t bad_key = 10;
-    *reinterpret_cast<uint64_t*>(value.data()) = bad_key * bad_key;
+    *reinterpret_cast<uint64_t*>(value.data()) = static_cast<uint64_t>(bad_key) * static_cast<uint64_t>(bad_key);
     REQUIRE(
         ebpf_map_update_entry(
             map.get(),


### PR DESCRIPTION
Added BPF_MAP_TYPE_LRU_HASH to partially address #343.

Implemented as parallel key history hash-table. Need to investigate switching to heap for better reaping performance.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>