### PR TITLE
fix CICD script to throw on test failure.

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -183,8 +183,10 @@ _create_array_map(
     ebpf_handle_t inner_map_handle,
     _Outptr_ ebpf_core_map_t** map)
 {
-    if (inner_map_handle != ebpf_handle_invalid)
-        return EBPF_INVALID_ARGUMENT;
+
+    // Temporarily removing check for inner map handle until
+    // https://github.com/microsoft/ebpf-for-windows/issues/739 is fixed.
+    UNREFERENCED_PARAMETER(inner_map_handle);
     return _create_array_map_with_map_struct_size(sizeof(ebpf_core_map_t), map_definition, map);
 }
 

--- a/scripts/run_tests.psm1
+++ b/scripts/run_tests.psm1
@@ -62,7 +62,8 @@ function Invoke-CICDTests
             Invoke-Test -TestName "ebpf_performance.exe" -VerboseLogs $VerboseLogs
         }
     } catch {
-        # Do nothing.
+        Write-Log "One or more tests failed."
+        throw
     }
 
     # Stop the components, so that Driver Verifier can catch memory leaks etc.

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -122,13 +122,13 @@ ring_buffer_test_event_handler(_In_ void* ctx, _In_opt_ void* data, size_t size)
 
     if (event_context->canceled) {
         // Ring buffer subscription is canceled.
-        // Free the callback context and return.
+        // Free the callback context and return error so that no further callback is made.
         delete event_context;
-        return 0;
+        return -1;
     }
 
     if (event_context->matched_entry_count == RING_BUFFER_TEST_EVENT_COUNT)
-        // Required number of event notifications already reserved.
+        // Required number of event notifications already received.
         return 0;
 
     if ((data == nullptr) || (size == 0))


### PR DESCRIPTION
This fixes #740.

- Change PS script to re-throw exception raised due to test failure.
- Add temporary workaround for #739 .
- Fix ring buffer API test bug (which too was hidden due to the script issue).