### PR TITLE
Support map fds with bpf_load_program

### DIFF
--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -277,9 +277,14 @@ ebpf_result_to_errno(ebpf_result_t result)
 }
 
 ebpf_result_t
+ebpf_object_get_info(
+    ebpf_handle_t handle,
+    _Out_writes_bytes_to_(*info_size, *info_size) void* info,
+    _Inout_ uint32_t* info_size) noexcept;
+
+ebpf_result_t
 query_map_definition(
     ebpf_handle_t handle,
-    _Out_ uint32_t* size,
     _Out_ uint32_t* type,
     _Out_ uint32_t* key_size,
     _Out_ uint32_t* value_size,

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -632,30 +632,6 @@ _ebpf_core_protocol_get_next_program(
 }
 
 static ebpf_result_t
-_ebpf_core_protocol_query_map_definition(
-    _In_ const struct _ebpf_operation_query_map_definition_request* request,
-    _Inout_ struct _ebpf_operation_query_map_definition_reply* reply,
-    uint16_t reply_length)
-{
-    EBPF_LOG_ENTRY();
-    UNREFERENCED_PARAMETER(reply_length);
-
-    ebpf_object_t* object;
-    ebpf_result_t result = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, &object);
-    if (result != EBPF_SUCCESS) {
-        EBPF_RETURN_RESULT(result);
-    }
-
-    ebpf_map_t* map = (ebpf_map_t*)object;
-    reply->map_definition = *ebpf_map_get_definition(map);
-    reply->map_definition.value_size = ebpf_map_get_effective_value_size(map);
-
-    ebpf_object_release_reference(object);
-
-    EBPF_RETURN_RESULT(EBPF_SUCCESS);
-}
-
-static ebpf_result_t
 _ebpf_core_protocol_query_program_info(
     _In_ const struct _ebpf_operation_query_program_info_request* request,
     _Inout_ struct _ebpf_operation_query_program_info_reply* reply,
@@ -1456,11 +1432,6 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_get_next_program,
      sizeof(struct _ebpf_operation_get_next_program_request),
      sizeof(struct _ebpf_operation_get_next_program_reply)},
-
-    // EBPF_OPERATION_QUERY_MAP_DEFINITION
-    {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_query_map_definition,
-     sizeof(struct _ebpf_operation_query_map_definition_request),
-     sizeof(struct _ebpf_operation_query_map_definition_reply)},
 
     // EBPF_OPERATION_QUERY_PROGRAM_INFO
     {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_query_program_info,

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -21,7 +21,6 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_MAP_GET_NEXT_KEY,
     EBPF_OPERATION_GET_NEXT_MAP,
     EBPF_OPERATION_GET_NEXT_PROGRAM,
-    EBPF_OPERATION_QUERY_MAP_DEFINITION,
     EBPF_OPERATION_QUERY_PROGRAM_INFO,
     EBPF_OPERATION_UPDATE_PINNING,
     EBPF_OPERATION_GET_PINNING,
@@ -186,18 +185,6 @@ typedef struct _ebpf_operation_get_next_program_reply
     struct _ebpf_operation_header header;
     ebpf_handle_t next_handle;
 } ebpf_operation_get_next_program_reply_t;
-
-typedef struct _ebpf_operation_query_map_definition_request
-{
-    struct _ebpf_operation_header header;
-    ebpf_handle_t handle;
-} ebpf_operation_query_map_definition_request;
-
-typedef struct _ebpf_operation_query_map_definition_reply
-{
-    struct _ebpf_operation_header header;
-    ebpf_map_definition_in_memory_t map_definition;
-} ebpf_operation_query_map_definition_reply_t;
 
 typedef struct _ebpf_operation_get_handle_by_id_request
 {

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -121,6 +121,7 @@ _resolve_ec_function(ebpf_ec_function_t function, uint64_t* address)
     return EBPF_SUCCESS;
 }
 
+// Replace map handles with map addresses.
 static ebpf_result_t
 _resolve_maps_in_byte_code(ebpf_handle_t program_handle, ebpf_code_buffer_t& byte_code)
 {
@@ -319,7 +320,7 @@ ebpf_verify_and_load_program(
             goto Exit;
         }
 
-        // Verify the program
+        // Verify the program.
         result = verify_byte_code(program_type, byte_code, byte_code_size, error_message, error_message_size);
         if (result != EBPF_SUCCESS) {
             goto Exit;

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -121,18 +121,18 @@ _resolve_ec_function(ebpf_ec_function_t function, uint64_t* address)
     return EBPF_SUCCESS;
 }
 
-// Replace map handles with map addresses.
+// Replace map fds with map addresses.
 static ebpf_result_t
 _resolve_maps_in_byte_code(ebpf_handle_t program_handle, ebpf_code_buffer_t& byte_code)
 {
-    std::vector<size_t> instruction_offsets;
-    std::vector<uint64_t> map_handles;
+    // Create parallel vectors indexed by # of occurrence in the instructions.
+    std::vector<size_t> instruction_offsets; // 0-based instruction number.
+    std::vector<fd_t> map_fds;               // map_fd used in the bytecode.
 
     ebpf_inst* instructions = reinterpret_cast<ebpf_inst*>(byte_code.data());
     ebpf_inst* instruction_end = reinterpret_cast<ebpf_inst*>(byte_code.data() + byte_code.size());
     for (size_t index = 0; index < byte_code.size() / sizeof(ebpf_inst); index++) {
         ebpf_inst& first_instruction = instructions[index];
-        ebpf_inst& second_instruction = instructions[index + 1];
         if (first_instruction.opcode != INST_OP_LDDW_IMM) {
             continue;
         }
@@ -146,21 +146,20 @@ _resolve_maps_in_byte_code(ebpf_handle_t program_handle, ebpf_code_buffer_t& byt
             continue;
         }
 
-        uint64_t imm =
-            static_cast<uint64_t>(first_instruction.imm) | (static_cast<uint64_t>(second_instruction.imm) << 32);
+        fd_t map_fd = static_cast<fd_t>(first_instruction.imm);
         instruction_offsets.push_back(index - 1);
-        map_handles.push_back(imm);
+        map_fds.push_back(map_fd);
     }
 
-    if (map_handles.empty()) {
+    if (map_fds.empty()) {
         return EBPF_SUCCESS;
     }
 
     ebpf_protocol_buffer_t request_buffer(
-        offsetof(ebpf_operation_resolve_map_request_t, map_handle) + sizeof(uint64_t) * map_handles.size());
+        offsetof(ebpf_operation_resolve_map_request_t, map_handle) + sizeof(uint64_t) * map_fds.size());
 
     ebpf_protocol_buffer_t reply_buffer(
-        offsetof(ebpf_operation_resolve_map_reply_t, address) + sizeof(uint64_t) * map_handles.size());
+        offsetof(ebpf_operation_resolve_map_reply_t, address) + sizeof(uint64_t) * map_fds.size());
 
     auto request = reinterpret_cast<ebpf_operation_resolve_map_request_t*>(request_buffer.data());
     auto reply = reinterpret_cast<ebpf_operation_resolve_map_reply_t*>(reply_buffer.data());
@@ -168,11 +167,8 @@ _resolve_maps_in_byte_code(ebpf_handle_t program_handle, ebpf_code_buffer_t& byt
     request->header.length = static_cast<uint16_t>(request_buffer.size());
     request->program_handle = program_handle;
 
-    for (size_t index = 0; index < map_handles.size(); index++) {
-        if (map_handles[index] > get_map_descriptor_size()) {
-            return EBPF_INVALID_OBJECT;
-        }
-        request->map_handle[index] = (uint64_t)get_map_handle_at_index((int)map_handles[index] - 1);
+    for (size_t index = 0; index < map_fds.size(); index++) {
+        request->map_handle[index] = get_map_handle(map_fds[index]);
     }
 
     uint32_t result = invoke_ioctl(request_buffer, reply_buffer);
@@ -180,7 +176,7 @@ _resolve_maps_in_byte_code(ebpf_handle_t program_handle, ebpf_code_buffer_t& byt
         return win32_error_code_to_ebpf_result(result);
     }
 
-    for (size_t index = 0; index < map_handles.size(); index++) {
+    for (size_t index = 0; index < map_fds.size(); index++) {
         ebpf_inst& first_instruction = instructions[instruction_offsets[index]];
         ebpf_inst& second_instruction = instructions[instruction_offsets[index] + 1];
 
@@ -205,12 +201,10 @@ _query_and_cache_map_descriptors(
 
     if (handle_map_count > 0) {
         for (uint32_t i = 0; i < handle_map_count; i++) {
-            uint32_t size;
             descriptor = {0};
             ebpf_id_t inner_map_id;
             result = query_map_definition(
                 reinterpret_cast<ebpf_handle_t>(handle_map[i].handle),
-                &size,
                 &descriptor.type,
                 &descriptor.key_size,
                 &descriptor.value_size,

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -162,7 +162,7 @@ TEST_CASE("libbpf program", "[libbpf]")
     int result = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
-    REQUIRE(program_fd != -1);
+    REQUIRE(program_fd != ebpf_fd_invalid);
 
     const char* name = bpf_object__name(object);
     REQUIRE(strcmp(name, "droppacket.o") == 0);


### PR DESCRIPTION
Fixes #714

This also removes the EBPF_OPERATION_QUERY_MAP_DEFINITION ioctl which was now redundant with EBPF_OPERATION_GET_OBJECT_INFO for a map.  The only functional difference is that EBPF_OPERATION_QUERY_MAP_DEFINITION returned the original inner_map_id value set by the user mode app even for map types it was irrelevant for, whereas EBPF_OPERATION_GET_OBJECT_INFO would return EBPF_ID_NONE in such cases.  The latter is more correct, there's no use case that needs to preserve the original nonsense value other than EBPF_ID_NONE.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>