### PR TITLE
Remove checkboxes from issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
 name: 🐛 Bug report
 description: Report a bug or unexpected behavior
 title: "Bug title"
@@ -10,23 +13,10 @@ body:
       label: Describe the bug
       description: Please enter a clear and short description of your bug here.
       placeholder: A crash occurs if X is called from Y.
-  - type: checkboxes
-    validations:
-      required: true
-    attributes:
-      label: Affected OS
-      description: What operating systems are affected by this bug?
-      options:
-        - label: Windows Server 2022
-        - label: Windows Server 2019
-        - label: Windows 11
-        - label: Windows 10
-        - label: Windows Insider Preview (specify affected build below)
-        - label: Other (specify below)
   - type: textarea
     attributes:
-      label: Additional OS information
-      description: Please provide any additional details about the affected operating system here, if applicable. You must specify the affected OS and its respective build/version if you have selected the "Windows Insider Preview" or "Other" options.
+      label: OS information
+      description: Please provide any additional details about the affected operating system(s) here, if applicable. You must specify the affected OS and its respective build/version if you specify "Windows Insider Preview".
       placeholder: Windows 11 Insider Preview (10.0.22463.1000.rs_prerelease.210917-1503)
   - type: textarea
     validations:


### PR DESCRIPTION
The problem is that every bug report showed up as having "tasks" to be
done as can be seen at
https://github.com/microsoft/ebpf-for-windows/issues where a number of
bugs show "6 tasks". The checkboxes involved are not tasks, and indeed
they weren't providing us any value at present, so removed them.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

_Describe the purpose of and changes within this Pull Request._

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_
