### PR TITLE
Use upstream main branch for ebpf-verifier

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,6 @@
 [submodule "external/ebpf-verifier"]
 	path = external/ebpf-verifier
-	url = https://github.com/dthaler/ebpf-verifier.git
-	branch = twostackvars
+	url = https://github.com/vbpf/ebpf-verifier.git
 [submodule "external/ubpf"]
 	path = external/ubpf
 	url = https://github.com/iovisor/ubpf.git

--- a/include/elfio_wrapper.hpp
+++ b/include/elfio_wrapper.hpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma warning(push)
+#pragma warning(disable : 4244)  // conversion from 'int' to 'ELFIO::Elf_Half', possible loss of data
 #pragma warning(disable : 4458)  // declaration of 'name' hides class member
 #pragma warning(disable : 6011)  // 'Dereferencing NULL pointer - https://github.com/vbpf/ebpf-verifier/issues/239
 #pragma warning(disable : 26451) // Arithmetic overflow

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -268,7 +268,7 @@ bpf_code_generator::extract_relocations_and_maps(const std::string& section_name
         for (ELFIO::Elf_Xword index = 0; index < relocation_count; index++) {
             ELFIO::Elf64_Addr offset{};
             ELFIO::Elf_Word symbol{};
-            ELFIO::Elf_Word type{};
+            unsigned char type{};
             ELFIO::Elf_Sxword addend{};
             relocation_reader.get_entry(index, offset, symbol, type, addend);
             {

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -10,10 +10,7 @@
 #include "btf_parser.h"
 #include "ebpf.h"
 #include "ebpf_structs.h"
-#pragma warning(push)
-#pragma warning(disable : 4458) /* declaration of 'name' hides class member */
-#include "elfio/elfio.hpp"
-#pragma warning(pop)
+#include "elfio_wrapper.hpp"
 
 class bpf_code_generator
 {


### PR DESCRIPTION
Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

Switch back to the main upstream repo for ebpf-verifier now that PRs have been merged upstream.

## Testing

Existing tests pass.  Also manually tested that the ebpf programs used in the Cilium demo pass verification.

## Documentation

No impact.
