### PR TITLE
Upload baseline for bpf2c tests

### DIFF
--- a/.github/workflows/bpf2c-test.yml
+++ b/.github/workflows/bpf2c-test.yml
@@ -3,7 +3,10 @@
 
 name: "bpf2c-test"
 
-on: pull_request
+on:
+  push:
+    branches: [ main ]
+  pull_request:
 
 permissions:
   contents: read


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

For correctly determining the code coverage delta there needs to be a baseline value from the main branch. Both the build and bpf2c-test yml files upload code coverage data and should run on push to main.

## Testing

CI/CD

## Documentation

N/A
