### PR TITLE
Move schedule cleanup from program to object

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -49,7 +49,7 @@ ebpf_link_create(ebpf_link_t** link)
 
     memset(*link, 0, sizeof(ebpf_link_t));
 
-    ebpf_result_t result = ebpf_object_initialize(&(*link)->object, EBPF_OBJECT_LINK, _ebpf_link_free, NULL);
+    ebpf_result_t result = ebpf_object_initialize(&(*link)->object, EBPF_OBJECT_LINK, NULL, _ebpf_link_free, NULL);
     if (result != EBPF_SUCCESS) {
         ebpf_epoch_free(link);
         return result;

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -307,6 +307,7 @@ ebpf_epoch_allocate_work_item(_In_ void* callback_context, _In_ void (*callback)
     work_item->callback = callback;
     work_item->callback_context = callback_context;
     work_item->header.entry_type = EBPF_EPOCH_ALLOCATION_WORK_ITEM;
+    ebpf_list_initialize(&work_item->header.list_entry);
 
     return work_item;
 }

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "ebpf_epoch.h"
 #include "ebpf_platform.h"
 #include "ebpf_structs.h"
 #include "framework.h"
@@ -31,6 +32,7 @@ extern "C"
         uint32_t marker;
         volatile int32_t reference_count;
         ebpf_object_type_t type;
+        ebpf_epoch_work_item_t* cleanup_work_item;
         ebpf_free_object_t free_function;
         ebpf_object_get_program_type_t get_program_type;
         // ID for this object.

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -23,6 +23,7 @@ extern "C"
 
     typedef struct _ebpf_object ebpf_object_t;
     typedef void (*ebpf_free_object_t)(ebpf_object_t* object);
+    typedef void (*ebpf_zero_ref_count_object_t)(ebpf_object_t* object);
     typedef const ebpf_program_type_t* (*ebpf_object_get_program_type_t)(_In_ const ebpf_object_t* object);
 
     // This type probably ought to be renamed to avoid confusion with
@@ -33,6 +34,7 @@ extern "C"
         volatile int32_t reference_count;
         ebpf_object_type_t type;
         ebpf_epoch_work_item_t* cleanup_work_item;
+        ebpf_zero_ref_count_object_t zero_ref_count_function;
         ebpf_free_object_t free_function;
         ebpf_object_get_program_type_t get_program_type;
         // ID for this object.
@@ -62,6 +64,7 @@ extern "C"
      *
      * @param[in,out] object ebpf_object_t structure to initialize.
      * @param[in] object_type The type of the object.
+     * @param[in] zero_ref_count_function The function invoked when the ref-count reaches zero.
      * @param[in] free_function The function used to free the object.
      * @param[in] get_program_type_function The function used to get a program type, or NULL.  Each program
      * has a program type, and hence so do maps that can contain programs, whether directly (like
@@ -71,10 +74,11 @@ extern "C"
      */
     ebpf_result_t
     ebpf_object_initialize(
-        ebpf_object_t* object,
+        _In_ ebpf_object_t* object,
         ebpf_object_type_t object_type,
-        ebpf_free_object_t free_function,
-        ebpf_object_get_program_type_t get_program_type_function);
+        _In_opt_ ebpf_zero_ref_count_object_t zero_ref_count_function,
+        _In_ ebpf_free_object_t free_function,
+        _In_opt_ ebpf_object_get_program_type_t get_program_type_function);
 
     /**
      * @brief Acquire a reference to this object.

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -218,10 +218,10 @@ TEST_CASE("pinning_test", "[platform]")
 
     REQUIRE(
         ebpf_object_initialize(
-            &an_object.object, EBPF_OBJECT_MAP, [](ebpf_object_t*) {}, NULL) == EBPF_SUCCESS);
+            &an_object.object, EBPF_OBJECT_MAP, NULL, [](ebpf_object_t*) {}, NULL) == EBPF_SUCCESS);
     REQUIRE(
         ebpf_object_initialize(
-            &another_object.object, EBPF_OBJECT_MAP, [](ebpf_object_t*) {}, NULL) == EBPF_SUCCESS);
+            &another_object.object, EBPF_OBJECT_MAP, NULL, [](ebpf_object_t*) {}, NULL) == EBPF_SUCCESS);
 
     ebpf_pinning_table_t* pinning_table = nullptr;
     REQUIRE(ebpf_pinning_table_allocate(&pinning_table) == EBPF_SUCCESS);

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -141,16 +141,6 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
     </CustomBuild>
-    <CustomBuild Include="encap_reflect_packet.c">
-      <FileType>CppCode</FileType>
-      <Command>clang -target bpf -O2 -Wall -c %(Filename).c -o %(Filename).o</Command>
-      <Outputs>%(Filename).o;%(Outputs)</Outputs>
-      <TreatOutputAsContent>true</TreatOutputAsContent>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -I../xdp -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -I../xdp -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
-      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
-    </CustomBuild>
     <CustomBuild Include="test_sample_ebpf.c">
       <FileType>CppCode</FileType>
       <Command>clang -target bpf -O2 -Werror -c %(Filename).c -o %(Filename).o</Command>

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -141,6 +141,16 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
     </CustomBuild>
+    <CustomBuild Include="encap_reflect_packet.c">
+      <FileType>CppCode</FileType>
+      <Command>clang -target bpf -O2 -Wall -c %(Filename).c -o %(Filename).o</Command>
+      <Outputs>%(Filename).o;%(Outputs)</Outputs>
+      <TreatOutputAsContent>true</TreatOutputAsContent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Wall -I../../include -I../xdp -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Wall -I../../include -I../xdp -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+    </CustomBuild>
     <CustomBuild Include="test_sample_ebpf.c">
       <FileType>CppCode</FileType>
       <Command>clang -target bpf -O2 -Werror -c %(Filename).c -o %(Filename).o</Command>


### PR DESCRIPTION
Move schedule cleanup from program to object and add function to notify when ref-count reaches zero.

This is to resolve a race condition that is breaking kernel CI/CD.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>