### PR TITLE
bpf2c: emit maps in order they appear in ELF file

### DIFF
--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -562,6 +562,17 @@ TEST_CASE("bindmonitor_tailcall_native_test", "[native_tests]")
         cleanup();
     REQUIRE(outer_map_fd > 0);
 
+    // Test map-in-maps.
+    struct bpf_map* outer_idx_map = bpf_object__find_map_by_name(object, "dummy_outer_idx_map");
+    if (outer_idx_map == nullptr)
+        cleanup();
+    REQUIRE(outer_idx_map != nullptr);
+
+    int outer_idx_map_fd = bpf_map__fd(outer_idx_map);
+    if (outer_idx_map_fd <= 0)
+        cleanup();
+    REQUIRE(outer_idx_map_fd > 0);
+
     // Cleanup tail calls.
     cleanup();
 }

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -573,6 +573,6 @@ TEST_CASE("bindmonitor_tailcall_native_test", "[native_tests]")
         cleanup();
     REQUIRE(outer_idx_map_fd > 0);
 
-    // Cleanup tail calls.
+    // Clean up tail calls.
     cleanup();
 }

--- a/tests/sample/bindmonitor_tailcall.c
+++ b/tests/sample/bindmonitor_tailcall.c
@@ -60,6 +60,14 @@ struct _ebpf_map_definition_in_file dummy_outer_map = {
     .inner_id = INNER_MAP_ID};
 
 SEC("maps")
+struct _ebpf_map_definition_in_file dummy_outer_idx_map = {
+    .type = BPF_MAP_TYPE_HASH_OF_MAPS,
+    .key_size = sizeof(uint32_t),
+    .value_size = sizeof(uint32_t),
+    .max_entries = 10,
+    .inner_map_idx = 6};
+
+SEC("maps")
 struct _ebpf_map_definition_in_file dummy_inner_map = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(uint32_t),


### PR DESCRIPTION
## Description

This PR does the following:
1. Save the original map index while parsing the maps section.
2. Print the maps in the same order when emitting the C code.

## Testing

Added new test in api_test.

## Documentation

NA

Fixes #875 
