### PR TITLE
Disable color output to avoid appverif problem

### DIFF
--- a/tests/libs/util/catch_wrapper.hpp
+++ b/tests/libs/util/catch_wrapper.hpp
@@ -8,6 +8,7 @@
 #pragma warning(disable : 26495) // Always initialize a member variable
 #pragma warning(disable : 26812) // Prefer 'enum class' over 'enum'
 #pragma warning(disable : 26816) // The pointer points to memory allocated on the stack
-#define CATCH_CONFIG_COLOUR_NONE 1
+
+#define CATCH_CONFIG_COLOUR_NONE 1 // Disable color until https://github.com/catchorg/Catch2/issues/2345 is fixed.
 #include "catch2\catch.hpp"
 #pragma warning(pop)

--- a/tests/libs/util/catch_wrapper.hpp
+++ b/tests/libs/util/catch_wrapper.hpp
@@ -8,5 +8,6 @@
 #pragma warning(disable : 26495) // Always initialize a member variable
 #pragma warning(disable : 26812) // Prefer 'enum class' over 'enum'
 #pragma warning(disable : 26816) // The pointer points to memory allocated on the stack
+#define CATCH_CONFIG_COLOUR_NONE 1
 #include "catch2\catch.hpp"
 #pragma warning(pop)


### PR DESCRIPTION
There does not appear to be any simple way to use a custom color
class with CATCH2 so we just disable color as is done for a UWP.

Fixes #679

Signed-off-by: Dave Thaler <dthaler@microsoft.com>