### PR TITLE
Add libbpf bpf_create_map_in_map() API

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -6,6 +6,7 @@
 LIBRARY
 EXPORTS
     bpf_create_map
+    bpf_create_map_in_map
     bpf_create_map_xattr
     bpf_link__destroy
     bpf_link__disconnect

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -79,7 +79,8 @@ _ebpf_result_to_ntstatus(ebpf_result_t result)
         status = STATUS_NOT_FOUND;
         break;
     }
-    case EBPF_INVALID_ARGUMENT: {
+    case EBPF_INVALID_ARGUMENT:
+    case EBPF_INVALID_OBJECT: {
         status = STATUS_INVALID_PARAMETER;
         break;
     }
@@ -91,7 +92,7 @@ _ebpf_result_to_ntstatus(ebpf_result_t result)
         status = STATUS_NO_MORE_MATCHES;
         break;
     }
-    case EBPF_INVALID_OBJECT: {
+    case EBPF_INVALID_FD: {
         status = STATUS_INVALID_HANDLE;
         break;
     }

--- a/include/bpf/bpf.h
+++ b/include/bpf/bpf.h
@@ -78,6 +78,27 @@ int
 bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size, int max_entries, __u32 map_flags);
 
 /**
+ * @brief Create a new map-in-map.
+ *
+ * @param[in] map_type Type of outer map to create.
+ * @param[in] name Optionally, the name to use for the map.
+ * @param[in] key_size Size in bytes of keys.
+ * @param[in] inner_map_fd File descriptor of the inner map template.
+ * @param[in] max_entries Maximum number of entries in the map.
+ * @param[in] map_flags Flags (currently 0).
+ *
+ * @returns A new file descriptor that refers to the map.  A negative
+ * value indicates an error occurred and errno was set.
+ *
+ * @exception EBADF The file descriptor was not found.
+ * @exception EINVAL An invalid argument was provided.
+ * @exception ENOMEM Out of memory.
+ */
+int
+bpf_create_map_in_map(
+    enum bpf_map_type map_type, const char* name, int key_size, int inner_map_fd, int max_entries, __u32 map_flags);
+
+/**
  * @brief Create a new map.
  *
  * @param[in] create_attr Structure of attributes using which a map gets created.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -153,6 +153,7 @@ ebpf_create_map_xattr(_In_ const struct bpf_create_map_attr* create_attr, _Out_ 
 {
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_handle_t map_handle = ebpf_handle_invalid;
+    ebpf_handle_t inner_map_handle = ebpf_handle_invalid;
     ebpf_map_definition_in_memory_t map_definition = {0};
 
     if (create_attr->map_flags != 0 || map_fd == nullptr) {
@@ -168,7 +169,9 @@ ebpf_create_map_xattr(_In_ const struct bpf_create_map_attr* create_attr, _Out_ 
         map_definition.value_size = create_attr->value_size;
         map_definition.max_entries = create_attr->max_entries;
 
-        result = _create_map(create_attr->name, &map_definition, ebpf_handle_invalid, &map_handle);
+        inner_map_handle = _get_handle_from_file_descriptor(create_attr->inner_map_fd);
+
+        result = _create_map(create_attr->name, &map_definition, inner_map_handle, &map_handle);
         if (result != EBPF_SUCCESS) {
             goto Exit;
         }

--- a/libs/api/libbpf_map.cpp
+++ b/libs/api/libbpf_map.cpp
@@ -39,6 +39,23 @@ bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size, int max
     return bpf_create_map_xattr(&map_attr);
 }
 
+int
+bpf_create_map_in_map(
+    enum bpf_map_type map_type, const char* name, int key_size, int inner_map_fd, int max_entries, __u32 map_flags)
+{
+    struct bpf_create_map_attr map_attr = {0};
+
+    map_attr.map_type = map_type;
+    map_attr.name = name;
+    map_attr.key_size = key_size;
+    map_attr.value_size = sizeof(ebpf_id_t);
+    map_attr.inner_map_fd = inner_map_fd;
+    map_attr.max_entries = max_entries;
+    map_attr.map_flags = map_flags;
+
+    return bpf_create_map_xattr(&map_attr);
+}
+
 struct bpf_map*
 bpf_map__next(const struct bpf_map* previous, const struct bpf_object* object)
 {

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -109,7 +109,7 @@ windows_error_to_ebpf_result(uint32_t error)
         break;
 
     case ERROR_INVALID_HANDLE:
-        result = EBPF_INVALID_OBJECT;
+        result = EBPF_INVALID_FD;
         break;
 
     case ERROR_NOT_SUPPORTED:

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -290,6 +290,53 @@ _check_value_type(_In_ const ebpf_core_map_t* outer_map, _In_ const ebpf_object_
     return allowed;
 }
 
+// Validate that a value handle is appropriate for this map,
+// and if so, return a pointer to the object with that handle.
+static ebpf_result_t
+_get_map_value_object(
+    _In_ const ebpf_core_map_t* map,
+    ebpf_handle_t value_handle,
+    ebpf_object_type_t value_type,
+    _Outptr_ ebpf_object_t** value_object_result)
+{
+    // Convert value handle to an object pointer.
+    ebpf_object_t* value_object = NULL;
+    ebpf_result_t result = ebpf_reference_object_by_handle(value_handle, value_type, &value_object);
+    if (result != EBPF_SUCCESS)
+        return result;
+
+    const ebpf_program_type_t* value_program_type =
+        (value_object->get_program_type) ? value_object->get_program_type(value_object) : NULL;
+
+    if (value_type == EBPF_OBJECT_MAP) {
+        // Validate that the value is of the correct type.
+        if (!_check_value_type(map, value_object)) {
+            result = EBPF_INVALID_OBJECT;
+            goto Error;
+        }
+    }
+
+    // Validate that the value's program type (if any) is
+    // not in conflict with the map's program type.
+    if (value_program_type != NULL) {
+        ebpf_core_object_map_t* map_of_objects = (ebpf_core_object_map_t*)map;
+        if (!map_of_objects->is_program_type_set) {
+            map_of_objects->is_program_type_set = TRUE;
+            map_of_objects->program_type = *value_program_type;
+        } else if (memcmp(&map_of_objects->program_type, value_program_type, sizeof(*value_program_type)) != 0) {
+            result = EBPF_INVALID_FD;
+            goto Error;
+        }
+    }
+
+    *value_object_result = value_object;
+    return EBPF_SUCCESS;
+
+Error:
+    ebpf_object_release_reference((ebpf_object_t*)value_object);
+    return result;
+}
+
 static ebpf_result_t
 _update_array_map_entry_with_handle(
     _In_ ebpf_core_map_t* map,
@@ -306,43 +353,17 @@ _update_array_map_entry_with_handle(
     if (index >= map->ebpf_map_definition.max_entries)
         return EBPF_INVALID_ARGUMENT;
 
-    // Convert value handle to an object pointer.
-    ebpf_object_t* value_object;
-    int return_value = ebpf_reference_object_by_handle(value_handle, value_type, &value_object);
-    if (return_value != EBPF_SUCCESS)
-        return return_value;
-
     // The following addition is safe since it was checked during map creation.
     size_t actual_value_size = ((size_t)map->ebpf_map_definition.value_size) + sizeof(struct _ebpf_object*);
 
     ebpf_result_t result = EBPF_SUCCESS;
 
-    const ebpf_program_type_t* value_program_type =
-        (value_object->get_program_type) ? value_object->get_program_type(value_object) : NULL;
-
     ebpf_lock_state_t lock_state = ebpf_lock_lock(&map->lock);
 
-    if (value_type == EBPF_OBJECT_MAP) {
-        // Validate that the value is of the correct type.
-        if (!_check_value_type(map, value_object)) {
-            ebpf_object_release_reference(value_object);
-            result = EBPF_INVALID_FD;
-            goto Done;
-        }
-    }
-
-    // Validate that the value's program type (if any) is
-    // not in conflict with the map's program type.
-    if (value_program_type) {
-        ebpf_core_object_map_t* map_of_objects = (ebpf_core_object_map_t*)map;
-        if (!map_of_objects->is_program_type_set) {
-            map_of_objects->is_program_type_set = TRUE;
-            map_of_objects->program_type = *value_program_type;
-        } else if (memcmp(&map_of_objects->program_type, value_program_type, sizeof(*value_program_type)) != 0) {
-            ebpf_object_release_reference(value_object);
-            result = EBPF_INVALID_FD;
-            goto Done;
-        }
+    ebpf_object_t* value_object = NULL;
+    result = _get_map_value_object(map, value_handle, value_type, &value_object);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
     }
 
     // Release the reference on the old ID stored here, if any.
@@ -693,11 +714,10 @@ _update_hash_map_entry_with_handle(
     _In_ ebpf_core_map_t* map,
     _In_ const uint8_t* key,
     ebpf_object_type_t value_type,
-    uintptr_t value_handle,
+    ebpf_handle_t value_handle,
     ebpf_map_option_t option)
 {
     ebpf_result_t result = EBPF_SUCCESS;
-    ebpf_lock_state_t lock_state;
     size_t entry_count = 0;
     if (!map || !key)
         return EBPF_INVALID_ARGUMENT;
@@ -717,54 +737,42 @@ _update_hash_map_entry_with_handle(
         return EBPF_INVALID_ARGUMENT;
     }
 
-    // Convert value handle to an object pointer.
-    struct _ebpf_object* object;
-    int return_value = ebpf_reference_object_by_handle(value_handle, value_type, &object);
-    if (return_value != EBPF_SUCCESS)
-        return return_value;
+    ebpf_lock_state_t lock_state = ebpf_lock_lock(&map->lock);
 
-    // Validate that the object's program type is
-    // not in conflict with the map's program type.
-    const ebpf_program_type_t* program_type = (object->get_program_type) ? object->get_program_type(object) : NULL;
-    ebpf_core_object_map_t* object_map = (ebpf_core_object_map_t*)map;
-
-    lock_state = ebpf_lock_lock(&map->lock);
     entry_count = ebpf_hash_table_key_count((ebpf_hash_table_t*)map->data);
 
     uint8_t* old_value = NULL;
     ebpf_result_t found_result = ebpf_hash_table_find((ebpf_hash_table_t*)map->data, key, &old_value);
+    ebpf_id_t old_id = (old_value) ? *(ebpf_id_t*)old_value : 0;
+    ebpf_object_t* value_object = NULL;
 
     if ((entry_count == map->ebpf_map_definition.max_entries) && (found_result != EBPF_SUCCESS)) {
         // The hash table is already full.
         result = EBPF_INVALID_ARGUMENT;
-    } else {
-        if (program_type != NULL) {
-            // Verify that the program type of the object being set is not in
-            // conflict with the map's program type.
-            if (!object_map->is_program_type_set) {
-                object_map->is_program_type_set = TRUE;
-                object_map->program_type = *program_type;
-            } else if (memcmp(&object_map->program_type, program_type, sizeof(*program_type)) != 0) {
-                ebpf_object_release_reference((ebpf_object_t*)object);
-                result = EBPF_INVALID_FD;
-                goto Done;
-            }
-        }
+        goto Done;
+    }
 
-        // Release the reference on the old ID stored here, if any.
-        if (old_value) {
-            ebpf_id_t old_id = *(ebpf_id_t*)old_value;
-            if (old_id) {
-                ebpf_object_dereference_by_id(old_id, value_type);
-            }
-        }
+    result = _get_map_value_object(map, value_handle, value_type, &value_object);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
 
-        // Store the new object ID as the value.
-        result =
-            ebpf_hash_table_update((ebpf_hash_table_t*)map->data, key, (uint8_t*)&object->id, hash_table_operation);
+    // Store the new object ID as the value.
+    result =
+        ebpf_hash_table_update((ebpf_hash_table_t*)map->data, key, (uint8_t*)&value_object->id, hash_table_operation);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    // Release the reference on the old ID stored here, if any.
+    if (old_id) {
+        ebpf_object_dereference_by_id(old_id, value_type);
     }
 
 Done:
+    if ((result != EBPF_SUCCESS) && (value_object != NULL)) {
+        ebpf_object_release_reference((ebpf_object_t*)value_object);
+    }
     ebpf_lock_unlock(&map->lock, lock_state);
     return result;
 }
@@ -1100,6 +1108,13 @@ ebpf_map_create(
         result = ebpf_reference_object_by_handle(inner_map_handle, EBPF_OBJECT_MAP, &inner_map_template_object);
         if (result != EBPF_SUCCESS)
             goto Exit;
+    }
+    if ((local_map_definition.type == BPF_MAP_TYPE_ARRAY_OF_MAPS ||
+         local_map_definition.type == BPF_MAP_TYPE_HASH_OF_MAPS) &&
+        (inner_map_template_object == NULL)) {
+        // Must have a valid inner_map_handle.
+        result = EBPF_INVALID_FD;
+        goto Exit;
     }
 
     local_map = ebpf_map_function_tables[type].create_map(&local_map_definition);

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1103,18 +1103,18 @@ ebpf_map_create(
         goto Exit;
     }
 
-    if (inner_map_handle != ebpf_handle_invalid) {
+    if (local_map_definition.type == BPF_MAP_TYPE_ARRAY_OF_MAPS ||
+        local_map_definition.type == BPF_MAP_TYPE_HASH_OF_MAPS) {
+        if (inner_map_handle == ebpf_handle_invalid) {
+            // Must have a valid inner_map_handle.
+            result = EBPF_INVALID_FD;
+            goto Exit;
+        }
+
         // Convert value handle to an object pointer.
         result = ebpf_reference_object_by_handle(inner_map_handle, EBPF_OBJECT_MAP, &inner_map_template_object);
         if (result != EBPF_SUCCESS)
             goto Exit;
-    }
-    if ((local_map_definition.type == BPF_MAP_TYPE_ARRAY_OF_MAPS ||
-         local_map_definition.type == BPF_MAP_TYPE_HASH_OF_MAPS) &&
-        (inner_map_template_object == NULL)) {
-        // Must have a valid inner_map_handle.
-        result = EBPF_INVALID_FD;
-        goto Exit;
     }
 
     local_map = ebpf_map_function_tables[type].create_map(&local_map_definition);

--- a/libs/platform/ebpf_handle.h
+++ b/libs/platform/ebpf_handle.h
@@ -57,7 +57,7 @@ extern "C"
      * @param[in] object_type Object type to match.
      * @param[out] object Pointer to memory that contains object success.
      * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_ERROR_INVALID_HANDLE The provided handle is not valid.
+     * @retval EBPF_INVALID_OBJECT The provided handle is not valid.
      */
     ebpf_result_t
     ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_type, struct _ebpf_object** object);

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -112,6 +112,9 @@ Fail:
         case EBPF_INVALID_ARGUMENT:
             SetLastError(ERROR_INVALID_PARAMETER);
             break;
+        case EBPF_INVALID_FD:
+            SetLastError(ERROR_INVALID_HANDLE);
+            break;
         case EBPF_NO_MORE_KEYS:
             SetLastError(ERROR_NO_MORE_MATCHES);
             break;


### PR DESCRIPTION
* bpf_create_map() now fails for outer maps.  You must use  bpf_create_map_in_map() instead.
* Fixed bug where EBPF_INVALID_FD was incorrectly converted to EBPF_INVALID_ARGUMENT by ioctl handling code (part of issue #595). One symptom of this bug was that errno was being set to EINVAL in a number of cases which should have been EBADF.
* Fixed bug where a HASH_OF_MAPS (unlike ARRAY_OF_MAPS) wasn't enforcing that an inner map value had to match the inner map template. Refactored the code in ebpf_maps.c so the checking is done in one  place called by both maps, to ensure consistency.
* Fixed bug in HASH_OF_MAPS where if an update failed, it would leave the old entry but incorrectly drop the reference it held.  It now preserves the reference since the entry is unchanged.
* Added test case for ARRAY_OF_MAPS created via libbpf.  Previously only HASH_OF_MAPS creation was tested for that path.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>