### PR TITLE
Add support for bpf_printk helper without additional arguments

### DIFF
--- a/include/bpf_helper_defs.h
+++ b/include/bpf_helper_defs.h
@@ -144,3 +144,23 @@ EBPF_HELPER(int, bpf_ringbuf_output, (struct bpf_map * ring_buffer, void* data, 
 #ifndef __doxygen
 #define bpf_ringbuf_output ((bpf_ringbuf_output_t)BPF_FUNC_ringbuf_output)
 #endif
+
+/**
+ * @brief Print debug output.
+ *
+ * @param[in] fmt Printf-style format string.
+ * @param[in] fmt_size Size in bytes of *fmt*.
+ *
+ * @returns The number of bytes written, or a negative error in case of failure.
+ */
+EBPF_HELPER(long, bpf_trace_printk, (const char* fmt, uint32_t fmt_size, ...));
+#ifndef __doxygen
+#define bpf_trace_printk ((bpf_trace_printk_t)BPF_FUNC_trace_printk)
+#endif
+
+#undef bpf_printk
+#define bpf_printk(fmt, ...)                                       \
+    ({                                                             \
+        char ____fmt[] = fmt;                                      \
+        bpf_trace_printk(____fmt, sizeof(____fmt), ##__VA_ARGS__); \
+    })

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -92,7 +92,7 @@ typedef enum _bind_action
 } bind_action_t;
 
 /**
- * @brief Handle a socket bind() request.
+ * @brief Handle an AF_INET socket bind() request.
  *
  * Program type: \ref EBPF_PROGRAM_TYPE_BIND
  *

--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -101,7 +101,8 @@ typedef enum
     BPF_FUNC_get_smp_processor_id = 8,
     BPF_FUNC_ktime_get_ns = 9,
     BPF_FUNC_csum_diff = 10,
-    BPF_FUNC_ringbuf_output = 11
+    BPF_FUNC_ringbuf_output = 11,
+    BPF_FUNC_trace_printk = 12,
 } ebpf_helper_id_t;
 
 // Cross-platform BPF program types.

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1345,8 +1345,8 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size)
     }
     memcpy(output, fmt, fmt_size);
 
-    // Make sure the output is null-terminated.
-    // Remove the newline if not already present.
+    // Make sure the output is null-terminated, and
+    // remove the newline if present.
     // A well-formed input should be null terminated,
     // so look at the next-to-last byte.
     char* end = output + fmt_size - 2;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1362,9 +1362,10 @@ _ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size)
     }
 
     ebpf_platform_printk(output);
+    long bytes_written = (long)(end - output + 1);
 
     ebpf_free(output);
-    return (long)(end - output + 1);
+    return bytes_written;
 }
 
 int

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -39,7 +39,7 @@ _ebpf_core_get_time_since_boot_ns();
 static uint64_t
 _ebpf_core_get_time_ns();
 static long
-_ebpf_core_trace_printk(_In_z_ const char* fmt, size_t fmt_size);
+_ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size);
 static int
 _ebpf_core_ring_buffer_output(
     _In_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length, uint64_t flags);
@@ -1331,7 +1331,7 @@ _ebpf_core_get_time_ns()
 #define MAX_PRINTK_STRING_SIZE 512
 
 long
-_ebpf_core_trace_printk(_In_ const char* fmt, size_t fmt_size)
+_ebpf_core_trace_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size)
 {
     if (fmt_size > MAX_PRINTK_STRING_SIZE - 1) {
         // Disallow large fmt_size values.
@@ -1340,6 +1340,9 @@ _ebpf_core_trace_printk(_In_ const char* fmt, size_t fmt_size)
 
     // Make a copy of the original string.
     char* output = (char*)ebpf_allocate(fmt_size + 1);
+    if (output == NULL) {
+        return -1;
+    }
     memcpy(output, fmt, fmt_size);
 
     // Make sure the output is null-terminated.

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -38,6 +38,8 @@ static uint64_t
 _ebpf_core_get_time_since_boot_ns();
 static uint64_t
 _ebpf_core_get_time_ns();
+static long
+_ebpf_core_trace_printk(_In_z_ const char* fmt, size_t fmt_size);
 static int
 _ebpf_core_ring_buffer_output(
     _In_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length, uint64_t flags);
@@ -62,7 +64,8 @@ static const void* _ebpf_general_helpers[] = {
     (void*)&_ebpf_core_get_time_ns,
     (void*)&ebpf_core_csum_diff,
     // Ring buffer output.
-    (void*)&ebpf_ring_buffer_map_output};
+    (void*)&ebpf_ring_buffer_map_output,
+    (void*)&_ebpf_core_trace_printk};
 
 static ebpf_extension_provider_t* _ebpf_global_helper_function_provider_context = NULL;
 static ebpf_helper_function_addresses_t _ebpf_global_helper_function_dispatch_table = {
@@ -1322,6 +1325,12 @@ _ebpf_core_get_time_ns()
     // ebpf_query_time_since_boot returns time elapsed since
     // boot in units of 100 ns.
     return ebpf_query_time_since_boot(false) * 100;
+}
+
+long
+_ebpf_core_trace_printk(_In_ const char* fmt, size_t fmt_size)
+{
+    return ebpf_platform_printk(fmt, fmt_size);
 }
 
 int

--- a/libs/execution_context/ebpf_general_helpers.c
+++ b/libs/execution_context/ebpf_general_helpers.c
@@ -52,7 +52,11 @@ ebpf_helper_function_prototype_t ebpf_core_helper_function_prototype_array[] = {
      {EBPF_ARGUMENT_TYPE_PTR_TO_MAP,
       EBPF_ARGUMENT_TYPE_PTR_TO_MEM,
       EBPF_ARGUMENT_TYPE_CONST_SIZE,
-      EBPF_ARGUMENT_TYPE_ANYTHING}}};
+      EBPF_ARGUMENT_TYPE_ANYTHING}},
+    {BPF_FUNC_trace_printk,
+     "bpf_trace_printk",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}}};
 
 #ifdef __cplusplus
 extern "C"

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -967,13 +967,10 @@ extern "C"
     /**
      * @brief Output a debug message.
      *
-     * @param[in] fmt Format string.
-     * @param[in] fmt_size Length in bytes of format string.
-     *
-     * @return Bytes written, or -1 on error.
+     * @param[in] output String to output.
      */
-    long
-    ebpf_platform_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size);
+    void
+    ebpf_platform_printk(_In_z_ const char* output);
 
     TRACELOGGING_DECLARE_PROVIDER(ebpf_tracelog_provider);
 

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -964,6 +964,17 @@ extern "C"
     uint32_t
     ebpf_result_to_win32_error_code(ebpf_result_t result);
 
+    /**
+     * @brief Output a debug message.
+     *
+     * @param[in] fmt Format string.
+     * @param[in] fmt_size Length in bytes of format string.
+     *
+     * @return Bytes written, or -1 on error.
+     */
+    long
+    ebpf_platform_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size);
+
     TRACELOGGING_DECLARE_PROVIDER(ebpf_tracelog_provider);
 
     ebpf_result_t
@@ -986,6 +997,7 @@ extern "C"
 #define EBPF_TRACELOG_KEYWORD_MAP 0x40
 #define EBPF_TRACELOG_KEYWORD_PROGRAM 0x80
 #define EBPF_TRACELOG_KEYWORD_API 0x100
+#define EBPF_TRACELOG_KEYWORD_PRINTK 0x200
 
 #define EBPF_TRACELOG_LEVEL_LOG_ALWAYS WINEVENT_LEVEL_LOG_ALWAYS
 #define EBPF_TRACELOG_LEVEL_CRITICAL WINEVENT_LEVEL_CRITICAL

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -676,38 +676,8 @@ ebpf_guid_create(_Out_ GUID* new_guid)
         return EBPF_OPERATION_NOT_SUPPORTED;
 }
 
-// Pick a limit on string size based on the size of the eBPF stack.
-#define MAX_PRINTK_STRING_SIZE 512
-
-long
-ebpf_platform_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size)
+void
+ebpf_platform_printk(_In_z_ const char* output)
 {
-    if (fmt_size > MAX_PRINTK_STRING_SIZE - 1) {
-        // Disallow large fmt_size values.
-        return -1;
-    }
-
-    // Make a copy of the original string.
-    char* output = (char*)ebpf_allocate(fmt_size + 1);
-    memcpy(output, fmt, fmt_size);
-
-    // Make sure the output is null-terminated.
-    // Remove the newline if not already present.
-    // A well-formed input should be null terminated,
-    // so look at the next-to-last byte.
-    char* end = output + fmt_size - 2;
-    if (*end != '\n') {
-        end++;
-    }
-    *end = '\0';
-
-    char* percent = strchr(output, '%');
-    if (percent != NULL) {
-        // We don't yet support %'s in format strings.
-        return -1;
-    }
-
     EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, output);
-    ebpf_free(output);
-    return (long)(end - output + 1);
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -679,5 +679,5 @@ ebpf_guid_create(_Out_ GUID* new_guid)
 void
 ebpf_platform_printk(_In_z_ const char* output)
 {
-    EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, output);
+    EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_PRINTK, output);
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -675,3 +675,39 @@ ebpf_guid_create(_Out_ GUID* new_guid)
     else
         return EBPF_OPERATION_NOT_SUPPORTED;
 }
+
+// Pick a limit on string size based on the size of the eBPF stack.
+#define MAX_PRINTK_STRING_SIZE 512
+
+long
+ebpf_platform_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size)
+{
+    if (fmt_size > MAX_PRINTK_STRING_SIZE - 1) {
+        // Disallow large fmt_size values.
+        return -1;
+    }
+
+    // Make a copy of the original string.
+    char* output = (char*)ebpf_allocate(fmt_size + 1);
+    memcpy(output, fmt, fmt_size);
+
+    // Make sure the output is null-terminated.
+    // Remove the newline if not already present.
+    // A well-formed input should be null terminated,
+    // so look at the next-to-last byte.
+    char* end = output + fmt_size - 2;
+    if (*end != '\n') {
+        end++;
+    }
+    *end = '\0';
+
+    char* percent = strchr(output, '%');
+    if (percent != NULL) {
+        // We don't yet support %'s in format strings.
+        return -1;
+    }
+
+    EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_BASE, output);
+    ebpf_free(output);
+    return (long)(end - output + 1);
+}

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -714,38 +714,8 @@ ebpf_result_to_win32_error_code(ebpf_result_t result)
     return RtlNtStatusToDosError(ebpf_result_to_ntstatus(result));
 }
 
-// Pick a limit on string size based on the size of the eBPF stack.
-#define MAX_PRINTK_STRING_SIZE 512
-
-long
-ebpf_platform_printk(_In_reads_(fmt_size) const char* fmt, size_t fmt_size)
+void
+ebpf_platform_printk(_In_z_ const char* output)
 {
-    if (fmt_size > MAX_PRINTK_STRING_SIZE - 1) {
-        // Disallow large fmt_size values.
-        return -1;
-    }
-
-    // Make a copy of the original string.
-    char* output = (char*)ebpf_allocate(fmt_size + 1);
-    memcpy(output, fmt, fmt_size);
-
-    // Make sure the output is null-terminated.
-    // Remove the newline if not already present.
-    // A well-formed input should be null terminated,
-    // so look at the next-to-last byte.
-    char* end = output + fmt_size - 2;
-    if (*end != '\n') {
-        end++;
-    }
-    *end = '\0';
-
-    char* percent = strchr(output, '%');
-    if (percent != NULL) {
-        // We don't yet support %'s in format strings.
-        return -1;
-    }
-
     puts(output);
-    ebpf_free(output);
-    return (long)(end - output + 1);
 }

--- a/scripts/deploy-ebpf.ps1
+++ b/scripts/deploy-ebpf.ps1
@@ -5,7 +5,7 @@
 ## Initialize parameters
 ##
 $build_directory=".\x64\Debug"
-[System.Collections.ArrayList]$built_files=@( "EbpfCore.sys", "EbpfApi.dll", "ebpfnetsh.dll", "ebpfsvc.exe", "NetEbpfExt.sys", "sample_ebpf_ext.sys", "sample_ext_app.exe", "ucrtbased.dll", "MSVCP140D.dll", "VCRUNTIME140D.dll", "VCRUNTIME140_1D.dll", "bpftool.exe", "bindmonitor.o", "bpf.o", "bpf_call.o", "divide_by_zero.o", "droppacket.o", "droppacket_unsafe.o", "map_in_map.o", "reflect_packet.o", "tail_call.o", "tail_call_bad.o", "tail_call_map.o", "test_sample_ebpf.o", "test_utility_helpers.o")
+[System.Collections.ArrayList]$built_files=@( "EbpfCore.sys", "EbpfApi.dll", "ebpfnetsh.dll", "ebpfsvc.exe", "NetEbpfExt.sys", "sample_ebpf_ext.sys", "sample_ext_app.exe", "ucrtbased.dll", "MSVCP140D.dll", "VCRUNTIME140D.dll", "VCRUNTIME140_1D.dll", "bpftool.exe", "bindmonitor.o", "bpf.o", "bpf_call.o", "divide_by_zero.o", "droppacket.o", "droppacket_unsafe.o", "map_in_map.o", "reflect_packet.o", "tail_call.o", "tail_call_bad.o", "tail_call_map.o", "test_sample_ebpf.o", "test_utility_helpers.o", "printk.o")
 $destination_directory="C:\Temp"
 $error.clear()
 $vm="Windows 10 dev environment"

--- a/scripts/deploy-ebpf.ps1
+++ b/scripts/deploy-ebpf.ps1
@@ -5,7 +5,7 @@
 ## Initialize parameters
 ##
 $build_directory=".\x64\Debug"
-[System.Collections.ArrayList]$built_files=@( "EbpfCore.sys", "EbpfApi.dll", "ebpfnetsh.dll", "ebpfsvc.exe", "NetEbpfExt.sys", "sample_ebpf_ext.sys", "sample_ext_app.exe", "ucrtbased.dll", "MSVCP140D.dll", "VCRUNTIME140D.dll", "VCRUNTIME140_1D.dll", "bpftool.exe", "bindmonitor.o", "bpf.o", "bpf_call.o", "divide_by_zero.o", "droppacket.o", "droppacket_unsafe.o", "map_in_map.o", "reflect_packet.o", "tail_call.o", "tail_call_bad.o", "tail_call_map.o", "test_sample_ebpf.o", "test_utility_helpers.o", "printk.o")
+[System.Collections.ArrayList]$built_files=@( "EbpfCore.sys", "EbpfApi.dll", "ebpfnetsh.dll", "ebpfsvc.exe", "NetEbpfExt.sys", "sample_ebpf_ext.sys", "sample_ext_app.exe", "ucrtbased.dll", "MSVCP140D.dll", "VCRUNTIME140D.dll", "VCRUNTIME140_1D.dll", "bpftool.exe", "bindmonitor.o", "bpf.o", "bpf_call.o", "divide_by_zero.o", "droppacket.o", "droppacket_unsafe.o", "map_in_map.o", "reflect_packet.o", "tail_call.o", "tail_call_bad.o", "tail_call_map.o", "test_sample_ebpf.o", "test_utility_helpers.o", "printk.o", "ebpfforwindows.wprp")
 $destination_directory="C:\Temp"
 $error.clear()
 $vm="Windows 10 dev environment"

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1243,24 +1243,24 @@ TEST_CASE("printk", "[end_to_end]")
         sizeof(ifindex),
         hook);
 
-    capture_helper_t capture;
-    errno_t error = capture.begin_capture();
-    REQUIRE(error == NO_ERROR);
-
     // The current bind hook only works with IPv4, so compose a sample IPv4 context.
     SOCKADDR_IN addr = {AF_INET};
     addr.sin_port = htons(80);
     bind_md_t ctx = {0};
     ctx.socket_address_length = sizeof(addr);
     memcpy(&ctx.socket_address, &addr, ctx.socket_address_length);
-    int hook_result;
-    hook.fire(&ctx, &hook_result);
 
-    std::string output = capture.get_stdout_contents();
+    capture_helper_t capture;
+    std::string output;
+    int hook_result;
+    errno_t error = capture.begin_capture();
+    if (error == NO_ERROR) {
+        hook.fire(&ctx, &hook_result);
+        output = capture.get_stdout_contents();
+    }
     REQUIRE(
         output == "Hello, world\n"
                   "Hello, world\n");
-
     REQUIRE(hook_result == output.length());
 }
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -1247,6 +1247,7 @@ TEST_CASE("printk", "[end_to_end]")
     errno_t error = capture.begin_capture();
     REQUIRE(error == NO_ERROR);
 
+    // The current bind hook only works with IPv4, so compose a sample IPv4 context.
     SOCKADDR_IN addr = {AF_INET};
     addr.sin_port = htons(80);
     bind_md_t ctx = {0};

--- a/tests/sample/printk.c
+++ b/tests/sample/printk.c
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "bpf_helpers.h"
+
+SEC("xdp")
+int
+func()
+{
+    int bytes_written = 0;
+    bytes_written += bpf_printk("Hello, world");
+    bytes_written += bpf_printk("Hello, world\n");
+    return bytes_written;
+}

--- a/tests/sample/printk.c
+++ b/tests/sample/printk.c
@@ -3,7 +3,7 @@
 
 #include "bpf_helpers.h"
 
-SEC("xdp")
+SEC("bind")
 int
 func()
 {

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -297,6 +297,17 @@
       <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <CustomBuild Include="printk.c">
+      <FileType>CppCode</FileType>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">clang -g -target bpf -O2 -Werror -I../../include -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(OutputPath)%(Filename).o</Outputs>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/tests/sample/sample.vcxproj.filters
+++ b/tests/sample/sample.vcxproj.filters
@@ -84,5 +84,8 @@
     <CustomBuild Include="decap_permit_packet.c">
       <Filter>Source Files</Filter>
     </CustomBuild>
+    <CustomBuild Include="printk.c">
+      <Filter>Source Files</Filter>
+    </CustomBuild>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
* Add bpf_printk() helper.  This initial version does not support any % arguments, that will come in a separate PR.  User-mode output goes to stdout.  Kernel-mode output goes to the trace log with a new printk keyword.
* Add a printk.c sample to test with, using the bind hook.
* Fix deployment script to deploy ebpfforwindows.wprp so that the "Getting traces" instructions actually work