### PR TITLE
add inner_id support for map of map

### DIFF
--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -69,6 +69,11 @@ typedef struct _ebpf_map_definition_in_file
      * file is the inner map template.
      */
     uint32_t inner_map_idx;
+
+    // id is the identifier for a map template.
+    uint32_t id;
+    // inner_id is the id of the inner map template.
+    uint32_t inner_id;
 } ebpf_map_definition_in_file_t;
 
 typedef enum

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -70,9 +70,11 @@ typedef struct _ebpf_map_definition_in_file
      */
     uint32_t inner_map_idx;
 
-    // id is the identifier for a map template.
+    /** id is the identifier for a map template.
+     */
     uint32_t id;
-    // inner_id is the id of the inner map template.
+    /** For a map of map, inner_id is the id of the inner map template.
+     */
     uint32_t inner_id;
 } ebpf_map_definition_in_file_t;
 

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -40,7 +40,20 @@ parse_maps_section_windows(
         int original_fd = i + ORIGINAL_FD_OFFSET;
         unsigned int inner_map_original_fd = UINT_MAX;
         if (s.type == BPF_MAP_TYPE_ARRAY_OF_MAPS || s.type == BPF_MAP_TYPE_HASH_OF_MAPS) {
-            inner_map_original_fd = (unsigned int)s.inner_map_idx + ORIGINAL_FD_OFFSET;
+            if (s.inner_map_idx != 0) {
+                inner_map_original_fd = (unsigned int)s.inner_map_idx + ORIGINAL_FD_OFFSET;
+            } else if (s.inner_id != 0) {
+                for (int j = 0; j < mapdefs.size(); j++) {
+                    auto& inner_s = mapdefs[j];
+                    if (inner_s.id == 0) {
+                        continue;
+                    }
+                    if (inner_s.id == s.inner_id && i != j) {
+                        inner_map_original_fd = j + ORIGINAL_FD_OFFSET;
+                        break;
+                    }
+                }
+            }
         }
 
         cache_map_handle(

--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -45,9 +45,6 @@ parse_maps_section_windows(
             } else if (s.inner_id != 0) {
                 for (int j = 0; j < mapdefs.size(); j++) {
                     auto& inner_s = mapdefs[j];
-                    if (inner_s.id == 0) {
-                        continue;
-                    }
                     if (inner_s.id == s.inner_id && i != j) {
                         inner_map_original_fd = j + ORIGINAL_FD_OFFSET;
                         break;

--- a/tests/sample/map_in_map_v2.c
+++ b/tests/sample/map_in_map_v2.c
@@ -25,10 +25,10 @@ struct _ebpf_map_definition_in_file inner_map = {
 SEC("xdp_prog") int lookup(struct xdp_md* ctx)
 {
     uint32_t outer_key = 0;
-    void* nolocal_lru_map = bpf_map_lookup_elem(&outer_map, &outer_key);
-    if (nolocal_lru_map) {
+    void* inner_map = bpf_map_lookup_elem(&outer_map, &outer_key);
+    if (inner_map) {
         uint32_t inner_key = 0;
-        uint32_t* value = (uint32_t*)bpf_map_lookup_elem(nolocal_lru_map, &inner_key);
+        uint32_t* value = (uint32_t*)bpf_map_lookup_elem(inner_map, &inner_key);
         if (value) {
             return *(uint32_t*)value;
         }

--- a/tests/sample/map_in_map_v2.c
+++ b/tests/sample/map_in_map_v2.c
@@ -1,0 +1,37 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "bpf_helpers.h"
+
+#define INNER_MAP_ID 10
+
+SEC("maps")
+struct _ebpf_map_definition_in_file outer_map = {
+    .type = BPF_MAP_TYPE_ARRAY_OF_MAPS,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(uint32_t),
+    .max_entries = 1,
+    // inner_id refers to the id of the inner map in the same ELF object.
+    .inner_id = INNER_MAP_ID}; // (uint32_t)&inner_map
+
+SEC("maps")
+struct _ebpf_map_definition_in_file inner_map = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(uint32_t),
+    .max_entries = 1,
+    .id = INNER_MAP_ID};
+
+SEC("xdp_prog") int lookup(struct xdp_md* ctx)
+{
+    uint32_t outer_key = 0;
+    void* nolocal_lru_map = bpf_map_lookup_elem(&outer_map, &outer_key);
+    if (nolocal_lru_map) {
+        uint32_t inner_key = 0;
+        uint32_t* value = (uint32_t*)bpf_map_lookup_elem(nolocal_lru_map, &inner_key);
+        if (value) {
+            return *(uint32_t*)value;
+        }
+    }
+    return 0;
+}

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -239,6 +239,17 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="map_in_map_v2.c">
+      <FileType>CppCode</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/tests/sample/sample.vcxproj.filters
+++ b/tests/sample/sample.vcxproj.filters
@@ -66,5 +66,8 @@
     <CustomBuild Include="encap_reflect_packet.c">
       <Filter>Source Files</Filter>
     </CustomBuild>
+    <CustomBuild Include="map_in_map_v2.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
   </ItemGroup>
 </Project>

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -703,6 +703,59 @@ TEST_CASE("array of maps", "[libbpf]")
     bpf_object__close(xdp_object);
 }
 
+// Create a map-in-map using id and inner_id.
+TEST_CASE("array of maps2", "[libbpf]")
+{
+    _test_helper_end_to_end test_helper;
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
+
+    struct bpf_object* xdp_object;
+    int xdp_object_fd;
+    int error = bpf_prog_load("map_in_map_v2.o", BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
+    REQUIRE(error == 0);
+    REQUIRE(xdp_object != nullptr);
+
+    struct bpf_program* caller = bpf_object__find_program_by_name(xdp_object, "lookup");
+    REQUIRE(caller != nullptr);
+
+    struct bpf_map* outer_map = bpf_object__find_map_by_name(xdp_object, "outer_map");
+    REQUIRE(outer_map != nullptr);
+
+    int outer_map_fd = bpf_map__fd(outer_map);
+    REQUIRE(outer_map_fd > 0);
+
+    // Create an inner map.
+    int inner_map_fd = bpf_create_map(BPF_MAP_TYPE_HASH, sizeof(__u32), sizeof(__u32), 1, 0);
+    REQUIRE(inner_map_fd > 0);
+
+    // Add a value to the inner map.
+    int inner_value = 42;
+    uint32_t inner_key = 0;
+    error = bpf_map_update_elem(inner_map_fd, &inner_key, &inner_value, 0);
+    REQUIRE(error == 0);
+
+    // Add inner map to outer map.
+    __u32 outer_key = 0;
+    error = bpf_map_update_elem(outer_map_fd, &outer_key, &inner_map_fd, 0);
+    REQUIRE(error == 0);
+
+    bpf_link* link = bpf_program__attach_xdp(caller, 1);
+    REQUIRE(link != nullptr);
+
+    // Now run the ebpf program.
+    auto packet = prepare_udp_packet(0, ETHERNET_TYPE_IPV4);
+    xdp_md_t ctx{packet.data(), packet.data() + packet.size()};
+    int result;
+    REQUIRE(hook.fire(&ctx, &result) == EBPF_SUCCESS);
+
+    // Verify the return value is what we saved in the inner map.
+    REQUIRE(result == inner_value);
+
+    Platform::_close(inner_map_fd);
+    bpf_object__close(xdp_object);
+}
+
 TEST_CASE("disallow wrong inner map types", "[libbpf]")
 {
     _test_helper_end_to_end test_helper;


### PR DESCRIPTION
Fixes #618 

The fix first tries to find inner map based on `inner_map_idx`. If `inner_map_idx` is 0, it tries to use `inner_id` to find the inner map template.