### PR TITLE
Only notify after all CI steps are complete

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -1,0 +1,6 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+codecov:
+  notify:
+    wait_for_ci: yes


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Set codecov task to only notify once all the CI/CD steps are complete.

## Testing

CI/CD

## Documentation

N/A
