### PR TITLE
Fix issues in NMR module implementations.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -64,18 +64,6 @@ jobs:
       code_coverage: true
       gather_dumps: true
 
-  # Run the API tests in GitHub.
-  ebpf_client:
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: ebpf_client
-      test_command: ebpf_client.exe -d yes
-      build_job: regular / build
-      build_artifact: Build-x64
-      environment: windows-2019
-      code_coverage: true
-      gather_dumps: true
-
   # Run the fuzzing tests in GitHub.
   fuzzing:
     uses: ./.github/workflows/reusable-test.yml

--- a/libs/platform/kernel/ebpf_extension_kernel.c
+++ b/libs/platform/kernel/ebpf_extension_kernel.c
@@ -152,9 +152,6 @@ _ebpf_extension_client_detach_provider(void* client_binding_context)
 
     _ebpf_extension_client_notify_change(local_client_context, local_client_binding_context);
 
-    ebpf_free(local_client_binding_context);
-    local_client_context->client_binding_context = NULL;
-
     EBPF_RETURN_NTSTATUS(STATUS_SUCCESS);
 }
 
@@ -162,7 +159,13 @@ void
 _ebpf_extension_client_cleanup_binding_context(void* client_binding_context)
 {
     EBPF_LOG_ENTRY();
-    UNREFERENCED_PARAMETER(client_binding_context);
+    ebpf_extension_client_binding_context_t* local_client_binding_context =
+        (ebpf_extension_client_binding_context_t*)client_binding_context;
+    ebpf_extension_client_t* local_client_context = local_client_binding_context->extension_client;
+
+    ebpf_free(local_client_binding_context);
+    local_client_context->client_binding_context = NULL;
+
     EBPF_RETURN_VOID();
 }
 

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -80,7 +80,7 @@ typedef struct _net_ebpf_extension_wfp_filter_context
 {
     volatile long reference_count;                                ///< Reference count.
     const struct _net_ebpf_extension_hook_client* client_context; ///< Pointer to hook NPI client.
-    uint64_t* filter_ids;                                         // Array of WFP filter Ids.
+    uint64_t* filter_ids;                                         ///< Array of WFP filter Ids.
 } net_ebpf_extension_wfp_filter_context_t;
 
 #define REFERENCE_FILTER_CONTEXT(filter_context) \

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -302,7 +302,7 @@ Exit:
  * @retval STATUS_NO_MEMORY Failed to allocate provider binding context.
  * @retval STATUS_INVALID_PARAMETER One or more arguments are incorrect.
  */
-NTSTATUS
+static NTSTATUS
 _net_ebpf_extension_hook_provider_attach_client(
     _In_ HANDLE nmr_binding_handle,
     _In_ void* provider_context,
@@ -381,7 +381,7 @@ Exit:
  * @retval STATUS_SUCCESS The operation succeeded.
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
-NTSTATUS
+static NTSTATUS
 _net_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context)
 {
     NTSTATUS status = STATUS_PENDING;
@@ -413,7 +413,7 @@ Exit:
     return status;
 }
 
-void
+static void
 _net_ebpf_extension_hook_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
 {
     ExFreePool(provider_binding_context);

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -178,7 +178,6 @@ _net_ebpf_extension_detach_client_completion(_In_ PDEVICE_OBJECT device_object, 
     NmrProviderDetachClientComplete(hook_client->nmr_binding_handle);
 
     IoFreeWorkItem(hook_client->detach_work_item);
-    ExFreePool(hook_client);
 }
 
 _Acquires_lock_(hook_client) bool net_ebpf_extension_hook_client_enter_rundown(
@@ -304,7 +303,7 @@ Exit:
  * @retval STATUS_INVALID_PARAMETER One or more arguments are incorrect.
  */
 NTSTATUS
-net_ebpf_extension_hook_provider_attach_client(
+_net_ebpf_extension_hook_provider_attach_client(
     _In_ HANDLE nmr_binding_handle,
     _In_ void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
@@ -383,7 +382,7 @@ Exit:
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
 NTSTATUS
-net_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context)
+_net_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context)
 {
     NTSTATUS status = STATUS_PENDING;
 
@@ -412,6 +411,12 @@ net_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_conte
 
 Exit:
     return status;
+}
+
+void
+_net_ebpf_extension_hook_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
+{
+    ExFreePool(provider_binding_context);
 }
 
 void
@@ -450,8 +455,9 @@ net_ebpf_extension_hook_provider_register(
 
     characteristics = &local_provider_context->characteristics;
     characteristics->Length = sizeof(NPI_PROVIDER_CHARACTERISTICS);
-    characteristics->ProviderAttachClient = net_ebpf_extension_hook_provider_attach_client;
-    characteristics->ProviderDetachClient = net_ebpf_extension_hook_provider_detach_client;
+    characteristics->ProviderAttachClient = _net_ebpf_extension_hook_provider_attach_client;
+    characteristics->ProviderDetachClient = _net_ebpf_extension_hook_provider_detach_client;
+    characteristics->ProviderCleanupBindingContext = _net_ebpf_extension_hook_provider_cleanup_binding_context;
     characteristics->ProviderRegistrationInstance.Size = sizeof(NPI_REGISTRATION_INSTANCE);
     characteristics->ProviderRegistrationInstance.NpiId = &EBPF_HOOK_EXTENSION_IID;
     characteristics->ProviderRegistrationInstance.NpiSpecificCharacteristics = parameters->provider_data;

--- a/netebpfext/net_ebpf_ext_prog_info_provider.c
+++ b/netebpfext/net_ebpf_ext_prog_info_provider.c
@@ -42,7 +42,7 @@ typedef struct _net_ebpf_extension_program_info_provider
  * @retval STATUS_INVALID_PARAMETER One or more arguments are incorrect.
  */
 NTSTATUS
-net_ebpf_extension_program_info_provider_attach_client(
+_net_ebpf_extension_program_info_provider_attach_client(
     _In_ HANDLE nmr_binding_handle,
     _In_ void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
@@ -96,14 +96,19 @@ Exit:
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
 NTSTATUS
-net_ebpf_extension_program_info_provider_detach_client(_Frees_ptr_opt_ void* provider_binding_context)
+_net_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_binding_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
 
-    if (provider_binding_context)
-        ExFreePool(provider_binding_context);
+    UNREFERENCED_PARAMETER(provider_binding_context);
 
     return status;
+}
+
+void
+_net_ebpf_extension_program_info_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
+{
+    ExFreePool(provider_binding_context);
 }
 
 void
@@ -137,8 +142,9 @@ net_ebpf_extension_program_info_provider_register(
 
     characteristics = &local_provider_context->characteristics;
     characteristics->Length = sizeof(NPI_PROVIDER_CHARACTERISTICS);
-    characteristics->ProviderAttachClient = net_ebpf_extension_program_info_provider_attach_client;
-    characteristics->ProviderDetachClient = net_ebpf_extension_program_info_provider_detach_client;
+    characteristics->ProviderAttachClient = _net_ebpf_extension_program_info_provider_attach_client;
+    characteristics->ProviderDetachClient = _net_ebpf_extension_program_info_provider_detach_client;
+    characteristics->ProviderCleanupBindingContext = _net_ebpf_extension_program_info_provider_cleanup_binding_context;
     characteristics->ProviderRegistrationInstance.Size = sizeof(NPI_REGISTRATION_INSTANCE);
     characteristics->ProviderRegistrationInstance.NpiId = &EBPF_PROGRAM_INFO_EXTENSION_IID;
     characteristics->ProviderRegistrationInstance.NpiSpecificCharacteristics = parameters->provider_data;

--- a/netebpfext/net_ebpf_ext_prog_info_provider.c
+++ b/netebpfext/net_ebpf_ext_prog_info_provider.c
@@ -41,7 +41,7 @@ typedef struct _net_ebpf_extension_program_info_provider
  * @retval STATUS_NO_MEMORY Failed to allocate provider binding context.
  * @retval STATUS_INVALID_PARAMETER One or more arguments are incorrect.
  */
-NTSTATUS
+static NTSTATUS
 _net_ebpf_extension_program_info_provider_attach_client(
     _In_ HANDLE nmr_binding_handle,
     _In_ void* provider_context,
@@ -95,7 +95,7 @@ Exit:
  * @retval STATUS_SUCCESS The operation succeeded.
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
-NTSTATUS
+static NTSTATUS
 _net_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_binding_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -105,7 +105,7 @@ _net_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_bind
     return status;
 }
 
-void
+static void
 _net_ebpf_extension_program_info_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
 {
     ExFreePool(provider_binding_context);

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -67,7 +67,7 @@ NPI_MODULEID DECLSPEC_SELECTANY _sample_ebpf_extension_program_info_provider_mod
  * @retval STATUS_NO_MEMORY Failed to allocate provider binding context.
  * @retval STATUS_INVALID_PARAMETER One or more arguments are incorrect.
  */
-NTSTATUS
+static NTSTATUS
 _sample_ebpf_extension_program_info_provider_attach_client(
     _In_ HANDLE nmr_binding_handle,
     _In_ void* provider_context,
@@ -84,7 +84,7 @@ _sample_ebpf_extension_program_info_provider_attach_client(
  * @retval STATUS_SUCCESS The operation succeeded.
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
-NTSTATUS
+static NTSTATUS
 _sample_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_binding_context);
 
 /**
@@ -92,7 +92,7 @@ _sample_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_b
  *
  * @param[in] provider_binding_context Provider module's context for binding with the client.
  */
-void
+static void
 _sample_ebpf_extension_program_info_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context);
 
 // Sample eBPF extension Program Information NPI provider characteristics
@@ -152,7 +152,7 @@ NPI_MODULEID DECLSPEC_SELECTANY _sample_ebpf_extension_hook_provider_moduleid = 
  * @retval STATUS_NO_MEMORY Failed to allocate provider binding context.
  * @retval STATUS_INVALID_PARAMETER One or more arguments are incorrect.
  */
-NTSTATUS
+static NTSTATUS
 _sample_ebpf_extension_hook_provider_attach_client(
     _In_ HANDLE nmr_binding_handle,
     _In_ void* provider_context,
@@ -169,7 +169,7 @@ _sample_ebpf_extension_hook_provider_attach_client(
  * @retval STATUS_SUCCESS The operation succeeded.
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
-NTSTATUS
+static NTSTATUS
 _sample_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context);
 
 /**
@@ -177,7 +177,7 @@ _sample_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_c
  *
  * @param[in] provider_binding_context Provider module's context for binding with the client.
  */
-void
+static void
 _sample_ebpf_extension_hook_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context);
 
 // Sample eBPF extension Hook NPI provider characteristics
@@ -234,7 +234,7 @@ typedef struct _sample_ebpf_extension_hook_provider
 
 static sample_ebpf_extension_hook_provider_t _sample_ebpf_extension_hook_provider_context = {0};
 
-NTSTATUS
+static NTSTATUS
 _sample_ebpf_extension_program_info_provider_attach_client(
     _In_ HANDLE nmr_binding_handle,
     _In_ void* provider_context,
@@ -279,7 +279,7 @@ Exit:
     return status;
 }
 
-NTSTATUS
+static NTSTATUS
 _sample_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_binding_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -289,7 +289,7 @@ _sample_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_b
     return status;
 }
 
-void
+static void
 _sample_ebpf_extension_program_info_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
 {
     ebpf_free(provider_binding_context);
@@ -340,7 +340,7 @@ Exit:
 // Hook Provider.
 //
 
-NTSTATUS
+static NTSTATUS
 _sample_ebpf_extension_hook_provider_attach_client(
     _In_ HANDLE nmr_binding_handle,
     _In_ void* provider_context,
@@ -401,7 +401,7 @@ Exit:
     return status;
 }
 
-NTSTATUS
+static NTSTATUS
 _sample_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -422,7 +422,7 @@ Exit:
     return status;
 }
 
-void
+static void
 _sample_ebpf_extension_hook_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
 {
     ebpf_free(provider_binding_context);

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -87,6 +87,14 @@ _sample_ebpf_extension_program_info_provider_attach_client(
 NTSTATUS
 _sample_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_binding_context);
 
+/**
+ * @brief Callback invoked after the provider module and a client module have detached from one another.
+ *
+ * @param[in] provider_binding_context Provider module's context for binding with the client.
+ */
+void
+_sample_ebpf_extension_program_info_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context);
+
 // Sample eBPF extension Program Information NPI provider characteristics
 
 const NPI_PROVIDER_CHARACTERISTICS _sample_ebpf_extension_program_info_provider_characteristics = {
@@ -94,7 +102,7 @@ const NPI_PROVIDER_CHARACTERISTICS _sample_ebpf_extension_program_info_provider_
     sizeof(NPI_PROVIDER_CHARACTERISTICS),
     _sample_ebpf_extension_program_info_provider_attach_client,
     _sample_ebpf_extension_program_info_provider_detach_client,
-    NULL,
+    _sample_ebpf_extension_program_info_provider_cleanup_binding_context,
     {0,
      sizeof(NPI_REGISTRATION_INSTANCE),
      &EBPF_PROGRAM_INFO_EXTENSION_IID,
@@ -157,12 +165,20 @@ _sample_ebpf_extension_hook_provider_attach_client(
 /**
  * @brief Callback invoked when a Hook NPI client detaches.
  *
- * @param[in] client_binding_context Provider module's context for binding with the client.
+ * @param[in] provider_binding_context Provider module's context for binding with the client.
  * @retval STATUS_SUCCESS The operation succeeded.
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
 NTSTATUS
 _sample_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context);
+
+/**
+ * @brief Callback invoked after the provider module and a client module have detached from one another.
+ *
+ * @param[in] provider_binding_context Provider module's context for binding with the client.
+ */
+void
+_sample_ebpf_extension_hook_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context);
 
 // Sample eBPF extension Hook NPI provider characteristics
 ebpf_attach_provider_data_t _sample_ebpf_extension_attach_provider_data;
@@ -177,7 +193,7 @@ const NPI_PROVIDER_CHARACTERISTICS _sample_ebpf_extension_hook_provider_characte
     sizeof(NPI_PROVIDER_CHARACTERISTICS),
     _sample_ebpf_extension_hook_provider_attach_client,
     _sample_ebpf_extension_hook_provider_detach_client,
-    NULL,
+    _sample_ebpf_extension_hook_provider_cleanup_binding_context,
     {0,
      sizeof(NPI_REGISTRATION_INSTANCE),
      &EBPF_HOOK_EXTENSION_IID,
@@ -268,9 +284,15 @@ _sample_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_b
 {
     NTSTATUS status = STATUS_SUCCESS;
 
-    ebpf_free(provider_binding_context);
+    UNREFERENCED_PARAMETER(provider_binding_context);
 
     return status;
+}
+
+void
+_sample_ebpf_extension_program_info_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
+{
+    ebpf_free(provider_binding_context);
 }
 
 void
@@ -396,10 +418,14 @@ _sample_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_c
     provider_context = &_sample_ebpf_extension_hook_provider_context;
     provider_context->attached_client = NULL;
 
-    ebpf_free(local_client_context);
-
 Exit:
     return status;
+}
+
+void
+_sample_ebpf_extension_hook_provider_cleanup_binding_context(_Frees_ptr_ void* provider_binding_context)
+{
+    ebpf_free(provider_binding_context);
 }
 
 void


### PR DESCRIPTION
## Description

This fixes #990.

To fix this issue the EC NPI client module frees its binding context in CleanupBindingContext callback.
Similar fixes were applied in netebpfext and sample_ebpf_ext provider modules.

In addition to the above issue which caused a crash, there was another issue in the sock_ops hook.
Unloading a sock_ops program invokes detach_client handler of sock_ops hook removes WFP contexts from flows, which causes synch invocation of flowDeleteFn - which in turn tries to invoke the eBPF program to notify about connection deletion. This is wrong as the connection could be still active.

Other than this typos were fixed and redundant ebpf_client was removed from github runner.

## Testing

Existing test caught the bug.

## Documentation

N/A.
