### PR TITLE
Pin actions/upload-artifact to version 2.2.4 to unblock ci/cd

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:Analysis='True' ${{env.SOLUTION_FILE_PATH}}
 
     - name: Upload Build Output
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.2.4
       with:
         name: Build x64 ${{ matrix.configurations }}
         path: ${{ github.workspace }}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
@@ -90,7 +90,7 @@ jobs:
       run: if (Test-Path *.dmp) { exit 1 }
 
     - name: Upload any crash dumps
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v2.2.4
       if: failure()
       with:
         name: Crash-Dumps-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}


### PR DESCRIPTION
Pin actions/upload-artifact to version 2.2.4 to unblock ci/cd

Signed-off-by: Alan Jowett <alanjo@microsoft.com>