### PR TITLE
Add filter in outbound L2 layer.

### DIFF
--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -54,7 +54,17 @@ typedef struct _net_ebpf_ext_wfp_callout_state
 
 static net_ebpf_ext_wfp_callout_state_t _net_ebpf_ext_wfp_callout_state[] = {
     {
-        &EBPF_HOOK_L2_CALLOUT,
+        &EBPF_HOOK_OUTBOUND_L2_CALLOUT,
+        &FWPM_LAYER_OUTBOUND_MAC_FRAME_NATIVE,
+        net_ebpf_ext_layer_2_classify,
+        _net_ebpf_ext_filter_change_notify,
+        _net_ebpf_ext_flow_delete,
+        L"L2 XDP Callout",
+        L"L2 callout driver for eBPF at XDP-like layer",
+        FWP_ACTION_CALLOUT_TERMINATING,
+    },
+    {
+        &EBPF_HOOK_INBOUND_L2_CALLOUT,
         &FWPM_LAYER_INBOUND_MAC_FRAME_NATIVE,
         net_ebpf_ext_layer_2_classify,
         _net_ebpf_ext_filter_change_notify,

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -59,8 +59,8 @@ static net_ebpf_ext_wfp_callout_state_t _net_ebpf_ext_wfp_callout_state[] = {
         net_ebpf_ext_layer_2_classify,
         _net_ebpf_ext_filter_change_notify,
         _net_ebpf_ext_flow_delete,
-        L"L2 XDP Callout",
-        L"L2 callout driver for eBPF at XDP-like layer",
+        L"L2 Callout",
+        L"L2 callout driver",
         FWP_ACTION_CALLOUT_TERMINATING,
     },
     {
@@ -69,8 +69,8 @@ static net_ebpf_ext_wfp_callout_state_t _net_ebpf_ext_wfp_callout_state[] = {
         net_ebpf_ext_layer_2_classify,
         _net_ebpf_ext_filter_change_notify,
         _net_ebpf_ext_flow_delete,
-        L"L2 XDP Callout",
-        L"L2 callout driver for eBPF at XDP-like layer",
+        L"L2 Callout",
+        L"L2 callout driver",
         FWP_ACTION_CALLOUT_TERMINATING,
     },
     {

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -297,6 +297,9 @@ net_ebpf_ext_layer_2_classify(
     if (!ebpf_ext_attach_enter_rundown(_ebpf_xdp_hook_provider_registration))
         goto Done;
 
+    if (incoming_fixed_values->layerId == FWPS_LAYER_OUTBOUND_MAC_FRAME_NATIVE)
+        goto Done;
+
     if (nbl == NULL) {
         KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "Null NBL \n"));
         goto Done;

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -297,6 +297,15 @@ net_ebpf_ext_layer_2_classify(
     if (!ebpf_ext_attach_enter_rundown(_ebpf_xdp_hook_provider_registration))
         goto Done;
 
+    //
+    // WFP MAC layers are implemented using NDIS light-weight filter (LWF).
+    // See https://docs.microsoft.com/en-us/windows-hardware/drivers/network/using-layer-2-filtering for details.
+    // FwpsInjectMacSendAsync API is used for injecting packets in outbound direction to implement XDP_TX.
+    // For packet injection to work WFP LWF must register packet send-completion handlers with NDIS.
+    // This handler is added only if WFP filters/callouts are added in FWPS_LAYER_OUTBOUND_MAC_FRAME_NATIVE layer.
+    // That is why a filter and a callout is added in this layer even though the callout at outbound layer
+    // need not process any outbound packets.
+    //
     if (incoming_fixed_values->layerId == FWPS_LAYER_OUTBOUND_MAC_FRAME_NATIVE)
         goto Done;
 

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -298,12 +298,12 @@ net_ebpf_ext_layer_2_classify(
         goto Done;
 
     //
-    // WFP MAC layers are implemented using NDIS light-weight filter (LWF).
+    // WFP MAC layers are implemented using NDIS light-weight filters (LWF).
     // See https://docs.microsoft.com/en-us/windows-hardware/drivers/network/using-layer-2-filtering for details.
-    // FwpsInjectMacSendAsync API is used for injecting packets in outbound direction to implement XDP_TX.
+    // FwpsInjectMacSendAsync API is used for injecting packets in the outbound direction to implement XDP_TX.
     // For packet injection to work WFP LWF must register packet send-completion handlers with NDIS.
-    // This handler is added only if WFP filters/callouts are added in FWPS_LAYER_OUTBOUND_MAC_FRAME_NATIVE layer.
-    // That is why a filter and a callout is added in this layer even though the callout at outbound layer
+    // This handler is added only if WFP filters/callouts are added in the FWPS_LAYER_OUTBOUND_MAC_FRAME_NATIVE layer.
+    // That is why a filter and a callout is added in this layer even though the callout at the outbound layer
     // need not process any outbound packets.
     //
     if (incoming_fixed_values->layerId == FWPS_LAYER_OUTBOUND_MAC_FRAME_NATIVE)

--- a/netebpfext/net_ebpf_ext_xdp.h
+++ b/netebpfext/net_ebpf_ext_xdp.h
@@ -5,11 +5,14 @@
 
 // Callout GUIDs
 
+// 5a5614e4-6b64-4738-8367-33c6ca07bf8f
+DEFINE_GUID(EBPF_HOOK_OUTBOUND_L2_CALLOUT, 0x5a5614e4, 0x6b64, 0x4738, 0x83, 0x67, 0x33, 0xc6, 0xca, 0x07, 0xbf, 0x8f);
+
 // 5a5614e5-6b64-4738-8367-33c6ca07bf8f
-DEFINE_GUID(EBPF_HOOK_L2_CALLOUT, 0x5a5614e5, 0x6b64, 0x4738, 0x83, 0x67, 0x33, 0xc6, 0xca, 0x07, 0xbf, 0x8f);
+DEFINE_GUID(EBPF_HOOK_INBOUND_L2_CALLOUT, 0x5a5614e5, 0x6b64, 0x4738, 0x83, 0x67, 0x33, 0xc6, 0xca, 0x07, 0xbf, 0x8f);
 
 /**
- * @brief WFP classifyFn callback for EBPF_HOOK_L2_CALLOUT.
+ * @brief Common WFP classifyFn callback for EBPF_HOOK_OUTBOUND_L2_CALLOUT and EBPF_HOOK_INBOUND_L2_CALLOUT.
  *
  */
 void

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -28,7 +28,7 @@ function Unregister-eBPFComponents
     }
 
     # Uninstall user mode service.
-    sc.exe delete eBPFSvc.exe 2>&1 | Write-Log
+    sc.exe delete eBPFSvc 2>&1 | Write-Log
 
     # Delete the eBPF netsh helper.
     netsh delete helper "$Env:systemroot\system32\ebpfnetsh.dll"  2>&1 | Write-Log
@@ -84,6 +84,9 @@ function Start-eBPFComponents
 
 function Install-eBPFComponents
 {
+    # Stop eBPF Components
+    Stop-eBPFComponents
+
     # Copy all binaries to system32.
     Copy-Item *.sys -Destination "$Env:systemroot\system32\drivers" -Force -ErrorAction Stop 2>&1 | Write-Log
     Copy-Item *.dll -Destination "$Env:systemroot\system32" -Force -ErrorAction Stop 2>&1 | Write-Log
@@ -99,10 +102,10 @@ function Install-eBPFComponents
 function Stop-eBPFComponents
 {
     # Stop user mode service.
-    Stop-Service "eBPFSvc" -ErrorAction Stop 2>&1 | Write-Log
+    Stop-Service "eBPFSvc" -ErrorAction Ignore 2>&1 | Write-Log
 
     # Stop the drivers.
     $EbpfDrivers.GetEnumerator() | ForEach-Object {
-        Stop-Service $_.Name -ErrorAction Stop 2>&1 | Write-Log
+        Stop-Service $_.Name -ErrorAction Ignore 2>&1 | Write-Log
     }
 }


### PR DESCRIPTION
This PR fixes issue described in #639 .

The netebpfext uses WFP callout at `INBOUND_MAC_FRAME_NATIVE` layer which caused WFP NDIS LWF to plumb receive handler only. However in `XDP_TX` code path the callout injects packets in outbound path, which required a send completion handler to be registered which was not present. NDIS invoked incorrect handler and OS crashed. The fix for this was to add WFP callout at `OUTBOUND_MAC_FRAME_NATIVE` layer as well which plumbed send completion handler.

The reason why this was not caught in internal testing was because the xdp_tests were run on other OS (client SKUs) that had some other Windows internal components that created WFP callouts in the `OUTBOUND_MAC` layer.

Some fixes were made to the installation script as well.