### PR TITLE
Rename EC ebpf_object_t to ebpf_core_object_t

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -167,7 +167,7 @@ ebpf_core_terminate()
     ebpf_epoch_flush();
     ebpf_epoch_terminate();
 
-    // Verify that all ebpf_object_t objects have been freed.
+    // Verify that all ebpf_core_object_t objects have been freed.
     ebpf_object_tracking_terminate();
 
     ebpf_trace_terminate();
@@ -195,7 +195,8 @@ _ebpf_core_protocol_load_code(_In_ const ebpf_operation_load_code_request_t* req
         }
     }
 
-    retval = ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+    retval =
+        ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -207,7 +208,7 @@ _ebpf_core_protocol_load_code(_In_ const ebpf_operation_load_code_request_t* req
         goto Done;
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)program);
+    ebpf_object_release_reference((ebpf_core_object_t*)program);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -245,7 +246,7 @@ _ebpf_core_protocol_resolve_helper(
         request_helper_ids[helper_index] = request->helper_id[helper_index];
 
     return_value =
-        ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+        ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program);
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
@@ -261,7 +262,7 @@ Done:
     if (return_value == EBPF_SUCCESS)
         reply->header.length = (uint16_t)required_reply_length;
 
-    ebpf_object_release_reference((ebpf_object_t*)program);
+    ebpf_object_release_reference((ebpf_core_object_t*)program);
     ebpf_free(request_helper_ids);
     EBPF_RETURN_RESULT(return_value);
 }
@@ -287,21 +288,21 @@ _ebpf_core_protocol_resolve_map(
     }
 
     return_value =
-        ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+        ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program);
     if (return_value != EBPF_SUCCESS)
         goto Done;
 
     for (map_index = 0; map_index < count_of_maps; map_index++) {
         ebpf_map_t* map;
-        return_value =
-            ebpf_reference_object_by_handle(request->map_handle[map_index], EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+        return_value = ebpf_reference_object_by_handle(
+            request->map_handle[map_index], EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
 
         if (return_value != EBPF_SUCCESS)
             goto Done;
 
         reply->address[map_index] = (uint64_t)map;
 
-        ebpf_object_release_reference((ebpf_object_t*)map);
+        ebpf_object_release_reference((ebpf_core_object_t*)map);
     }
 
     return_value = ebpf_program_associate_maps(program, (ebpf_map_t**)reply->address, count_of_maps);
@@ -309,7 +310,7 @@ _ebpf_core_protocol_resolve_map(
     reply->header.length = (uint16_t)required_reply_length;
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)program);
+    ebpf_object_release_reference((ebpf_core_object_t*)program);
 
     EBPF_RETURN_RESULT(return_value);
 }
@@ -335,7 +336,7 @@ _ebpf_core_protocol_create_map(
     if (retval != EBPF_SUCCESS)
         return retval;
 
-    ebpf_object_t* map_object = (ebpf_object_t*)map;
+    ebpf_core_object_t* map_object = (ebpf_core_object_t*)map;
 
     retval = ebpf_handle_create(&reply->handle, map_object);
     if (retval != EBPF_SUCCESS) {
@@ -396,14 +397,14 @@ _ebpf_core_protocol_create_program(
     if (retval != EBPF_SUCCESS)
         goto Done;
 
-    retval = ebpf_handle_create(&reply->program_handle, (ebpf_object_t*)program);
+    retval = ebpf_handle_create(&reply->program_handle, (ebpf_core_object_t*)program);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
     retval = EBPF_SUCCESS;
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)program);
+    ebpf_object_release_reference((ebpf_core_object_t*)program);
 
     EBPF_RETURN_RESULT(retval);
 }
@@ -420,7 +421,7 @@ _ebpf_core_protocol_map_find_element(
     size_t value_length;
     size_t key_length;
 
-    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -448,7 +449,7 @@ _ebpf_core_protocol_map_find_element(
     reply->header.length = reply_length;
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)map);
+    ebpf_object_release_reference((ebpf_core_object_t*)map);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -461,7 +462,7 @@ _ebpf_core_protocol_map_update_element(_In_ const epf_operation_map_update_eleme
     size_t value_length;
     size_t key_length;
 
-    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -482,7 +483,7 @@ _ebpf_core_protocol_map_update_element(_In_ const epf_operation_map_update_eleme
         map, key_length, request->data, value_length, request->data + key_length, request->option, 0);
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)map);
+    ebpf_object_release_reference((ebpf_core_object_t*)map);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -495,7 +496,7 @@ _ebpf_core_protocol_map_update_element_with_handle(
     ebpf_map_t* map = NULL;
     size_t key_length;
 
-    retval = ebpf_reference_object_by_handle(request->map_handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    retval = ebpf_reference_object_by_handle(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -516,7 +517,7 @@ _ebpf_core_protocol_map_update_element_with_handle(
     retval = ebpf_map_update_entry_with_handle(map, key_length, request->key, request->value_handle, request->option);
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)map);
+    ebpf_object_release_reference((ebpf_core_object_t*)map);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -528,7 +529,7 @@ _ebpf_core_protocol_map_delete_element(_In_ const ebpf_operation_map_delete_elem
     ebpf_map_t* map = NULL;
     size_t key_length;
 
-    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -540,7 +541,7 @@ _ebpf_core_protocol_map_delete_element(_In_ const ebpf_operation_map_delete_elem
     retval = ebpf_map_delete_entry(map, key_length, request->key, 0);
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)map);
+    ebpf_object_release_reference((ebpf_core_object_t*)map);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -556,7 +557,7 @@ _ebpf_core_protocol_map_get_next_key(
     size_t previous_key_length;
     size_t next_key_length;
 
-    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -581,7 +582,7 @@ _ebpf_core_protocol_map_get_next_key(
         map, next_key_length, previous_key_length == 0 ? NULL : request->previous_key, reply->next_key);
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)map);
+    ebpf_object_release_reference((ebpf_core_object_t*)map);
 
     EBPF_RETURN_RESULT(retval);
 }
@@ -591,11 +592,11 @@ _ebpf_core_get_next_handle(ebpf_handle_t previous_handle, ebpf_object_type_t typ
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t retval;
-    ebpf_object_t* previous_object = NULL;
-    ebpf_object_t* next_object = NULL;
+    ebpf_core_object_t* previous_object = NULL;
+    ebpf_core_object_t* next_object = NULL;
 
     if (previous_handle != UINT64_MAX) {
-        retval = ebpf_reference_object_by_handle(previous_handle, type, (ebpf_object_t**)&previous_object);
+        retval = ebpf_reference_object_by_handle(previous_handle, type, (ebpf_core_object_t**)&previous_object);
         if (retval != EBPF_SUCCESS)
             goto Done;
     }
@@ -650,7 +651,7 @@ _ebpf_core_protocol_query_program_info(
     size_t required_reply_length;
     const ebpf_program_parameters_t* parameters;
 
-    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+    retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -683,7 +684,7 @@ _ebpf_core_protocol_query_program_info(
     reply->header.length = (uint16_t)required_reply_length;
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)program);
+    ebpf_object_release_reference((ebpf_core_object_t*)program);
 
     EBPF_RETURN_RESULT(retval);
 }
@@ -696,7 +697,7 @@ _ebpf_core_protocol_update_pinning(_In_ const struct _ebpf_operation_update_map_
     const ebpf_utf8_string_t path = {
         (uint8_t*)request->path,
         request->header.length - EBPF_OFFSET_OF(ebpf_operation_update_pinning_request_t, path)};
-    ebpf_object_t* object = NULL;
+    ebpf_core_object_t* object = NULL;
 
     if (path.length == 0) {
         retval = EBPF_INVALID_ARGUMENT;
@@ -707,14 +708,14 @@ _ebpf_core_protocol_update_pinning(_In_ const struct _ebpf_operation_update_map_
         retval = ebpf_pinning_table_delete(_ebpf_core_map_pinning_table, &path);
         goto Done;
     } else {
-        retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_UNKNOWN, (ebpf_object_t**)&object);
+        retval = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_UNKNOWN, (ebpf_core_object_t**)&object);
         if (retval != EBPF_SUCCESS)
             goto Done;
 
-        retval = ebpf_pinning_table_insert(_ebpf_core_map_pinning_table, &path, (ebpf_object_t*)object);
+        retval = ebpf_pinning_table_insert(_ebpf_core_map_pinning_table, &path, (ebpf_core_object_t*)object);
     }
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)object);
+    ebpf_object_release_reference((ebpf_core_object_t*)object);
 
     EBPF_RETURN_RESULT(retval);
 }
@@ -727,7 +728,7 @@ _ebpf_core_protocol_get_pinned_object(
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t retval;
-    ebpf_object_t* object = NULL;
+    ebpf_core_object_t* object = NULL;
     const ebpf_utf8_string_t path = {
         (uint8_t*)request->path, request->header.length - EBPF_OFFSET_OF(ebpf_operation_get_pinning_request_t, path)};
     UNREFERENCED_PARAMETER(reply_length);
@@ -737,14 +738,14 @@ _ebpf_core_protocol_get_pinned_object(
         goto Done;
     }
 
-    retval = ebpf_pinning_table_find(_ebpf_core_map_pinning_table, &path, (ebpf_object_t**)&object);
+    retval = ebpf_pinning_table_find(_ebpf_core_map_pinning_table, &path, (ebpf_core_object_t**)&object);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
-    retval = ebpf_handle_create(&reply->handle, (ebpf_object_t*)object);
+    retval = ebpf_handle_create(&reply->handle, (ebpf_core_object_t*)object);
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)object);
+    ebpf_object_release_reference((ebpf_core_object_t*)object);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -757,7 +758,8 @@ _ebpf_core_protocol_link_program(
     ebpf_program_t* program = NULL;
     ebpf_link_t* link = NULL;
 
-    retval = ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+    retval =
+        ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -774,7 +776,7 @@ _ebpf_core_protocol_link_program(
     if (retval != EBPF_SUCCESS)
         goto Done;
 
-    retval = ebpf_handle_create(&reply->link_handle, (ebpf_object_t*)link);
+    retval = ebpf_handle_create(&reply->link_handle, (ebpf_core_object_t*)link);
     if (retval != EBPF_SUCCESS)
         goto Done;
 
@@ -782,8 +784,8 @@ Done:
     if (retval != EBPF_SUCCESS && link) {
         ebpf_link_detach_program(link);
     }
-    ebpf_object_release_reference((ebpf_object_t*)program);
-    ebpf_object_release_reference((ebpf_object_t*)link);
+    ebpf_object_release_reference((ebpf_core_object_t*)program);
+    ebpf_object_release_reference((ebpf_core_object_t*)link);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -794,7 +796,7 @@ _ebpf_core_protocol_unlink_program(_In_ const ebpf_operation_unlink_program_requ
     ebpf_result_t retval;
     ebpf_link_t* link = NULL;
 
-    retval = ebpf_reference_object_by_handle(request->link_handle, EBPF_OBJECT_LINK, (ebpf_object_t**)&link);
+    retval = ebpf_reference_object_by_handle(request->link_handle, EBPF_OBJECT_LINK, (ebpf_core_object_t**)&link);
     if (retval != EBPF_SUCCESS) {
         goto Done;
     }
@@ -802,7 +804,7 @@ _ebpf_core_protocol_unlink_program(_In_ const ebpf_operation_unlink_program_requ
     ebpf_link_detach_program(link);
 
 Done:
-    ebpf_object_release_reference((ebpf_object_t*)link);
+    ebpf_object_release_reference((ebpf_core_object_t*)link);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -852,8 +854,8 @@ _ebpf_core_protocol_get_program_info(
         if (retval != EBPF_SUCCESS)
             goto Done;
     } else {
-        retval =
-            ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+        retval = ebpf_reference_object_by_handle(
+            request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program);
         if (retval != EBPF_SUCCESS)
             goto Done;
     }
@@ -880,7 +882,7 @@ _ebpf_core_protocol_get_program_info(
 
 Done:
     ebpf_program_free_program_info(program_info);
-    ebpf_object_release_reference((ebpf_object_t*)program);
+    ebpf_object_release_reference((ebpf_core_object_t*)program);
     EBPF_RETURN_RESULT(retval);
 }
 
@@ -1021,7 +1023,7 @@ _get_handle_by_id(
     if (reply_length < sizeof(*reply)) {
         return EBPF_INVALID_ARGUMENT;
     }
-    ebpf_object_t* object;
+    ebpf_core_object_t* object;
     ebpf_result_t result = ebpf_object_reference_by_id(request->id, type, &object);
     if (result != EBPF_SUCCESS) {
         return result;
@@ -1142,12 +1144,13 @@ _ebpf_core_protocol_bind_map(_In_ const ebpf_operation_bind_map_request_t* reque
     ebpf_program_t* program = NULL;
     ebpf_map_t* map = NULL;
 
-    result = ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_object_t**)&program);
+    result =
+        ebpf_reference_object_by_handle(request->program_handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program);
     if (result != EBPF_SUCCESS) {
         goto Done;
     }
 
-    result = ebpf_reference_object_by_handle(request->map_handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    result = ebpf_reference_object_by_handle(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (result != EBPF_SUCCESS) {
         goto Done;
     }
@@ -1156,10 +1159,10 @@ _ebpf_core_protocol_bind_map(_In_ const ebpf_operation_bind_map_request_t* reque
 
 Done:
     if (program) {
-        ebpf_object_release_reference((ebpf_object_t*)program);
+        ebpf_object_release_reference((ebpf_core_object_t*)program);
     }
     if (map) {
-        ebpf_object_release_reference((ebpf_object_t*)map);
+        ebpf_object_release_reference((ebpf_core_object_t*)map);
     }
     EBPF_RETURN_RESULT(result);
 }
@@ -1173,7 +1176,7 @@ _ebpf_core_protocol_get_object_info(
     EBPF_LOG_ENTRY();
     uint16_t info_size = reply_length - FIELD_OFFSET(ebpf_operation_get_object_info_reply_t, info);
 
-    ebpf_object_t* object;
+    ebpf_core_object_t* object;
     ebpf_result_t result = ebpf_reference_object_by_handle(request->handle, EBPF_OBJECT_UNKNOWN, &object);
     if (result != EBPF_SUCCESS) {
         return result;
@@ -1211,14 +1214,15 @@ _ebpf_core_protocol_ring_buffer_map_query_buffer(
     UNREFERENCED_PARAMETER(reply_length);
 
     ebpf_map_t* map;
-    ebpf_result_t result = ebpf_reference_object_by_handle(request->map_handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    ebpf_result_t result =
+        ebpf_reference_object_by_handle(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (result != EBPF_SUCCESS) {
         return result;
     }
 
     result = ebpf_ring_buffer_map_query_buffer(map, (uint8_t**)(uintptr_t*)&reply->buffer_address);
 
-    ebpf_object_release_reference((ebpf_object_t*)map);
+    ebpf_object_release_reference((ebpf_core_object_t*)map);
     EBPF_RETURN_RESULT(result);
 }
 
@@ -1234,7 +1238,8 @@ _ebpf_core_protocol_ring_buffer_map_async_query(
     ebpf_map_t* map;
     bool reference_taken = FALSE;
 
-    ebpf_result_t result = ebpf_reference_object_by_handle(request->map_handle, EBPF_OBJECT_MAP, (ebpf_object_t**)&map);
+    ebpf_result_t result =
+        ebpf_reference_object_by_handle(request->map_handle, EBPF_OBJECT_MAP, (ebpf_core_object_t**)&map);
     if (result != EBPF_SUCCESS)
         goto Exit;
     reference_taken = TRUE;
@@ -1248,7 +1253,7 @@ _ebpf_core_protocol_ring_buffer_map_async_query(
 
 Exit:
     if (reference_taken)
-        ebpf_object_release_reference((ebpf_object_t*)map);
+        ebpf_object_release_reference((ebpf_core_object_t*)map);
     return result;
 }
 

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -10,7 +10,7 @@
 
 typedef struct _ebpf_link
 {
-    ebpf_object_t object;
+    ebpf_core_object_t object;
     ebpf_program_t* program;
 
     ebpf_attach_type_t attach_type;
@@ -33,7 +33,7 @@ static struct
 } _ebpf_link_dispatch_table = {1, {_ebpf_link_instance_invoke}};
 
 static void
-_ebpf_link_free(ebpf_object_t* object)
+_ebpf_link_free(ebpf_core_object_t* object)
 {
     ebpf_link_t* link = (ebpf_link_t*)object;
     ebpf_lock_destroy(&link->attach_lock);
@@ -216,7 +216,7 @@ ebpf_link_get_info(
     }
 
     info->id = link->object.id;
-    info->prog_id = (link->program) ? ((ebpf_object_t*)link->program)->id : EBPF_ID_NONE;
+    info->prog_id = (link->program) ? ((ebpf_core_object_t*)link->program)->id : EBPF_ID_NONE;
     info->type = BPF_LINK_TYPE_PLAIN;
     info->program_type_uuid = link->program_type;
     info->attach_type_uuid = link->attach_type;

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -28,7 +28,7 @@ template <typename T> class ebpf_object_deleter
     void
     operator()(T* object)
     {
-        ebpf_object_release_reference(reinterpret_cast<ebpf_object_t*>(object));
+        ebpf_object_release_reference(reinterpret_cast<ebpf_core_object_t*>(object));
     }
 };
 
@@ -570,9 +570,9 @@ TEST_CASE("program", "[execution_context]")
 
     ebpf_map_t* maps[] = {map.get()};
 
-    REQUIRE(((ebpf_object_t*)map.get())->reference_count == 1);
+    REQUIRE(((ebpf_core_object_t*)map.get())->reference_count == 1);
     REQUIRE(ebpf_program_associate_maps(program.get(), maps, EBPF_COUNT_OF(maps)) == EBPF_SUCCESS);
-    REQUIRE(((ebpf_object_t*)map.get())->reference_count == 2);
+    REQUIRE(((ebpf_core_object_t*)map.get())->reference_count == 2);
 
     ebpf_trampoline_table_t* table = NULL;
     ebpf_result_t (*test_function)();

--- a/libs/platform/ebpf_handle.h
+++ b/libs/platform/ebpf_handle.h
@@ -36,7 +36,7 @@ extern "C"
      *  operation.
      */
     ebpf_result_t
-    ebpf_handle_create(ebpf_handle_t* handle, struct _ebpf_object* object);
+    ebpf_handle_create(ebpf_handle_t* handle, struct _ebpf_core_object* object);
 
     /**
      * @brief Remove an existing handle from the handle table and release its
@@ -60,7 +60,8 @@ extern "C"
      * @retval EBPF_INVALID_OBJECT The provided handle is not valid.
      */
     ebpf_result_t
-    ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_type, struct _ebpf_object** object);
+    ebpf_reference_object_by_handle(
+        ebpf_handle_t handle, ebpf_object_type_t object_type, struct _ebpf_core_object** object);
 
 #ifdef __cplusplus
 }

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -37,7 +37,7 @@ typedef struct _ebpf_id_entry
     uint16_t counter;
 
     // Pointer to object.
-    ebpf_object_t* object;
+    ebpf_core_object_t* object;
 } ebpf_id_entry_t;
 
 // Currently we allow a maximum of 1024 objects (links, maps,
@@ -75,7 +75,7 @@ _get_index_from_id(ebpf_id_t id, _Out_ uint32_t* index)
 }
 
 static ebpf_result_t
-_ebpf_object_tracking_list_insert(_Inout_ ebpf_object_t* object)
+_ebpf_object_tracking_list_insert(_Inout_ ebpf_core_object_t* object)
 {
     int new_index;
     ebpf_result_t return_value;
@@ -105,7 +105,7 @@ Done:
 }
 
 _Requires_lock_held_(&_ebpf_object_tracking_list_lock) static void _ebpf_object_tracking_list_remove(
-    ebpf_object_t* object)
+    ebpf_core_object_t* object)
 {
     uint32_t index;
     ebpf_result_t return_value = _get_index_from_id(object->id, &index);
@@ -135,7 +135,7 @@ ebpf_object_tracking_terminate()
 
 ebpf_result_t
 ebpf_object_initialize(
-    ebpf_object_t* object,
+    ebpf_core_object_t* object,
     ebpf_object_type_t object_type,
     ebpf_free_object_t free_function,
     ebpf_object_get_program_type_t get_program_type_function)
@@ -153,7 +153,7 @@ ebpf_object_initialize(
 }
 
 void
-ebpf_object_acquire_reference(ebpf_object_t* object)
+ebpf_object_acquire_reference(ebpf_core_object_t* object)
 {
     ebpf_assert(object->marker == _ebpf_object_marker);
     ebpf_assert(object->reference_count != 0);
@@ -161,7 +161,7 @@ ebpf_object_acquire_reference(ebpf_object_t* object)
 }
 
 _Requires_lock_held_(&_ebpf_object_tracking_list_lock) void _ebpf_object_release_reference_under_lock(
-    ebpf_object_t* object)
+    ebpf_core_object_t* object)
 {
     uint32_t new_ref_count;
 
@@ -184,7 +184,7 @@ _Requires_lock_held_(&_ebpf_object_tracking_list_lock) void _ebpf_object_release
 }
 
 void
-ebpf_object_release_reference(ebpf_object_t* object)
+ebpf_object_release_reference(ebpf_core_object_t* object)
 {
     uint32_t new_ref_count;
 
@@ -208,7 +208,7 @@ ebpf_object_release_reference(ebpf_object_t* object)
 }
 
 ebpf_object_type_t
-ebpf_object_get_type(ebpf_object_t* object)
+ebpf_object_get_type(ebpf_core_object_t* object)
 {
     return object->type;
 }
@@ -230,7 +230,7 @@ ebpf_duplicate_utf8_string(_Out_ ebpf_utf8_string_t* destination, _In_ const ebp
     }
 }
 
-_Requires_lock_held_(&_ebpf_object_tracking_list_lock) static ebpf_object_t* _get_next_object_by_id(
+_Requires_lock_held_(&_ebpf_object_tracking_list_lock) static ebpf_core_object_t* _get_next_object_by_id(
     ebpf_id_t start_id, ebpf_object_type_t object_type)
 {
     // The start_id need not exist, so we can't call _get_index_from_id().
@@ -239,7 +239,7 @@ _Requires_lock_held_(&_ebpf_object_tracking_list_lock) static ebpf_object_t* _ge
         index++;
     }
     while (index < EBPF_COUNT_OF(_ebpf_id_table)) {
-        ebpf_object_t* object = _ebpf_id_table[index].object;
+        ebpf_core_object_t* object = _ebpf_id_table[index].object;
         if ((object != NULL) && (object->type == object_type)) {
             return object;
         }
@@ -255,7 +255,7 @@ ebpf_object_get_next_id(ebpf_id_t start_id, ebpf_object_type_t object_type, _Out
 
     ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);
 
-    ebpf_object_t* object = _get_next_object_by_id(start_id, object_type);
+    ebpf_core_object_t* object = _get_next_object_by_id(start_id, object_type);
     if (object != NULL) {
         *next_id = object->id;
         return_value = EBPF_SUCCESS;
@@ -266,7 +266,8 @@ ebpf_object_get_next_id(ebpf_id_t start_id, ebpf_object_type_t object_type, _Out
 }
 
 void
-ebpf_object_reference_next_object(ebpf_object_t* previous_object, ebpf_object_type_t type, ebpf_object_t** next_object)
+ebpf_object_reference_next_object(
+    ebpf_core_object_t* previous_object, ebpf_object_type_t type, ebpf_core_object_t** next_object)
 {
     ebpf_lock_state_t state;
     *next_object = NULL;
@@ -274,7 +275,7 @@ ebpf_object_reference_next_object(ebpf_object_t* previous_object, ebpf_object_ty
     state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);
 
     ebpf_id_t start_id = (previous_object) ? previous_object->id : 0;
-    ebpf_object_t* object = _get_next_object_by_id(start_id, type);
+    ebpf_core_object_t* object = _get_next_object_by_id(start_id, type);
     if (object != NULL) {
         *next_object = object;
         ebpf_object_acquire_reference(object);
@@ -284,14 +285,14 @@ ebpf_object_reference_next_object(ebpf_object_t* previous_object, ebpf_object_ty
 }
 
 ebpf_result_t
-ebpf_object_reference_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_ ebpf_object_t** object)
+ebpf_object_reference_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_ ebpf_core_object_t** object)
 {
     ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);
 
     uint32_t index;
     ebpf_result_t return_value = _get_index_from_id(id, &index);
     if (return_value == EBPF_SUCCESS) {
-        ebpf_object_t* found = _ebpf_id_table[index].object;
+        ebpf_core_object_t* found = _ebpf_id_table[index].object;
         if ((found != NULL) && (found->type == object_type)) {
             ebpf_object_acquire_reference(found);
             *object = found;
@@ -311,7 +312,7 @@ ebpf_object_dereference_by_id(ebpf_id_t id, ebpf_object_type_t object_type)
     uint32_t index;
     ebpf_result_t return_value = _get_index_from_id(id, &index);
     if (return_value == EBPF_SUCCESS) {
-        ebpf_object_t* found = _ebpf_id_table[index].object;
+        ebpf_core_object_t* found = _ebpf_id_table[index].object;
         if ((found != NULL) && (found->type == object_type)) {
             _ebpf_object_release_reference_under_lock(found);
         } else

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -20,13 +20,11 @@ extern "C"
         EBPF_OBJECT_PROGRAM,
     } ebpf_object_type_t;
 
-    typedef struct _ebpf_object ebpf_object_t;
-    typedef void (*ebpf_free_object_t)(ebpf_object_t* object);
-    typedef const ebpf_program_type_t* (*ebpf_object_get_program_type_t)(_In_ const ebpf_object_t* object);
+    typedef struct _ebpf_core_object ebpf_core_object_t;
+    typedef void (*ebpf_free_object_t)(ebpf_core_object_t* object);
+    typedef const ebpf_program_type_t* (*ebpf_object_get_program_type_t)(_In_ const ebpf_core_object_t* object);
 
-    // This type probably ought to be renamed to avoid confusion with
-    // ebpf_object_t in libs\api\api_internal.h
-    typedef struct _ebpf_object
+    typedef struct _ebpf_core_object
     {
         uint32_t marker;
         volatile int32_t reference_count;
@@ -39,7 +37,7 @@ extern "C"
         ebpf_list_entry_t object_list_entry;
         // # of pinned paths, for diagnostic purposes.
         uint32_t pinned_path_count;
-    } ebpf_object_t;
+    } ebpf_core_object_t;
 
     /**
      * @brief Initiate object tracking.
@@ -56,9 +54,9 @@ extern "C"
     ebpf_object_tracking_terminate();
 
     /**
-     * @brief Initialize an ebpf_object_t structure.
+     * @brief Initialize an ebpf_core_object_t structure.
      *
-     * @param[in,out] object ebpf_object_t structure to initialize.
+     * @param[in,out] object ebpf_core_object_t structure to initialize.
      * @param[in] object_type The type of the object.
      * @param[in] free_function The function used to free the object.
      * @param[in] get_program_type_function The function used to get a program type, or NULL.  Each program
@@ -69,7 +67,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_object_initialize(
-        ebpf_object_t* object,
+        ebpf_core_object_t* object,
         ebpf_object_type_t object_type,
         ebpf_free_object_t free_function,
         ebpf_object_get_program_type_t get_program_type_function);
@@ -80,7 +78,7 @@ extern "C"
      * @param[in] object Object on which to acquire a reference.
      */
     void
-    ebpf_object_acquire_reference(ebpf_object_t* object);
+    ebpf_object_acquire_reference(ebpf_core_object_t* object);
 
     /**
      * @brief Release a reference on this object. If the reference count reaches
@@ -89,7 +87,7 @@ extern "C"
      * @param[in] object Object on which to release a reference.
      */
     void
-    ebpf_object_release_reference(ebpf_object_t* object);
+    ebpf_object_release_reference(ebpf_core_object_t* object);
 
     /**
      * @brief Query the stored type of the object.
@@ -98,7 +96,7 @@ extern "C"
      * @return Type of the object.
      */
     ebpf_object_type_t
-    ebpf_object_get_type(ebpf_object_t* object);
+    ebpf_object_get_type(ebpf_core_object_t* object);
 
     /**
      * @brief Find the next object that is of this type and acquire reference
@@ -112,7 +110,7 @@ extern "C"
      */
     void
     ebpf_object_reference_next_object(
-        ebpf_object_t* previous_object, ebpf_object_type_t type, ebpf_object_t** next_object);
+        ebpf_core_object_t* previous_object, ebpf_object_type_t type, ebpf_core_object_t** next_object);
 
     /**
      * @brief Find an ID in the ID table, verify the type matches,
@@ -125,7 +123,7 @@ extern "C"
      * @retval EBPF_KEY_NOT_FOUND The provided ID is not valid.
      */
     ebpf_result_t
-    ebpf_object_reference_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_ ebpf_object_t** object);
+    ebpf_object_reference_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_ ebpf_core_object_t** object);
 
     /**
      * @brief Find an ID in the ID table, verify the type matches,

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -105,7 +105,8 @@ ebpf_pinning_table_free(ebpf_pinning_table_t* pinning_table)
 }
 
 ebpf_result_t
-ebpf_pinning_table_insert(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_object_t* object)
+ebpf_pinning_table_insert(
+    ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_core_object_t* object)
 {
     EBPF_LOG_ENTRY();
     ebpf_lock_state_t state;
@@ -164,7 +165,8 @@ Done:
 }
 
 ebpf_result_t
-ebpf_pinning_table_find(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_object_t** object)
+ebpf_pinning_table_find(
+    ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_core_object_t** object)
 {
     EBPF_LOG_ENTRY();
     ebpf_lock_state_t state;

--- a/libs/platform/ebpf_pinning_table.h
+++ b/libs/platform/ebpf_pinning_table.h
@@ -17,7 +17,7 @@ extern "C"
     typedef struct _ebpf_pinning_entry
     {
         ebpf_utf8_string_t path;
-        ebpf_object_t* object;
+        ebpf_core_object_t* object;
     } ebpf_pinning_entry_t;
 
     /**
@@ -53,7 +53,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_pinning_table_insert(
-        ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_object_t* object);
+        ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_core_object_t* object);
 
     /**
      * @brief Find an entry in the pinning table and acquire a reference on the
@@ -68,7 +68,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_pinning_table_find(
-        ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_object_t** object);
+        ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_core_object_t** object);
 
     /**
      * @brief Find an entry in the pinning table, remove it and release a

--- a/libs/platform/kernel/ebpf_handle_kernel.c
+++ b/libs/platform/kernel/ebpf_handle_kernel.c
@@ -18,7 +18,7 @@ ebpf_handle_table_terminate()
 {}
 
 ebpf_result_t
-ebpf_handle_create(ebpf_handle_t* handle, ebpf_object_t* object)
+ebpf_handle_create(ebpf_handle_t* handle, ebpf_core_object_t* object)
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t return_value;
@@ -88,12 +88,12 @@ ebpf_handle_close(ebpf_handle_t handle)
 }
 
 ebpf_result_t
-ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_type, ebpf_object_t** object)
+ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_type, ebpf_core_object_t** object)
 {
     ebpf_result_t return_value;
     NTSTATUS status;
     FILE_OBJECT* file_object = NULL;
-    ebpf_object_t* local_object;
+    ebpf_core_object_t* local_object;
 
     status = ObReferenceObjectByHandle((HANDLE)handle, 0, NULL, UserMode, &file_object, NULL);
     if (!NT_SUCCESS(status)) {
@@ -107,7 +107,7 @@ ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_
         goto Done;
     }
 
-    local_object = (ebpf_object_t*)file_object->FsContext2;
+    local_object = (ebpf_core_object_t*)file_object->FsContext2;
     if (local_object == NULL) {
         return_value = EBPF_INVALID_OBJECT;
         goto Done;

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -215,7 +215,7 @@ TEST_CASE("pinning_test", "[platform]")
 
     typedef struct _some_object
     {
-        ebpf_object_t object{};
+        ebpf_core_object_t object{};
         std::string name;
     } some_object_t;
 
@@ -227,10 +227,10 @@ TEST_CASE("pinning_test", "[platform]")
 
     REQUIRE(
         ebpf_object_initialize(
-            &an_object.object, EBPF_OBJECT_MAP, [](ebpf_object_t*) {}, NULL) == EBPF_SUCCESS);
+            &an_object.object, EBPF_OBJECT_MAP, [](ebpf_core_object_t*) {}, NULL) == EBPF_SUCCESS);
     REQUIRE(
         ebpf_object_initialize(
-            &another_object.object, EBPF_OBJECT_MAP, [](ebpf_object_t*) {}, NULL) == EBPF_SUCCESS);
+            &another_object.object, EBPF_OBJECT_MAP, [](ebpf_core_object_t*) {}, NULL) == EBPF_SUCCESS);
 
     ebpf_pinning_table_t* pinning_table = nullptr;
     REQUIRE(ebpf_pinning_table_allocate(&pinning_table) == EBPF_SUCCESS);
@@ -239,7 +239,7 @@ TEST_CASE("pinning_test", "[platform]")
     REQUIRE(an_object.object.reference_count == 2);
     REQUIRE(ebpf_pinning_table_insert(pinning_table, &bar, &another_object.object) == EBPF_SUCCESS);
     REQUIRE(another_object.object.reference_count == 2);
-    REQUIRE(ebpf_pinning_table_find(pinning_table, &foo, (ebpf_object_t**)&some_object) == EBPF_SUCCESS);
+    REQUIRE(ebpf_pinning_table_find(pinning_table, &foo, (ebpf_core_object_t**)&some_object) == EBPF_SUCCESS);
     REQUIRE(an_object.object.reference_count == 3);
     REQUIRE(some_object == &an_object);
     ebpf_object_release_reference(&some_object->object);

--- a/libs/platform/user/ebpf_handle_user.c
+++ b/libs/platform/user/ebpf_handle_user.c
@@ -3,7 +3,7 @@
 
 #include "ebpf_handle.h"
 
-typedef ebpf_object_t* ebpf_handle_entry_t;
+typedef ebpf_core_object_t* ebpf_handle_entry_t;
 
 // Simplified handle table implementation.
 // TODO: Replace this with the real Windows object manager handle table code.
@@ -39,7 +39,7 @@ ebpf_handle_table_terminate()
 }
 
 ebpf_result_t
-ebpf_handle_create(ebpf_handle_t* handle, ebpf_object_t* object)
+ebpf_handle_create(ebpf_handle_t* handle, ebpf_core_object_t* object)
 {
     EBPF_LOG_ENTRY();
     ebpf_handle_t new_handle;
@@ -85,7 +85,7 @@ ebpf_handle_close(ebpf_handle_t handle)
 }
 
 ebpf_result_t
-ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_type, ebpf_object_t** object)
+ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_type, ebpf_core_object_t** object)
 {
     ebpf_result_t return_value;
     ebpf_lock_state_t state;

--- a/tests/libs/util/dll_metadata_table.cpp
+++ b/tests/libs/util/dll_metadata_table.cpp
@@ -23,7 +23,7 @@ ebpf_map_create(
     ebpf_handle_t inner_map_handle,
     _Outptr_ ebpf_map_t** map);
 
-typedef struct _ebpf_object ebpf_object_t;
+typedef struct _ebpf_core_object ebpf_core_object_t;
 
 dll_metadata_table::dll_metadata_table(const std::string& dll_name, const std::string& table_name)
 {
@@ -140,7 +140,7 @@ dll_metadata_table::bind_metadata_table()
             throw std::runtime_error("ebpf_extension_load failed for ebpf_general_helper_function_interface_id");
         }
         ebpf_handle_t handle;
-        if (ebpf_handle_create(&handle, reinterpret_cast<ebpf_object_t*>(maps[i].address)) != EBPF_SUCCESS) {
+        if (ebpf_handle_create(&handle, reinterpret_cast<ebpf_core_object_t*>(maps[i].address)) != EBPF_SUCCESS) {
             throw std::runtime_error("ebpf_handle_create failed");
         }
         fd_t fd = Platform::_open_osfhandle(handle, 0);
@@ -163,7 +163,7 @@ dll_metadata_table::unbind_metadata_table()
     }
 
     for (size_t i = 0; i < map_count; i++) {
-        ebpf_object_release_reference(reinterpret_cast<ebpf_object_t*>(maps[i].address));
+        ebpf_object_release_reference(reinterpret_cast<ebpf_core_object_t*>(maps[i].address));
         maps[i].address = nullptr;
     }
     for (auto& [name, fd] : loaded_maps) {

--- a/tests/performance/ExecutionContext.cpp
+++ b/tests/performance/ExecutionContext.cpp
@@ -27,7 +27,7 @@ typedef class _ebpf_program_test_state
     }
     ~_ebpf_program_test_state()
     {
-        ebpf_object_release_reference(reinterpret_cast<ebpf_object_t*>(program));
+        ebpf_object_release_reference(reinterpret_cast<ebpf_core_object_t*>(program));
         ebpf_core_terminate();
     }
 
@@ -103,7 +103,7 @@ typedef class _ebpf_map_test_state
     }
     ~_ebpf_map_test_state()
     {
-        ebpf_object_release_reference((ebpf_object_t*)map);
+        ebpf_object_release_reference((ebpf_core_object_t*)map);
         ebpf_core_terminate();
     }
 
@@ -226,7 +226,7 @@ typedef class _ebpf_map_lpm_trie_test_state
 
     ~_ebpf_map_lpm_trie_test_state()
     {
-        ebpf_object_release_reference((ebpf_object_t*)map);
+        ebpf_object_release_reference((ebpf_core_object_t*)map);
         ebpf_core_terminate();
     }
 


### PR DESCRIPTION
Both usermode and EC use same name for ebpf_object. This causes clash if both EC and UM header files are included in a test file.

This PR renames `ebpf_object_t` used in EC to `ebpf_core_object_t`