### PR TITLE
Fix crash in kernel on divide by zero

### DIFF
--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -605,7 +605,13 @@ int32_t
 ebpf_log_function(_In_ void* context, _In_z_ const char* format_string, ...)
 {
     UNREFERENCED_PARAMETER(context);
-    UNREFERENCED_PARAMETER(format_string);
+
+    va_list arg_start;
+    va_start(arg_start, format_string);
+
+    vprintf(format_string, arg_start);
+
+    va_end(arg_start);
     return 0;
 }
 


### PR DESCRIPTION
Fix crash in the kernel on divide by zero.

Resolves: #666 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>