### PR TITLE
bpf2c should read and populate all the maps in ELF file

### DIFF
--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -92,6 +92,10 @@ main(int argc, char** argv)
             sections = generator.program_sections();
         }
 
+        // Parse global data.
+        generator.parse();
+
+        // Parse per-section data.
         for (const auto& section : sections) {
             generator.parse(section);
             generator.generate();

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -51,6 +51,13 @@ class bpf_code_generator
     parse(const std::string& section_name);
 
     /**
+     * @brief Parse global data (currently map information) in the eBPF file.
+     *
+     */
+    void
+    parse();
+
+    /**
      * @brief Generate C code from the parsed eBPF file.
      *
      */


### PR DESCRIPTION
## Description

bpf2c currently exports / emits map details for only those maps which are referenced in the ebpf programs. This causes the maps which are not referenced in the program to be never created. This at least breaks the scenario for map-in-map where the inner map is not really referenced by any program but is present in ELF file only as a template.

**Fix:**
Fix is to parse the maps section and read all the maps in that section.

## Testing

PR #811 contains tests for this scenario.

## Documentation

NA
