### PR TITLE
Set /Qspectre option on generated drivers

### DIFF
--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -188,6 +188,17 @@
       <Project>{7d5b4e68-c0fa-3f86-9405-f6400219b440}</Project>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="templates\kernel_mode_bpf2c.vcxproj">
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="templates\sources.def">
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+    <None Include="templates\user_mode_bpf2c.vcxproj">
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+    </None>
+  </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/tools/bpf2c/bpf2c.vcxproj.filters
+++ b/tools/bpf2c/bpf2c.vcxproj.filters
@@ -45,4 +45,11 @@
       <Filter>Source Files</Filter>
     </CustomBuild>
   </ItemGroup>
+  <ItemGroup>
+    <None Include="templates\kernel_mode_bpf2c.vcxproj" />
+    <None Include="templates\sources.def">
+      <Filter>Source Files</Filter>
+    </None>
+    <None Include="templates\user_mode_bpf2c.vcxproj" />
+  </ItemGroup>
 </Project>

--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -56,6 +56,7 @@
     <PlatformToolset>WindowsKernelModeDriver10.0</PlatformToolset>
     <ConfigurationType>Driver</ConfigurationType>
     <DriverType>WDM</DriverType>
+    <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Drivers generated by Convert-BpfToNative should have the correct spectre mitigation flags set.

## Testing

CI/CD

## Documentation

No.
