### PR TITLE
bpf2c should emit both symbol name and segment name in program_entry_t.

### DIFF
--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -46,7 +46,9 @@ extern "C"
     typedef struct _program_entry
     {
         uint64_t (*function)(void*);
-        const char* name;
+        const char* section_name;
+        const char* function_name;
+        size_t bpf_instruction_count;
     } program_entry_t;
 
     typedef struct _metadata_table

--- a/tests/bpf2c_test_wrapper/dllmain.cpp
+++ b/tests/bpf2c_test_wrapper/dllmain.cpp
@@ -11,9 +11,9 @@
 
 #include "bpf2c.h"
 
-extern "C" metadata_table_t bindmonitor;
-extern "C" metadata_table_t divide_by_zero;
-extern "C" metadata_table_t droppacket;
+extern "C" metadata_table_t bindmonitor_metadata_table;
+extern "C" metadata_table_t divide_by_zero_metadata_table;
+extern "C" metadata_table_t droppacket_metadata_table;
 
 BOOL APIENTRY
 DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
@@ -38,7 +38,7 @@ division_by_zero(uint32_t address)
 
 #define FIND_METADATA_ENTRTY(NAME, X) \
     if (std::string(NAME) == #X)      \
-        return &X;
+        return &X##_metadata_table;
 
 extern "C" metadata_table_t*
 get_metadata_table(const char* name)

--- a/tests/bpf2c_tests/bpf_test.cpp
+++ b/tests/bpf2c_tests/bpf_test.cpp
@@ -14,8 +14,8 @@ extern "C"
 #include "bpf2c.h"
 }
 
-#if !defined(SECTION)
-#define C_NAME test
+#if !defined(C_NAME)
+#define C_NAME test_metadata_table
 #endif
 
 extern "C" metadata_table_t C_NAME;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1714,14 +1714,14 @@ TEST_CASE("bpf2c_droppacket", "[bpf2c]")
     // Test that we drop the packet and increment the map
     xdp_md_t ctx{packet.data(), packet.data() + packet.size()};
 
-    REQUIRE(table.invoke("xdp", &ctx) == XDP_DROP);
+    REQUIRE(table.invoke("DropPacket", &ctx) == XDP_DROP);
     REQUIRE(bpf_map_lookup_elem(table.get_map("dropped_packet_map"), &key, &value) == 0);
     REQUIRE(value == 1);
 
     packet = prepare_udp_packet(10, ETHERNET_TYPE_IPV4);
     xdp_md_t ctx2{packet.data(), packet.data() + packet.size()};
 
-    REQUIRE(table.invoke("xdp", &ctx2) == XDP_PASS);
+    REQUIRE(table.invoke("DropPacket", &ctx2) == XDP_PASS);
     REQUIRE(bpf_map_lookup_elem(table.get_map("dropped_packet_map"), &key, &value) == 0);
     REQUIRE(value == 1);
 }
@@ -1736,7 +1736,7 @@ TEST_CASE("bpf2c_divide_by_zero", "[bpf2c]")
     xdp_md_t ctx{packet.data(), packet.data() + packet.size()};
 
     // Verify the program doesn't crash
-    REQUIRE(table.invoke("xdp", &ctx) == 0);
+    REQUIRE(table.invoke("divide_by_zero", &ctx) == 0);
 }
 
 TEST_CASE("bpf2c_bindmonitor", "[bpf2c]")
@@ -1755,7 +1755,7 @@ TEST_CASE("bpf2c_bindmonitor", "[bpf2c]")
     set_bind_limit(limit_map_fd, 2);
 
     std::function<ebpf_result_t(void*, int*)> invoke = [&table](void* context, int* result) -> ebpf_result_t {
-        *result = static_cast<int>(table.invoke("bind", context));
+        *result = static_cast<int>(table.invoke("BindMonitor", context));
         return EBPF_SUCCESS;
     };
     // Bind first port - success

--- a/tests/libs/util/dll_metadata_table.cpp
+++ b/tests/libs/util/dll_metadata_table.cpp
@@ -44,7 +44,7 @@ dll_metadata_table::dll_metadata_table(const std::string& dll_name, const std::s
     size_t count;
     table->programs(&programs, &count);
     for (size_t i = 0; i < count; i++) {
-        loaded_programs[programs->name] = programs->function;
+        loaded_programs[programs->function_name] = programs->function;
     }
 }
 

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -92,6 +92,7 @@ class bpf_code_generator
     {
         std::vector<output_instruction_t> output;
         std::set<std::string> referenced_registers;
+        std::string function_name;
     } section_t;
 
     /**


### PR DESCRIPTION
Add function name and instruction count to program_entry_t.

Resolves: #770 
Signed-off-by: Alan Jowett <alanjo@microsoft.com>