### PR TITLE
update ebpf-verifier to the fork with latest changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,7 @@
 [submodule "external/ebpf-verifier"]
 	path = external/ebpf-verifier
-	url = https://github.com/vbpf/ebpf-verifier.git
+	url = https://github.com/dthaler/ebpf-verifier.git
+	branch = twostackvars
 
 [submodule "external/ubpf"]
 	path = external/ubpf


### PR DESCRIPTION
This PR updates ebpf-verifier submodule to `https://github.com/dthaler/ebpf-verifier.git` (branch `twostackvars`), until these changes are up-streamed.