### PR TITLE
Update bpftool and libbpf dependencies

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -2,7 +2,6 @@
 	path = external/ebpf-verifier
 	url = https://github.com/dthaler/ebpf-verifier.git
 	branch = twostackvars
-
 [submodule "external/ubpf"]
 	path = external/ubpf
 	url = https://github.com/iovisor/ubpf.git
@@ -12,7 +11,8 @@
 	url = https://github.com/libbpf/libbpf.git
 [submodule "external/bpftool"]
 	path = external/bpftool
-	url = https://github.com/dthaler/bpftool.git
+	url = https://github.com/dthaler/bpftool-1.git
 [submodule "external/win-c"]
 	path = external/win-c
 	url = https://github.com/takamin/win-c.git
+	branch = windows

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,9 +6,6 @@
 	path = external/ubpf
 	url = https://github.com/iovisor/ubpf.git
 	branch = master
-[submodule "external/libbpf"]
-	path = external/libbpf
-	url = https://github.com/libbpf/libbpf.git
 [submodule "external/bpftool"]
 	path = external/bpftool
 	url = https://github.com/dthaler/bpftool-1.git

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -57,7 +57,7 @@ EXPORTS
     bpf_object__unpin_programs
     bpf_prog_bind_map
     bpf_prog_get_fd_by_id
-    bpf_prog_load
+    bpf_prog_load_deprecated
     bpf_prog_get_next_id
     bpf_program__attach
     bpf_program__attach_xdp

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -30,6 +30,7 @@ EXPORTS
     bpf_map__type
     bpf_map__unpin
     bpf_map__value_size
+    bpf_map_create
     bpf_map_delete_elem
     bpf_map_get_fd_by_id
     bpf_map_get_next_id
@@ -48,10 +49,14 @@ EXPORTS
     bpf_object__load_xattr
     bpf_object__name
     bpf_object__next
+    bpf_object__next_map
+    bpf_object__next_program
     bpf_object__open_file
     bpf_object__pin
     bpf_object__pin_maps
     bpf_object__pin_programs
+    bpf_object__prev_map
+    bpf_object__prev_program
     bpf_object__unload
     bpf_object__unpin_maps
     bpf_object__unpin_programs
@@ -81,8 +86,6 @@ EXPORTS
     ebpf_api_close_handle
     ebpf_api_get_pinned_map_info
     ebpf_api_map_info_free
-    ebpf_create_map
-    ebpf_create_map_name
     ebpf_free_string
     ebpf_get_attach_type_name
     ebpf_get_next_map

--- a/include/asm/errno.h
+++ b/include/asm/errno.h
@@ -1,0 +1,3 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once

--- a/include/asm/posix_types.h
+++ b/include/asm/posix_types.h
@@ -1,0 +1,3 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once

--- a/include/asm/types.h
+++ b/include/asm/types.h
@@ -1,0 +1,9 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+#include <stdint.h>
+typedef uint16_t __u16;
+typedef uint32_t __u32;
+typedef uint64_t __u64;
+#define __SIZEOF_LONG_LONG__ 8 /* only x64 is supported */
+#define __SIZEOF_LONG__ 4      /* only x64 is supported */

--- a/include/bpf/bpf.h
+++ b/include/bpf/bpf.h
@@ -314,6 +314,6 @@ bpf_prog_get_next_id(__u32 start_id, __u32* next_id);
 
 #else
 #pragma warning(push)
-#include "../external/libbpf/src/bpf.h"
+#include "../external/bpftool/libbpf/src/bpf.h"
 #pragma warning(pop)
 #endif

--- a/include/bpf/bpf.h
+++ b/include/bpf/bpf.h
@@ -113,6 +113,31 @@ int
 bpf_create_map_xattr(const struct bpf_create_map_attr* create_attr);
 
 /**
+ * @brief Create a new map.
+ *
+ * @param[in] map_type Type of outer map to create.
+ * @param[in] map_name Optionally, the name to use for the map.
+ * @param[in] key_size Size in bytes of keys.
+ * @param[in] value_size Size in bytes of values.
+ * @param[in] max_entries Maximum number of entries in the map.
+ * @param[in] opts Structure of options using which a map gets created.
+ *
+ * @returns A new file descriptor that refers to the map.  A negative
+ * value indicates an error occurred and errno was set.
+ *
+ * @exception EINVAL An invalid argument was provided.
+ * @exception ENOMEM Out of memory.
+ */
+int
+bpf_map_create(
+    enum bpf_map_type map_type,
+    const char* map_name,
+    __u32 key_size,
+    __u32 value_size,
+    __u32 max_entries,
+    const struct bpf_map_create_opts* opts);
+
+/**
  * @brief Look up and delete an element by key in a specified map.
  *
  * @param[in] fd File descriptor of map to update.

--- a/include/bpf/hashmap.h
+++ b/include/bpf/hashmap.h
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+#pragma warning(push)
+#include "../external/bpftool/libbpf/src/hashmap.h"
+#pragma warning(pop)

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -797,6 +797,7 @@ ring_buffer__free(struct ring_buffer* rb);
 #else
 #pragma warning(push)
 #pragma warning(disable : 4200) // Zero-sized array in struct/union
-#include "../external/libbpf/src/libbpf.h"
+#pragma warning(disable : 4201) // Zero-sized array in struct/union
+#include "../external/bpftool/libbpf/src/libbpf.h"
 #pragma warning(pop)
 #endif

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -557,7 +557,7 @@ bpf_prog_load(const char* file, enum bpf_prog_type type, struct bpf_object** pob
  * @sa ebpf_link_close
  */
 struct bpf_link*
-bpf_program__attach(struct bpf_program* prog);
+bpf_program__attach(const struct bpf_program* prog);
 
 /**
  * @brief Attach an eBPF program to an XDP hook.

--- a/include/bpf_helpers.h
+++ b/include/bpf_helpers.h
@@ -16,7 +16,7 @@
 // libbpf's bpf_helpers.h for the rest of the platform-agnostic
 // defines.
 #ifndef _MSC_VER
-#include "../external/libbpf/src/bpf_helpers.h"
+#include "../external/bpftool/libbpf/src/bpf_helpers.h"
 #endif
 
 #ifndef __doxygen

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -427,7 +427,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_program_attach(
-        _In_ struct bpf_program* program,
+        _In_ const struct bpf_program* program,
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
         _In_ size_t attach_params_size,

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -13,6 +13,8 @@
 #include "libbpf_common.h"
 #undef LIBBPF_DEPRECATED
 #define LIBBPF_DEPRECATED(x)
+#define __SIZEOF_SIZE_T__ 8    /* only x64 is supported */
+#define __SIZEOF_LONG_LONG__ 8 /* only x64 is supported */
 
 typedef int32_t __s32;
 

--- a/include/linux/stddef.h
+++ b/include/linux/stddef.h
@@ -1,0 +1,3 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once

--- a/libs/api/api.vcxproj
+++ b/libs/api/api.vcxproj
@@ -97,7 +97,7 @@
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\libbpf\src;$(SolutionDir)libs\api;$(SolutionDir)rpc_interface;$(SolutionDir)libs\service;$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\external\elfio;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api;$(SolutionDir)rpc_interface;$(SolutionDir)libs\service;$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\external\elfio;$(OutDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -116,7 +116,8 @@
       <PrecompiledHeader>Use</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <LanguageStandard>stdcpplatest</LanguageStandard>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\libbpf\src;</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>
+      </AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -134,7 +135,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\libbpf\src;$(SolutionDir)libs\api_common;$(SolutionDir)libs\api;$(SolutionDir)rpc_interface;$(SolutionDir)libs\service;$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\external\elfio;$(OutDir);%(AdditionalIncludeDirectories);$(SolutionDir)libs\thunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)libs\api;$(SolutionDir)rpc_interface;$(SolutionDir)libs\service;$(SolutionDir)include;$(SolutionDir)include\bpf;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\external\elfio;$(OutDir);%(AdditionalIncludeDirectories);$(SolutionDir)libs\thunk</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>
       <TreatWarningAsError>true</TreatWarningAsError>
@@ -157,7 +158,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)external\libbpf\src;$(SolutionDir)libs\api_common;$(SolutionDir)libs\api;$(SolutionDir)rpc_interface;$(SolutionDir)libs\service;$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\external\elfio;$(OutDir);%(AdditionalIncludeDirectories);$(SolutionDir)libs\thunk</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)libs\api;$(SolutionDir)rpc_interface;$(SolutionDir)libs\service;$(SolutionDir)include;$(SolutionDir)include\bpf;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ebpf-verifier\external;$(SolutionDir)external\ebpf-verifier\external\elfio;$(OutDir);%(AdditionalIncludeDirectories);$(SolutionDir)libs\thunk</AdditionalIncludeDirectories>
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -184,7 +184,12 @@ ebpf_map_previous(_In_opt_ const struct bpf_map* next, _In_ const struct bpf_obj
 /**
  * @brief Create a new map.
  *
- * @param[in] create_attr Structure of attributes to create a map using.
+ * @param[in] map_type Type of outer map to create.
+ * @param[in] map_name Optionally, the name to use for the map.
+ * @param[in] key_size Size in bytes of keys.
+ * @param[in] value_size Size in bytes of values.
+ * @param[in] max_entries Maximum number of entries in the map.
+ * @param[in] opts Structure of options using which a map gets created.
  * @param[out] map_fd File descriptor for the created map. The caller needs to
  *  call _close() on the returned fd when done.
  *
@@ -193,7 +198,14 @@ ebpf_map_previous(_In_opt_ const struct bpf_map* next, _In_ const struct bpf_obj
  * @retval EBPF_NO_MEMORY Out of memory.
  */
 ebpf_result_t
-ebpf_create_map_xattr(_In_ const struct bpf_create_map_attr* create_attr, _Out_ fd_t* map_fd);
+ebpf_map_create(
+    enum bpf_map_type map_type,
+    _In_opt_z_ const char* map_name,
+    uint32_t key_size,
+    uint32_t value_size,
+    uint32_t max_entries,
+    _In_opt_ const struct bpf_map_create_opts* opts,
+    _Out_ fd_t* map_fd);
 
 /**
  * @brief Fetch fd for a program object.

--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -1,10 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 #include "bpf.h"
-#pragma warning(push)
-#pragma warning(disable : 4200)
 #include "libbpf.h"
-#pragma warning(pop)
 #include <linux/bpf.h>
 
 #define CHECK_SIZE(last_field_name)                                                         \

--- a/libs/api/libbpf_link.cpp
+++ b/libs/api/libbpf_link.cpp
@@ -3,10 +3,7 @@
 
 #include "api_internal.h"
 #include "bpf.h"
-#pragma warning(push)
-#pragma warning(disable : 4200)
 #include "libbpf.h"
-#pragma warning(pop)
 #include "libbpf_internal.h"
 
 int

--- a/libs/api/libbpf_map.cpp
+++ b/libs/api/libbpf_map.cpp
@@ -3,10 +3,7 @@
 
 #include "api_internal.h"
 #include "bpf.h"
-#pragma warning(push)
-#pragma warning(disable : 4200)
 #include "libbpf.h"
-#pragma warning(pop)
 #include "libbpf_internal.h"
 
 // This file implements APIs in LibBPF's libbpf.h and is based on code in external/libbpf/src/libbpf.c

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -3,10 +3,7 @@
 
 #include "api_internal.h"
 #include "bpf.h"
-#pragma warning(push)
-#pragma warning(disable : 4200)
 #include "libbpf.h"
-#pragma warning(pop)
 #include "libbpf_internal.h"
 
 // This file implements APIs in LibBPF's libbpf.h and is based on code in external/libbpf/src/libbpf.c

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -3,10 +3,7 @@
 
 #include "api_internal.h"
 #include "bpf.h"
-#pragma warning(push)
-#pragma warning(disable : 4200)
 #include "libbpf.h"
-#pragma warning(pop)
 #include "libbpf_internal.h"
 
 // This file implements APIs in LibBPF's libbpf.h and is based on code in external/libbpf/src/libbpf.c
@@ -114,7 +111,7 @@ bpf_load_program(
 }
 
 int
-bpf_prog_load(const char* file_name, enum bpf_prog_type type, struct bpf_object** object, int* program_fd)
+bpf_prog_load_deprecated(const char* file_name, enum bpf_prog_type type, struct bpf_object** object, int* program_fd)
 {
     const ebpf_program_type_t* program_type = _get_ebpf_program_type(type);
 

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -101,7 +101,7 @@ bpf_load_program(
     memset(&load_attr, 0, sizeof(struct bpf_load_program_attr));
     load_attr.prog_type = type;
     load_attr.expected_attach_type = BPF_ATTACH_TYPE_UNSPEC;
-    load_attr.name = nullptr;
+    load_attr.name = NULL;
     load_attr.insns = insns;
     load_attr.insns_cnt = insns_cnt;
     load_attr.license = license;
@@ -135,9 +135,9 @@ bpf_program__fd(const struct bpf_program* program)
 }
 
 const char*
-bpf_program__name(const struct bpf_program* program)
+bpf_program__name(const struct bpf_program* prog)
 {
-    return program->program_name;
+    return prog->program_name;
 }
 
 const char*
@@ -196,9 +196,9 @@ bpf_program__next(struct bpf_program* prev, const struct bpf_object* obj)
 }
 
 struct bpf_program*
-bpf_object__next_program(const struct bpf_object* object, struct bpf_program* previous)
+bpf_object__next_program(const struct bpf_object* obj, struct bpf_program* prev)
 {
-    return ebpf_program_next(previous, object);
+    return ebpf_program_next(prev, obj);
 }
 
 struct bpf_program*
@@ -208,9 +208,9 @@ bpf_program__prev(struct bpf_program* next, const struct bpf_object* obj)
 }
 
 struct bpf_program*
-bpf_object__prev_program(const struct bpf_object* object, struct bpf_program* next)
+bpf_object__prev_program(const struct bpf_object* obj, struct bpf_program* next)
 {
-    return ebpf_program_previous(next, object);
+    return ebpf_program_previous(next, obj);
 }
 
 int

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -7,7 +7,7 @@
 #include "libbpf_internal.h"
 
 // This file implements APIs in LibBPF's libbpf.h and is based on code in external/libbpf/src/libbpf.c
-// used under the BSD-2-Clause license , so the coding style tries to match the libbpf.c style to
+// used under the BSD-2-Clause license, so the coding style tries to match the libbpf.c style to
 // minimize diffs until libbpf becomes cross-platform capable.  This is a temporary workaround for
 // issue #351 until we can compile and use libbpf.c directly.
 
@@ -153,7 +153,7 @@ bpf_program__size(const struct bpf_program* program)
 }
 
 struct bpf_link*
-bpf_program__attach(struct bpf_program* program)
+bpf_program__attach(const struct bpf_program* program)
 {
     if (program == nullptr) {
         errno = EINVAL;
@@ -170,7 +170,7 @@ bpf_program__attach(struct bpf_program* program)
 }
 
 struct bpf_link*
-bpf_program__attach_xdp(struct bpf_program* program, int ifindex)
+bpf_program__attach_xdp(const struct bpf_program* program, int ifindex)
 {
     if (program == nullptr) {
         errno = EINVAL;
@@ -190,13 +190,25 @@ bpf_program__attach_xdp(struct bpf_program* program, int ifindex)
 }
 
 struct bpf_program*
-bpf_program__next(struct bpf_program* previous, const struct bpf_object* object)
+bpf_program__next(struct bpf_program* prev, const struct bpf_object* obj)
+{
+    return bpf_object__next_program(obj, prev);
+}
+
+struct bpf_program*
+bpf_object__next_program(const struct bpf_object* object, struct bpf_program* previous)
 {
     return ebpf_program_next(previous, object);
 }
 
 struct bpf_program*
-bpf_program__prev(struct bpf_program* next, const struct bpf_object* object)
+bpf_program__prev(struct bpf_program* next, const struct bpf_object* obj)
+{
+    return bpf_object__prev_program(obj, next);
+}
+
+struct bpf_program*
+bpf_object__prev_program(const struct bpf_object* object, struct bpf_program* next)
 {
     return ebpf_program_previous(next, object);
 }

--- a/libs/api/libbpf_system.cpp
+++ b/libs/api/libbpf_system.cpp
@@ -2,10 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <windows.h>
-#pragma warning(push)
-#pragma warning(disable : 4200)
 #include "libbpf.h"
-#pragma warning(pop)
 
 long
 libbpf_get_error(const void* ptr)

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1044,14 +1044,12 @@ TEST_CASE("create_map", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;
 
-    ebpf_result_t result;
     fd_t map_fd;
     uint32_t key = 0;
     uint64_t value = 10;
     int element_count = 2;
 
-    result = ebpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(uint32_t), sizeof(uint64_t), 5, 0, &map_fd);
-    REQUIRE(result == EBPF_SUCCESS);
+    map_fd = bpf_map_create(BPF_MAP_TYPE_ARRAY, nullptr, sizeof(uint32_t), sizeof(uint64_t), 5, nullptr);
     REQUIRE(map_fd > 0);
 
     for (int i = 0; i < element_count; i++) {
@@ -1077,15 +1075,13 @@ TEST_CASE("create_map_name", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;
 
-    ebpf_result_t result;
     fd_t map_fd;
     uint32_t key = 0;
     uint64_t value = 10;
     int element_count = 2;
     const char* map_name = "array_map";
 
-    result = ebpf_create_map_name(BPF_MAP_TYPE_ARRAY, map_name, sizeof(uint32_t), sizeof(uint64_t), 5, 0, &map_fd);
-    REQUIRE(result == EBPF_SUCCESS);
+    map_fd = bpf_map_create(BPF_MAP_TYPE_ARRAY, map_name, sizeof(uint32_t), sizeof(uint64_t), 5, nullptr);
     REQUIRE(map_fd > 0);
 
     for (int i = 0; i < element_count; i++) {

--- a/tests/unit/test.vcxproj
+++ b/tests/unit/test.vcxproj
@@ -95,7 +95,7 @@
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\libbpf\src;$(SolutionDir)\tests\xdp;$(SolutionDir)tools\encode_program_info;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\bpftool\libbpf\src;$(SolutionDir)\tests\xdp;$(SolutionDir)tools\encode_program_info;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -111,7 +111,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\libbpf\src;$(SolutionDir)\tests\xdp;$(SolutionDir)tools\encode_program_info;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)external\bpftool\libbpf\src;$(SolutionDir)\tests\xdp;$(SolutionDir)tools\encode_program_info;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tools/bpftool/bpftool.vcxproj
+++ b/tools/bpftool/bpftool.vcxproj
@@ -15,6 +15,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\external\bpftool\libbpf\src\hashmap.c" />
     <ClCompile Include="..\..\external\bpftool\src\btf.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
@@ -156,7 +157,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>BPFTOOL_VERSION="0.1";_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)include;$(SolutionDir)external/bpftool/libbpf/src;$(SolutionDir)external/win-c/include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)include;$(SolutionDir)external/bpftool/libbpf/src;$(SolutionDir)external/bpftool/libbpf/include;$(SolutionDir)external/win-c/include</AdditionalIncludeDirectories>
       <AdditionalOptions>/analyze:stacksize 163884 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -173,7 +174,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>BPFTOOL_VERSION="0.1";NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)include;$(SolutionDir)external/bpftool/libbpf/src;$(SolutionDir)external/win-c/include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)include;$(SolutionDir)external/bpftool/libbpf/src;$(SolutionDir)external/bpftool/libbpf/include;$(SolutionDir)external/win-c/include</AdditionalIncludeDirectories>
       <AdditionalOptions>/analyze:stacksize 163884 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/tools/bpftool/bpftool.vcxproj
+++ b/tools/bpftool/bpftool.vcxproj
@@ -15,96 +15,96 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\external\bpftool\btf.c">
+    <ClCompile Include="..\..\external\bpftool\src\btf.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\btf_dumper.c">
+    <ClCompile Include="..\..\external\bpftool\src\btf_dumper.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\cfg.c">
+    <ClCompile Include="..\..\external\bpftool\src\cfg.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\cgroup.c">
+    <ClCompile Include="..\..\external\bpftool\src\cgroup.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\common.c" />
-    <ClCompile Include="..\..\external\bpftool\feature.c">
+    <ClCompile Include="..\..\external\bpftool\src\common.c" />
+    <ClCompile Include="..\..\external\bpftool\src\feature.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\gen.c">
+    <ClCompile Include="..\..\external\bpftool\src\gen.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\iter.c">
+    <ClCompile Include="..\..\external\bpftool\src\iter.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\jit_disasm.c">
+    <ClCompile Include="..\..\external\bpftool\src\jit_disasm.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\json_writer.c" />
-    <ClCompile Include="..\..\external\bpftool\link.c" />
-    <ClCompile Include="..\..\external\bpftool\main.c" />
-    <ClCompile Include="..\..\external\bpftool\map.c" />
-    <ClCompile Include="..\..\external\bpftool\map_perf_ring.c">
+    <ClCompile Include="..\..\external\bpftool\src\json_writer.c" />
+    <ClCompile Include="..\..\external\bpftool\src\link.c" />
+    <ClCompile Include="..\..\external\bpftool\src\main.c" />
+    <ClCompile Include="..\..\external\bpftool\src\map.c" />
+    <ClCompile Include="..\..\external\bpftool\src\map_perf_ring.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\net.c">
+    <ClCompile Include="..\..\external\bpftool\src\net.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\netlink_dumper.c">
+    <ClCompile Include="..\..\external\bpftool\src\netlink_dumper.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\perf.c">
+    <ClCompile Include="..\..\external\bpftool\src\perf.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\pids.c">
+    <ClCompile Include="..\..\external\bpftool\src\pids.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\prog.c" />
-    <ClCompile Include="..\..\external\bpftool\skeleton\pid_iter.bpf.c">
+    <ClCompile Include="..\..\external\bpftool\src\prog.c" />
+    <ClCompile Include="..\..\external\bpftool\src\skeleton\pid_iter.bpf.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\skeleton\profiler.bpf.c">
+    <ClCompile Include="..\..\external\bpftool\src\skeleton\profiler.bpf.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\struct_ops.c">
+    <ClCompile Include="..\..\external\bpftool\src\struct_ops.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\tracelog.c">
+    <ClCompile Include="..\..\external\bpftool\src\tracelog.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\xlated_dumper.c">
+    <ClCompile Include="..\..\external\bpftool\src\xlated_dumper.c">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </ClCompile>
     <ClCompile Include="..\..\external\win-c\source\getopt.c" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\external\bpftool\cfg.h" />
-    <ClInclude Include="..\..\external\bpftool\json_writer.h" />
-    <ClInclude Include="..\..\external\bpftool\main.h" />
-    <ClInclude Include="..\..\external\bpftool\netlink_dumper.h" />
-    <ClInclude Include="..\..\external\bpftool\skeleton\pid_iter.h" />
-    <ClInclude Include="..\..\external\bpftool\xlated_dumper.h" />
+    <ClInclude Include="..\..\external\bpftool\src\cfg.h" />
+    <ClInclude Include="..\..\external\bpftool\src\json_writer.h" />
+    <ClInclude Include="..\..\external\bpftool\src\main.h" />
+    <ClInclude Include="..\..\external\bpftool\src\netlink_dumper.h" />
+    <ClInclude Include="..\..\external\bpftool\src\skeleton\pid_iter.h" />
+    <ClInclude Include="..\..\external\bpftool\src\xlated_dumper.h" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\external\bpftool\Makefile" />
+    <None Include="..\..\external\bpftool\src\Makefile" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\ebpfapi\ebpfapi.vcxproj">
@@ -156,7 +156,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>BPFTOOL_VERSION="0.1";_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)include;$(SolutionDir)external/libbpf/src;$(SolutionDir)external/win-c/include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)include;$(SolutionDir)external/bpftool/libbpf/src;$(SolutionDir)external/win-c/include</AdditionalIncludeDirectories>
       <AdditionalOptions>/analyze:stacksize 163884 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -173,7 +173,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>BPFTOOL_VERSION="0.1";NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)include;$(SolutionDir)external/libbpf/src;$(SolutionDir)external/win-c/include</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(ProjectDir);$(SolutionDir)include;$(SolutionDir)external/bpftool/libbpf/src;$(SolutionDir)external/win-c/include</AdditionalIncludeDirectories>
       <AdditionalOptions>/analyze:stacksize 163884 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>

--- a/tools/bpftool/bpftool.vcxproj.filters
+++ b/tools/bpftool/bpftool.vcxproj.filters
@@ -19,103 +19,103 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\external\bpftool\skeleton\pid_iter.bpf.c">
+    <ClCompile Include="..\..\external\bpftool\src\skeleton\pid_iter.bpf.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\skeleton\profiler.bpf.c">
+    <ClCompile Include="..\..\external\bpftool\src\skeleton\profiler.bpf.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\btf.c">
+    <ClCompile Include="..\..\external\bpftool\src\btf.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\btf_dumper.c">
+    <ClCompile Include="..\..\external\bpftool\src\btf_dumper.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\cgroup.c">
+    <ClCompile Include="..\..\external\bpftool\src\cgroup.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\common.c">
+    <ClCompile Include="..\..\external\bpftool\src\common.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\feature.c">
+    <ClCompile Include="..\..\external\bpftool\src\feature.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\gen.c">
+    <ClCompile Include="..\..\external\bpftool\src\gen.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\iter.c">
+    <ClCompile Include="..\..\external\bpftool\src\iter.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\jit_disasm.c">
+    <ClCompile Include="..\..\external\bpftool\src\jit_disasm.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\json_writer.c">
+    <ClCompile Include="..\..\external\bpftool\src\json_writer.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\link.c">
+    <ClCompile Include="..\..\external\bpftool\src\link.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\main.c">
+    <ClCompile Include="..\..\external\bpftool\src\main.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\map.c">
+    <ClCompile Include="..\..\external\bpftool\src\map.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\map_perf_ring.c">
+    <ClCompile Include="..\..\external\bpftool\src\map_perf_ring.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\net.c">
+    <ClCompile Include="..\..\external\bpftool\src\net.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\netlink_dumper.c">
+    <ClCompile Include="..\..\external\bpftool\src\netlink_dumper.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\perf.c">
+    <ClCompile Include="..\..\external\bpftool\src\perf.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\pids.c">
+    <ClCompile Include="..\..\external\bpftool\src\pids.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\prog.c">
+    <ClCompile Include="..\..\external\bpftool\src\prog.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\struct_ops.c">
+    <ClCompile Include="..\..\external\bpftool\src\struct_ops.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\tracelog.c">
+    <ClCompile Include="..\..\external\bpftool\src\tracelog.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\xlated_dumper.c">
+    <ClCompile Include="..\..\external\bpftool\src\xlated_dumper.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\external\win-c\source\getopt.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\external\bpftool\cfg.c">
+    <ClCompile Include="..\..\external\bpftool\src\cfg.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\external\bpftool\skeleton\pid_iter.h">
+    <ClInclude Include="..\..\external\bpftool\src\skeleton\pid_iter.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\external\bpftool\cfg.h">
+    <ClInclude Include="..\..\external\bpftool\src\cfg.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\external\bpftool\json_writer.h">
+    <ClInclude Include="..\..\external\bpftool\src\json_writer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\external\bpftool\main.h">
+    <ClInclude Include="..\..\external\bpftool\src\main.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\external\bpftool\netlink_dumper.h">
+    <ClInclude Include="..\..\external\bpftool\src\netlink_dumper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\external\bpftool\xlated_dumper.h">
+    <ClInclude Include="..\..\external\bpftool\src\xlated_dumper.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\..\external\bpftool\Makefile" />
+    <None Include="..\..\external\bpftool\src\Makefile" />
   </ItemGroup>
 </Project>

--- a/tools/bpftool/bpftool.vcxproj.filters
+++ b/tools/bpftool/bpftool.vcxproj.filters
@@ -94,6 +94,9 @@
     <ClCompile Include="..\..\external\bpftool\src\cfg.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\external\bpftool\libbpf\src\hashmap.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\external\bpftool\src\skeleton\pid_iter.h">


### PR DESCRIPTION
* Added bpf_map_create, bpf_object__next_map, bpf_object__next_program, bpf_object__prev_map, bpf_object__prev_program libbpf APIs
* Removed obsolete exports ebpf_create_map and ebpf_create_map_name
* Updated prototype of bpf_program__attach and bpf_progam__attach_xdp to match latest libbpf header
* Now that bpftool has an official mirror, this PR switches the dependency to use it instead of Matteo's copy.
* Since libbpf is a submodule of bpftool, use it from that path rather than keeping libbpf as a separate submodule under ebpf-for-windows.