### PR TITLE
refactor maps

### DIFF
--- a/.github/workflows/driver_test_vm.yml
+++ b/.github/workflows/driver_test_vm.yml
@@ -85,13 +85,14 @@ jobs:
       uses: fountainhead/action-wait-for-check@v1.0.0
       id: wait-for-build
       with:
-        timeoutSeconds: 900
+        timeoutSeconds: 1500
         intervalSeconds: 15
         token: ${{ secrets.GITHUB_TOKEN }}
         checkName: build_job (${{env.BUILD_CONFIGURATION}})
         ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Download build artifact
+      if: success()
       uses: actions/download-artifact@v2.1.0
       with:
         name: Build x64 ${{ matrix.configurations }}

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -257,6 +257,7 @@ ebpf_result_to_errno(ebpf_result_t result)
     case EBPF_FILE_NOT_FOUND:
     case EBPF_KEY_NOT_FOUND:
     case EBPF_NO_MORE_KEYS:
+    case EBPF_OBJECT_NOT_FOUND:
         error = ENOENT;
         break;
 


### PR DESCRIPTION
This fixes #562 .

This PR refactors the ebpf_maps module as follows:
1. Move `inner_template` field to `ebpf_core_object_map`.
2. Move the lock field to individual map types that need lock.
3. Change signature of `create_map` to return a result.
4. Modify `ebpf_map_create` and `ebpf_map_delete` to not have inner template specific logic and instead have those in `create_map` and `delete_map` implementations of the various map types that use `ebpf_core_object_map`.