### PR TITLE
Fix stack overrun and fix EC to return correct size

### DIFF
--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -341,7 +341,7 @@ _ebpf_driver_io_device_control(
                 // buffer.
                 if (status == STATUS_SUCCESS && user_reply) {
                     user_reply->id = user_request->id;
-                    user_reply->length = (uint16_t)actual_output_length;
+                    user_reply->length = min((uint16_t)actual_output_length, user_reply->length);
                 }
                 goto Done;
             }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1943,7 +1943,7 @@ ebpf_get_next_pinned_program_path(
     ebpf_protocol_buffer_t request_buffer(
         EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_path_request_t, start_path) + start_path_length);
     ebpf_protocol_buffer_t reply_buffer(
-        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_path_reply_t, next_path) + EBPF_MAX_PIN_PATH_LENGTH);
+        EBPF_OFFSET_OF(ebpf_operation_get_next_pinned_path_reply_t, next_path) + EBPF_MAX_PIN_PATH_LENGTH - 1);
     ebpf_operation_get_next_pinned_path_request_t* request =
         reinterpret_cast<ebpf_operation_get_next_pinned_path_request_t*>(request_buffer.data());
     ebpf_operation_get_next_pinned_path_reply_t* reply =


### PR DESCRIPTION
Fix two bugs:
1) IOCTL handler shouldn't increase the reply length if the protocol handler sets it.
2) ebpf_get_next_pinned_program_path null terminates the return string, so the maximum length should be EBPF_MAX_PIN_PATH_LENGTH-1 to account for the null terminator.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>