### PR TITLE
add auto-pinning option for maps.

### DIFF
--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -35,6 +35,14 @@ typedef enum ebpf_map_option
     EBPF_EXIST
 } ebpf_map_option_t;
 
+typedef enum ebpf_pin_type
+{
+    PIN_NONE,
+    PIN_OBJECT_NS,
+    PIN_GLOBAL_NS,
+    PIN_CUSTOM_NS
+} ebpf_pin_type_t;
+
 typedef uint32_t ebpf_id_t;
 #define EBPF_ID_NONE UINT32_MAX
 
@@ -49,6 +57,7 @@ typedef struct _ebpf_map_definition_in_memory
     uint32_t value_size;  ///< Size in bytes of a map value.
     uint32_t max_entries; ///< Maximum number of entries allowed in the map.
     ebpf_id_t inner_map_id;
+    ebpf_pin_type_t pinning;
 } ebpf_map_definition_in_memory_t;
 
 /**
@@ -67,6 +76,7 @@ typedef struct _ebpf_map_definition_in_file
      * file is the inner map template.
      */
     uint32_t inner_map_idx;
+    ebpf_pin_type_t pinning;
 } ebpf_map_definition_in_file_t;
 
 typedef enum

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -150,6 +150,7 @@ load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* sectionname,
     _In_ ebpf_verifier_options_t* verifier_options,
+    _In_z_ const char* pin_root_path,
     _Inout_ std::vector<ebpf_program_t*>& programs,
     _Inout_ std::vector<ebpf_map_t*>& maps,
     _Outptr_result_maybenull_z_ const char** error_message) noexcept
@@ -266,6 +267,12 @@ load_byte_code(
                 goto Exit;
             }
 
+            // Currently only PIN_NONE and PIN_GLOBAL_NS pinning options are supported.
+            if (descriptor.pinning != PIN_NONE && descriptor.pinning != PIN_GLOBAL_NS) {
+                result = EBPF_INVALID_ARGUMENT;
+                goto Exit;
+            }
+
             map = (ebpf_map_t*)calloc(1, sizeof(ebpf_map_t));
             if (map == nullptr) {
                 result = EBPF_NO_MEMORY;
@@ -276,6 +283,19 @@ load_byte_code(
             if (map->name == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
+            }
+            if (descriptor.pinning == PIN_GLOBAL_NS) {
+                char buf[EBPF_MAX_PIN_PATH_LENGTH];
+                int len = snprintf(buf, EBPF_MAX_PIN_PATH_LENGTH, "%s/%s", pin_root_path, map->name);
+                if (len < 0 || len >= EBPF_MAX_PIN_PATH_LENGTH) {
+                    result = EBPF_INVALID_ARGUMENT;
+                    goto Exit;
+                }
+                map->pin_path = _strdup(buf);
+                if (map->pin_path == nullptr) {
+                    result = EBPF_NO_MEMORY;
+                    goto Exit;
+                }
             }
             maps.emplace_back(map);
             map = nullptr;

--- a/libs/api/Verifier.h
+++ b/libs/api/Verifier.h
@@ -16,6 +16,7 @@ load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* sectionname,
     _In_ ebpf_verifier_options_t* verifier_options,
+    _In_z_ const char* pin_root_path,
     _Inout_ std::vector<ebpf_program_t*>& programs,
     _Inout_ std::vector<ebpf_map_t*>& maps,
     _Outptr_result_maybenull_z_ const char** error_message) noexcept;

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -49,6 +49,7 @@ typedef struct bpf_map
     ebpf_map_definition_in_memory_t map_definition;
     char* pin_path;
     bool pinned;
+    bool reused;
 } ebpf_map_t;
 
 typedef struct bpf_link

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -51,7 +51,8 @@ parse_maps_section_windows(
             s.value_size,
             s.max_entries,
             inner_map_original_fd,
-            section_offset);
+            section_offset,
+            s.pinning);
 
         verifier_map_descriptors.emplace_back(EbpfMapDescriptor{
             .original_fd = original_fd,

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -19,11 +19,12 @@ typedef struct _map_cache
     ebpf_handle_t handle;
     size_t section_offset;
     EbpfMapDescriptor verifier_map_descriptor;
+    ebpf_pin_type_t pinning;
 
-    _map_cache() : handle(0), section_offset(0), verifier_map_descriptor() {}
+    _map_cache() : handle(0), section_offset(0), verifier_map_descriptor(), pinning(PIN_NONE) {}
 
-    _map_cache(ebpf_handle_t handle, size_t section_offset, EbpfMapDescriptor descriptor)
-        : handle(handle), section_offset(section_offset), verifier_map_descriptor(descriptor)
+    _map_cache(ebpf_handle_t handle, size_t section_offset, EbpfMapDescriptor descriptor, ebpf_pin_type_t pinning)
+        : handle(handle), section_offset(section_offset), verifier_map_descriptor(descriptor), pinning(pinning)
     {}
 
     _map_cache(
@@ -34,8 +35,9 @@ typedef struct _map_cache
         unsigned int value_size,
         unsigned int max_entries,
         unsigned int inner_map_original_fd, // original fd of inner map
-        size_t section_offset)
-        : handle(handle), section_offset(section_offset)
+        size_t section_offset,
+        ebpf_pin_type_t pinning)
+        : handle(handle), section_offset(section_offset), pinning(pinning)
     {
         verifier_map_descriptor.original_fd = original_fd;
         verifier_map_descriptor.type = type;
@@ -64,7 +66,8 @@ cache_map_handle(
     uint32_t value_size,
     uint32_t max_entries,
     uint32_t inner_map_original_fd,
-    size_t section_offset);
+    size_t section_offset,
+    ebpf_pin_type_t pinning);
 
 size_t
 get_map_descriptor_size(void);

--- a/libs/api_common/map_descriptors.cpp
+++ b/libs/api_common/map_descriptors.cpp
@@ -20,7 +20,7 @@ cache_map_original_file_descriptors(const EbpfMapDescriptor* map_descriptors, ui
         // Temporarily store the original_fd as a mock handle.
         ebpf_handle_t handle = (ebpf_handle_t)(uintptr_t)descriptor.original_fd;
 
-        _map_file_descriptors.emplace_back(handle, 0, descriptor);
+        _map_file_descriptors.emplace_back(handle, 0, descriptor, PIN_NONE);
     }
 }
 
@@ -87,22 +87,6 @@ get_all_map_descriptors()
 }
 
 void
-cache_map_original_file_descriptor(
-    int original_fd,
-    uint32_t type,
-    uint32_t key_size,
-    uint32_t value_size,
-    uint32_t max_entries,
-    uint32_t inner_map_original_fd)
-{
-    // Temporarily store the original fd as a mock handle.
-    ebpf_handle_t handle = (ebpf_handle_t)(uintptr_t)original_fd;
-
-    _map_file_descriptors.emplace_back(
-        handle, original_fd, type, key_size, value_size, max_entries, inner_map_original_fd, 0);
-}
-
-void
 cache_map_original_file_descriptor_with_handle(
     int original_fd,
     uint32_t type,
@@ -114,7 +98,7 @@ cache_map_original_file_descriptor_with_handle(
     size_t section_offset)
 {
     _map_file_descriptors.emplace_back(
-        handle, original_fd, type, key_size, value_size, max_entries, inner_map_original_fd, section_offset);
+        handle, original_fd, type, key_size, value_size, max_entries, inner_map_original_fd, section_offset, PIN_NONE);
 }
 
 void
@@ -126,10 +110,11 @@ cache_map_handle(
     uint32_t value_size,
     uint32_t max_entries,
     uint32_t inner_map_original_fd,
-    size_t section_offset)
+    size_t section_offset,
+    ebpf_pin_type_t pinning)
 {
     _map_file_descriptors.emplace_back(
-        handle, original_fd, type, key_size, value_size, max_entries, inner_map_original_fd, section_offset);
+        handle, original_fd, type, key_size, value_size, max_entries, inner_map_original_fd, section_offset, pinning);
 }
 
 size_t

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -519,7 +519,7 @@ _delete_object_hash_map(_In_ ebpf_core_map_t* map)
     for (uint8_t* previous_key = NULL;; previous_key = next_key) {
         uint8_t* value;
         ebpf_result_t result =
-            ebpf_hash_table_next_key_pointer_and_value((ebpf_hash_table_t*)map->data, NULL, &next_key, &value);
+            ebpf_hash_table_next_key_pointer_and_value((ebpf_hash_table_t*)map->data, previous_key, &next_key, &value);
         if (result != EBPF_SUCCESS) {
             break;
         }

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -26,6 +26,9 @@ _program_load_attach_helper::_program_load_attach_helper(
     // Load BPF object from ELF file.
     result = ebpf_program_load(
         _file_name.c_str(), &_program_type, nullptr, _execution_type, &_object, &program_fd, &log_buffer);
+    if (log_buffer != nullptr) {
+        printf("ebpf_program_load: error: %s", log_buffer);
+    }
     REQUIRE(result == EBPF_SUCCESS);
     REQUIRE(program_fd > 0);
 

--- a/tests/sample/map_reuse.c
+++ b/tests/sample/map_reuse.c
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// clang -O2 -Werror -c droppacket.c -o dropjit.o
+//
+// For bpf code: clang -target bpf -O2 -Werror -c droppacket.c -o droppacket.o
+// this passes the checker
+
+#include "bpf_helpers.h"
+#include "ebpf.h"
+
+#define PIN_NONE 0
+#define PIN_GLOBAL_NS 2
+SEC("maps")
+struct _ebpf_map_definition_in_file outer_map = {
+    .type = BPF_MAP_TYPE_HASH_OF_MAPS,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(uint32_t),
+    .max_entries = 1,
+    .pinning = PIN_GLOBAL_NS,
+    // inner_map_idx refers to the map index in the same ELF object.
+    .inner_map_idx = 1}; // (uint32_t)&inner_map
+
+SEC("maps")
+struct _ebpf_map_definition_in_file inner_map = {
+    .type = BPF_MAP_TYPE_ARRAY, .key_size = sizeof(uint32_t), .value_size = sizeof(uint32_t), .max_entries = 1};
+
+SEC("maps")
+ebpf_map_definition_in_file_t port_map = {
+    .size = sizeof(ebpf_map_definition_in_file_t),
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(uint32_t),
+    .pinning = PIN_GLOBAL_NS,
+    .max_entries = 1};
+
+SEC("xdp_prog") int lookup_update(struct xdp_md* ctx)
+{
+    uint32_t outer_key = 0;
+
+    // Read value from inner map.
+    void* inner_map = bpf_map_lookup_elem(&outer_map, &outer_key);
+    if (inner_map) {
+        uint32_t inner_key = 0;
+        uint32_t* inner_value = (uint32_t*)bpf_map_lookup_elem(inner_map, &inner_key);
+        if (inner_value) {
+            // Update the value in port_map
+            uint32_t key = 0;
+            uint32_t value = (uint32_t)(*inner_value);
+            bpf_map_update_elem(&port_map, &key, &value, 0);
+
+            return *inner_value;
+        }
+    }
+    return 0;
+}

--- a/tests/sample/map_reuse_bad.c
+++ b/tests/sample/map_reuse_bad.c
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// clang -O2 -Werror -c map_reuse_bad.c -o map_reuse_bad.o
+//
+// For bpf code: clang -target bpf -O2 -Werror -c map_reuse_bad.c -o map_reuse_bad.o
+// this passes the checker
+
+#include "bpf_helpers.h"
+#include "ebpf.h"
+
+#define PIN_NONE 0
+#define PIN_GLOBAL_NS 2
+SEC("maps")
+struct _ebpf_map_definition_in_file outer_map = {
+    .type = BPF_MAP_TYPE_HASH_OF_MAPS,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(uint32_t),
+    .max_entries = 1,
+    .pinning = PIN_GLOBAL_NS,
+    // inner_map_idx refers to the map index in the same ELF object.
+    .inner_map_idx = 1}; // (uint32_t)&inner_map
+
+SEC("maps")
+struct _ebpf_map_definition_in_file inner_map = {
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(uint32_t),
+    .max_entries = 1,
+    .pinning = PIN_GLOBAL_NS};
+
+SEC("maps")
+ebpf_map_definition_in_file_t port_map = {
+    .size = sizeof(ebpf_map_definition_in_file_t),
+    .type = BPF_MAP_TYPE_ARRAY,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(uint32_t),
+    .pinning = PIN_GLOBAL_NS,
+    .max_entries = 1};
+
+SEC("xdp_prog") int lookup_update(struct xdp_md* ctx)
+{
+    uint32_t outer_key = 0;
+
+    // Read value from inner map.
+    void* inner_map = bpf_map_lookup_elem(&outer_map, &outer_key);
+    if (inner_map) {
+        uint32_t inner_key = 0;
+        uint32_t* inner_value = (uint32_t*)bpf_map_lookup_elem(inner_map, &inner_key);
+        if (inner_value) {
+            // Update the value in port_map
+            uint32_t key = 0;
+            uint32_t value = (uint32_t)(*inner_value);
+            bpf_map_update_elem(&port_map, &key, &value, 0);
+
+            return *inner_value;
+        }
+    }
+    return 0;
+}

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -239,6 +239,26 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="map_reuse.c">
+      <FileType>CppCode</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
+    <CustomBuild Include="map_reuse_bad.c">
+      <FileType>CppCode</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/tests/sample/sample.vcxproj.filters
+++ b/tests/sample/sample.vcxproj.filters
@@ -63,5 +63,14 @@
     <CustomBuild Include="test_utility_helpers.c">
       <Filter>Source Files</Filter>
     </CustomBuild>
+    <CustomBuild Include="encap_reflect_packet.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="map_reuse.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
+    <CustomBuild Include="map_reuse_bad.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fixes #414

This PR adds auto-pinning option for maps.

For auto-pinning, this PR supports PIN_GLOBAL_NS option only. Support for other pinning options can be added in a separate PR. 

**Behavior**:
When PIN_GLOBAL_NS is enabled, then ebpfclient tries to re-use a map which is already pinned to the path. If an existing map is not found, new map is created and pinned to the path. For auto-pinning, the path prefix is "/ebpf/global"


This PR also fixes a bug in EC where deleting a map gets stuck in a loop.