### PR TITLE
Move common interlocked API's into their own file

### DIFF
--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -148,18 +148,10 @@ _ebpf_get_per_cpu_flag(_In_ const ebpf_epoch_cpu_entry_t* cpu_entry, ebpf_epoch_
 static void
 _ebpf_set_per_cpu_flag(_In_ ebpf_epoch_cpu_entry_t* cpu_entry, ebpf_epoch_per_cpu_flags_t flag, bool state)
 {
-    for (;;) {
-        int32_t old_flag_value = cpu_entry->flags;
-        int32_t new_flag_value = old_flag_value;
-        if (state) {
-            new_flag_value |= flag;
-        } else {
-            new_flag_value &= flag;
-        }
-        if (ebpf_interlocked_compare_exchange_int32(&cpu_entry->flags, new_flag_value, old_flag_value) ==
-            old_flag_value) {
-            break;
-        }
+    if (state) {
+        ebpf_interlocked_or_int32(&cpu_entry->flags, flag);
+    } else {
+        ebpf_interlocked_and_int32(&cpu_entry->flags, ~flag);
     }
 }
 

--- a/libs/platform/ebpf_interlocked.c
+++ b/libs/platform/ebpf_interlocked.c
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "ebpf_platform.h"
+
+int32_t
+ebpf_interlocked_or_int32(_Inout_ volatile int32_t* target, int32_t mask)
+{
+    return InterlockedOr((volatile long*)target, mask);
+}
+
+int32_t
+ebpf_interlocked_and_int32(_Inout_ volatile int32_t* target, int32_t mask)
+{
+    return InterlockedAnd((volatile long*)target, mask);
+}
+
+int32_t
+ebpf_interlocked_xor_int32(_Inout_ volatile int32_t* target, int32_t mask)
+{
+    return InterlockedXor((volatile long*)target, mask);
+}
+
+int64_t
+ebpf_interlocked_or_int64(_Inout_ volatile int64_t* target, int64_t mask)
+{
+    return InterlockedOr64(target, mask);
+}
+
+int64_t
+ebpf_interlocked_and_int64(_Inout_ volatile int64_t* target, int64_t mask)
+{
+    return InterlockedAnd64(target, mask);
+}
+
+int64_t
+ebpf_interlocked_xor_int64(_Inout_ volatile int64_t* target, int64_t mask)
+{
+    return InterlockedXor64(target, mask);
+}
+
+int32_t
+ebpf_interlocked_increment_int32(_Inout_ volatile int32_t* addend)
+{
+    return InterlockedIncrement((volatile long*)addend);
+}
+
+int32_t
+ebpf_interlocked_decrement_int32(_Inout_ volatile int32_t* addend)
+{
+    return InterlockedDecrement((volatile long*)addend);
+}
+
+int64_t
+ebpf_interlocked_increment_int64(_Inout_ volatile int64_t* addend)
+{
+    return InterlockedIncrement64(addend);
+}
+
+int64_t
+ebpf_interlocked_decrement_int64(_Inout_ volatile int64_t* addend)
+{
+    return InterlockedDecrement64(addend);
+}
+
+int32_t
+ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, int32_t exchange, int32_t comperand)
+{
+    return InterlockedCompareExchange((long volatile*)destination, exchange, comperand);
+}
+
+void*
+ebpf_interlocked_compare_exchange_pointer(
+    _Inout_ void* volatile* destination, _In_opt_ const void* exchange, _In_opt_ const void* comperand)
+{
+    return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
+}

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -667,6 +667,66 @@ extern "C"
     ebpf_interlocked_compare_exchange_pointer(
         _Inout_ void* volatile* destination, _In_opt_ const void* exchange, _In_opt_ const void* comperand);
 
+    /**
+     * @brief Performs an atomic OR of the value stored at destination with mask and stores the result in destination.
+     *
+     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in] mask Value to be applied to the value stored at the destination.
+     * @return The original value stored at destination.
+     */
+    int32_t
+    ebpf_interlocked_or_int32(_Inout_ volatile int32_t* destination, int32_t mask);
+
+    /**
+     * @brief Performs an atomic AND of the value stored at destination with mask and stores the result in destination.
+     *
+     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in] mask Value to be applied to the value stored at the destination.
+     * @return The original value stored at destination.
+     */
+    int32_t
+    ebpf_interlocked_and_int32(_Inout_ volatile int32_t* destination, int32_t mask);
+
+    /**
+     * @brief Performs an atomic XOR of the value stored at destination with mask and stores the result in destination.
+     *
+     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in] mask Value to be applied to the value stored at the destination.
+     * @return The original value stored at destination.
+     */
+    int32_t
+    ebpf_interlocked_xor_int32(_Inout_ volatile int32_t* destination, int32_t mask);
+
+    /**
+     * @brief Performs an atomic OR of the value stored at destination with mask and stores the result in destination.
+     *
+     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in] mask Value to be applied to the value stored at the destination.
+     * @return The original value stored at destination.
+     */
+    int64_t
+    ebpf_interlocked_or_int64(_Inout_ volatile int64_t* destination, int64_t mask);
+
+    /**
+     * @brief Performs an atomic AND of the value stored at destination with mask and stores the result in destination.
+     *
+     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in] mask Value to be applied to the value stored at the destination.
+     * @return The original value stored at destination.
+     */
+    int64_t
+    ebpf_interlocked_and_int64(_Inout_ volatile int64_t* destination, int64_t mask);
+
+    /**
+     * @brief Performs an atomic XOR of the value stored at destination with mask and stores the result in destination.
+     *
+     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in] mask Value to be applied to the value stored at the destination.
+     * @return The original value stored at destination.
+     */
+    int64_t
+    ebpf_interlocked_xor_int64(_Inout_ volatile int64_t* destination, int64_t mask);
+
     typedef void (*ebpf_extension_change_callback_t)(
         _In_ void* client_binding_context,
         _In_ const void* provider_binding_context,

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -373,43 +373,6 @@ _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVE
     KeReleaseSpinLock(lock, state);
 }
 
-int32_t
-ebpf_interlocked_increment_int32(_Inout_ volatile int32_t* addend)
-{
-    return InterlockedIncrement((volatile long*)addend);
-}
-
-int32_t
-ebpf_interlocked_decrement_int32(_Inout_ volatile int32_t* addend)
-{
-    return InterlockedDecrement((volatile long*)addend);
-}
-
-int64_t
-ebpf_interlocked_increment_int64(_Inout_ volatile int64_t* addend)
-{
-    return InterlockedIncrement64(addend);
-}
-
-int64_t
-ebpf_interlocked_decrement_int64(_Inout_ volatile int64_t* addend)
-{
-    return InterlockedDecrement64(addend);
-}
-
-int32_t
-ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, int32_t exchange, int32_t comperand)
-{
-    return InterlockedCompareExchange((long volatile*)destination, exchange, comperand);
-}
-
-void*
-ebpf_interlocked_compare_exchange_pointer(
-    _Inout_ void* volatile* destination, _In_opt_ const void* exchange, _In_opt_ const void* comperand)
-{
-    return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
-}
-
 ebpf_result_t
 ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask)
 {

--- a/libs/platform/kernel/platform_kernel.vcxproj
+++ b/libs/platform/kernel/platform_kernel.vcxproj
@@ -45,6 +45,7 @@
     <ClCompile Include="..\ebpf_error.c" />
     <ClCompile Include="..\ebpf_etw.c" />
     <ClCompile Include="..\ebpf_hash_table.c" />
+    <ClCompile Include="..\ebpf_interlocked.c" />
     <ClCompile Include="..\ebpf_object.c" />
     <ClCompile Include="..\ebpf_pinning_table.c" />
     <ClCompile Include="..\ebpf_program_types.c" />

--- a/libs/platform/kernel/platform_kernel.vcxproj.filters
+++ b/libs/platform/kernel/platform_kernel.vcxproj.filters
@@ -67,6 +67,9 @@
     <ClCompile Include="..\ebpf_etw.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ebpf_interlocked.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ebpf_epoch.h">

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -375,43 +375,6 @@ _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVE
     ReleaseSRWLockExclusive(reinterpret_cast<PSRWLOCK>(lock));
 }
 
-int32_t
-ebpf_interlocked_increment_int32(_Inout_ volatile int32_t* addend)
-{
-    return InterlockedIncrement((volatile long*)addend);
-}
-
-int32_t
-ebpf_interlocked_decrement_int32(_Inout_ volatile int32_t* addend)
-{
-    return InterlockedDecrement((volatile long*)addend);
-}
-
-int64_t
-ebpf_interlocked_increment_int64(_Inout_ volatile int64_t* addend)
-{
-    return InterlockedIncrement64(addend);
-}
-
-int64_t
-ebpf_interlocked_decrement_int64(_Inout_ volatile int64_t* addend)
-{
-    return InterlockedDecrement64(addend);
-}
-
-int32_t
-ebpf_interlocked_compare_exchange_int32(_Inout_ volatile int32_t* destination, int32_t exchange, int32_t comperand)
-{
-    return InterlockedCompareExchange((long volatile*)destination, exchange, comperand);
-}
-
-void*
-ebpf_interlocked_compare_exchange_pointer(
-    _Inout_ void* volatile* destination, _In_opt_ const void* exchange, _In_opt_ const void* comperand)
-{
-    return InterlockedCompareExchangePointer((void* volatile*)destination, (void*)exchange, (void*)comperand);
-}
-
 uint32_t
 ebpf_random_uint32()
 {

--- a/libs/platform/user/platform_user.vcxproj
+++ b/libs/platform/user/platform_user.vcxproj
@@ -29,6 +29,7 @@
     <ClCompile Include="..\ebpf_error.c" />
     <ClCompile Include="..\ebpf_etw.c" />
     <ClCompile Include="..\ebpf_hash_table.c" />
+    <ClCompile Include="..\ebpf_interlocked.c" />
     <ClCompile Include="..\ebpf_object.c" />
     <ClCompile Include="..\ebpf_pinning_table.c" />
     <ClCompile Include="..\ebpf_program_types.c" />

--- a/libs/platform/user/platform_user.vcxproj.filters
+++ b/libs/platform/user/platform_user.vcxproj.filters
@@ -70,6 +70,9 @@
     <ClCompile Include="..\ebpf_etw.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ebpf_interlocked.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="..\ebpf_program_types.idl">


### PR DESCRIPTION
Move common interlocked APIs into their own file.
Add bitwise interlocked operations.
Modify ebpf_epoch.c to use bitwise interlocked operations.

Signed-off-by: Alan Jowett <alanjo@microsoft.com>