### PR TITLE
Fix AV in netebpfext when packet with multiple MDLs is received

### DIFF
--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -212,7 +212,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     }
 
 #pragma warning(push)
-#pragma warning(disable : 28145) /* The opaque MDL structure should not be modified by a driver except for
+#pragma warning(disable : 28145) /* The opaque MDL structure should not be modified by a driver except for \
                                     MDL_PAGES_LOCKED and MDL_MAPPING_CAN_FAIL. */
     ring_descriptor->memory_descriptor_list->MdlFlags |= MDL_PAGES_LOCKED;
 #pragma warning(pop)


### PR DESCRIPTION
This fixes an issue in netebpfext where it hits a bugcheck when trying to clone an NBL whose NB has multiple MDLs. 