### PR TITLE
Capture code coverage from bpf2c in build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ name: MSBuild
 # Run on push so we can capture the baseline code coverage for any squash commit.
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
 
 permissions:
@@ -84,7 +84,7 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       # Add additional options to the MSBuild command line here (like platform or verbosity level).
       # See https://docs.microsoft.com/visualstudio/msbuild/msbuild-command-line-reference
-      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:Analysis='True' ${{env.SOLUTION_FILE_PATH}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} /p:Analysis='True' /p:CodeCoverage='True' ${{env.SOLUTION_FILE_PATH}}
 
     - name: Upload Build Output
       uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535

--- a/tests/bpf2c_test_wrapper/bpf2c_test_wrapper.vcxproj
+++ b/tests/bpf2c_test_wrapper/bpf2c_test_wrapper.vcxproj
@@ -137,12 +137,6 @@
       <ModuleDefinitionFile>source.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>pushd $(OutDir)
-bpf2c.exe --bpf bindmonitor.o &gt;bindmonitor_c.c
-bpf2c.exe --bpf droppacket.o &gt;droppacket_c.c
-bpf2c.exe --bpf divide_by_zero.o &gt;divide_by_zero.c</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
       <Message>Run bpf2 over ELF files</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
@@ -162,12 +156,6 @@ bpf2c.exe --bpf divide_by_zero.o &gt;divide_by_zero.c</Command>
       <EnableUAC>false</EnableUAC>
       <ModuleDefinitionFile>source.def</ModuleDefinitionFile>
     </Link>
-    <PreBuildEvent>
-      <Command>pushd $(OutDir)
-bpf2c.exe --bpf bindmonitor.o &gt;bindmonitor_c.c
-bpf2c.exe --bpf droppacket.o &gt;droppacket_c.c
-bpf2c.exe --bpf divide_by_zero.o &gt;divide_by_zero.c</Command>
-    </PreBuildEvent>
     <PreBuildEvent>
       <Message>Run bpf2 over ELF files</Message>
     </PreBuildEvent>
@@ -192,4 +180,26 @@ bpf2c.exe --bpf divide_by_zero.o &gt;divide_by_zero.c</Command>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+  <ItemDefinitionGroup Condition="'$(CodeCoverage)'!='True'">
+    <PreBuildEvent>
+      <Command>
+        pushd $(OutDir)
+        bpf2c.exe --bpf bindmonitor.o &gt;bindmonitor_c.c
+        bpf2c.exe --bpf droppacket.o &gt;droppacket_c.c
+        bpf2c.exe --bpf divide_by_zero.o &gt;divide_by_zero.c
+      </Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(CodeCoverage)'=='True'">
+    <PreBuildEvent>
+      <Command>
+        pushd $(OutDir)
+        OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_bindmonitor.cov --working_dir $(OutDir) -- bpf2c.exe --bpf bindmonitor.o &gt;bindmonitor_c.c
+        OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_droppacket.cov --working_dir $(OutDir) -- bpf2c.exe --bpf droppacket.o &gt;droppacket_c.c
+        OpenCppCoverage.exe --sources $(SolutionDir) --input_coverage $(OutDir)bpf2c_bindmonitor.cov --input_coverage $(OutDir)bpf2c_droppacket.cov --export_type cobertura:$(OutDir)bpf2c.xml --working_dir $(OutDir) -- bpf2c.exe --bpf divide_by_zero.o &gt;divide_by_zero.c
+      </Command>
+    </PreBuildEvent>
+  </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Capture code coverage from bpf2c run during the build that is used to generate test dlls.

## Testing

N/A

## Documentation

No.
