### PR TITLE
Only set codecoverage status after both bpf2c and build complete

### DIFF
--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -4,3 +4,5 @@
 codecov:
   notify:
     wait_for_ci: yes
+comment:
+    after_n_builds: 2

--- a/.github/.codecov.yml
+++ b/.github/.codecov.yml
@@ -4,5 +4,6 @@
 codecov:
   notify:
     wait_for_ci: yes
+    after_n_builds: 2
 comment:
     after_n_builds: 2


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Codecov.io sets the status as soon as the first coverage report is uploaded. The issue is that coverage data comes from parallel CI/CD jobs, resulting in the premature notification of status.

## Testing

CI/CD

## Documentation

N/A