### PR TITLE
WFP ALE Flow established callout, tests etc.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -64,6 +64,18 @@ jobs:
       code_coverage: true
       gather_dumps: true
 
+  # Run the API tests in GitHub.
+  ebpf_client:
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: ebpf_client
+      test_command: ebpf_client.exe -d yes
+      build_job: regular / build
+      build_artifact: Build-x64
+      environment: windows-2019
+      code_coverage: true
+      gather_dumps: true
+
   # Run the fuzzing tests in GitHub.
   fuzzing:
     uses: ./.github/workflows/reusable-test.yml
@@ -89,16 +101,17 @@ jobs:
       code_coverage: true
       gather_dumps: true
 
-  # Run the performance tests in GitHub.
-  performance:
+  # Run the quick stress tests in GitHub.
+  stress:
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: performance
+      name: stress
+      # Until there is a dedicated stress test, re-use the perf test.
       test_command: ebpf_performance.exe
       build_job: regular / build
       build_artifact: Build-x64
       environment: windows-2019
-      # No code coverage on performance tests.
+      # No code coverage on stress.
       code_coverage: false
       gather_dumps: true
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -64,18 +64,6 @@ jobs:
       code_coverage: true
       gather_dumps: true
 
-  # Run the API tests in GitHub.
-  ebpf_client:
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: ebpf_client
-      test_command: ebpf_client.exe -d yes
-      build_job: regular / build
-      build_artifact: Build-x64
-      environment: windows-2019
-      code_coverage: true
-      gather_dumps: true
-
   # Run the fuzzing tests in GitHub.
   fuzzing:
     uses: ./.github/workflows/reusable-test.yml
@@ -101,17 +89,16 @@ jobs:
       code_coverage: true
       gather_dumps: true
 
-  # Run the quick stress tests in GitHub.
-  stress:
+  # Run the performance tests in GitHub.
+  performance:
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: stress
-      # Until there is a dedicated stress test, re-use the perf test.
+      name: performance
       test_command: ebpf_performance.exe
       build_job: regular / build
       build_artifact: Build-x64
       environment: windows-2019
-      # No code coverage on stress.
+      # No code coverage on performance tests.
       code_coverage: false
       gather_dumps: true
 

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -214,7 +214,7 @@ typedef struct _bpf_sock_ops
  *  \ref EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS
  *
  * @param[in] context \ref bpf_sock_ops_t
- * @return 0 on success, or a negative error in case of failure.
+ * @return 0 on success, or error value in case of failure.
  *
  */
 typedef int

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -189,6 +189,49 @@ static HANDLE _fwp_engine_handle;
 // WFP component management related utility functions.
 //
 
+ebpf_result_t
+net_ebpf_extension_wfp_filter_context_create(
+    size_t filter_context_size,
+    _In_ const net_ebpf_extension_hook_client_t* client_context,
+    _Outptr_ net_ebpf_extension_wfp_filter_context_t** filter_context)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    net_ebpf_extension_wfp_filter_context_t* local_filter_context = NULL;
+
+    *filter_context = NULL;
+
+    // Allocate buffer for WFP filter context.
+    local_filter_context = (net_ebpf_extension_wfp_filter_context_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, filter_context_size, NET_EBPF_EXTENSION_POOL_TAG);
+    if (local_filter_context == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+    memset(local_filter_context, 0, filter_context_size);
+    local_filter_context->reference_count = 1; // Initial reference.
+    local_filter_context->client_context = client_context;
+
+    *filter_context = local_filter_context;
+    local_filter_context = NULL;
+Exit:
+    if (local_filter_context != NULL)
+        ExFreePool(local_filter_context);
+
+    return result;
+}
+
+void
+net_ebpf_extension_wfp_filter_context_cleanup(_Frees_ptr_ net_ebpf_extension_wfp_filter_context_t* filter_context)
+{
+    // Since the hook client is detaching, the eBPF program should not be invoked any further.
+    // The client_context field in filter_context is set to NULL for this reason. This way any
+    // lingering WFP classify callbacks will exit as it would not find any hook client associated with the filter
+    // context. This is best effort & no locks are held.
+    filter_context->client_context = NULL;
+    filter_context->filter_ids = NULL;
+    DEREFERENCE_FILTER_CONTEXT(filter_context);
+}
+
 net_ebpf_extension_hook_id_t
 net_ebpf_extension_get_hook_id_from_wfp_layer_id(uint16_t wfp_layer_id)
 {
@@ -250,10 +293,11 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
     return callout_id;
 }
 void
-net_ebpf_extension_delete_wfp_filters(uint32_t filter_count, _In_count_(filter_count) uint64_t* filter_ids)
+net_ebpf_extension_delete_wfp_filters(uint32_t filter_count, _Frees_ptr_ _In_count_(filter_count) uint64_t* filter_ids)
 {
     for (uint32_t index = 0; index < filter_count; index++)
         FwpmFilterDeleteById(_fwp_engine_handle, filter_ids[index]);
+    ExFreePool(filter_ids);
 }
 
 ebpf_result_t
@@ -262,12 +306,27 @@ net_ebpf_extension_add_wfp_filters(
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,
     uint32_t condition_count,
     _In_opt_count_(condition_count) const FWPM_FILTER_CONDITION* conditions,
-    _In_ const void* raw_context,
-    _Out_writes_(filter_count) uint64_t* filter_ids)
+    _In_ net_ebpf_extension_wfp_filter_context_t* filter_context,
+    _Outptr_result_buffer_maybenull_(filter_count) uint64_t** filter_ids)
 {
     NTSTATUS status = STATUS_SUCCESS;
     ebpf_result_t result = EBPF_SUCCESS;
     BOOL is_in_transaction = FALSE;
+    uint64_t* local_filter_ids = NULL;
+    *filter_ids = NULL;
+
+    if (filter_count == 0) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
+    local_filter_ids = (uint64_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, sizeof(uint64_t) * filter_count, NET_EBPF_EXTENSION_POOL_TAG);
+    if (local_filter_ids == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+    memset(local_filter_ids, 0, sizeof(uint64_t) * filter_count);
 
     status = FwpmTransactionBegin(_fwp_engine_handle, 0);
     if (!NT_SUCCESS(status)) {
@@ -293,9 +352,10 @@ net_ebpf_extension_add_wfp_filters(
         filter.numFilterConditions = condition_count;
         filter.subLayerKey = EBPF_SUBLAYER;
         filter.weight.type = FWP_EMPTY; // auto-weight.
-        filter.rawContext = (uint64_t)(uintptr_t)raw_context;
+        REFERENCE_FILTER_CONTEXT(filter_context);
+        filter.rawContext = (uint64_t)(uintptr_t)filter_context;
 
-        status = FwpmFilterAdd(_fwp_engine_handle, &filter, NULL, &filter_ids[index]);
+        status = FwpmFilterAdd(_fwp_engine_handle, &filter, NULL, &local_filter_ids[index]);
 
         if (!NT_SUCCESS(status)) {
             KdPrintEx(
@@ -320,8 +380,12 @@ net_ebpf_extension_add_wfp_filters(
     }
     is_in_transaction = FALSE;
 
+    *filter_ids = local_filter_ids;
+
 Exit:
     if (!NT_SUCCESS(status)) {
+        if (local_filter_ids != NULL)
+            ExFreePool(local_filter_ids);
         if (is_in_transaction)
             FwpmTransactionAbort(_fwp_engine_handle);
     }
@@ -556,9 +620,12 @@ static NTSTATUS
 _net_ebpf_ext_filter_change_notify(
     FWPS_CALLOUT_NOTIFY_TYPE callout_notification_type, _In_ const GUID* filter_key, _Inout_ const FWPS_FILTER* filter)
 {
-    UNREFERENCED_PARAMETER(callout_notification_type);
     UNREFERENCED_PARAMETER(filter_key);
-    UNREFERENCED_PARAMETER(filter);
+    if (callout_notification_type == FWPS_CALLOUT_NOTIFY_DELETE_FILTER) {
+        net_ebpf_extension_wfp_filter_context_t* filter_context =
+            (net_ebpf_extension_wfp_filter_context_t*)(uintptr_t)filter->context;
+        DEREFERENCE_FILTER_CONTEXT((filter_context));
+    }
 
     return STATUS_SUCCESS;
 }

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -193,15 +193,6 @@ net_ebpf_extension_hook_id_t
 net_ebpf_extension_get_hook_id_from_wfp_layer_id(uint16_t wfp_layer_id)
 {
     net_ebpf_extension_hook_id_t hook_id = 0;
-    ASSERT(
-        (wfp_layer_id == FWPS_LAYER_OUTBOUND_MAC_FRAME_NATIVE) ||
-        (wfp_layer_id == FWPS_LAYER_INBOUND_MAC_FRAME_NATIVE) ||
-        (wfp_layer_id == FWPS_LAYER_ALE_RESOURCE_ASSIGNMENT_V4) ||
-        (wfp_layer_id == FWPS_LAYER_ALE_RESOURCE_ASSIGNMENT_V6) ||
-        (wfp_layer_id == FWPS_LAYER_ALE_RESOURCE_RELEASE_V4) || (wfp_layer_id == FWPS_LAYER_ALE_RESOURCE_RELEASE_V6) ||
-        (wfp_layer_id == FWPS_LAYER_ALE_AUTH_CONNECT_V4) || (wfp_layer_id == FWPS_LAYER_ALE_AUTH_CONNECT_V6) ||
-        (wfp_layer_id == FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4) || (wfp_layer_id == FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6) ||
-        (wfp_layer_id == FWPS_LAYER_ALE_FLOW_ESTABLISHED_V4) || (wfp_layer_id == FWPS_LAYER_ALE_FLOW_ESTABLISHED_V6));
 
     switch (wfp_layer_id) {
     case FWPS_LAYER_OUTBOUND_MAC_FRAME_NATIVE:
@@ -239,6 +230,9 @@ net_ebpf_extension_get_hook_id_from_wfp_layer_id(uint16_t wfp_layer_id)
         break;
     case FWPS_LAYER_ALE_FLOW_ESTABLISHED_V6:
         hook_id = EBPF_HOOK_ALE_FLOW_ESTABLISHED_V6;
+        break;
+    default:
+        ASSERT(FALSE);
         break;
     }
 

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -52,6 +52,17 @@ Environment:
 #define htonl(x) _byteswap_ulong(x)
 #define htons(x) _byteswap_ushort(x)
 
+typedef struct _wfp_ale_layer_fields
+{
+    uint16_t local_ip_address_field;
+    uint16_t local_port_field;
+    uint16_t remote_ip_address_field;
+    uint16_t remote_port_field;
+    uint16_t protocol_field;
+    uint32_t direction_field;
+    uint16_t compartment_id_field;
+} wfp_ale_layer_fields_t;
+
 typedef struct _net_ebpf_extension_wfp_filter_parameters
 {
     const GUID* layer_guid;     ///< GUID of WFP layer to which this filter is associated.
@@ -59,6 +70,42 @@ typedef struct _net_ebpf_extension_wfp_filter_parameters
     const wchar_t* name;        ///< Display name of filter.
     const wchar_t* description; ///< Description of filter.
 } net_ebpf_extension_wfp_filter_parameters_t;
+
+typedef enum _net_ebpf_extension_hook_id
+{
+    EBPF_HOOK_OUTBOUND_L2 = 0,
+    EBPF_HOOK_INBOUND_L2,
+    EBPF_HOOK_ALE_RESOURCE_ALLOC_V4,
+    EBPF_HOOK_ALE_RESOURCE_ALLOC_V6,
+    EBPF_HOOK_ALE_RESOURCE_RELEASE_V4,
+    EBPF_HOOK_ALE_RESOURCE_RELEASE_V6, // 5
+    EBPF_HOOK_ALE_AUTH_CONNECT_V4,
+    EBPF_HOOK_ALE_AUTH_CONNECT_V6,
+    EBPF_HOOK_ALE_AUTH_RECV_ACCEPT_V4,
+    EBPF_HOOK_ALE_AUTH_RECV_ACCEPT_V6,
+    EBPF_HOOK_ALE_FLOW_ESTABLISHED_V4, // 10
+    EBPF_HOOK_ALE_FLOW_ESTABLISHED_V6
+} net_ebpf_extension_hook_id_t;
+
+/**
+ * @brief Helper function to return the eBPF network extension hook Id for the input WFP layer Id.
+ *
+ * @param[in] wfp_layer_id WFP layer Id.
+ *
+ * @returns eBPF network extension hook Id for the input WFP layer Id.
+ */
+net_ebpf_extension_hook_id_t
+net_ebpf_extension_get_hook_id_from_wfp_layer_id(uint16_t wfp_layer_id);
+
+/**
+ * @brief Helper function to return the assigned Id for the WFP callout corresponding to the eBPF hook.
+ *
+ * @param[in] hook_id eBPF network extension hook id.
+ *
+ * @returns assigned Id for the WFP callout corresponding to the eBPF hook.
+ */
+uint32_t
+net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id);
 
 /**
  * @brief Add WFP filters with specified conditions at specified layers.

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -1,0 +1,452 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file This file implements the hook for the SOCK_OPS program type and associated attach types, on eBPF for
+ * Windows.
+ *
+ */
+
+#define INITGUID
+
+#include "net_ebpf_ext_sock_ops.h"
+
+//
+// WFP related types & globals for SOCK_OPS hook.
+//
+
+struct _net_ebpf_extension_sock_ops_wfp_filter_context;
+
+/**
+ * @brief Custom context associated with WFP flows that are notified to eBPF programs
+ */
+typedef struct _net_ebpf_extension_sock_ops_wfp_flow_context
+{
+    LIST_ENTRY link;     ///< link to next flow context.
+    uint64_t flow_id;    ///< WFP flow Id.
+    uint16_t layer_id;   ///< WFP layer Id that this flow is associated to.
+    uint32_t callout_id; ///< WFP callout Id that this flow is associated to.
+    struct _net_ebpf_extension_sock_ops_wfp_filter_context*
+        filter_context;     ///< WFP filter context associated with this flow.
+    bpf_sock_ops_t context; ///< sock_ops context.
+} net_ebpf_extension_sock_ops_wfp_flow_context_t;
+
+typedef struct _net_ebpf_extension_sock_ops_wfp_flow_context_list
+{
+    KSPIN_LOCK lock;                         ///< Lock for synchronization.
+    _Guarded_by_(lock) LIST_ENTRY list_head; ///< List of WFP flow contexts.
+} net_ebpf_extension_sock_ops_wfp_flow_context_list_t;
+
+const net_ebpf_extension_wfp_filter_parameters_t _net_ebpf_extension_sock_ops_wfp_filter_parameters[] = {
+    {&FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4,
+     &EBPF_HOOK_ALE_FLOW_ESTABLISHED_V4_CALLOUT,
+     L"net eBPF sock_ops hook",
+     L"net eBPF sock_ops hook WFP filter"},
+    {&FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6,
+     &EBPF_HOOK_ALE_FLOW_ESTABLISHED_V6_CALLOUT,
+     L"net eBPF sock_ops hook",
+     L"net eBPF sock_ops hook WFP filter"}};
+
+#define NET_EBPF_SOCK_OPS_FILTER_COUNT EBPF_COUNT_OF(_net_ebpf_extension_sock_ops_wfp_filter_parameters)
+
+typedef struct _net_ebpf_extension_sock_ops_wfp_filter_context
+{
+    const net_ebpf_extension_hook_client_t* client_context;
+    uint32_t compartment_id;
+    uint64_t filter_ids[NET_EBPF_SOCK_OPS_FILTER_COUNT];
+    net_ebpf_extension_sock_ops_wfp_flow_context_list_t flow_context_list;
+} net_ebpf_extension_sock_ops_wfp_filter_context_t;
+
+//
+// SOCK_OPS Program Information NPI Provider.
+//
+
+static ebpf_program_data_t _ebpf_sock_ops_program_data = {&_ebpf_sock_ops_program_info, NULL};
+
+static ebpf_extension_data_t _ebpf_sock_ops_program_info_provider_data = {
+    NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_sock_ops_program_data), &_ebpf_sock_ops_program_data};
+
+NPI_MODULEID DECLSPEC_SELECTANY _ebpf_sock_ops_program_info_provider_moduleid = {sizeof(NPI_MODULEID), MIT_GUID, {0}};
+
+static net_ebpf_extension_program_info_provider_t* _ebpf_sock_ops_program_info_provider_context = NULL;
+
+//
+// SOCK_OPS Hook NPI Provider.
+//
+
+ebpf_attach_provider_data_t _net_ebpf_sock_ops_hook_provider_data;
+
+ebpf_extension_data_t _net_ebpf_extension_sock_ops_hook_provider_data = {
+    EBPF_ATTACH_PROVIDER_DATA_VERSION,
+    sizeof(_net_ebpf_sock_ops_hook_provider_data),
+    &_net_ebpf_sock_ops_hook_provider_data};
+
+NPI_MODULEID DECLSPEC_SELECTANY _ebpf_sock_ops_hook_provider_moduleid = {sizeof(NPI_MODULEID), MIT_GUID, {0}};
+
+static net_ebpf_extension_hook_provider_t* _ebpf_sock_ops_hook_provider_context = NULL;
+
+//
+// NMR Registration Helper Routines.
+//
+
+static ebpf_result_t
+net_ebpf_extension_sock_ops_on_client_attach(
+    _In_ const net_ebpf_extension_hook_client_t* attaching_client,
+    _In_ const net_ebpf_extension_hook_provider_t* provider_context)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    const ebpf_extension_data_t* client_data = net_ebpf_extension_hook_client_get_client_data(attaching_client);
+    uint32_t compartment_id;
+    uint32_t wild_card_compartment_id = UNSPECIFIED_COMPARTMENT_ID;
+    uint32_t filter_count;
+    FWPM_FILTER_CONDITION condition = {0};
+    net_ebpf_extension_sock_ops_wfp_filter_context_t* filter_context = NULL;
+
+    // SOCK_OPS hook clients must always provide data.
+    if (client_data == NULL) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
+    if (client_data->size > 0) {
+        if ((client_data->size != sizeof(uint32_t)) || (client_data->data == NULL)) {
+            result = EBPF_INVALID_ARGUMENT;
+            goto Exit;
+        }
+        compartment_id = *(uint32_t*)client_data->data;
+    } else {
+        // If the client did not specify any attach parameters, we treat that as a wildcard interface index.
+        compartment_id = wild_card_compartment_id;
+    }
+
+    result = net_ebpf_extension_hook_check_attach_parameter(
+        sizeof(compartment_id),
+        &compartment_id,
+        &wild_card_compartment_id,
+        (net_ebpf_extension_hook_provider_t*)provider_context);
+    if (result != EBPF_SUCCESS)
+        goto Exit;
+
+    if (client_data->data != NULL)
+        compartment_id = *(uint32_t*)client_data->data;
+
+    // Set compartment id (if not UNSPECIFIED_COMPARTMENT_ID) as WFP filter condition.
+    if (compartment_id != UNSPECIFIED_COMPARTMENT_ID) {
+        condition.fieldKey = FWPM_CONDITION_COMPARTMENT_ID;
+        condition.matchType = FWP_MATCH_EQUAL;
+        condition.conditionValue.type = FWP_UINT32;
+        condition.conditionValue.uint32 = compartment_id;
+    }
+
+    // Allocate buffer for WFP filter context.
+    filter_context = (net_ebpf_extension_sock_ops_wfp_filter_context_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, sizeof(net_ebpf_extension_sock_ops_wfp_filter_context_t), NET_EBPF_EXTENSION_POOL_TAG);
+    if (filter_context == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+    memset(filter_context, 0, sizeof(net_ebpf_extension_sock_ops_wfp_filter_context_t));
+    filter_context->client_context = attaching_client;
+    filter_context->compartment_id = compartment_id;
+
+    // Initialize the flow contexts list.
+    KeInitializeSpinLock(&filter_context->flow_context_list.lock);
+    InitializeListHead(&filter_context->flow_context_list.list_head);
+
+    // Add WFP filters at appropriate layers and set the hook NPI client as the filter's raw context.
+    filter_count = NET_EBPF_SOCK_OPS_FILTER_COUNT;
+    result = net_ebpf_extension_add_wfp_filters(
+        NET_EBPF_SOCK_OPS_FILTER_COUNT,
+        _net_ebpf_extension_sock_ops_wfp_filter_parameters,
+        (compartment_id == UNSPECIFIED_COMPARTMENT_ID) ? 0 : 1,
+        (compartment_id == UNSPECIFIED_COMPARTMENT_ID) ? NULL : &condition,
+        filter_context,
+        filter_context->filter_ids);
+    if (result != EBPF_SUCCESS)
+        goto Exit;
+
+    // Set the filter context as the client context's provider data.
+    net_ebpf_extension_hook_client_set_provider_data(
+        (net_ebpf_extension_hook_client_t*)attaching_client, filter_context);
+
+Exit:
+    if (result != EBPF_SUCCESS) {
+        if (filter_context != NULL)
+            ExFreePool(filter_context);
+    }
+
+    return result;
+}
+
+static void
+_net_ebpf_extension_sock_ops_on_client_detach(_In_ const net_ebpf_extension_hook_client_t* detaching_client)
+{
+    net_ebpf_extension_sock_ops_wfp_filter_context_t* filter_context =
+        (net_ebpf_extension_sock_ops_wfp_filter_context_t*)net_ebpf_extension_hook_client_get_provider_data(
+            detaching_client);
+    ASSERT(filter_context != NULL);
+    net_ebpf_extension_delete_wfp_filters(NET_EBPF_SOCK_OPS_FILTER_COUNT, filter_context->filter_ids);
+    // Remove any remaining flow contexts. A lock is not needed at this time.
+    while (!IsListEmpty(&filter_context->flow_context_list.list_head)) {
+        LIST_ENTRY* entry = RemoveHeadList(&filter_context->flow_context_list.list_head);
+        net_ebpf_extension_sock_ops_wfp_flow_context_t* flow_context =
+            CONTAINING_RECORD(entry, net_ebpf_extension_sock_ops_wfp_flow_context_t, link);
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/fwpsk/nf-fwpsk-fwpsflowremovecontext0
+        // Calling FwpsFlowRemoveContext may cause flowDeleteFn callback on the callout to be invoked synchronously.
+        // The net_ebpf_extension_sock_ops_flow_delete function invokes eBPF program. Since the client
+        // is deteaching, the eBPF program should not be invoked. The filter_context field is set to NULL
+        // for that reason.
+        // The net_ebpf_extension_sock_ops_flow_delete function frees the flow context memory.
+        flow_context->filter_context = NULL;
+#pragma warning(push)
+#pragma warning(disable : 4189) // 'status': local variable is initialized but not referenced
+        NTSTATUS status =
+            FwpsFlowRemoveContext(flow_context->flow_id, flow_context->layer_id, flow_context->callout_id);
+        ASSERT(status == STATUS_SUCCESS);
+#pragma warning(pop)
+    }
+    ExFreePool(filter_context);
+}
+
+NTSTATUS
+net_ebpf_ext_sock_ops_register_providers()
+{
+    NTSTATUS status = STATUS_SUCCESS;
+
+    const net_ebpf_extension_program_info_provider_parameters_t program_info_provider_parameters = {
+        &_ebpf_sock_ops_program_info_provider_moduleid, &_ebpf_sock_ops_program_info_provider_data};
+
+    _ebpf_sock_ops_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_SOCK_OPS;
+    // Set the program type as the provider module id.
+    _ebpf_sock_ops_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_SOCK_OPS;
+    status = net_ebpf_extension_program_info_provider_register(
+        &program_info_provider_parameters, &_ebpf_sock_ops_program_info_provider_context);
+    if (status != STATUS_SUCCESS)
+        goto Exit;
+
+    _net_ebpf_sock_ops_hook_provider_data.supported_program_type = EBPF_PROGRAM_TYPE_SOCK_OPS;
+    const net_ebpf_extension_hook_provider_parameters_t hook_provider_parameters = {
+        &_ebpf_sock_ops_hook_provider_moduleid, &_net_ebpf_extension_sock_ops_hook_provider_data, EXECUTION_DISPATCH};
+
+    // Set the attach type as the provider module id.
+    _ebpf_sock_ops_hook_provider_moduleid.Guid = EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS;
+    // Register the provider context and pass the pointer to the WFP filter parameters
+    // corresponding to this hook type as custom data.
+    status = net_ebpf_extension_hook_provider_register(
+        &hook_provider_parameters,
+        net_ebpf_extension_sock_ops_on_client_attach,
+        _net_ebpf_extension_sock_ops_on_client_detach,
+        NULL,
+        &_ebpf_sock_ops_hook_provider_context);
+
+    if (status != EBPF_SUCCESS)
+        goto Exit;
+
+Exit:
+    return status;
+}
+
+void
+net_ebpf_ext_sock_ops_unregister_providers()
+{
+    net_ebpf_extension_hook_provider_unregister(_ebpf_sock_ops_hook_provider_context);
+    net_ebpf_extension_program_info_provider_unregister(_ebpf_sock_ops_program_info_provider_context);
+}
+
+wfp_ale_layer_fields_t wfp_flow_established_fields[] = {
+    // EBPF_HOOK_ALE_FLOW_ESTABLISHED_V4
+    {FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_LOCAL_ADDRESS,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_LOCAL_PORT,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_REMOTE_ADDRESS,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_REMOTE_PORT,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_PROTOCOL,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_DIRECTION,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_COMPARTMENT_ID},
+    // EBPF_HOOK_ALE_FLOW_ESTABLISHED_V6
+    {FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_LOCAL_ADDRESS,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_LOCAL_PORT,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_REMOTE_ADDRESS,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_REMOTE_PORT,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_PROTOCOL,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_DIRECTION,
+     FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_COMPARTMENT_ID}};
+
+static void
+_net_ebpf_extension_sock_ops_copy_wfp_connection_fields(
+    _In_ const FWPS_INCOMING_VALUES* incoming_fixed_values,
+    _Out_ bpf_sock_ops_t* sock_ops_ctx,
+    _Out_ uint32_t* compartment_id)
+{
+    uint16_t wfp_layer_id = incoming_fixed_values->layerId;
+    net_ebpf_extension_hook_id_t hook_id = net_ebpf_extension_get_hook_id_from_wfp_layer_id(wfp_layer_id);
+    wfp_ale_layer_fields_t* fields = &wfp_flow_established_fields[hook_id - EBPF_HOOK_ALE_FLOW_ESTABLISHED_V4];
+
+    FWPS_INCOMING_VALUE0* incoming_values = incoming_fixed_values->incomingValue;
+
+    sock_ops_ctx->op = (incoming_values[fields->direction_field].value.uint32 == FWP_DIRECTION_OUTBOUND)
+                           ? BPF_SOCK_OPS_ACTIVE_ESTABLISHED_CB
+                           : BPF_SOCK_OPS_PASSIVE_ESTABLISHED_CB;
+
+    // Copy IP address fields.
+    if (hook_id == EBPF_HOOK_ALE_FLOW_ESTABLISHED_V4) {
+        sock_ops_ctx->family = AF_INET;
+        sock_ops_ctx->local_ip4 = htonl(incoming_values[fields->local_ip_address_field].value.uint32);
+        sock_ops_ctx->remote_ip4 = htonl(incoming_values[fields->remote_ip_address_field].value.uint32);
+    } else {
+        sock_ops_ctx->family = AF_INET6;
+        RtlCopyMemory(
+            sock_ops_ctx->local_ip6,
+            incoming_values[fields->local_ip_address_field].value.byteArray16,
+            sizeof(FWP_BYTE_ARRAY16));
+        RtlCopyMemory(
+            sock_ops_ctx->remote_ip6,
+            incoming_values[fields->remote_ip_address_field].value.byteArray16,
+            sizeof(FWP_BYTE_ARRAY16));
+    }
+    sock_ops_ctx->local_port = htons(incoming_values[fields->local_port_field].value.uint16);
+    sock_ops_ctx->remote_port = htons(incoming_values[fields->remote_port_field].value.uint16);
+    sock_ops_ctx->protocol = incoming_values[fields->protocol_field].value.uint8;
+    *compartment_id = incoming_values[fields->compartment_id_field].value.uint32;
+}
+
+//
+// WFP callout callback function.
+//
+void
+net_ebpf_extension_sock_ops_flow_established_classify(
+    _In_ const FWPS_INCOMING_VALUES* incoming_fixed_values,
+    _In_ const FWPS_INCOMING_METADATA_VALUES* incoming_metadata_values,
+    _Inout_opt_ void* layer_data,
+    _In_opt_ const void* classify_context,
+    _In_ const FWPS_FILTER* filter,
+    uint64_t flow_context,
+    _Inout_ FWPS_CLASSIFY_OUT* classify_output)
+{
+    NTSTATUS status;
+    uint32_t result;
+    net_ebpf_extension_sock_ops_wfp_filter_context_t* filter_context = NULL;
+    net_ebpf_extension_hook_client_t* attached_client = NULL;
+    net_ebpf_extension_hook_execution_t execution_type =
+        (KeGetCurrentIrql() < DISPATCH_LEVEL) ? EXECUTION_PASSIVE : EXECUTION_DISPATCH;
+    net_ebpf_extension_sock_ops_wfp_flow_context_t* local_flow_context = NULL;
+    bpf_sock_ops_t* sock_ops_ctx = NULL;
+    uint32_t client_compartment_id = UNSPECIFIED_COMPARTMENT_ID;
+    uint32_t compartment_id = UNSPECIFIED_COMPARTMENT_ID;
+    net_ebpf_extension_hook_id_t hook_id =
+        net_ebpf_extension_get_hook_id_from_wfp_layer_id(incoming_fixed_values->layerId);
+    KIRQL irql;
+
+    UNREFERENCED_PARAMETER(layer_data);
+    UNREFERENCED_PARAMETER(classify_context);
+    UNREFERENCED_PARAMETER(flow_context);
+
+    classify_output->actionType = FWP_ACTION_PERMIT;
+
+    filter_context = (net_ebpf_extension_sock_ops_wfp_filter_context_t*)filter->context;
+    ASSERT(filter_context != NULL);
+
+    attached_client = (net_ebpf_extension_hook_client_t*)filter_context->client_context;
+    ASSERT(attached_client != NULL);
+    if (attached_client == NULL)
+        goto Exit;
+
+    if (!net_ebpf_extension_hook_client_enter_rundown(attached_client, execution_type))
+        goto Exit;
+
+    local_flow_context = (net_ebpf_extension_sock_ops_wfp_flow_context_t*)ExAllocatePoolUninitialized(
+        NonPagedPoolNx, sizeof(net_ebpf_extension_sock_ops_wfp_flow_context_t), NET_EBPF_EXTENSION_POOL_TAG);
+    if (local_flow_context == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+    memset(local_flow_context, 0, sizeof(net_ebpf_extension_sock_ops_wfp_flow_context_t));
+
+    local_flow_context->filter_context = filter_context;
+
+    sock_ops_ctx = &local_flow_context->context;
+    _net_ebpf_extension_sock_ops_copy_wfp_connection_fields(incoming_fixed_values, sock_ops_ctx, &compartment_id);
+
+    client_compartment_id = filter_context->compartment_id;
+    ASSERT((client_compartment_id == UNSPECIFIED_COMPARTMENT_ID) || (client_compartment_id == compartment_id));
+    if (client_compartment_id != UNSPECIFIED_COMPARTMENT_ID && client_compartment_id != compartment_id) {
+        // The client is not interested in this compartment Id.
+        goto Exit;
+    }
+
+    local_flow_context->flow_id = incoming_metadata_values->flowHandle;
+    local_flow_context->layer_id = incoming_fixed_values->layerId;
+    local_flow_context->callout_id = net_ebpf_extension_get_callout_id_for_hook(hook_id);
+
+    if (net_ebpf_extension_hook_invoke_program(attached_client, sock_ops_ctx, &result) != EBPF_SUCCESS)
+        goto Exit;
+
+    status = FwpsFlowAssociateContext(
+        local_flow_context->flow_id,
+        local_flow_context->layer_id,
+        local_flow_context->callout_id,
+        (uint64_t)(uintptr_t)local_flow_context);
+    if (!NT_SUCCESS(status))
+        goto Exit;
+
+    KeAcquireSpinLock(&filter_context->flow_context_list.lock, &irql);
+    InsertTailList(&filter_context->flow_context_list.list_head, &local_flow_context->link);
+    KeReleaseSpinLock(&filter_context->flow_context_list.lock, irql);
+    local_flow_context = NULL;
+
+    classify_output->actionType = (result == 0) ? FWP_ACTION_PERMIT : FWP_ACTION_BLOCK;
+    if (classify_output->actionType == FWP_ACTION_BLOCK)
+        classify_output->rights &= ~FWPS_RIGHT_ACTION_WRITE;
+
+Exit:
+    if (local_flow_context != NULL)
+        ExFreePool(local_flow_context);
+    if (attached_client != NULL)
+        net_ebpf_extension_hook_client_leave_rundown(attached_client, execution_type);
+}
+
+void
+net_ebpf_extension_sock_ops_flow_delete(uint16_t layer_id, uint32_t callout_id, uint64_t flow_context)
+{
+    net_ebpf_extension_sock_ops_wfp_flow_context_t* local_flow_context =
+        (net_ebpf_extension_sock_ops_wfp_flow_context_t*)(uintptr_t)flow_context;
+    net_ebpf_extension_sock_ops_wfp_filter_context_t* filter_context;
+    net_ebpf_extension_hook_client_t* attached_client = NULL;
+    bpf_sock_ops_t* sock_ops_ctx = NULL;
+    uint32_t result;
+    net_ebpf_extension_hook_execution_t execution_type =
+        (KeGetCurrentIrql() < DISPATCH_LEVEL) ? EXECUTION_PASSIVE : EXECUTION_DISPATCH;
+    KIRQL irql;
+
+    UNREFERENCED_PARAMETER(layer_id);
+    UNREFERENCED_PARAMETER(callout_id);
+
+    if (local_flow_context == NULL)
+        goto Exit;
+
+    filter_context = local_flow_context->filter_context;
+    if (filter_context == NULL)
+        goto Exit;
+
+    attached_client = (net_ebpf_extension_hook_client_t*)filter_context->client_context;
+    if (attached_client == NULL)
+        goto Exit;
+
+    if (!net_ebpf_extension_hook_client_enter_rundown(attached_client, execution_type))
+        goto Exit;
+
+    KeAcquireSpinLock(&filter_context->flow_context_list.lock, &irql);
+    RemoveEntryList(&local_flow_context->link);
+    KeReleaseSpinLock(&filter_context->flow_context_list.lock, irql);
+
+    // Invoke eBPF program with connection deleted socket event.
+    sock_ops_ctx = &local_flow_context->context;
+    sock_ops_ctx->op = BPF_SOCK_OPS_CONNECTION_DELETED_CB;
+    if (net_ebpf_extension_hook_invoke_program(attached_client, sock_ops_ctx, &result) != EBPF_SUCCESS)
+        goto Exit;
+
+Exit:
+    if (local_flow_context != NULL)
+        ExFreePool(local_flow_context);
+    if (attached_client != NULL)
+        net_ebpf_extension_hook_client_leave_rundown(attached_client, execution_type);
+}

--- a/netebpfext/net_ebpf_ext_sock_ops.h
+++ b/netebpfext/net_ebpf_ext_sock_ops.h
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "net_ebpf_ext.h"
+
+// Callout GUIDs
+
+// f53b4577-bc47-11ec-9a30-18602489beee
+DEFINE_GUID(
+    EBPF_HOOK_ALE_FLOW_ESTABLISHED_V4_CALLOUT,
+    0xf53b4577,
+    0xbc47,
+    0x11ec,
+    0x9a,
+    0x30,
+    0x18,
+    0x60,
+    0x24,
+    0x89,
+    0xbe,
+    0xee);
+
+// f53b4578-bc47-11ec-9a30-18602489beee
+DEFINE_GUID(
+    EBPF_HOOK_ALE_FLOW_ESTABLISHED_V6_CALLOUT,
+    0xf53b4578,
+    0xbc47,
+    0x11ec,
+    0x9a,
+    0x30,
+    0x18,
+    0x60,
+    0x24,
+    0x89,
+    0xbe,
+    0xee);
+
+/**
+ * @brief WFP classifyFn callback for EBPF_HOOK_ALE_FLOW_ESTABLISHED_V4/6_CALLOUT.
+ */
+void
+net_ebpf_extension_sock_ops_flow_established_classify(
+    _In_ const FWPS_INCOMING_VALUES* incoming_fixed_values,
+    _In_ const FWPS_INCOMING_METADATA_VALUES* incoming_metadata_values,
+    _Inout_opt_ void* layer_data,
+    _In_opt_ const void* classify_context,
+    _In_ const FWPS_FILTER* filter,
+    uint64_t flow_context,
+    _Inout_ FWPS_CLASSIFY_OUT* classify_output);
+
+/**
+ * @brief WFP flowDeleteFn callback for EBPF_HOOK_ALE_FLOW_ESTABLISHED_V4/6_CALLOUT.
+ */
+void
+net_ebpf_extension_sock_ops_flow_delete(uint16_t layer_id, uint32_t callout_id, uint64_t flow_context);
+
+/**
+ * @brief Unregister SOCK_OPS NPI providers.
+ *
+ */
+void
+net_ebpf_ext_sock_ops_unregister_providers();
+
+/**
+ * @brief Register SOCK_OPS NPI providers.
+ *
+ * @retval STATUS_SUCCESS Operation succeeded.
+ * @retval STATUS_UNSUCCESSFUL Operation failed.
+ */
+NTSTATUS
+net_ebpf_ext_sock_ops_register_providers();

--- a/netebpfext/netebpfext.vcxproj
+++ b/netebpfext/netebpfext.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="net_ebpf_ext_hook_provider.c" />
     <ClCompile Include="net_ebpf_ext_prog_info_provider.c"/>
     <ClCompile Include="net_ebpf_ext_sock_addr.c" />
+    <ClCompile Include="net_ebpf_ext_sock_ops.c" />
     <ClCompile Include="net_ebpf_ext_xdp.c" />
   </ItemGroup>
   <ItemGroup>
@@ -149,6 +150,7 @@
     <ClInclude Include="net_ebpf_ext_program_info.h" />
     <ClInclude Include="net_ebpf_ext_prog_info_provider.h"/>
     <ClInclude Include="net_ebpf_ext_sock_addr.h" />
+    <ClInclude Include="net_ebpf_ext_sock_ops.h" />
     <ClInclude Include="net_ebpf_ext_xdp.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -251,7 +251,7 @@ function Import-ResultsFromVM
         }
 
         Write-Log ("Copy $LogFileName from eBPF on $VMName to $pwd\TestLogs")
-        Copy-Item -FromSession $VMSession "$VMSystemDrive\eBPF\$LogFileName" -Destination ".\TestLogs\$VMName\Logs" -Recurse -Force -ErrorAction Stop 2>&1 | Write-Log
+        Copy-Item -FromSession $VMSession "$VMSystemDrive\eBPF\$LogFileName" -Destination ".\TestLogs\$VMName\Logs" -Recurse -Force -ErrorAction Ignore 2>&1 | Write-Log
 
         Write-Log ("Copy CodeCoverage from eBPF on $VMName to $pwd\..\..")
         Copy-Item -FromSession $VMSession "$VMSystemDrive\eBPF\ebpf_for_windows.xml" -Destination "$pwd\..\.." -Recurse -Force -ErrorAction Ignore 2>&1 | Write-Log
@@ -259,10 +259,10 @@ function Import-ResultsFromVM
         # Copy ETL from Test VM.
         $EtlFile = $LogFileName.Substring(0, $LogFileName.IndexOf('.')) + ".etl"
         Write-Log ("Copy $EtlFile from eBPF on $VMName to $pwd\TestLogs")
-        Copy-Item -FromSession $VMSession -Path "$VMSystemDrive\eBPF\$EtlFile" -Destination ".\TestLogs\$VMName\Logs" -Recurse -Force -ErrorAction Stop 2>&1 | Write-Log
+        Copy-Item -FromSession $VMSession -Path "$VMSystemDrive\eBPF\$EtlFile" -Destination ".\TestLogs\$VMName\Logs" -Recurse -Force -ErrorAction Ignore 2>&1 | Write-Log
     }
     # Move runner test logs to TestLogs folder.
-    Move-Item $LogFileName -Destination ".\TestLogs" -Force -ErrorAction Stop 2>&1 | Write-Log
+    Move-Item $LogFileName -Destination ".\TestLogs" -Force -ErrorAction Ignore 2>&1 | Write-Log
 }
 
 function Install-eBPFComponentsOnVM

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -59,7 +59,7 @@ function Invoke-Test
     $ArgumentsList = @()
 
     if ($Coverage) {
-        $ArgumentsList += @('--modules=C:\eBPF', '--export_type', ('binary:' + $TestName + '.cov'), '--', $TestName)
+        $ArgumentsList += @('-q', '--modules=C:\eBPF', '--export_type', ('binary:' + $TestName + '.cov'), '--', $TestName)
         $TestName = $CodeCoverage
     }
     # Execute Test.
@@ -67,6 +67,7 @@ function Invoke-Test
         $ArgumentsList += '-s'
     }
 
+    Write-Log "$TestName $ArgumentsList"
     $Output = &$TestName $ArgumentsList
     $TestName = $OriginalTestName
 

--- a/tests/bpf2c_tests/expected/sockops_dll.txt
+++ b/tests/bpf2c_tests/expected/sockops_dll.txt
@@ -73,718 +73,718 @@ static uint16_t connection_monitor_maps[] = {
 
 static uint64_t connection_monitor(void* context)
 {
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	// Prologue
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r0 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r1 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r2 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r3 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r4 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r5 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r6 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r7 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r8 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r9 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r10 = 0;
 
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r1 = (uintptr_t)context;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
 	// EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=2
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r7 = IMMEDIATE(2);
 	// EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r4 = IMMEDIATE(1);
 	// EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 == IMMEDIATE(0)) goto label_2;
 	// EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 == IMMEDIATE(2)) goto label_1;
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
 	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	goto label_2;
 label_1:
 	// EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_MOV64_IMM pc=11 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r7 = IMMEDIATE(0);
 label_2:
 	// EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=51 imm=2
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	if (r2 != IMMEDIATE(2)) goto label_7;
 	// EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
 	// EBPF_OP_STXW pc=15 dst=r10 src=r6 offset=-4 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=16 dst=r10 src=r6 offset=-8 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=17 dst=r10 src=r6 offset=-12 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=18 dst=r10 src=r6 offset=-16 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=19 dst=r10 src=r6 offset=-20 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=20 dst=r10 src=r6 offset=-24 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=21 dst=r10 src=r6 offset=-28 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=22 dst=r10 src=r6 offset=-32 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=23 dst=r10 src=r6 offset=-36 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=24 dst=r10 src=r6 offset=-40 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=25 dst=r10 src=r6 offset=-44 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r6;
 	// EBPF_OP_MOV64_IMM pc=26 dst=r2 src=r0 offset=0 imm=28
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_3;
 	// EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r5 = IMMEDIATE(28);
 label_3:
 	// EBPF_OP_MOV64_REG pc=30 dst=r3 src=r1 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_REG pc=31 dst=r3 src=r5 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 += r5;
 	// EBPF_OP_LDXW pc=32 dst=r3 src=r3 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = *(uint32_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-48 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r3;
 	// EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=44
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_4;
 	// EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = IMMEDIATE(44);
 label_4:
 	// EBPF_OP_MOV64_REG pc=38 dst=r5 src=r1 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r5 = r1;
 	// EBPF_OP_ADD64_REG pc=39 dst=r5 src=r3 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r5 += r3;
 	// EBPF_OP_LDXW pc=40 dst=r3 src=r5 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = *(uint32_t *)(uintptr_t)(r5 + OFFSET(0));
 	// EBPF_OP_STXH pc=41 dst=r10 src=r3 offset=-32 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r3;
 	// EBPF_OP_JNE_IMM pc=42 dst=r4 src=r0 offset=1 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_5;
 	// EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r0 = IMMEDIATE(24);
 label_5:
 	// EBPF_OP_JNE_IMM pc=44 dst=r4 src=r0 offset=1 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_6;
 	// EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r2 = IMMEDIATE(8);
 label_6:
 	// EBPF_OP_OR64_REG pc=46 dst=r7 src=r4 offset=0 imm=0
-#line 36 "sample/sockops.c"
+#line 29 "sample/sockops.c"
 	r7 |= r4;
 	// EBPF_OP_MOV64_REG pc=47 dst=r3 src=r1 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_REG pc=48 dst=r3 src=r2 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r3 += r2;
 	// EBPF_OP_LDXW pc=49 dst=r2 src=r3 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_STXW pc=50 dst=r10 src=r2 offset=-28 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r2;
 	// EBPF_OP_MOV64_REG pc=51 dst=r2 src=r1 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 = r1;
 	// EBPF_OP_ADD64_REG pc=52 dst=r2 src=r0 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 += r0;
 	// EBPF_OP_LDXW pc=53 dst=r2 src=r2 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r2 + OFFSET(0));
 	// EBPF_OP_STXH pc=54 dst=r10 src=r2 offset=-12 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r2;
 	// EBPF_OP_LDXB pc=55 dst=r1 src=r1 offset=48 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(48));
 	// EBPF_OP_STXB pc=56 dst=r10 src=r7 offset=-4 imm=0
-#line 37 "sample/sockops.c"
+#line 30 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r7;
 	// EBPF_OP_STXW pc=57 dst=r10 src=r1 offset=-8 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=58 dst=r2 src=r10 offset=0 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=59 dst=r2 src=r0 offset=0 imm=-48
-#line 36 "sample/sockops.c"
+#line 29 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
 	// EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=1
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
 	// EBPF_OP_STXDW pc=65 dst=r10 src=r7 offset=-56 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r7;
 	// EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r2 = IMMEDIATE(0);
 	// EBPF_OP_STXDW pc=67 dst=r10 src=r2 offset=-8 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=68 dst=r10 src=r2 offset=-16 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=69 dst=r10 src=r2 offset=-24 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=70 dst=r10 src=r2 offset=-32 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
 	// EBPF_OP_MOV64_REG pc=71 dst=r3 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
 	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
 	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r1 += IMMEDIATE(8);
 	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r0 = r1;
 	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
 	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
 	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
 	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
 	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
 	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
 	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 |= r5;
 	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
 	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
 	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
 	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
 	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
 	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 |= r5;
 	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
 	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
 	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_9;
 	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r3 = r1;
 label_9:
 	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
 	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r2 |= r1;
 	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
 	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r6 |= r1;
 	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r9 <<= IMMEDIATE(16);
 	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r8 <<= IMMEDIATE(16);
 	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
 	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
 	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r7 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
 	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
 	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
 	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
 	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
 label_10:
 	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
 	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r9 |= r6;
 	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r8 |= r2;
 	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
 	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r5 |= r1;
 	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
 	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r7 |= r1;
 	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
 	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
 	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_11:
 	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
 	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	r1 |= r4;
 	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
 	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
 	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 |= r9;
 	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
 	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 |= r5;
 	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
 	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
 	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 |= r2;
 	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
 	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
 	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r2;
 	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r1;
 	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
 	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r7;
 	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
 	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
 	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = r6;
 	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
 	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 += r2;
 	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
 	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
 	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
 	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 |= r1;
 	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
 	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
 	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 |= r1;
 	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
 	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r1;
 	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
 	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
 	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r0;
 	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r5;
 	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 |= r4;
 	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
 	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
 	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 |= r5;
 	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
 	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
 	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r0;
 	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r4;
 	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
 	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
 	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
 	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
 	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
 	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r2;
 	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
 	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
 	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
 	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 |= r2;
 	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 |= r1;
 	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
 	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = r6;
 	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
 	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 += r2;
 	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
 	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
 	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
-#line 61 "sample/sockops.c"
+#line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
 	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
-#line 61 "sample/sockops.c"
+#line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
 	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
 	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
 	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
 	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
 	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
 	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
 	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 	r0 = r6;
 	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 	return r0;
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 }
 #line __LINE__ __FILE__
 

--- a/tests/bpf2c_tests/expected/sockops_raw.txt
+++ b/tests/bpf2c_tests/expected/sockops_raw.txt
@@ -31,718 +31,718 @@ static uint16_t connection_monitor_maps[] = {
 
 static uint64_t connection_monitor(void* context)
 {
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	// Prologue
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r0 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r1 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r2 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r3 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r4 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r5 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r6 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r7 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r8 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r9 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r10 = 0;
 
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r1 = (uintptr_t)context;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
 	// EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=2
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r7 = IMMEDIATE(2);
 	// EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r4 = IMMEDIATE(1);
 	// EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 == IMMEDIATE(0)) goto label_2;
 	// EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 == IMMEDIATE(2)) goto label_1;
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
 	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	goto label_2;
 label_1:
 	// EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_MOV64_IMM pc=11 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r7 = IMMEDIATE(0);
 label_2:
 	// EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=51 imm=2
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	if (r2 != IMMEDIATE(2)) goto label_7;
 	// EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
 	// EBPF_OP_STXW pc=15 dst=r10 src=r6 offset=-4 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=16 dst=r10 src=r6 offset=-8 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=17 dst=r10 src=r6 offset=-12 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=18 dst=r10 src=r6 offset=-16 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=19 dst=r10 src=r6 offset=-20 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=20 dst=r10 src=r6 offset=-24 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=21 dst=r10 src=r6 offset=-28 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=22 dst=r10 src=r6 offset=-32 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=23 dst=r10 src=r6 offset=-36 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=24 dst=r10 src=r6 offset=-40 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=25 dst=r10 src=r6 offset=-44 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r6;
 	// EBPF_OP_MOV64_IMM pc=26 dst=r2 src=r0 offset=0 imm=28
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_3;
 	// EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r5 = IMMEDIATE(28);
 label_3:
 	// EBPF_OP_MOV64_REG pc=30 dst=r3 src=r1 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_REG pc=31 dst=r3 src=r5 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 += r5;
 	// EBPF_OP_LDXW pc=32 dst=r3 src=r3 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = *(uint32_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-48 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r3;
 	// EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=44
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_4;
 	// EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = IMMEDIATE(44);
 label_4:
 	// EBPF_OP_MOV64_REG pc=38 dst=r5 src=r1 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r5 = r1;
 	// EBPF_OP_ADD64_REG pc=39 dst=r5 src=r3 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r5 += r3;
 	// EBPF_OP_LDXW pc=40 dst=r3 src=r5 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = *(uint32_t *)(uintptr_t)(r5 + OFFSET(0));
 	// EBPF_OP_STXH pc=41 dst=r10 src=r3 offset=-32 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r3;
 	// EBPF_OP_JNE_IMM pc=42 dst=r4 src=r0 offset=1 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_5;
 	// EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r0 = IMMEDIATE(24);
 label_5:
 	// EBPF_OP_JNE_IMM pc=44 dst=r4 src=r0 offset=1 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_6;
 	// EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r2 = IMMEDIATE(8);
 label_6:
 	// EBPF_OP_OR64_REG pc=46 dst=r7 src=r4 offset=0 imm=0
-#line 36 "sample/sockops.c"
+#line 29 "sample/sockops.c"
 	r7 |= r4;
 	// EBPF_OP_MOV64_REG pc=47 dst=r3 src=r1 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_REG pc=48 dst=r3 src=r2 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r3 += r2;
 	// EBPF_OP_LDXW pc=49 dst=r2 src=r3 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_STXW pc=50 dst=r10 src=r2 offset=-28 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r2;
 	// EBPF_OP_MOV64_REG pc=51 dst=r2 src=r1 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 = r1;
 	// EBPF_OP_ADD64_REG pc=52 dst=r2 src=r0 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 += r0;
 	// EBPF_OP_LDXW pc=53 dst=r2 src=r2 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r2 + OFFSET(0));
 	// EBPF_OP_STXH pc=54 dst=r10 src=r2 offset=-12 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r2;
 	// EBPF_OP_LDXB pc=55 dst=r1 src=r1 offset=48 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(48));
 	// EBPF_OP_STXB pc=56 dst=r10 src=r7 offset=-4 imm=0
-#line 37 "sample/sockops.c"
+#line 30 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r7;
 	// EBPF_OP_STXW pc=57 dst=r10 src=r1 offset=-8 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=58 dst=r2 src=r10 offset=0 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=59 dst=r2 src=r0 offset=0 imm=-48
-#line 36 "sample/sockops.c"
+#line 29 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
 	// EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=1
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
 	// EBPF_OP_STXDW pc=65 dst=r10 src=r7 offset=-56 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r7;
 	// EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r2 = IMMEDIATE(0);
 	// EBPF_OP_STXDW pc=67 dst=r10 src=r2 offset=-8 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=68 dst=r10 src=r2 offset=-16 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=69 dst=r10 src=r2 offset=-24 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=70 dst=r10 src=r2 offset=-32 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
 	// EBPF_OP_MOV64_REG pc=71 dst=r3 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
 	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
 	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r1 += IMMEDIATE(8);
 	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r0 = r1;
 	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
 	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
 	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
 	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
 	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
 	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
 	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 |= r5;
 	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
 	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
 	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
 	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
 	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
 	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 |= r5;
 	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
 	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
 	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_9;
 	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r3 = r1;
 label_9:
 	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
 	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r2 |= r1;
 	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
 	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r6 |= r1;
 	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r9 <<= IMMEDIATE(16);
 	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r8 <<= IMMEDIATE(16);
 	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
 	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
 	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r7 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
 	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
 	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
 	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
 	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
 label_10:
 	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
 	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r9 |= r6;
 	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r8 |= r2;
 	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
 	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r5 |= r1;
 	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
 	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r7 |= r1;
 	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
 	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
 	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_11:
 	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
 	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	r1 |= r4;
 	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
 	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
 	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 |= r9;
 	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
 	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 |= r5;
 	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
 	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
 	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 |= r2;
 	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
 	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
 	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r2;
 	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r1;
 	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
 	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r7;
 	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
 	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
 	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = r6;
 	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
 	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 += r2;
 	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
 	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
 	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
 	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 |= r1;
 	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
 	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
 	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 |= r1;
 	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
 	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r1;
 	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
 	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
 	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r0;
 	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r5;
 	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 |= r4;
 	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
 	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
 	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 |= r5;
 	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
 	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
 	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r0;
 	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r4;
 	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
 	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
 	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
 	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
 	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
 	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r2;
 	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
 	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
 	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
 	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 |= r2;
 	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 |= r1;
 	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
 	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = r6;
 	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
 	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 += r2;
 	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
 	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
 	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
-#line 61 "sample/sockops.c"
+#line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
 	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
-#line 61 "sample/sockops.c"
+#line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
 	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
 	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
 	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
 	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
 	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
 	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
 	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 	r0 = r6;
 	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 	return r0;
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 }
 #line __LINE__ __FILE__
 

--- a/tests/bpf2c_tests/expected/sockops_sys.txt
+++ b/tests/bpf2c_tests/expected/sockops_sys.txt
@@ -198,718 +198,718 @@ static uint16_t connection_monitor_maps[] = {
 
 static uint64_t connection_monitor(void* context)
 {
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	// Prologue
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r0 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r1 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r2 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r3 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r4 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r5 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r6 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r7 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r8 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r9 = 0;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	register uint64_t r10 = 0;
 
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r1 = (uintptr_t)context;
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
 	// EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=2
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r7 = IMMEDIATE(2);
 	// EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 72 "sample/sockops.c"
+#line 65 "sample/sockops.c"
 	r4 = IMMEDIATE(1);
 	// EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 == IMMEDIATE(0)) goto label_2;
 	// EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 == IMMEDIATE(2)) goto label_1;
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
 	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	goto label_2;
 label_1:
 	// EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_MOV64_IMM pc=11 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/sockops.c"
+#line 70 "sample/sockops.c"
 	r7 = IMMEDIATE(0);
 label_2:
 	// EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=51 imm=2
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	if (r2 != IMMEDIATE(2)) goto label_7;
 	// EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
-#line 94 "sample/sockops.c"
+#line 87 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
 	// EBPF_OP_STXW pc=15 dst=r10 src=r6 offset=-4 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=16 dst=r10 src=r6 offset=-8 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=17 dst=r10 src=r6 offset=-12 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=18 dst=r10 src=r6 offset=-16 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=19 dst=r10 src=r6 offset=-20 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=20 dst=r10 src=r6 offset=-24 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=21 dst=r10 src=r6 offset=-28 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=22 dst=r10 src=r6 offset=-32 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=23 dst=r10 src=r6 offset=-36 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=24 dst=r10 src=r6 offset=-40 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r6;
 	// EBPF_OP_STXW pc=25 dst=r10 src=r6 offset=-44 imm=0
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r6;
 	// EBPF_OP_MOV64_IMM pc=26 dst=r2 src=r0 offset=0 imm=28
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 29 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_3;
 	// EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r5 = IMMEDIATE(28);
 label_3:
 	// EBPF_OP_MOV64_REG pc=30 dst=r3 src=r1 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_REG pc=31 dst=r3 src=r5 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 += r5;
 	// EBPF_OP_LDXW pc=32 dst=r3 src=r3 offset=0 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = *(uint32_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-48 imm=0
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r3;
 	// EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=44
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 31 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_4;
 	// EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = IMMEDIATE(44);
 label_4:
 	// EBPF_OP_MOV64_REG pc=38 dst=r5 src=r1 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r5 = r1;
 	// EBPF_OP_ADD64_REG pc=39 dst=r5 src=r3 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r5 += r3;
 	// EBPF_OP_LDXW pc=40 dst=r3 src=r5 offset=0 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = *(uint32_t *)(uintptr_t)(r5 + OFFSET(0));
 	// EBPF_OP_STXH pc=41 dst=r10 src=r3 offset=-32 imm=0
-#line 32 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r3;
 	// EBPF_OP_JNE_IMM pc=42 dst=r4 src=r0 offset=1 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_5;
 	// EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r0 = IMMEDIATE(24);
 label_5:
 	// EBPF_OP_JNE_IMM pc=44 dst=r4 src=r0 offset=1 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_6;
 	// EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r2 = IMMEDIATE(8);
 label_6:
 	// EBPF_OP_OR64_REG pc=46 dst=r7 src=r4 offset=0 imm=0
-#line 36 "sample/sockops.c"
+#line 29 "sample/sockops.c"
 	r7 |= r4;
 	// EBPF_OP_MOV64_REG pc=47 dst=r3 src=r1 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_REG pc=48 dst=r3 src=r2 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r3 += r2;
 	// EBPF_OP_LDXW pc=49 dst=r2 src=r3 offset=0 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_STXW pc=50 dst=r10 src=r2 offset=-28 imm=0
-#line 33 "sample/sockops.c"
+#line 26 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r2;
 	// EBPF_OP_MOV64_REG pc=51 dst=r2 src=r1 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 = r1;
 	// EBPF_OP_ADD64_REG pc=52 dst=r2 src=r0 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 += r0;
 	// EBPF_OP_LDXW pc=53 dst=r2 src=r2 offset=0 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	r2 = *(uint32_t *)(uintptr_t)(r2 + OFFSET(0));
 	// EBPF_OP_STXH pc=54 dst=r10 src=r2 offset=-12 imm=0
-#line 34 "sample/sockops.c"
+#line 27 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r2;
 	// EBPF_OP_LDXB pc=55 dst=r1 src=r1 offset=48 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(48));
 	// EBPF_OP_STXB pc=56 dst=r10 src=r7 offset=-4 imm=0
-#line 37 "sample/sockops.c"
+#line 30 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r7;
 	// EBPF_OP_STXW pc=57 dst=r10 src=r1 offset=-8 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=58 dst=r2 src=r10 offset=0 imm=0
-#line 35 "sample/sockops.c"
+#line 28 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=59 dst=r2 src=r0 offset=0 imm=-48
-#line 36 "sample/sockops.c"
+#line 29 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
 	// EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=1
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
 	// EBPF_OP_STXDW pc=65 dst=r10 src=r7 offset=-56 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r7;
 	// EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=0
-#line 39 "sample/sockops.c"
+#line 32 "sample/sockops.c"
 	r2 = IMMEDIATE(0);
 	// EBPF_OP_STXDW pc=67 dst=r10 src=r2 offset=-8 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=68 dst=r10 src=r2 offset=-16 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=69 dst=r10 src=r2 offset=-24 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
 	// EBPF_OP_STXDW pc=70 dst=r10 src=r2 offset=-32 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
 	// EBPF_OP_MOV64_REG pc=71 dst=r3 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r3 = r1;
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
 	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
 	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r1 += IMMEDIATE(8);
 	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r0 = r1;
 	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
-#line 53 "sample/sockops.c"
+#line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
 	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
 	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
 	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
 	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
 	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
 	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 |= r5;
 	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
 	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
 	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
 	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
 	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
 	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r9 |= r5;
 	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
 	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
 	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_9;
 	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r3 = r1;
 label_9:
 	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
 	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r2 |= r1;
 	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
 	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r6 |= r1;
 	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r9 <<= IMMEDIATE(16);
 	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r8 <<= IMMEDIATE(16);
 	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
 	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
 	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r7 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
 	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
 	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
 	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
 	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
 label_10:
 	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
 	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r9 |= r6;
 	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r8 |= r2;
 	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
 	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r5 |= r1;
 	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
 	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r7 |= r1;
 	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
 	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
 	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_11:
 	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
 	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	r1 |= r4;
 	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
 	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
 	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r8 |= r9;
 	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
 	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r7 |= r5;
 	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
 	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
 	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r1 |= r2;
 	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
 	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
 	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r2;
 	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r1;
 	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
 	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r4 |= r7;
 	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
 	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
-#line 54 "sample/sockops.c"
+#line 47 "sample/sockops.c"
 	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
 	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = r6;
 	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
 	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 += r2;
 	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
-#line 55 "sample/sockops.c"
+#line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
 	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
 	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
 	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 |= r1;
 	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
 	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
 	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 |= r1;
 	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
 	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
 	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r1;
 	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
 	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
 	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r0;
 	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r5;
 	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 |= r4;
 	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
 	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
 	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r4 |= r5;
 	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
 	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
 	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r0;
 	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r5 |= r4;
 	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
 	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
 	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
 	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
 	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
 	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
 	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r1 |= r2;
 	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
 	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
 	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
 	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 |= r2;
 	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
 	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	r3 |= r1;
 	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
-#line 57 "sample/sockops.c"
+#line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
 	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = r6;
 	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
 	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 += r2;
 	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
 	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
-#line 58 "sample/sockops.c"
+#line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
 	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
 	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
-#line 61 "sample/sockops.c"
+#line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
 	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
-#line 61 "sample/sockops.c"
+#line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
 	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
-#line 59 "sample/sockops.c"
+#line 52 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
-#line 60 "sample/sockops.c"
+#line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
 	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
 	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
 	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r2 = r10;
 	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
 	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
 	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
 	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
 	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
 	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
-#line 63 "sample/sockops.c"
+#line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
 	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 	r0 = r6;
 	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 	return r0;
-#line 96 "sample/sockops.c"
+#line 89 "sample/sockops.c"
 }
 #line __LINE__ __FILE__
 

--- a/tests/libs/common/common_tests.h
+++ b/tests/libs/common/common_tests.h
@@ -20,6 +20,20 @@ ebpf_test_pinned_map_enum();
 void
 verify_utility_helper_results(_In_ const bpf_object* object);
 
+typedef struct _ring_buffer_test_event_context
+{
+    _ring_buffer_test_event_context();
+    ~_ring_buffer_test_event_context();
+    void
+    unsubscribe();
+    std::promise<void> ring_buffer_event_promise;
+    struct ring_buffer* ring_buffer;
+    std::vector<std::vector<char>>* records;
+    bool canceled;
+    int matched_entry_count;
+    int test_event_count;
+} ring_buffer_test_event_context_t;
+
 int
 ring_buffer_test_event_handler(_In_ void* ctx, _In_opt_ void* data, size_t size);
 

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -55,6 +55,8 @@ typedef class _sender_socket : public _base_socket
     send_message_to_remote_host(_In_z_ const char* message, sockaddr_storage& remote_address, uint16_t remote_port) = 0;
     virtual void
     cancel_send_message() = 0;
+    void
+    close();
 } sender_socket_t;
 
 /**
@@ -104,6 +106,8 @@ typedef class _receiver_socket : public _base_socket
     post_async_receive() = 0;
     virtual void
     get_sender_address(_Out_ PSOCKADDR& from, _Out_ int& from_length) = 0;
+    virtual void
+    close() = 0;
 
   protected:
     WSAOVERLAPPED overlapped;
@@ -124,6 +128,8 @@ typedef class _datagram_receiver_socket : public _receiver_socket
     post_async_receive();
     void
     get_sender_address(_Out_ PSOCKADDR& from, _Out_ int& from_length);
+    void
+    close();
 
   private:
     sockaddr_storage sender_address;
@@ -142,6 +148,8 @@ typedef class _stream_receiver_socket : public _receiver_socket
     post_async_receive();
     void
     get_sender_address(_Out_ PSOCKADDR& from, _Out_ int& from_length);
+    void
+    close();
 
   private:
     LPFN_ACCEPTEX acceptex;

--- a/tests/sample/sockops.c
+++ b/tests/sample/sockops.c
@@ -15,13 +15,6 @@ struct bpf_map_def connection_map = {
 SEC("maps")
 struct bpf_map_def audit_map = {.type = BPF_MAP_TYPE_RINGBUF, .max_entries = 256 * 1024};
 
-typedef struct _audit_entry
-{
-    connection_tuple_t tuple;
-    bool outbound : 1;
-    bool connected : 1;
-} audit_entry_t;
-
 int
 handle_v4(bpf_sock_ops_t* ctx, bool outbound, bool connected)
 {

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -87,7 +87,7 @@ connection_test(
     if (address_family == AF_INET)
         IN6ADDR_SETV4MAPPED((PSOCKADDR_IN6)&destination_address, &in4addr_loopback, scopeid_unspecified, 0);
     else
-        INETADDR_SETSOCKADDR(AF_INET6, (PSOCKADDR)&destination_address, &in6addr_loopback, scopeid_unspecified, 0);
+        IN6ADDR_SETLOOPBACK((PSOCKADDR_IN6)&destination_address);
     sender_socket.send_message_to_remote_host(message, destination_address, SOCKET_TEST_PORT);
 
     // The packet should be blocked by the connect program.
@@ -287,7 +287,7 @@ connection_monitor_test(
     if (address_family == AF_INET)
         IN6ADDR_SETV4MAPPED((PSOCKADDR_IN6)&destination_address, &in4addr_loopback, scopeid_unspecified, 0);
     else
-        INETADDR_SETSOCKADDR(AF_INET6, (PSOCKADDR)&destination_address, &in6addr_loopback, scopeid_unspecified, 0);
+        IN6ADDR_SETLOOPBACK((PSOCKADDR_IN6)&destination_address);
     sender_socket.send_message_to_remote_host(message, destination_address, SOCKET_TEST_PORT);
     // Receive the packet on test port.
     receiver_socket.complete_async_receive();

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -5,12 +5,17 @@
 
 #define CATCH_CONFIG_RUNNER
 
+#include <chrono>
+#include <future>
+using namespace std::chrono_literals;
+
 #include "bpf/bpf.h"
 #pragma warning(push)
 #pragma warning(disable : 4200)
 #include "bpf/libbpf.h"
 #pragma warning(pop)
 #include "catch_wrapper.hpp"
+#include "common_tests.h"
 #include "ebpf_nethooks.h"
 #include "ebpf_structs.h"
 #include "socket_helper.h"
@@ -119,14 +124,14 @@ connection_test(
     bpf_object__close(object);
 }
 
-TEST_CASE("connection_test_udp_v4", "[socket_tests]")
+TEST_CASE("connection_test_udp_v4", "[sock_addr_tests]")
 {
     datagram_sender_socket_t datagram_sender_socket(SOCK_DGRAM, IPPROTO_UDP, 0);
     datagram_receiver_socket_t datagram_receiver_socket(SOCK_DGRAM, IPPROTO_UDP, SOCKET_TEST_PORT);
 
     connection_test(AF_INET, datagram_sender_socket, datagram_receiver_socket, IPPROTO_UDP);
 }
-TEST_CASE("connection_test_udp_v6", "[socket_tests]")
+TEST_CASE("connection_test_udp_v6", "[sock_addr_tests]")
 {
     datagram_sender_socket_t datagram_sender_socket(SOCK_DGRAM, IPPROTO_UDP, 0);
     datagram_receiver_socket_t datagram_receiver_socket(SOCK_DGRAM, IPPROTO_UDP, SOCKET_TEST_PORT);
@@ -134,14 +139,14 @@ TEST_CASE("connection_test_udp_v6", "[socket_tests]")
     connection_test(AF_INET6, datagram_sender_socket, datagram_receiver_socket, IPPROTO_UDP);
 }
 
-TEST_CASE("connection_test_tcp_v4", "[socket_tests]")
+TEST_CASE("connection_test_tcp_v4", "[sock_addr_tests]")
 {
     stream_sender_socket_t stream_sender_socket(SOCK_STREAM, IPPROTO_TCP, 0);
     stream_receiver_socket_t stream_receiver_socket(SOCK_STREAM, IPPROTO_TCP, SOCKET_TEST_PORT);
 
     connection_test(AF_INET, stream_sender_socket, stream_receiver_socket, IPPROTO_TCP);
 }
-TEST_CASE("connection_test_tcp_v6", "[socket_tests]")
+TEST_CASE("connection_test_tcp_v6", "[sock_addr_tests]")
 {
     stream_sender_socket_t stream_sender_socket(SOCK_STREAM, IPPROTO_TCP, 0);
     stream_receiver_socket_t stream_receiver_socket(SOCK_STREAM, IPPROTO_TCP, SOCKET_TEST_PORT);
@@ -149,7 +154,7 @@ TEST_CASE("connection_test_tcp_v6", "[socket_tests]")
     connection_test(AF_INET6, stream_sender_socket, stream_receiver_socket, IPPROTO_TCP);
 }
 
-TEST_CASE("attach_programs", "[socket_tests]")
+TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
 {
     struct bpf_object* object;
     int program_fd;
@@ -183,6 +188,202 @@ TEST_CASE("attach_programs", "[socket_tests]")
 
     result = bpf_prog_attach(
         bpf_program__fd(const_cast<const bpf_program*>(recv_accept6_program)), 0, BPF_CGROUP_INET6_RECV_ACCEPT, 0);
+    REQUIRE(result == 0);
+
+    bpf_object__close(object);
+}
+
+void
+connection_monitor_test(
+    ADDRESS_FAMILY address_family,
+    sender_socket_t& sender_socket,
+    receiver_socket_t& receiver_socket,
+    uint32_t protocol,
+    bool disconnect)
+{
+    struct bpf_object* object;
+    int program_fd;
+    int result = bpf_prog_load("sockops.o", BPF_PROG_TYPE_SOCK_OPS, &object, &program_fd);
+    REQUIRE(result == 0);
+    REQUIRE(object != nullptr);
+
+    // Ring buffer event callback context.
+    std::unique_ptr<ring_buffer_test_event_context_t> context = std::make_unique<ring_buffer_test_event_context_t>();
+    context->test_event_count = disconnect ? 4 : 2;
+
+    bpf_program* _program = bpf_object__find_program_by_name(object, "connection_monitor");
+    REQUIRE(_program != nullptr);
+
+    PSOCKADDR local_address = nullptr;
+    int local_address_length = 0;
+    sender_socket.get_local_address(local_address, local_address_length);
+
+    connection_tuple_t tuple{};
+    if (address_family == AF_INET) {
+        tuple.src_ip.ipv4 = htonl(INADDR_LOOPBACK);
+        tuple.dst_ip.ipv4 = htonl(INADDR_LOOPBACK);
+    } else {
+        memcpy(tuple.src_ip.ipv6, &in6addr_loopback, sizeof(tuple.src_ip.ipv6));
+        memcpy(tuple.dst_ip.ipv6, &in6addr_loopback, sizeof(tuple.src_ip.ipv6));
+    }
+    tuple.src_port = INETADDR_PORT(local_address);
+    tuple.dst_port = htons(SOCKET_TEST_PORT);
+    tuple.protocol = protocol;
+
+    std::vector<std::vector<char>> audit_entry_list;
+    audit_entry_t audit_entries[3] = {0};
+
+    // Connect outbound.
+    audit_entries[0].tuple = tuple;
+    audit_entries[0].connected = true;
+    audit_entries[0].outbound = true;
+    char* p = reinterpret_cast<char*>(&audit_entries[0]);
+    audit_entry_list.push_back(std::vector<char>(p, p + sizeof(audit_entry_t)));
+
+    // Connect inbound.
+    audit_entries[1].tuple = tuple;
+    audit_entries[1].connected = true;
+    audit_entries[1].outbound = false;
+    p = reinterpret_cast<char*>(&audit_entries[1]);
+    audit_entry_list.push_back(std::vector<char>(p, p + sizeof(audit_entry_t)));
+
+    // Disconnect.
+    audit_entries[2].tuple = tuple;
+    audit_entries[2].connected = false;
+    audit_entries[2].outbound = false;
+    p = reinterpret_cast<char*>(&audit_entries[2]);
+    audit_entry_list.push_back(std::vector<char>(p, p + sizeof(audit_entry_t)));
+
+    context->records = &audit_entry_list;
+
+    // Get the std::future from the promise field in ring buffer event context, which should be in ready state
+    // once notifications for all events are received.
+    auto ring_buffer_event_callback = context->ring_buffer_event_promise.get_future();
+
+    // Create a new ring buffer manager and subscribe to ring buffer events.
+    bpf_map* ring_buffer_map = bpf_object__find_map_by_name(object, "audit_map");
+    REQUIRE(ring_buffer_map != nullptr);
+    context->ring_buffer =
+        ring_buffer__new(bpf_map__fd(ring_buffer_map), ring_buffer_test_event_handler, context.get(), nullptr);
+    REQUIRE(context->ring_buffer != nullptr);
+
+    bpf_map* connection_map = bpf_object__find_map_by_name(object, "connection_map");
+    REQUIRE(connection_map != nullptr);
+
+    // Update connection map with loopback packet tuple.
+    uint32_t verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
+    REQUIRE(bpf_map_update_elem(bpf_map__fd(connection_map), &tuple, &verdict, EBPF_ANY) == 0);
+
+    // Post an asynchronous receive on the receiver socket.
+    receiver_socket.post_async_receive();
+
+    // Attach the sockops program.
+    result = bpf_prog_attach(bpf_program__fd(const_cast<const bpf_program*>(_program)), 0, BPF_CGROUP_SOCK_OPS, 0);
+    REQUIRE(result == 0);
+
+    // Send loopback message to test port.
+    const char* message = "eBPF for Windows!";
+    sockaddr_storage destination_address{};
+    if (address_family == AF_INET)
+        IN6ADDR_SETV4MAPPED((PSOCKADDR_IN6)&destination_address, &in4addr_loopback, scopeid_unspecified, 0);
+    else
+        INETADDR_SETSOCKADDR(AF_INET6, (PSOCKADDR)&destination_address, &in6addr_loopback, scopeid_unspecified, 0);
+    sender_socket.send_message_to_remote_host(message, destination_address, SOCKET_TEST_PORT);
+    // Receive the packet on test port.
+    receiver_socket.complete_async_receive();
+
+    if (disconnect) {
+        sender_socket.close();
+        receiver_socket.close();
+    }
+
+    // Wait for event handler getting notifications for all connection audit events.
+    REQUIRE(ring_buffer_event_callback.wait_for(1s) == std::future_status::ready);
+
+    // Mark the event context as canceled, such that the event callback stops processing events.
+    context->canceled = true;
+
+    // Release the raw pointer such that the final callback frees the callback context.
+    ring_buffer_test_event_context_t* raw_context = context.release();
+
+    // Unsubscribe.
+    raw_context->unsubscribe();
+
+    bpf_object__close(object);
+}
+
+TEST_CASE("connection_monitor_test_udp_v4", "[sock_ops_tests]")
+{
+    datagram_sender_socket_t datagram_sender_socket(SOCK_DGRAM, IPPROTO_UDP, 0);
+    datagram_receiver_socket_t datagram_receiver_socket(SOCK_DGRAM, IPPROTO_UDP, SOCKET_TEST_PORT);
+
+    connection_monitor_test(AF_INET, datagram_sender_socket, datagram_receiver_socket, IPPROTO_UDP, false);
+}
+TEST_CASE("connection_monitor_test_disconnect_udp_v4", "[sock_ops_tests]")
+{
+    datagram_sender_socket_t datagram_sender_socket(SOCK_DGRAM, IPPROTO_UDP, 0);
+    datagram_receiver_socket_t datagram_receiver_socket(SOCK_DGRAM, IPPROTO_UDP, SOCKET_TEST_PORT);
+
+    connection_monitor_test(AF_INET, datagram_sender_socket, datagram_receiver_socket, IPPROTO_UDP, true);
+}
+
+TEST_CASE("connection_monitor_test_udp_v6", "[sock_ops_tests]")
+{
+    datagram_sender_socket_t datagram_sender_socket(SOCK_DGRAM, IPPROTO_UDP, 0);
+    datagram_receiver_socket_t datagram_receiver_socket(SOCK_DGRAM, IPPROTO_UDP, SOCKET_TEST_PORT);
+
+    connection_monitor_test(AF_INET6, datagram_sender_socket, datagram_receiver_socket, IPPROTO_UDP, false);
+}
+TEST_CASE("connection_monitor_test_disconnect_udp_v6", "[sock_ops_tests]")
+{
+    datagram_sender_socket_t datagram_sender_socket(SOCK_DGRAM, IPPROTO_UDP, 0);
+    datagram_receiver_socket_t datagram_receiver_socket(SOCK_DGRAM, IPPROTO_UDP, SOCKET_TEST_PORT);
+
+    connection_monitor_test(AF_INET6, datagram_sender_socket, datagram_receiver_socket, IPPROTO_UDP, true);
+}
+
+TEST_CASE("connection_monitor_test_tcp_v4", "[sock_ops_tests]")
+{
+    stream_sender_socket_t stream_sender_socket(SOCK_STREAM, IPPROTO_TCP, 0);
+    stream_receiver_socket_t stream_receiver_socket(SOCK_STREAM, IPPROTO_TCP, SOCKET_TEST_PORT);
+
+    connection_monitor_test(AF_INET, stream_sender_socket, stream_receiver_socket, IPPROTO_TCP, false);
+}
+TEST_CASE("connection_monitor_test_disconnect_tcp_v4", "[sock_ops_tests]")
+{
+    stream_sender_socket_t stream_sender_socket(SOCK_STREAM, IPPROTO_TCP, 0);
+    stream_receiver_socket_t stream_receiver_socket(SOCK_STREAM, IPPROTO_TCP, SOCKET_TEST_PORT);
+
+    connection_monitor_test(AF_INET, stream_sender_socket, stream_receiver_socket, IPPROTO_TCP, true);
+}
+
+TEST_CASE("connection_monitor_test_tcp_v6", "[sock_ops_tests]")
+{
+    stream_sender_socket_t stream_sender_socket(SOCK_STREAM, IPPROTO_TCP, 0);
+    stream_receiver_socket_t stream_receiver_socket(SOCK_STREAM, IPPROTO_TCP, SOCKET_TEST_PORT);
+
+    connection_monitor_test(AF_INET6, stream_sender_socket, stream_receiver_socket, IPPROTO_TCP, false);
+}
+TEST_CASE("connection_monitor_test_disconnect_tcp_v6", "[sock_ops_tests]")
+{
+    stream_sender_socket_t stream_sender_socket(SOCK_STREAM, IPPROTO_TCP, 0);
+    stream_receiver_socket_t stream_receiver_socket(SOCK_STREAM, IPPROTO_TCP, SOCKET_TEST_PORT);
+
+    connection_monitor_test(AF_INET6, stream_sender_socket, stream_receiver_socket, IPPROTO_TCP, true);
+}
+
+TEST_CASE("attach_sockops_programs", "[sock_ops_tests]")
+{
+    struct bpf_object* object;
+    int program_fd;
+    int result = bpf_prog_load("sockops.o", BPF_PROG_TYPE_SOCK_OPS, &object, &program_fd);
+    REQUIRE(result == 0);
+    REQUIRE(object != nullptr);
+
+    bpf_program* _program = bpf_object__find_program_by_name(object, "connection_monitor");
+    REQUIRE(_program != nullptr);
+
+    result = bpf_prog_attach(bpf_program__fd(const_cast<const bpf_program*>(_program)), 0, BPF_CGROUP_SOCK_OPS, 0);
     REQUIRE(result == 0);
 
     bpf_object__close(object);

--- a/tests/socket/socket_tests.vcxproj
+++ b/tests/socket/socket_tests.vcxproj
@@ -113,7 +113,7 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\util;$(OutDir);$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\common;$(SolutionDir)tests\libs\util;$(OutDir);$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -125,7 +125,7 @@
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\util;$(OutDir);$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\common;$(SolutionDir)tests\libs\util;$(OutDir);$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/socket/socket_tests_common.h
+++ b/tests/socket/socket_tests_common.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include <stdbool.h>
 #include <stdint.h>
 
 #define SOCKET_TEST_PORT 8989
@@ -24,3 +25,10 @@ typedef struct _connection_tuple
     uint16_t dst_port;
     uint32_t protocol;
 } connection_tuple_t;
+
+typedef struct _audit_entry
+{
+    connection_tuple_t tuple;
+    bool outbound : 1;
+    bool connected : 1;
+} audit_entry_t;


### PR DESCRIPTION
## Description

Fixes #786 

- WFP callout for WFP ALE established. The callout invokes the eBPF program notifying about new inbound/outbound connections. If the eBPF program returns success, the WFP flow is associated with a context.
- Upon flow deletion, eBPF program is notified of connection tearing down.
- Some changes to common code in netebpfext.
- Fixed some race conditions between WFP callbacks and program detach.
- Changes to socket and ring-buffer test libraries.
- Ran generate_expected_bpf2c_output.ps1.
- Some minor CICD WF changes.

## Testing

New test cases added in socket_tests.exe

## Documentation

None.
