### PR TITLE
Add more bpftool tests

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -799,6 +799,8 @@ _ebpf_core_protocol_map_get_next_key(
     retval = ebpf_map_next_key(
         map, next_key_length, previous_key_length == 0 ? NULL : request->previous_key, reply->next_key);
 
+    reply->header.length = reply_length;
+
 Done:
     ebpf_object_release_reference((ebpf_core_object_t*)map);
 

--- a/scripts/deploy-ebpf.ps1
+++ b/scripts/deploy-ebpf.ps1
@@ -49,6 +49,7 @@ $build_directory=".\x64\Debug"
     "ebpf_client.exe",
     "ebpf_client.pdb",
     "EbpfApi.pdb",
+    "ebpfnetsh.pdb",
     "encap_reflect_packet.o",
     "map.o",
     "map_in_map.o",

--- a/tests/bpftool_tests/bpftool_tests.cpp
+++ b/tests/bpftool_tests/bpftool_tests.cpp
@@ -14,6 +14,8 @@
 std::string
 run_command(_In_ PCSTR command_line, _Out_ int* result)
 {
+    printf("Running command: %s\n\n", command_line);
+
     capture_helper_t capture;
     errno_t error = capture.begin_capture();
     if (error != NO_ERROR) {
@@ -21,34 +23,11 @@ run_command(_In_ PCSTR command_line, _Out_ int* result)
         return "Couldn't capture output\n";
     }
 
-    STARTUPINFOA startup_info = {0};
-    startup_info.dwFlags = STARTF_USESTDHANDLES;
-    startup_info.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
-    startup_info.hStdError = GetStdHandle(STD_ERROR_HANDLE);
-    PROCESS_INFORMATION process_info;
-    PSTR writable_command_line = _strdup(command_line);
-    BOOL ok = CreateProcessA(
-        nullptr, writable_command_line, nullptr, nullptr, true, 0, nullptr, nullptr, &startup_info, &process_info);
-    free(writable_command_line);
-    if (!ok) {
-        *result = GetLastError();
-        return "Couldn't start bpftool.exe\n";
-    }
-
-    WaitForSingleObject(process_info.hProcess, INFINITE);
-
-    DWORD exit_code;
-    if (!GetExitCodeProcess(process_info.hProcess, &exit_code)) {
-        exit_code = GetLastError();
-    }
-
-    CloseHandle(process_info.hProcess);
-    CloseHandle(process_info.hThread);
+    *result = system(command_line);
 
     std::string stderr_contents = capture.get_stderr_contents();
     std::string stdout_contents = capture.get_stdout_contents();
 
-    *result = exit_code;
     return stdout_contents + stderr_contents;
 }
 
@@ -75,12 +54,10 @@ TEST_CASE("prog help", "[prog][help]")
         output == "Usage: bpftool prog { show | list } [PROG]\n"
                   "       bpftool prog pin   PROG FILE\n"
                   "       bpftool prog { load | loadall } OBJ  PATH \\\n"
-                  "                         [type TYPE] [dev NAME] \\\n"
-                  "                         [map { idx IDX | name NAME } MAP]\\\n"
+                  "                         [type TYPE] \\\n"
                   "                         [pinmaps MAP_DIR]\n"
                   "       bpftool prog help\n"
                   "\n"
-                  "       MAP := { id MAP_ID | pinned FILE | name MAP_NAME }\n"
                   "       PROG := { id PROG_ID | pinned FILE | name PROG_NAME }\n"
                   "       TYPE := { bind | xdp }\n"
                   "       OPTIONS := { {-j|--json} [{-p|--pretty}] | {-d|--debug} | {-l|--legacy} |\n"
@@ -88,10 +65,7 @@ TEST_CASE("prog help", "[prog][help]")
     REQUIRE(result == 0);
 }
 
-// The !shouldfail tag indicates that this test is known to fail
-// even though the test code is probably correct.  The tag should
-// be removed once the code it tests is fixed.
-TEST_CASE("prog load map_in_map.o", "[!shouldfail][prog][load]")
+TEST_CASE("prog load map_in_map.o", "[prog][load]")
 {
     int result;
     std::string output;
@@ -104,22 +78,32 @@ TEST_CASE("prog load map_in_map.o", "[!shouldfail][prog][load]")
     REQUIRE(output == "");
     REQUIRE(result == 0);
 
-    output = run_command("netsh ebpf sh prog", &result);
-    REQUIRE(
-        output == "    ID  Pins  Links  Mode       Type           Name\n"
-                  "======  ====  =====  =========  =============  ====================\n"
-                  "196609     1      0  JIT        xdp            lookup\n\n");
-    REQUIRE(result == 0);
-
     output = run_command("bpftool prog show", &result);
-    REQUIRE(output == "196609: xdp  name lookup\n\n");
+    REQUIRE(result == 0);
+    std::string id = std::to_string(atoi(output.c_str()));
+    REQUIRE(output == id + ": xdp  name lookup  \n\n");
+
+    output = run_command(("bpftool prog pin id " + id + " pin2").c_str(), &result);
+    REQUIRE(output == "");
     REQUIRE(result == 0);
 
-    // Netsh currently outputs a spurious "Program not found" after the delete.
-    output = run_command("netsh ebpf delete prog 196609", &result);
+    output = run_command("netsh ebpf show pins", &result);
     REQUIRE(
-        output == "Unpinned 196609 from map_in_map\n"
-                  "Program not found\n\n");
+        output == "\n\n     ID     Type  Path\n"
+                  "=======  =======  ==============\n"
+                  " " +
+                      id +
+                      "  Program  map_in_map\n"
+                      " " +
+                      id + "  Program  pin2\n");
+    REQUIRE(result == 0);
+
+    output = run_command(("netsh ebpf delete prog " + id).c_str(), &result);
+    REQUIRE(
+        output == "\nUnpinned " + id +
+                      " from map_in_map\n"
+                      "Unpinned " +
+                      id + " from pin2\n");
     REQUIRE(result == 0);
 
     output = run_command("bpftool prog show", &result);
@@ -127,7 +111,7 @@ TEST_CASE("prog load map_in_map.o", "[!shouldfail][prog][load]")
     REQUIRE(result == 0);
 }
 
-TEST_CASE("map create", "[!shouldfail][map]")
+TEST_CASE("map create", "[map]")
 {
     int status;
     std::string output =
@@ -135,7 +119,12 @@ TEST_CASE("map create", "[!shouldfail][map]")
     REQUIRE(output == "");
     REQUIRE(status == 0);
 
-    output = run_command("bpftool map dump id 65537", &status);
+    output = run_command("bpftool map show", &status);
+    REQUIRE(status == 0);
+    std::string id = std::to_string(atoi(output.c_str()));
+    REQUIRE(output == id + ": array  name Name  flags 0x0\n\tkey 4B  value 4B  max_entries 2\n");
+
+    output = run_command(("bpftool map dump id " + id).c_str(), &status);
     REQUIRE(
         output == "key: 00 00 00 00  value: 00 00 00 00\n"
                   "key: 01 00 00 00  value: 00 00 00 00\n"

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -512,9 +512,14 @@ TEST_CASE("delete pinned program", "[netsh][programs]")
     REQUIRE(result == ERROR_OKAY);
     REQUIRE(output == "");
 
+    // Pin the program to a second path.
+    output = _run_netsh_command(handle_ebpf_set_program, L"196609", L"pinpath=mypinname2", nullptr, &result);
+    REQUIRE(result == ERROR_OKAY);
+    REQUIRE(output == "");
+
     // Verify we can delete a pinned program.
     output = _run_netsh_command(handle_ebpf_delete_program, L"196609", nullptr, nullptr, &result);
-    REQUIRE(output == "Unpinned 196609 from mypinname\n");
+    REQUIRE(output == "Unpinned 196609 from mypinname\nUnpinned 196609 from mypinname2\n");
     REQUIRE(result == NO_ERROR);
     REQUIRE(bpf_object__next(nullptr) == nullptr);
 

--- a/tests/libs/util/netsh_helper.cpp
+++ b/tests/libs/util/netsh_helper.cpp
@@ -130,15 +130,12 @@ run_netsh_command_with_args(_In_ FN_HANDLE_CMD* command, _Out_ int* result, int 
         }
     }
 
-    error = command(nullptr, (LPWSTR*)argv.data(), 0, argc, 0, 0, nullptr);
+    *result = command(nullptr, (LPWSTR*)argv.data(), 0, argc, 0, 0, nullptr);
 
     va_end(args);
 
-    if (error != 0) {
-        *result = error;
-        return capture.get_stderr_contents();
-    }
+    std::string stderr_contents = capture.get_stderr_contents();
+    std::string stdout_contents = capture.get_stdout_contents();
 
-    *result = NO_ERROR;
-    return capture.get_stdout_contents();
+    return stdout_contents + stderr_contents;
 }


### PR DESCRIPTION
## Description

This PR is the next in the series of bpftool test PRs.  It adds more bpftool tests and fixes various issues they uncovered.

* Fix netsh delete program to delete all pinned paths and remove spurious "Program not found" output.
* Remove bpftool help text output that only applies to Linux at the moment
* Make bpftool tests work regardless of the actual program/map id value so the tests can be run multiple times
* Fix bugs in capture_helper that sometimes lost output

## Testing

This PR includes new tests.

## Documentation

No impact.

Resolves: #992 