### PR TITLE
Switch to run CI/CD on Server 2019 + VS2019

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       # Path to the solution file relative to the root of the project.
       SOLUTION_FILE_PATH: ebpf-for-windows.sln

--- a/.github/workflows/driver_test_vm.yml
+++ b/.github/workflows/driver_test_vm.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         configurations: [Debug, Release]
-    runs-on: windows-latest
+    runs-on: windows-2019
     env:
       # Path to the solution file relative to the root of the project.
       SOLUTION_FILE_PATH: ebpf-for-windows.sln


### PR DESCRIPTION
Switch CI/CD to explicitly use Server 2019 & VS 2019.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>