### PR TITLE
Resolve BA2004 - Missing /Qspectre flag

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -85,11 +85,15 @@ jobs:
 
     - name: Create verifier project
       working-directory: ${{env.GITHUB_WORKSPACE}}
+      env:
+        CXXFLAGS: /Qspectre /ZH:SHA_256 /W4 /WX
       run: |
         cmake -G "Visual Studio 16 2019" -S external\ebpf-verifier -B external\ebpf-verifier\build
 
     - name: Create catch2 project
       working-directory: ${{env.GITHUB_WORKSPACE}}
+      env:
+        CXXFLAGS: /Qspectre /ZH:SHA_256 /W4 /WX
       run: |
         cmake -G "Visual Studio 16 2019" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Set /W4 and /Qspectre on catch2 and ebpf-verifier projects.

## Testing

CI/CD

## Documentation

No.
