### PR TITLE
Set the multi-processor build flag globally

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,4 +9,9 @@
     <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
     <CodeAnalysisRuleSet>$(SolutionDir)Analyze.default.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Set the multi-processor build flag globally.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>