### PR TITLE
Fix calling ObReferenceObjectByHandle at DISPATCH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,6 +9,7 @@
 [submodule "external/bpftool"]
 	path = external/bpftool
 	url = https://github.com/dthaler/bpftool-1.git
+	branch = windows
 [submodule "external/win-c"]
 	path = external/win-c
 	url = https://github.com/takamin/win-c.git

--- a/libs/platform/ebpf_handle.h
+++ b/libs/platform/ebpf_handle.h
@@ -59,8 +59,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_OBJECT The provided handle is not valid.
      */
-    ebpf_result_t
-    ebpf_reference_object_by_handle(
+    _IRQL_requires_max_(PASSIVE_LEVEL) ebpf_result_t ebpf_reference_object_by_handle(
         ebpf_handle_t handle, ebpf_object_type_t object_type, _Outptr_ struct _ebpf_core_object** object);
 
 #ifdef __cplusplus

--- a/libs/platform/ebpf_handle.h
+++ b/libs/platform/ebpf_handle.h
@@ -61,7 +61,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_reference_object_by_handle(
-        ebpf_handle_t handle, ebpf_object_type_t object_type, struct _ebpf_core_object** object);
+        ebpf_handle_t handle, ebpf_object_type_t object_type, _Outptr_ struct _ebpf_core_object** object);
 
 #ifdef __cplusplus
 }

--- a/libs/platform/kernel/ebpf_handle_kernel.c
+++ b/libs/platform/kernel/ebpf_handle_kernel.c
@@ -87,8 +87,8 @@ ebpf_handle_close(ebpf_handle_t handle)
         EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
-ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_type, ebpf_core_object_t** object)
+_IRQL_requires_max_(PASSIVE_LEVEL) ebpf_result_t ebpf_reference_object_by_handle(
+    ebpf_handle_t handle, ebpf_object_type_t object_type, _Outptr_ ebpf_core_object_t** object)
 {
     ebpf_result_t return_value;
     NTSTATUS status;

--- a/libs/platform/user/ebpf_handle_user.c
+++ b/libs/platform/user/ebpf_handle_user.c
@@ -84,8 +84,8 @@ ebpf_handle_close(ebpf_handle_t handle)
     return return_value;
 }
 
-ebpf_result_t
-ebpf_reference_object_by_handle(ebpf_handle_t handle, ebpf_object_type_t object_type, ebpf_core_object_t** object)
+_IRQL_requires_max_(PASSIVE_LEVEL) ebpf_result_t ebpf_reference_object_by_handle(
+    ebpf_handle_t handle, ebpf_object_type_t object_type, _Outptr_ ebpf_core_object_t** object)
 {
     ebpf_result_t return_value;
     ebpf_lock_state_t state;

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -314,3 +314,83 @@ TEST_CASE("divide_by_zero_jit", "[divide_by_zero]") { divide_by_zero_test_km(EBP
 TEST_CASE("ringbuf_api_interpret", "[test_ringbuf_api]") { ring_buffer_api_test(EBPF_EXECUTION_INTERPRET); }
 TEST_CASE("divide_by_zero_interpret", "[divide_by_zero]") { divide_by_zero_test_km(EBPF_EXECUTION_INTERPRET); }
 #endif
+
+void
+_test_nested_maps(bpf_map_type type)
+{
+    // Create 2 inner maps.
+    fd_t inner1 = bpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(uint32_t), sizeof(uint32_t), 1, 0);
+    REQUIRE(inner1 > 0);
+
+    // Create outer map.
+    fd_t outer_map_fd = bpf_create_map_in_map(type, "outer_map", sizeof(uint32_t), inner1, 10, 0);
+    REQUIRE(outer_map_fd > 0);
+
+    fd_t inner2 = bpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(uint32_t), sizeof(uint32_t), 1, 0);
+    REQUIRE(inner2 > 0);
+
+    // Insert both inner maps in outer map.
+    uint32_t key = 1;
+    uint32_t result = bpf_map_update_elem(outer_map_fd, &key, &inner1, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 2;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner1, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    // Remove the inner maps from outer map.
+    key = 1;
+    result = bpf_map_delete_elem(outer_map_fd, &key);
+    REQUIRE(result == ERROR_SUCCESS);
+    key = 2;
+    result = bpf_map_delete_elem(outer_map_fd, &key);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    _close(inner1);
+    _close(inner2);
+    _close(outer_map_fd);
+}
+
+TEST_CASE("array_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
+
+TEST_CASE("hash_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }
+
+TEST_CASE("tailcall_load_test", "[tailcall_load_test]")
+{
+    ebpf_result_t result;
+    struct bpf_object* object = nullptr;
+    fd_t program_fd;
+
+    result =
+        _program_load_helper("tail_call_multiple.o", &EBPF_PROGRAM_TYPE_XDP, EBPF_EXECUTION_ANY, &object, &program_fd);
+    REQUIRE(result == EBPF_SUCCESS);
+
+    REQUIRE(program_fd > 0);
+
+    // Setup tail calls.
+    struct bpf_program* callee0 = bpf_object__find_program_by_name(object, "callee0");
+    REQUIRE(callee0 != nullptr);
+    fd_t callee0_fd = bpf_program__fd(callee0);
+    REQUIRE(callee0_fd > 0);
+
+    struct bpf_program* callee1 = bpf_object__find_program_by_name(object, "callee1");
+    REQUIRE(callee1 != nullptr);
+    fd_t callee1_fd = bpf_program__fd(callee1);
+    REQUIRE(callee1_fd > 0);
+
+    fd_t prog_map_fd = bpf_object__find_map_fd_by_name(object, "map");
+    REQUIRE(prog_map_fd > 0);
+
+    uint32_t index = 0;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee0_fd, 0) == 0);
+    index = 1;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    // Cleanup tail calls.
+    index = 0;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+    index = 1;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+    bpf_object__close(object);
+}

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -318,7 +318,7 @@ TEST_CASE("divide_by_zero_interpret", "[divide_by_zero]") { divide_by_zero_test_
 void
 _test_nested_maps(bpf_map_type type)
 {
-    // Create 2 inner maps.
+    // Create first inner map.
     fd_t inner1 = bpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(uint32_t), sizeof(uint32_t), 1, 0);
     REQUIRE(inner1 > 0);
 
@@ -326,6 +326,7 @@ _test_nested_maps(bpf_map_type type)
     fd_t outer_map_fd = bpf_create_map_in_map(type, "outer_map", sizeof(uint32_t), inner1, 10, 0);
     REQUIRE(outer_map_fd > 0);
 
+    // Create second inner map.
     fd_t inner2 = bpf_create_map(BPF_MAP_TYPE_ARRAY, sizeof(uint32_t), sizeof(uint32_t), 1, 0);
     REQUIRE(inner2 > 0);
 

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -368,7 +368,7 @@ TEST_CASE("tailcall_load_test", "[tailcall_load_test]")
 
     REQUIRE(program_fd > 0);
 
-    // Setup tail calls.
+    // Set up tail calls.
     struct bpf_program* callee0 = bpf_object__find_program_by_name(object, "callee0");
     REQUIRE(callee0 != nullptr);
     fd_t callee0_fd = bpf_program__fd(callee0);


### PR DESCRIPTION
## Description

### Issue
`ObReferenceObjectByHandle` can only be called at PASSVIE, but it was being called at DISPATCH. The map-in-map code is calling this API with spin lock held. This was not caught earlier due to missing map-in-map test cases in API test.

### Fix
This PR changes code to not hold the lock when calling `ObReferenceObjectByHandle`

## Testing

Added new test cases in api_test to cover this scenario.

## Documentation

NA
