### PR TITLE
Call ebpf_verifier prior to code gen

### DIFF
--- a/ebpf-for-windows.sln
+++ b/ebpf-for-windows.sln
@@ -168,8 +168,15 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "fuzz", "tests\fuzz\fuzz.vcxproj", "{D88F9CE2-8DA2-44FB-AF7C-06466A180F31}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bindmonitor_um", "tests\sample\generated\dll\bindmonitor_um\bindmonitor_dll.vcxproj", "{128660AB-71BD-480B-AB39-D1AB3AE811B5}"
+	ProjectSection(ProjectDependencies) = postProject
+		{69B97E52-18DC-434E-A6E4-4C0F3E88C44A} = {69B97E52-18DC-434E-A6E4-4C0F3E88C44A}
+	EndProjectSection
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "bindmonitor_tailcall_um", "tests\sample\generated\dll\bindmonitor_tailcall_um\bindmonitor_tailcall_dll.vcxproj", "{FD1A4291-5BCA-4C11-916C-90BFEA2A1881}"
+	ProjectSection(ProjectDependencies) = postProject
+		{69B97E52-18DC-434E-A6E4-4C0F3E88C44A} = {69B97E52-18DC-434E-A6E4-4C0F3E88C44A}
+	EndProjectSection
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "socket_tests", "tests\socket\socket_tests.vcxproj", "{EED9DAC6-8B98-4C33-969A-E8CEDE8E985E}"
 EndProject
 Global

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -85,7 +85,8 @@ EXPORTS
     bpf_xdp_query_id
     ebpf_api_elf_enumerate_sections
     ebpf_api_elf_disassemble_section
-    ebpf_api_elf_verify_section
+    ebpf_api_elf_verify_section_from_file
+    ebpf_api_elf_verify_section_from_memory
     ebpf_api_elf_free
     ebpf_api_link_program
     ebpf_api_close_handle

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -157,7 +157,7 @@ extern "C"
     } ebpf_api_verifier_stats_t;
 
     /**
-     * @brief Convert an eBPF program to human readable byte code.
+     * @brief Verify that the program is safe to execute.
      * @param[in] file Name of ELF file containing eBPF program.
      * @param[in] section The name of the section to query.
      * @param[in] verbose Obtain additional info about the programs.
@@ -168,8 +168,30 @@ extern "C"
      * @param[out] stats If non-NULL, returns verification statistics.
      */
     uint32_t
-    ebpf_api_elf_verify_section(
+    ebpf_api_elf_verify_section_from_file(
         const char* file,
+        const char* section,
+        bool verbose,
+        const char** report,
+        const char** error_message,
+        ebpf_api_verifier_stats_t* stats);
+
+    /**
+     * @brief Verify that the program is safe to execute.
+     * @param[in] data Memory containing the ELF file containing eBPF program.
+     * @param[in] data_length Length of data.
+     * @param[in] section The name of the section to query.
+     * @param[in] verbose Obtain additional info about the programs.
+     * @param[out] report Points to a text section describing why the program
+     *  failed verification.
+     * @param[out] error_message On failure points to a text description of
+     *  the error.
+     * @param[out] stats If non-NULL, returns verification statistics.
+     */
+    uint32_t
+    ebpf_api_elf_verify_section_from_memory(
+        const char* data,
+        size_t data_length,
         const char* section,
         bool verbose,
         const char** report,

--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -228,7 +228,7 @@ handle_ebpf_show_verification(
     const char* error_message;
     ebpf_api_verifier_stats_t stats;
 
-    status = ebpf_api_elf_verify_section(
+    status = ebpf_api_elf_verify_section_from_file(
         filename.c_str(), section.c_str(), level == VL_VERBOSE, &report, &error_message, &stats);
     if (status == ERROR_SUCCESS) {
         std::cout << report;

--- a/tests/bpf2c_test_wrapper/bpf2c_test_wrapper.vcxproj
+++ b/tests/bpf2c_test_wrapper/bpf2c_test_wrapper.vcxproj
@@ -160,24 +160,55 @@
       <Message>Run bpf2c over ELF files</Message>
     </PreBuildEvent>
   </ItemDefinitionGroup>
-  <ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile Include="$(OutDir)bindmonitor_c.c" />
     <ClCompile Include="$(OutDir)bindmonitor_ringbuf_c.c" />
     <ClCompile Include="$(OutDir)bindmonitor_tailcall_c.c" />
-    <ClCompile Include="$(OutDir)cgroup_sock_addr_c.c" />
+    <ClCompile Include="$(OutDir)bpf_c.c" />
+    <ClCompile Include="$(OutDir)bpf_call_c.c" />
     <ClCompile Include="$(OutDir)decap_permit_packet_c.c" />
-    <ClCompile Include="$(OutDir)divide_by_zero.c" />
+    <ClCompile Include="$(OutDir)divide_by_zero_c.c" />
     <ClCompile Include="$(OutDir)droppacket_c.c" />
-    <ClCompile Include="$(OutDir)droppacket_unsafe_c.c" />
+    <ClCompile Include="$(OutDir)encap_reflect_packet_c.c" />
     <ClCompile Include="$(OutDir)map_c.c" />
     <ClCompile Include="$(OutDir)map_in_map_c.c" />
     <ClCompile Include="$(OutDir)map_in_map_v2_c.c" />
     <ClCompile Include="$(OutDir)map_reuse_c.c" />
     <ClCompile Include="$(OutDir)map_reuse_2_c.c" />
+    <ClCompile Include="$(OutDir)printk_c.c" />
+    <ClCompile Include="$(OutDir)printk_legacy_c.c" />
+    <ClCompile Include="$(OutDir)reflect_packet_c.c" />
+    <ClCompile Include="$(OutDir)tail_call_c.c" />
+    <ClCompile Include="$(OutDir)tail_call_bad_c.c" />
+    <ClCompile Include="$(OutDir)tail_call_multiple_c.c" />
+    <ClCompile Include="$(OutDir)test_utility_helpers_c.c" />
+    <ClCompile Include="dllmain.cpp" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile Include="$(OutDir)bindmonitor_c.c" />
+    <ClCompile Include="$(OutDir)bindmonitor_ringbuf_c.c" />
+    <ClCompile Include="$(OutDir)bindmonitor_tailcall_c.c" />
+    <ClCompile Include="$(OutDir)bpf_c.c" />
+    <ClCompile Include="$(OutDir)bpf_call_c.c" />
+    <ClCompile Include="$(OutDir)cgroup_sock_addr_c.c" />
+    <ClCompile Include="$(OutDir)decap_permit_packet_c.c" />
+    <ClCompile Include="$(OutDir)divide_by_zero_c.c" />
+    <ClCompile Include="$(OutDir)droppacket_c.c" />
+    <ClCompile Include="$(OutDir)encap_reflect_packet_c.c" />
+    <ClCompile Include="$(OutDir)map_c.c" />
+    <ClCompile Include="$(OutDir)map_in_map_c.c" />
+    <ClCompile Include="$(OutDir)map_in_map_v2_c.c" />
+    <ClCompile Include="$(OutDir)map_reuse_c.c" />
+    <ClCompile Include="$(OutDir)map_reuse_2_c.c" />
+    <ClCompile Include="$(OutDir)printk_c.c" />
+    <ClCompile Include="$(OutDir)printk_legacy_c.c" />
+    <ClCompile Include="$(OutDir)reflect_packet_c.c" />
+    <ClCompile Include="$(OutDir)sockops_c.c" />
     <ClCompile Include="$(OutDir)tail_call_c.c" />
     <ClCompile Include="$(OutDir)tail_call_bad_c.c" />
     <ClCompile Include="$(OutDir)tail_call_map_c.c" />
     <ClCompile Include="$(OutDir)tail_call_multiple_c.c" />
+    <ClCompile Include="$(OutDir)test_sample_ebpf_c.c" />
     <ClCompile Include="$(OutDir)test_utility_helpers_c.c" />
     <ClCompile Include="dllmain.cpp" />
   </ItemGroup>
@@ -197,60 +228,72 @@
   </ImportGroup>
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>
-  <ItemDefinitionGroup Condition="'$(CodeCoverage)'!='True'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <PreBuildEvent>
       <Command>
         pushd $(OutDir)
-        bpf2c.exe --bpf bindmonitor.o &gt;bindmonitor_c.c
-        bpf2c.exe --bpf bindmonitor_ringbuf.o &gt;bindmonitor_ringbuf_c.c
-        bpf2c.exe --bpf bindmonitor_tailcall.o &gt;bindmonitor_tailcall_c.c
-	bpf2c.exe --bpf cgroup_sock_addr.o &gt;cgroup_sock_addr_c.c
-	bpf2c.exe --bpf decap_permit_packet.o &gt;decap_permit_packet_c.c
-        bpf2c.exe --bpf divide_by_zero.o &gt;divide_by_zero.c
-	bpf2c.exe --bpf droppacket.o &gt;droppacket_c.c
-	bpf2c.exe --bpf droppacket_unsafe.o &gt;droppacket_unsafe_c.c
-	bpf2c.exe --bpf map.o &gt;map_c.c
-	bpf2c.exe --bpf map_in_map.o &gt;map_in_map_c.c
-	bpf2c.exe --bpf map_in_map_v2.o &gt;map_in_map_v2_c.c
-	bpf2c.exe --bpf map_reuse.o &gt;map_reuse_c.c
-	bpf2c.exe --bpf map_reuse_2.o &gt;map_reuse_2_c.c
-	bpf2c.exe --bpf tail_call.o &gt;tail_call_c.c
-	bpf2c.exe --bpf tail_call_bad.o &gt;tail_call_bad_c.c
-	bpf2c.exe --bpf tail_call_map.o &gt;tail_call_map_c.c
-	bpf2c.exe --bpf tail_call_multiple.o &gt;tail_call_multiple_c.c
-        bpf2c.exe --bpf test_utility_helpers.o &gt;test_utility_helpers_c.c
+        bpf2c --bpf bindmonitor.o &gt;bindmonitor_c.c
+        bpf2c --bpf bindmonitor_ringbuf.o &gt;bindmonitor_ringbuf_c.c
+        bpf2c --bpf bindmonitor_tailcall.o &gt;bindmonitor_tailcall_c.c
+        bpf2c --bpf bpf.o &gt;bpf_c.c
+        bpf2c --bpf bpf_call.o &gt;bpf_call_c.c
+        bpf2c --bpf decap_permit_packet.o &gt;decap_permit_packet_c.c
+        bpf2c --bpf divide_by_zero.o &gt;divide_by_zero_c.c
+        bpf2c --bpf droppacket.o &gt;droppacket_c.c
+        bpf2c --bpf encap_reflect_packet.o &gt;encap_reflect_packet_c.c
+        bpf2c --bpf map.o &gt;map_c.c
+        bpf2c --bpf map_in_map.o &gt;map_in_map_c.c
+        bpf2c --bpf map_in_map_v2.o &gt;map_in_map_v2_c.c
+        bpf2c --bpf map_reuse.o &gt;map_reuse_c.c
+        bpf2c --bpf map_reuse_2.o &gt;map_reuse_2_c.c
+        bpf2c --bpf printk.o &gt;printk_c.c
+        bpf2c --bpf printk_legacy.o &gt;printk_legacy_c.c
+        bpf2c --bpf reflect_packet.o &gt;reflect_packet_c.c
+        bpf2c --bpf tail_call.o &gt;tail_call_c.c
+        bpf2c --bpf tail_call_bad.o &gt;tail_call_bad_c.c
+        bpf2c --bpf tail_call_multiple.o &gt;tail_call_multiple_c.c
+        bpf2c --bpf test_utility_helpers.o &gt;test_utility_helpers_c.c
+        popd
       </Command>
     </PreBuildEvent>
     <ClCompile>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
-    </ClCompile>
-    <ClCompile>
-      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+      <DisableSpecificWarnings>4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(CodeCoverage)'=='True'">
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PreBuildEvent>
       <Command>
         pushd $(OutDir)
-        OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_bindmonitor.cov --working_dir $(OutDir) -- bpf2c.exe --bpf bindmonitor.o &gt;bindmonitor_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_bindmonitor_ringbuf.cov --working_dir $(OutDir) -- bpf2c.exe --bpf bindmonitor_ringbuf.o &gt;bindmonitor_ringbuf_c.c
-        OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_bindmonitor_tailcall.cov --working_dir $(OutDir) -- bpf2c.exe --bpf bindmonitor_tailcall.o &gt;bindmonitor_tailcall_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_cgroup_sock_addr.cov --working_dir $(OutDir) -- bpf2c.exe --bpf cgroup_sock_addr.o &gt;cgroup_sock_addr_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_decap_permit_packet.cov --working_dir $(OutDir) -- bpf2c.exe --bpf decap_permit_packet.o &gt;decap_permit_packet_c.c
-        OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_droppacket.cov --working_dir $(OutDir) -- bpf2c.exe --bpf droppacket.o &gt;droppacket_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_droppacket_unsafe.cov --working_dir $(OutDir) -- bpf2c.exe --bpf droppacket_unsafe.o &gt;droppacket_unsafe_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_map.cov --working_dir $(OutDir) -- bpf2c.exe --bpf map.o &gt;map_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_map_in_map.cov --working_dir $(OutDir) -- bpf2c.exe --bpf map_in_map.o &gt;map_in_map_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_map_in_map_v2.cov --working_dir $(OutDir) -- bpf2c.exe --bpf map_in_map_v2.o &gt;map_in_map_v2_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_map_reuse.cov --working_dir $(OutDir) -- bpf2c.exe --bpf map_reuse.o &gt;map_reuse_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_map_reuse_2.cov --working_dir $(OutDir) -- bpf2c.exe --bpf map_reuse_2.o &gt;map_reuse_2_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_tail_call.cov --working_dir $(OutDir) -- bpf2c.exe --bpf tail_call.o &gt;tail_call_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_tail_call_bad.cov --working_dir $(OutDir) -- bpf2c.exe --bpf tail_call_bad.o &gt;tail_call_bad_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_tail_call_map.cov --working_dir $(OutDir) -- bpf2c.exe --bpf tail_call_map.o &gt;tail_call_map_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_tail_call_multiple.cov --working_dir $(OutDir) -- bpf2c.exe --bpf tail_call_multiple.o &gt;tail_call_multiple_c.c
-	OpenCppCoverage.exe --sources $(SolutionDir) --export_type binary:$(OutDir)bpf2c_test_utility_helpers.cov --working_dir $(OutDir) -- bpf2c.exe --bpf test_utility_helpers.o &gt;test_utility_helpers_c.c
-        OpenCppCoverage.exe --sources $(SolutionDir) --input_coverage $(OutDir)bpf2c_bindmonitor.cov --input_coverage $(OutDir)bpf2c_bindmonitor_ringbuf.cov --input_coverage $(OutDir)bpf2c_bindmonitor_tailcall.cov --input_coverage $(OutDir)bpf2c_cgroup_sock_addr.cov --input_coverage $(OutDir)bpf2c_decap_permit_packet.cov --input_coverage $(OutDir)bpf2c_droppacket.cov --input_coverage $(OutDir)bpf2c_droppacket_unsafe.cov --input_coverage $(OutDir)bpf2c_map.cov --input_coverage $(OutDir)bpf2c_map_in_map.cov --input_coverage $(OutDir)bpf2c_map_in_map_v2.cov --input_coverage $(OutDir)bpf2c_map_reuse.cov --input_coverage $(OutDir)bpf2c_map_reuse_2.cov --input_coverage $(OutDir)bpf2c_tail_call.cov --input_coverage $(OutDir)bpf2c_tail_call_bad.cov --input_coverage $(OutDir)bpf2c_tail_call_map.cov --input_coverage $(OutDir)bpf2c_tail_call_multiple.cov --input-coverage $(OutDir)bpf2c_test_utility_helpers.cov --export_type cobertura:$(OutDir)bpf2c.xml --working_dir $(OutDir) -- bpf2c.exe --bpf divide_by_zero.o &gt;divide_by_zero.c
+        bpf2c --bpf bindmonitor.o &gt;bindmonitor_c.c
+        bpf2c --bpf bindmonitor_ringbuf.o &gt;bindmonitor_ringbuf_c.c
+        bpf2c --bpf bindmonitor_tailcall.o &gt;bindmonitor_tailcall_c.c
+        bpf2c --bpf bpf.o &gt;bpf_c.c
+        bpf2c --bpf bpf_call.o &gt;bpf_call_c.c
+        bpf2c --no-verify --bpf cgroup_sock_addr.o &gt;cgroup_sock_addr_c.c
+        bpf2c --bpf decap_permit_packet.o &gt;decap_permit_packet_c.c
+        bpf2c --bpf divide_by_zero.o &gt;divide_by_zero_c.c
+        bpf2c --bpf droppacket.o &gt;droppacket_c.c
+        bpf2c --bpf encap_reflect_packet.o &gt;encap_reflect_packet_c.c
+        bpf2c --bpf map.o &gt;map_c.c
+        bpf2c --bpf map_in_map.o &gt;map_in_map_c.c
+        bpf2c --bpf map_in_map_v2.o &gt;map_in_map_v2_c.c
+        bpf2c --bpf map_reuse.o &gt;map_reuse_c.c
+        bpf2c --bpf map_reuse_2.o &gt;map_reuse_2_c.c
+        bpf2c --bpf printk.o &gt;printk_c.c
+        bpf2c --bpf printk_legacy.o &gt;printk_legacy_c.c
+        bpf2c --bpf reflect_packet.o &gt;reflect_packet_c.c
+        bpf2c --no-verify --bpf sockops.o &gt;sockops_c.c
+        bpf2c --bpf tail_call.o &gt;tail_call_c.c
+        bpf2c --bpf tail_call_bad.o &gt;tail_call_bad_c.c
+        bpf2c --no-verify --bpf tail_call_map.o &gt;tail_call_map_c.c
+        bpf2c --bpf tail_call_multiple.o &gt;tail_call_multiple_c.c
+        bpf2c --no-verify --bpf test_sample_ebpf.o &gt;test_sample_ebpf_c.c
+        bpf2c --bpf test_utility_helpers.o &gt;test_utility_helpers_c.c
+        popd
       </Command>
     </PreBuildEvent>
+    <ClCompile>
+      <DisableSpecificWarnings>4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
+    </ClCompile>
   </ItemDefinitionGroup>
 </Project>

--- a/tests/bpf2c_test_wrapper/bpf2c_test_wrapper.vcxproj.filters
+++ b/tests/bpf2c_test_wrapper/bpf2c_test_wrapper.vcxproj.filters
@@ -28,22 +28,13 @@
     <ClCompile Include="$(OutDir)bindmonitor_tailcall_c.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="$(OutDir)divide_by_zero.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="$(OutDir)droppacket_c.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(OutDir)bindmonitor_ringbuf_c.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="$(OutDir)cgroup_sock_addr_c.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="$(OutDir)decap_permit_packet_c.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(OutDir)droppacket_unsafe_c.c">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(OutDir)map_c.c">
@@ -67,10 +58,43 @@
     <ClCompile Include="$(OutDir)tail_call_bad_c.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(OutDir)tail_call_multiple_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)test_utility_helpers_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)bpf_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)bpf_call_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)cgroup_sock_addr_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)divide_by_zero_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)encap_reflect_packet_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)printk_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)printk_legacy_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)reflect_packet_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(OutDir)sockops_c.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(OutDir)tail_call_map_c.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="$(OutDir)tail_call_multiple_c.c">
+    <ClCompile Include="$(OutDir)test_sample_ebpf_c.c">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/tests/bpf2c_test_wrapper/dllmain.cpp
+++ b/tests/bpf2c_test_wrapper/dllmain.cpp
@@ -11,20 +11,34 @@
 
 #include "bpf2c.h"
 
+extern "C" metadata_table_t bindmonitor_metadata_table;
+extern "C" metadata_table_t bindmonitor_ringbuf_metadata_table;
+extern "C" metadata_table_t bindmonitor_tailcall_metadata_table;
+extern "C" metadata_table_t bpf_metadata_table;
+extern "C" metadata_table_t bpf_call_metadata_table;
+extern "C" metadata_table_t decap_permit_packet_metadata_table;
 extern "C" metadata_table_t divide_by_zero_metadata_table;
 extern "C" metadata_table_t droppacket_metadata_table;
-extern "C" metadata_table_t bindmonitor_tailcall_metadata_table;
-extern "C" metadata_table_t bindmonitor_ringbuf_metadata_table;
+extern "C" metadata_table_t encap_reflect_packet_metadata_table;
 extern "C" metadata_table_t map_metadata_table;
-extern "C" metadata_table_t cgroup_sock_addr_metadata_table;
-extern "C" metadata_table_t test_utility_helpers_metadata_table;
-extern "C" metadata_table_t map_reuse_metadata_table;
-extern "C" metadata_table_t map_reuse_2_metadata_table;
 extern "C" metadata_table_t map_in_map_metadata_table;
 extern "C" metadata_table_t map_in_map_v2_metadata_table;
+extern "C" metadata_table_t map_reuse_metadata_table;
+extern "C" metadata_table_t map_reuse_2_metadata_table;
+extern "C" metadata_table_t printk_metadata_table;
+extern "C" metadata_table_t printk_legacy_metadata_table;
+extern "C" metadata_table_t reflect_packet_metadata_table;
 extern "C" metadata_table_t tail_call_metadata_table;
 extern "C" metadata_table_t tail_call_bad_metadata_table;
 extern "C" metadata_table_t tail_call_multiple_metadata_table;
+extern "C" metadata_table_t test_utility_helpers_metadata_table;
+
+#if defined(_DEBUG)
+extern "C" metadata_table_t cgroup_sock_addr_metadata_table;
+extern "C" metadata_table_t sockops_metadata_table;
+extern "C" metadata_table_t test_sample_ebpf_metadata_table;
+extern "C" metadata_table_t tail_call_map_metadata_table;
+#endif
 
 BOOL APIENTRY
 DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved)
@@ -54,19 +68,32 @@ division_by_zero(uint32_t address)
 extern "C" metadata_table_t*
 get_metadata_table(const char* name)
 {
+    FIND_METADATA_ENTRY(name, bindmonitor);
+    FIND_METADATA_ENTRY(name, bindmonitor_ringbuf);
+    FIND_METADATA_ENTRY(name, bindmonitor_tailcall);
+    FIND_METADATA_ENTRY(name, bpf);
+    FIND_METADATA_ENTRY(name, bpf_call);
+    FIND_METADATA_ENTRY(name, decap_permit_packet);
     FIND_METADATA_ENTRY(name, divide_by_zero);
     FIND_METADATA_ENTRY(name, droppacket);
-    FIND_METADATA_ENTRY(name, bindmonitor_tailcall);
-    FIND_METADATA_ENTRY(name, bindmonitor_ringbuf);
+    FIND_METADATA_ENTRY(name, encap_reflect_packet);
     FIND_METADATA_ENTRY(name, map);
-    FIND_METADATA_ENTRY(name, cgroup_sock_addr);
-    FIND_METADATA_ENTRY(name, test_utility_helpers);
-    FIND_METADATA_ENTRY(name, map_reuse);
-    FIND_METADATA_ENTRY(name, map_reuse_2);
     FIND_METADATA_ENTRY(name, map_in_map);
     FIND_METADATA_ENTRY(name, map_in_map_v2);
+    FIND_METADATA_ENTRY(name, map_reuse);
+    FIND_METADATA_ENTRY(name, map_reuse_2);
+    FIND_METADATA_ENTRY(name, printk);
+    FIND_METADATA_ENTRY(name, printk_legacy);
+    FIND_METADATA_ENTRY(name, reflect_packet);
     FIND_METADATA_ENTRY(name, tail_call);
     FIND_METADATA_ENTRY(name, tail_call_bad);
     FIND_METADATA_ENTRY(name, tail_call_multiple);
+    FIND_METADATA_ENTRY(name, test_utility_helpers);
+#if defined(_DEBUG)
+    FIND_METADATA_ENTRY(name, cgroup_sock_addr);
+    FIND_METADATA_ENTRY(name, sockops);
+    FIND_METADATA_ENTRY(name, tail_call_map);
+    FIND_METADATA_ENTRY(name, test_sample_ebpf);
+#endif
     return nullptr;
 }

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -924,7 +924,7 @@ _cgroup_load_test(
 
     bpf_object__close(object);
 }
-
+// TODO: Re-enable this once https://github.com/microsoft/ebpf-for-windows/issues/971 is resolved.
 #if defined(_DEBUG)
 static void
 _cgroup_sock_addr_load_test(

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -925,6 +925,7 @@ _cgroup_load_test(
     bpf_object__close(object);
 }
 
+#if defined(_DEBUG)
 static void
 _cgroup_sock_addr_load_test(
     _In_z_ const char* file,
@@ -959,6 +960,7 @@ DECLARE_CGROUP_SOCK_ADDR_LOAD_TEST(
     SAMPLE_PATH "cgroup_sock_addr", "authorize_recv_accept4", EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT);
 DECLARE_CGROUP_SOCK_ADDR_LOAD_TEST(
     SAMPLE_PATH "cgroup_sock_addr", "authorize_recv_accept6", EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT);
+#endif
 
 TEST_CASE("cgroup_sockops_load_test", "[cgroup_sockops]")
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -877,11 +877,12 @@ TEST_CASE("verify section", "[end_to_end]")
     program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
 
     ebpf_api_verifier_stats_t stats;
-    REQUIRE((
-        result = ebpf_api_elf_verify_section(SAMPLE_PATH "droppacket.o", "xdp", false, &report, &error_message, &stats),
-        ebpf_free_string(error_message),
-        error_message = nullptr,
-        result == 0));
+    REQUIRE(
+        (result = ebpf_api_elf_verify_section_from_file(
+             SAMPLE_PATH "droppacket.o", "xdp", false, &report, &error_message, &stats),
+         ebpf_free_string(error_message),
+         error_message = nullptr,
+         result == 0));
     REQUIRE(report != nullptr);
     ebpf_free_string(report);
 }
@@ -980,7 +981,7 @@ TEST_CASE("verify_test0", "[sample_extension]")
 
     ebpf_api_verifier_stats_t stats;
     REQUIRE(
-        (result = ebpf_api_elf_verify_section(
+        (result = ebpf_api_elf_verify_section_from_file(
              SAMPLE_PATH "test_sample_ebpf.o", "sample_ext", false, &report, &error_message, &stats),
          ebpf_free_string(error_message),
          error_message = nullptr,
@@ -1001,7 +1002,7 @@ TEST_CASE("verify_test1", "[sample_extension]")
     ebpf_api_verifier_stats_t stats;
 
     REQUIRE(
-        (result = ebpf_api_elf_verify_section(
+        (result = ebpf_api_elf_verify_section_from_file(
              SAMPLE_PATH "test_sample_ebpf.o", "sample_ext/utility", false, &report, &error_message, &stats),
          ebpf_free_string(error_message),
          error_message = nullptr,

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -7,8 +7,10 @@
 #include <map>
 #include <regex>
 #include <string>
+#include <sstream>
 #include <tuple>
 #include <vector>
+
 #include "bpf_code_generator.h"
 #include "ebpf_api.h"
 
@@ -30,6 +32,24 @@ emit_skeleton(const std::string& c_name, const std::string& code)
     std::cout << output << std::endl;
 }
 
+std::string
+load_file_to_memory(const std::string& path)
+{
+    struct stat st;
+    if (stat(path.c_str(), &st)) {
+        throw std::runtime_error(std::string("Failed to read file: ") + path);
+    }
+    if (std::ifstream stream{path, std::ios::in | std::ios::binary}) {
+        std::string data;
+        data.resize(st.st_size);
+        if (!stream.read(data.data(), data.size())) {
+            throw std::runtime_error(std::string("Failed to read file: ") + path);
+        }
+        return data;
+    }
+    throw std::runtime_error(std::string("Failed to read file: ") + path);
+}
+
 int
 main(int argc, char** argv)
 {
@@ -43,6 +63,7 @@ main(int argc, char** argv)
         std::string verifier_output_file;
         std::string file;
         std::vector<std::string> sections;
+        bool verify_programs = true;
         std::map<std::string, std::tuple<std::string, std::function<void(std::vector<std::string>::iterator&)>>>
             options = {
                 {"--sys",
@@ -51,6 +72,11 @@ main(int argc, char** argv)
                 {"--dll",
                  {"Generate code for a Windows DLL",
                   [&](std::vector<std::string>::iterator&) { type = output_type::UserPE; }}},
+#if defined(ENABLE_SKIP_VERIFY)
+                {"--no-verify",
+                 {"Skip validate code using verifier",
+                  [&](std::vector<std::string>::iterator&) { verify_programs = false; }}},
+#endif
                 {"--bpf",
                  {"Input ELF file containing BPF byte code",
                   [&](std::vector<std::string>::iterator& it) { file = *(++it); }}},
@@ -89,8 +115,10 @@ main(int argc, char** argv)
 
         std::string c_name = file.substr(file.find_last_of("\\") + 1);
         c_name = c_name.substr(0, c_name.find("."));
-
-        bpf_code_generator generator(file, c_name);
+        auto data = load_file_to_memory(file);
+        auto stream = std::stringstream(data);
+        // TODO: Issue #834 - validate the ELF is well formed
+        bpf_code_generator generator(stream, c_name);
 
         // Special case of no section name.
         if (sections.size() == 0) {
@@ -106,6 +134,16 @@ main(int argc, char** argv)
             ebpf_attach_type_t attach_type;
             if (ebpf_get_program_type_by_name(section.c_str(), &program_type, &attach_type) != EBPF_SUCCESS) {
                 throw std::runtime_error(std::string("Cannot get program / attach type for section ") + section);
+            }
+            const char* report = nullptr;
+            const char* error_message = nullptr;
+            ebpf_api_verifier_stats_t stats;
+            if (verify_programs &&
+                ebpf_api_elf_verify_section_from_memory(
+                    data.c_str(), data.size(), section.c_str(), false, &report, &error_message, &stats) != 0) {
+                throw std::runtime_error(
+                    std::string("Verification failed for ") + section + std::string(" with error ") +
+                    std::string(error_message) + std::string("\n Report:\n") + std::string(report));
             }
             generator.parse(section, program_type, attach_type);
         }

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -6,8 +6,8 @@
 #include <iostream>
 #include <map>
 #include <regex>
-#include <string>
 #include <sstream>
+#include <string>
 #include <tuple>
 #include <vector>
 
@@ -74,7 +74,7 @@ main(int argc, char** argv)
                   [&](std::vector<std::string>::iterator&) { type = output_type::UserPE; }}},
 #if defined(ENABLE_SKIP_VERIFY)
                 {"--no-verify",
-                 {"Skip validate code using verifier",
+                 {"Skip validating code using verifier",
                   [&](std::vector<std::string>::iterator&) { verify_programs = false; }}},
 #endif
                 {"--bpf",

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -113,7 +113,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;ENABLE_SKIP_VERIFY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -119,11 +119,11 @@ bpf_code_generator::get_register_name(uint8_t id)
     }
 }
 
-bpf_code_generator::bpf_code_generator(const std::string& path, const std::string& c_name)
+bpf_code_generator::bpf_code_generator(std::istream& stream, const std::string& c_name)
     : current_section(nullptr), c_name(c_name), path(path)
 {
-    if (!reader.load(path)) {
-        throw std::runtime_error(std::string("Can't process ELF file ") + path);
+    if (!reader.load(stream)) {
+        throw std::runtime_error(std::string("Can't process ELF file ") + c_name);
     }
 
     extract_btf_information();

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #pragma once
+#include <fstream>
 #include <map>
 #include <set>
 #include <string>
@@ -17,10 +18,10 @@ class bpf_code_generator
     /**
      * @brief Construct a new bpf code generator object.
      *
-     * @param[in] path Path to the eBPF file to parse.
+     * @param[in] stream Input stream containing the eBPF file to parse.
      * @param[in] c_name C compatible name to export this as.
      */
-    bpf_code_generator(const std::string& path, const std::string& c_name);
+    bpf_code_generator(std::istream& stream, const std::string& c_name);
 
     /**
      * @brief Construct a new bpf code generator object from raw eBPF byte code.


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Integrate bpf2c with ebpf-veriifer to permit calling verifier prior to performing code generation.

## Testing

Updated bpf2c_tests.

## Documentation

Updated help output.
