### PR TITLE
add script to copy pre-commit file to relative hooks folder

### DIFF
--- a/scripts/copy_pre_commit.ps1
+++ b/scripts/copy_pre_commit.ps1
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+function copy-precommit
+{
+    param([string]$file_path)
+    $command = "git rev-parse --git-path hooks"
+    $destination = Invoke-Expression $command
+
+    Write-Host "Copy $file_path to $destination."
+    Copy-Item $file_path $destination
+}
+
+copy-precommit $args[0]

--- a/scripts/setup_build/setup_build.vcxproj
+++ b/scripts/setup_build/setup_build.vcxproj
@@ -23,7 +23,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="..\pre-commit">
+    <None Include="..\pre-commit">
       <FileType>Document</FileType>
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">echo copy %(FullPath) $(SolutionDir).git\hooks</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir).git\hooks\%(Filename)</Outputs>
@@ -31,7 +31,7 @@
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir).git\hooks\%(Filename)</Outputs>
       <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir).git\hooks</DestinationFolders>
       <DestinationFolders Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir).git\hooks</DestinationFolders>
-    </CopyFileToFolders>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <CopyFileToFolders Include="..\install-ebpf.bat">
@@ -191,7 +191,8 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\generate-commitid.ps1 $(SolutionDir)\include
+      <Command>powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\copy_pre_commit.ps1 $(SolutionDir)scripts\pre-commit
+powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\generate-commitid.ps1 $(SolutionDir)\include
 copy "$(VC_DebugCppRuntimeFilesPath_x64)\Microsoft.VC142.DebugCRT\*" "$(OutDir)"
 copy "$(UniversalDebugCRT_ExecutablePath_x64)\ucrtbased.dll" "$(OutDir)"</Command>
     </PreBuildEvent>
@@ -212,7 +213,8 @@ copy "$(UniversalDebugCRT_ExecutablePath_x64)\ucrtbased.dll" "$(OutDir)"</Comman
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\generate-commitid.ps1 $(SolutionDir)\include
+      <Command>powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\copy_pre_commit.ps1 $(SolutionDir)scripts\pre-commit
+powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\generate-commitid.ps1 $(SolutionDir)\include
 copy "$(VC_CppRuntimeFilesPath_x64)\Microsoft.VC142.CRT" "$(OutDir)"</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/scripts/setup_build/setup_build.vcxproj.filters
+++ b/scripts/setup_build/setup_build.vcxproj.filters
@@ -19,9 +19,6 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <CopyFileToFolders Include="..\pre-commit">
-      <Filter>Source Files</Filter>
-    </CopyFileToFolders>
     <CopyFileToFolders Include="..\install-ebpf.bat">
       <Filter>Source Files</Filter>
     </CopyFileToFolders>
@@ -58,5 +55,11 @@
     <CopyFileToFolders Include="..\vm_list.json">
       <Filter>Source Files</Filter>
     </CopyFileToFolders>
+    <CopyFileToFolders Include="..\ebpfforwindows.wprp" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\pre-commit">
+      <Filter>Source Files</Filter>
+    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
**Issue**

**setup_build** project copies pre-commit script to .git\hooks path as part of the build. This works fine when `ebpf-for-windows` repo is directly cloned. But if `ebpf-for-windows` is added as a submodule, then `setup_build` fails to build as it tries to copy the file to .git\hooks, but in case of submodule, there is no .git folder, instead, there is a .git file which has an entry to the root .git folder.

Ideally the file should be copied to the path which is returned by `git rev-parse --git-path hooks`. This command will return the correct .git path both in case of a submodule and a normal repo.

**Fix**
The fix adds a script which first executes `git rev-parse --git-path hooks` command to get the destination folder and then copy the precommit file to that folder. This allows the build for `ebpf-for-windows` to succeed when it is added as a submodule.