### PR TITLE
Add more libbpf api tests

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -435,7 +435,7 @@ extern "C"
      * @sa bpf_link_detach
      */
     ebpf_result_t
-    ebpf_link_close(_In_ struct bpf_link* link);
+    ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link);
 
     /**
      * @brief Close a file descriptor. Also close the underlying handle.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1161,7 +1161,7 @@ ebpf_link_detach(_In_ struct bpf_link* link)
 }
 
 ebpf_result_t
-ebpf_link_close(_In_ struct bpf_link* link)
+ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link)
 {
     if (link == nullptr) {
         return EBPF_INVALID_ARGUMENT;

--- a/libs/api/libbpf_link.cpp
+++ b/libs/api/libbpf_link.cpp
@@ -33,7 +33,7 @@ bpf_link__unpin(struct bpf_link* link)
     ebpf_result_t result;
 
     if (!link->pin_path)
-        return libbpf_err(-EINVAL);
+        return libbpf_err(-ENOENT);
 
     result = ebpf_object_unpin(link->pin_path);
     if (result != EBPF_SUCCESS) {

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -239,9 +239,7 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
     bpf_link* link = nullptr;
     ebpf_result_t result = EBPF_SUCCESS;
 
-    UNREFERENCED_PARAMETER(flags);
-
-    if (_does_attach_type_support_attachable_fd(type)) {
+    if (_does_attach_type_support_attachable_fd(type) && (flags == 0)) {
         result = ebpf_program_attach_by_fd(
             prog_fd, _get_ebpf_attach_type(type), &attachable_fd, sizeof(attachable_fd), &link);
     } else {
@@ -249,9 +247,8 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
     }
 
     if (result != EBPF_SUCCESS)
-        errno = ebpf_result_to_errno(result);
-
-    return (result == EBPF_SUCCESS) ? 0 : -1;
+        return libbpf_result_err(result);
+    return 0;
 }
 
 struct bpf_program*

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -527,6 +527,10 @@ _test_helper_libbpf::_test_helper_libbpf()
 
     bind_program_info = new program_info_provider_t(EBPF_PROGRAM_TYPE_BIND);
     bind_hook = new single_instance_hook_t(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+
+    cgroup_sock_addr_program_info = new program_info_provider_t(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR);
+    cgroup_inet4_connect_hook =
+        new single_instance_hook_t(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR, EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT);
 }
 
 _test_helper_libbpf::~_test_helper_libbpf()
@@ -536,4 +540,7 @@ _test_helper_libbpf::~_test_helper_libbpf()
 
     delete bind_hook;
     delete bind_program_info;
+
+    delete cgroup_inet4_connect_hook;
+    delete cgroup_sock_addr_program_info;
 }

--- a/tests/end_to_end/test_helper.hpp
+++ b/tests/end_to_end/test_helper.hpp
@@ -28,4 +28,6 @@ class _test_helper_libbpf
     _single_instance_hook* xdp_hook;
     _program_info_provider* bind_program_info;
     _single_instance_hook* bind_hook;
+    _program_info_provider* cgroup_sock_addr_program_info;
+    _single_instance_hook* cgroup_inet4_connect_hook;
 };


### PR DESCRIPTION
Addresses most of #1021

Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

Add tests for:
* bpf_link__pin
* bpf_link__unpin
* libbpf_num_possible_cpus
* bpf_prog_attach
* bpf_program__unload

## Testing

This PR adds tests.

## Documentation

No impact.
