### PR TITLE
Implement trivial version of BPF_MAP_TYPE_LPM_TRIE

### DIFF
--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -22,6 +22,7 @@ typedef enum bpf_map_type
     BPF_MAP_TYPE_HASH_OF_MAPS = 6,
     BPF_MAP_TYPE_ARRAY_OF_MAPS = 7,
     BPF_MAP_TYPE_LRU_HASH = 8,
+    BPF_MAP_TYPE_LPM_TRIE = 9,
 } ebpf_map_type_t;
 
 typedef enum ebpf_map_option

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -872,35 +872,35 @@ _lpm_trie_matching_key_prefix_length(
     const uint8_t* key_a, size_t key_length_a, const uint8_t* key_b, size_t key_length_b)
 {
     size_t maximum_matching_length = key_length_a > key_length_b ? key_length_b : key_length_a;
-    size_t remainin_key_length_in_bits = maximum_matching_length;
+    size_t remaining_key_length_in_bits = maximum_matching_length;
     uint8_t key_a_last_byte;
     uint8_t key_b_last_byte;
     size_t index;
 
-    while (remainin_key_length_in_bits >= 8) {
-        index = (maximum_matching_length - remainin_key_length_in_bits) / 8;
+    while (remaining_key_length_in_bits >= 8) {
+        index = (maximum_matching_length - remaining_key_length_in_bits) / 8;
         if (key_a[index] != key_b[index]) {
             break;
         }
-        remainin_key_length_in_bits -= 8;
+        remaining_key_length_in_bits -= 8;
     }
-    if (!remainin_key_length_in_bits) {
+    if (!remaining_key_length_in_bits) {
         return maximum_matching_length;
     }
 
-    index = (maximum_matching_length - remainin_key_length_in_bits) / 8;
+    index = (maximum_matching_length - remaining_key_length_in_bits) / 8;
     key_a_last_byte = key_a[index];
     key_b_last_byte = key_b[index];
 
-    while (remainin_key_length_in_bits) {
+    while (remaining_key_length_in_bits) {
         if ((key_a_last_byte & 0x80) != (key_b_last_byte & 0x80)) {
             break;
         }
-        remainin_key_length_in_bits--;
+        remaining_key_length_in_bits--;
         key_a_last_byte <<= 1;
         key_b_last_byte <<= 1;
     }
-    return maximum_matching_length - remainin_key_length_in_bits;
+    return maximum_matching_length - remaining_key_length_in_bits;
 }
 
 static uint8_t*

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -887,7 +887,7 @@ _lpm_trie_matching_key_prefix_length(
         }
         remaining_key_length_in_bits -= 8;
     }
-    if (!remaining_key_length_in_bits) {
+    if (remaining_key_length_in_bits == 0) {
         return maximum_matching_length;
     }
 

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -866,6 +866,7 @@ _update_entry_per_cpu(
     return EBPF_SUCCESS;
 }
 
+// Given two keys, compute the number of bits that match.
 static size_t
 _lpm_trie_matching_key_prefix_length(
     const uint8_t* key_a, size_t key_length_a, const uint8_t* key_b, size_t key_length_b)

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -869,7 +869,10 @@ _update_entry_per_cpu(
 // Given two keys, compute the number of bits that match.
 static size_t
 _lpm_trie_matching_key_prefix_length(
-    const uint8_t* key_a, size_t key_length_a, const uint8_t* key_b, size_t key_length_b)
+    _In_reads_((key_length_a + 7) / 8) const uint8_t* key_a,
+    size_t key_length_a,
+    _In_reads_((key_length_b + 7) / 8) const uint8_t* key_b,
+    size_t key_length_b)
 {
     size_t maximum_matching_length = key_length_a > key_length_b ? key_length_b : key_length_a;
     size_t remaining_key_length_in_bits = maximum_matching_length;

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -144,7 +144,7 @@ TEST_CASE("map_crud_operations_lpm_trie", "[execution_context]")
 
     typedef struct _lpm_trie_key
     {
-        uint32_t key;
+        uint32_t prefix_length;
         uint8_t value[4];
     } lpm_trie_key_t;
     ebpf_map_definition_in_memory_t map_definition{

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -138,7 +138,7 @@ TEST_CASE("map_crud_operations_lru_hash", "[execution_context]")
     _test_crud_operations(BPF_MAP_TYPE_LRU_HASH, false, true);
 }
 
-TEST_CASE("map_crud_operations_lpm_trie", "[execution_context]")
+TEST_CASE("map_crud_operations_lpm_trie_32", "[execution_context]")
 {
     _ebpf_core_initializer core;
 
@@ -179,6 +179,115 @@ TEST_CASE("map_crud_operations_lpm_trie", "[execution_context]")
         {{32, 10, 10, 10, 10}, "10.0.0.0/16"},
         {{32, 10, 11, 10, 10}, "10.0.0.0/8"},
     };
+
+    for (auto& [key, value] : keys) {
+        REQUIRE(
+            ebpf_map_update_entry(
+                map.get(),
+                0,
+                reinterpret_cast<const uint8_t*>(&key),
+                0,
+                reinterpret_cast<const uint8_t*>(value),
+                EBPF_ANY,
+                EBPF_MAP_FLAG_HELPER) == EBPF_SUCCESS);
+    }
+
+    for (auto& [key, result] : tests) {
+        char* value = nullptr;
+        REQUIRE(
+            ebpf_map_find_entry(
+                map.get(),
+                0,
+                reinterpret_cast<const uint8_t*>(&key),
+                0,
+                reinterpret_cast<uint8_t*>(&value),
+                EBPF_MAP_FLAG_HELPER) == EBPF_SUCCESS);
+        REQUIRE(std::string(value) == result);
+    }
+}
+
+void
+generate_prefix(size_t length, uint8_t value, uint8_t prefix[16])
+{
+    size_t index = 0;
+    memset(prefix, 0, sizeof(prefix));
+    for (index = 0; index < length / 8; index++) {
+        prefix[index] = value;
+    }
+    prefix[index] = value << (8 - (length % 8));
+}
+
+TEST_CASE("map_crud_operations_lpm_trie_128", "[execution_context]")
+{
+    _ebpf_core_initializer core;
+
+    typedef struct _lpm_trie_key
+    {
+        uint32_t prefix_length;
+        uint8_t value[16];
+    } lpm_trie_key_t;
+
+    ebpf_map_definition_in_memory_t map_definition{
+        sizeof(ebpf_map_definition_in_memory_t), BPF_MAP_TYPE_LPM_TRIE, sizeof(lpm_trie_key_t), 20, 10};
+    map_ptr map;
+    {
+        ebpf_map_t* local_map;
+        ebpf_utf8_string_t map_name = {0};
+        REQUIRE(
+            ebpf_map_create(&map_name, &map_definition, (uintptr_t)ebpf_handle_invalid, &local_map) == EBPF_SUCCESS);
+        map.reset(local_map);
+    }
+
+    std::vector<std::pair<lpm_trie_key_t, const char*>> keys{
+        {{96}, "CC/96"},
+        {{96}, "CD/96"},
+        {{124}, "DD/124"},
+        {{120}, "DD/120"},
+        {{116}, "DD/116"},
+        {{64}, "AA/64"},
+        {{64}, "BB/64"},
+        {{32}, "BB/32"},
+    };
+    {
+        std::vector<uint8_t> values{
+            0xCC,
+            0xCD,
+            0xDD,
+            0xDD,
+            0xDD,
+            0xAA,
+            0xBB,
+            0xBB,
+        };
+        for (size_t index = 0; index < values.size(); index++) {
+            generate_prefix(keys[index].first.prefix_length, values[index], keys[index].first.value);
+        }
+    }
+    std::vector<std::pair<lpm_trie_key_t, std::string>> tests{
+        {{96}, "CC/96"},
+        {{96}, "CD/96"},
+        {{124}, "DD/124"},
+        {{120}, "DD/120"},
+        {{116}, "DD/116"},
+        {{64}, "AA/64"},
+        {{64}, "BB/64"},
+        {{32}, "BB/32"},
+    };
+    {
+        std::vector<uint8_t> values{
+            0xCC,
+            0xCD,
+            0xDD,
+            0xDD,
+            0xDD,
+            0xAA,
+            0xBB,
+            0xBB,
+        };
+        for (size_t index = 0; index < values.size(); index++) {
+            generate_prefix(tests[index].first.prefix_length, values[index], tests[index].first.value);
+        }
+    }
 
     for (auto& [key, value] : keys) {
         REQUIRE(

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -138,6 +138,74 @@ TEST_CASE("map_crud_operations_lru_hash", "[execution_context]")
     _test_crud_operations(BPF_MAP_TYPE_LRU_HASH, false, true);
 }
 
+TEST_CASE("map_crud_operations_lpm_trie", "[execution_context]")
+{
+    _ebpf_core_initializer core;
+
+    typedef struct _lpm_trie_key
+    {
+        uint32_t key;
+        uint8_t value[4];
+    } lpm_trie_key_t;
+    ebpf_map_definition_in_memory_t map_definition{
+        sizeof(ebpf_map_definition_in_memory_t), BPF_MAP_TYPE_LPM_TRIE, sizeof(lpm_trie_key_t), 16, 10};
+    map_ptr map;
+    {
+        ebpf_map_t* local_map;
+        ebpf_utf8_string_t map_name = {0};
+        REQUIRE(
+            ebpf_map_create(&map_name, &map_definition, (uintptr_t)ebpf_handle_invalid, &local_map) == EBPF_SUCCESS);
+        map.reset(local_map);
+    }
+
+    std::vector<std::pair<lpm_trie_key_t, const char*>> keys{
+        {{24, 192, 168, 15, 0}, "192.168.15.0/24"},
+        {{24, 192, 168, 16, 0}, "192.168.16.0/24"},
+        {{31, 192, 168, 14, 0}, "192.168.14.0/31"},
+        {{30, 192, 168, 14, 0}, "192.168.14.0/30"},
+        {{29, 192, 168, 14, 0}, "192.168.14.0/29"},
+        {{16, 192, 168, 0, 0}, "192.168.0.0/16"},
+        {{16, 10, 10, 0, 0}, "10.0.0.0/16"},
+        {{8, 10, 0, 0, 0}, "10.0.0.0/8"},
+    };
+
+    std::vector<std::pair<lpm_trie_key_t, std::string>> tests{
+        {{32, 192, 168, 15, 1}, "192.168.15.0/24"},
+        {{32, 192, 168, 16, 25}, "192.168.16.0/24"},
+        {{32, 192, 168, 14, 1}, "192.168.14.0/31"},
+        {{32, 192, 168, 14, 2}, "192.168.14.0/30"},
+        {{32, 192, 168, 14, 4}, "192.168.14.0/29"},
+        {{32, 192, 168, 14, 9}, "192.168.0.0/16"},
+        {{32, 10, 10, 10, 10}, "10.0.0.0/16"},
+        {{32, 10, 11, 10, 10}, "10.0.0.0/8"},
+    };
+
+    for (auto& [key, value] : keys) {
+        REQUIRE(
+            ebpf_map_update_entry(
+                map.get(),
+                0,
+                reinterpret_cast<const uint8_t*>(&key),
+                0,
+                reinterpret_cast<const uint8_t*>(value),
+                EBPF_ANY,
+                EBPF_MAP_FLAG_HELPER) == EBPF_SUCCESS);
+    }
+
+    for (auto& [key, result] : tests) {
+        char* value = nullptr;
+        REQUIRE(
+            ebpf_map_find_entry(
+                map.get(),
+                0,
+                reinterpret_cast<const uint8_t*>(&key),
+                0,
+                reinterpret_cast<uint8_t*>(&value),
+                EBPF_MAP_FLAG_HELPER) == EBPF_SUCCESS);
+        REQUIRE(std::string(value) == result);
+    }
+}
+
 TEST_CASE("map_crud_operations_array_per_cpu", "[execution_context]")
 {
     emulate_dpc_t dpc(0);


### PR DESCRIPTION
This version of BPF_MAP_TYPE_LPM_TRIE should be performant enough for experimentation / small instances of BPF_MAP_TYPE_LPM_TRIE.  This implementation is a placeholder until we get a more performant version.

Addresses: #560 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>