### PR TITLE
Add logic to track asynchronous ebpf operations 

### DIFF
--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -97,6 +97,9 @@ extern "C"
 
         /// Caller has reached tail call limit.
         EBPF_NO_MORE_TAIL_CALLS,
+
+        // Requested action is still pending.
+        EBPF_PENDING,
     } ebpf_result_t;
 
 #ifdef __cplusplus

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "ebpf_core.h"
+#include "ebpf_completion.h"
 #include "ebpf_epoch.h"
 #include "ebpf_handle.h"
 #include "ebpf_link.h"
@@ -92,6 +93,10 @@ ebpf_core_initiate()
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
+    return_value = ebpf_completion_initiate();
+    if (return_value != EBPF_SUCCESS)
+        goto Done;
+
     ebpf_object_tracking_initiate();
 
     return_value = ebpf_pinning_table_allocate(&_ebpf_core_map_pinning_table);
@@ -140,6 +145,8 @@ ebpf_core_terminate()
     ebpf_program_terminate();
 
     ebpf_handle_table_terminate();
+
+    ebpf_completion_terminate();
 
     ebpf_pinning_table_free(_ebpf_core_map_pinning_table);
 

--- a/libs/platform/ebpf_completion.h
+++ b/libs/platform/ebpf_completion.h
@@ -1,0 +1,106 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Library to tie an asynchronous action initiator and an action handler together.
+// There flow is as follows:
+//
+// 1) Action initiator calls ebpf_completion_set_completion_callback to associate their context with a completion
+// method.
+//
+// 2) Action initiator calls handler to start the asynchronous action.
+//
+// 3) Action handler calls ebpf_completion_set_cancel_callback to permit it to be notified if a cancellation occurs.
+//
+// 4) Action handler starts the asynchronous operation and returns to action initiator.
+//
+// 5) a) Success path: Action handler calls ebpf_completion_complete to notify the action initiator that the action has
+// completed.
+//
+// 5) b) Cancellation path: Action initiator calls ebpf_completion_cancel to notify the action handler that
+// the request has been canceled.
+//
+// Notes:
+//
+// 1) ebpf_completion_complete and ebpf_completion_cancel can be called
+// concurrently, with one becoming a no-op.
+//
+// 2) Action initiator must not re-use context until after prior actions are
+// completed or canceled.
+//
+// 3) Action handler must register for cancellation prior to returning to action initiator.
+
+#pragma once
+#include "ebpf_platform.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * @brief Initialize the completion tracking module.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  operation.
+     */
+    ebpf_result_t
+    ebpf_completion_initiate();
+
+    /**
+     * @brief Shutdown the completion tracking module.
+     *
+     */
+    void
+    ebpf_completion_terminate();
+
+    /**
+     * @brief Set a completion function to be called when actions associated with this context complete.
+     *
+     * @param context Context of action to track.
+     * @param on_complete Function to call when the action associated with this context completes.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  operation.
+     */
+    ebpf_result_t
+    ebpf_completion_set_completion_callback(
+        _In_ void* context, _In_ void (*on_complete)(_In_ void* context, ebpf_result_t result));
+
+    /**
+     * @brief Set a cancellation function to be called when actions associated with this context are cancelled.
+     *
+     * @param context Context of action to track.
+     * @param cancelation_context Context to pass when this action is cancelled.
+     * @param on_cancel Function to call this action is canceled.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NOT_FOUND The action context hasn't been registered.
+     */
+    ebpf_result_t
+    ebpf_completion_set_cancel_callback(
+        _In_ void* context, _In_ void* cancelation_context, _In_ void (*on_cancel)(_In_ void* cancelation_context));
+
+    /**
+     * @brief Cancel the action associated with this context.
+     *
+     * @param context Context associated with the action.
+     * @return true Action was cancelled.
+     * @return false Action was already completed.
+     */
+    bool
+    ebpf_completion_cancel(_In_ void* context);
+
+    /**
+     * @brief Complete the action associated with this context.
+     *
+     * @param context Context associated with the action.
+     * @param result
+     * @return true Action was cancelled.
+     * @return false Action was already completed.
+     */
+    bool
+    ebpf_completion_complete(_In_ void* context, ebpf_result_t result);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libs/platform/kernel/platform_kernel.vcxproj
+++ b/libs/platform/kernel/platform_kernel.vcxproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\ebpf_bitmap.c" />
+    <ClCompile Include="..\ebpf_completion.c" />
     <ClCompile Include="..\ebpf_epoch.c" />
     <ClCompile Include="..\ebpf_hash_table.c" />
     <ClCompile Include="..\ebpf_object.c" />
@@ -60,6 +61,7 @@
     <ClInclude Include="..\..\..\include\ebpf_structs.h" />
     <ClInclude Include="..\..\..\include\ebpf_windows.h" />
     <ClInclude Include="..\ebpf_bitmap.h" />
+    <ClInclude Include="..\ebpf_completion.h" />
     <ClInclude Include="..\ebpf_epoch.h" />
     <ClInclude Include="..\ebpf_handle.h" />
     <ClInclude Include="..\ebpf_object.h" />

--- a/libs/platform/kernel/platform_kernel.vcxproj.filters
+++ b/libs/platform/kernel/platform_kernel.vcxproj.filters
@@ -55,6 +55,9 @@
     <ClCompile Include="..\ebpf_bitmap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ebpf_completion.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ebpf_epoch.h">
@@ -106,6 +109,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\ebpf_bitmap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ebpf_completion.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/libs/platform/user/platform_user.vcxproj
+++ b/libs/platform/user/platform_user.vcxproj
@@ -24,6 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\ebpf_bitmap.c" />
+    <ClCompile Include="..\ebpf_completion.c" />
     <ClCompile Include="..\ebpf_epoch.c" />
     <ClCompile Include="..\ebpf_hash_table.c" />
     <ClCompile Include="..\ebpf_object.c" />
@@ -36,6 +37,7 @@
     <ClCompile Include="ebpf_handle_user.c" />
     <ClCompile Include="ebpf_platform_user.cpp" />
     <ClInclude Include="..\ebpf_bitmap.h" />
+    <ClInclude Include="..\ebpf_completion.h" />
     <ClInclude Include="..\ebpf_epoch.h" />
     <ClInclude Include="..\ebpf_handle.h" />
     <ClInclude Include="..\ebpf_object.h" />

--- a/libs/platform/user/platform_user.vcxproj.filters
+++ b/libs/platform/user/platform_user.vcxproj.filters
@@ -58,6 +58,9 @@
     <ClCompile Include="..\ebpf_bitmap.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ebpf_completion.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="..\ebpf_program_types.idl">
@@ -92,6 +95,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\ebpf_bitmap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ebpf_completion.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This logic is needed to support asynchronous ebpf operations (such as notification when a ring buffer's state changes).


Signed-off-by: Alan Jowett <alanjo@microsoft.com>