### PR TITLE
Update codeql-analysis.yml

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       SOLUTION_FILE_PATH: ebpf-for-windows.sln
       BUILD_CONFIGURATION: Release


### PR DESCRIPTION
Code-ql task can only run on Server 2019 (doesn't support Server 2022 yet). This is causing the code-ql task to fail.

The fix is to change runs-on from "windows-latest" to "windows-2019"

Signed-off-by: Alan Jowett <alanjo@microsoft.com>