### PR TITLE
Set CMAKE_SYSTEM_VERSION and CMAKE_CXX_STANDARD

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -41,6 +41,13 @@ jobs:
       build_artifact: Build-x64
       generate_release_package: true
 
+  cmake:
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
+    uses: ./.github/workflows/reusable-cmake-build.yml
+    with:
+      build_artifact: Build-x64-cmake
+
   # Run the unit tests in GitHub.
   unit_tests:
     # Always run this job.
@@ -109,7 +116,7 @@ jobs:
   # ---------------------------------------------------------------------------
   # Build with C++ static analyzer.
   analyze:
-    # Skip for push request.
+    # Only run on schedule and pull request.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-build.yml
     with:
@@ -118,7 +125,7 @@ jobs:
 
   # Build with C++ address sanitizer.
   sanitize:
-    # Skip for push request.
+    # Only run on schedule and pull request.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-build.yml
     with:
@@ -172,15 +179,8 @@ jobs:
 
   # Additional jobs to on a schedule only (skip push and pull request).
   # ---------------------------------------------------------------------------
-  cmake:
-    # For now, only run during daily scheduled run. Fixed in PR #1027.
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-cmake-build.yml
-    with:
-      build_artifact: Build-x64
-
   codeql:
-    # Only run daily.
+    # Only run during daily scheduled run
     if: github.event_name == 'schedule'
     uses: ./.github/workflows/reusable-build.yml
     with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 cmake_minimum_required(VERSION 3.20)
+# It is necessary to set this before the first project directive.
+# Use the CMAKE_SYSTEM_VERSION directive to select the SDK version.
+# The docs/GettingStarted.md guide points developers to the 2004 version of the
+# SDK which corresponds to 19041.
+set(CMAKE_SYSTEM_VERSION 10.0.19041.0)
+
 project("ebpf-for-windows")
 
 include("cmake/options.cmake")

--- a/cmake/settings.cmake
+++ b/cmake/settings.cmake
@@ -50,6 +50,4 @@ target_link_libraries("ebpf_for_windows_cpp_settings" INTERFACE
   "ebpf_for_windows_common_settings"
 )
 
-target_compile_features("ebpf_for_windows_cpp_settings" INTERFACE
-  cxx_std_17
-)
+set(CMAKE_CXX_STANDARD 20)


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Set CMAKE settings to target Windows SDK 10.0.19041.0.

## Testing

CI/CD

## Documentation

No.
