### PR TITLE
Add SHA256 hash of ELF file when generating native binary

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,7 +69,10 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+      pre_test: |
+        powershell choco install -y llvm --version 11.0.1 --allow-downgrade
+        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+
       test_command: bpf2c_tests.exe -d yes
       name: bpf2c
       build_job: regular / build

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,10 +69,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: |
-        powershell choco install -y llvm --version 11.0.1 --allow-downgrade
-        call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
-
+      pre_test: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       test_command: bpf2c_tests.exe -d yes
       name: bpf2c
       build_job: regular / build

--- a/.github/workflows/reusable-cmake-build.yml
+++ b/.github/workflows/reusable-cmake-build.yml
@@ -49,16 +49,12 @@ jobs:
     - name: Configure the project
       working-directory: ${{env.GITHUB_WORKSPACE}}
       shell: cmd
-      env:
-        CXXFLAGS: /Qspectre /ZH:SHA_256 /W4 /WX /D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
       run: |
         cmake -S . -B build -G "${{env.CMAKE_GENERATOR}}" -A ${{env.BUILD_PLATFORM}} -T ${{env.PLATFORM_TOOLSET}}
 
     - name: Build the project
       working-directory: ${{env.GITHUB_WORKSPACE}}
       shell: cmd
-      env:
-        CXXFLAGS: /Qspectre /ZH:SHA_256 /W4 /WX /D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
       run: |
         cmake --build build --config ${{env.BUILD_CONFIGURATION }}
 

--- a/.github/workflows/reusable-cmake-build.yml
+++ b/.github/workflows/reusable-cmake-build.yml
@@ -49,12 +49,16 @@ jobs:
     - name: Configure the project
       working-directory: ${{env.GITHUB_WORKSPACE}}
       shell: cmd
+      env:
+        CXXFLAGS: /Qspectre /ZH:SHA_256 /W4 /WX /D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
       run: |
         cmake -S . -B build -G "${{env.CMAKE_GENERATOR}}" -A ${{env.BUILD_PLATFORM}} -T ${{env.PLATFORM_TOOLSET}}
 
     - name: Build the project
       working-directory: ${{env.GITHUB_WORKSPACE}}
       shell: cmd
+      env:
+        CXXFLAGS: /Qspectre /ZH:SHA_256 /W4 /WX /D_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
       run: |
         cmake --build build --config ${{env.BUILD_CONFIGURATION }}
 

--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -78,6 +78,7 @@ extern "C"
     {
         void (*programs)(program_entry_t** programs, size_t* count);
         void (*maps)(map_entry_t** maps, size_t* count);
+        void (*hash)(uint8_t** hash, size_t* size);
     } metadata_table_t;
 
     inline uint16_t

--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -76,9 +76,9 @@ extern "C"
 
     typedef struct _metadata_table
     {
-        void (*programs)(program_entry_t** programs, size_t* count);
-        void (*maps)(map_entry_t** maps, size_t* count);
-        void (*hash)(uint8_t** hash, size_t* size);
+        void (*programs)(_Outptr_result_buffer_maybenull_(*count) program_entry_t** programs, _Out_ size_t* count);
+        void (*maps)(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count);
+        void (*hash)(_Outptr_result_buffer_maybenull_(*size) uint8_t** hash, _Out_ size_t* size);
     } metadata_table_t;
 
     inline uint16_t

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include "pch.h"
 
 #include <codecvt>

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include "pch.h"
 
 #include <codecvt>

--- a/libs/ebpfnetsh/utilities.cpp
+++ b/libs/ebpfnetsh/utilities.cpp
@@ -3,6 +3,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include <codecvt>
 #include <ws2def.h>
 #include <ws2ipdef.h>

--- a/libs/ebpfnetsh/utilities.cpp
+++ b/libs/ebpfnetsh/utilities.cpp
@@ -3,7 +3,6 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
-#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include <codecvt>
 #include <ws2def.h>
 #include <ws2ipdef.h>

--- a/scripts/generate_expected_bpf2c_output.ps1
+++ b/scripts/generate_expected_bpf2c_output.ps1
@@ -79,15 +79,15 @@ function Update-ExpectedOutput
         $ExpectedDllFileWithPath = $ExpectedOutputPath + "\" + $FileName + "_dll.txt"
         $ExpectedRawFileWithPath = $ExpectedOutputPath + "\" + $FileName + "_raw.txt"
 
-        $SysCommand = $Bpf2cCommand + " --bpf " + $ObjectFileWithPath + " --sys"
+        $SysCommand = $Bpf2cCommand + " --bpf " + $ObjectFileWithPath + " --sys" + " --hash none"
         $Output = Invoke-Expression $SysCommand
         TrimAndExport-Output -InputBuffer $Output -OutputFile $ExpectedSysFileWithPath
 
-        $DllCommand = $Bpf2cCommand + " --bpf " + $ObjectFileWithPath + " --dll"
+        $DllCommand = $Bpf2cCommand + " --bpf " + $ObjectFileWithPath + " --dll" + " --hash none"
         $Output = Invoke-Expression $DllCommand
         TrimAndExport-Output -InputBuffer $Output -OutputFile $ExpectedDllFileWithPath
 
-        $RawCommand = $Bpf2cCommand + " --bpf " + $ObjectFileWithPath
+        $RawCommand = $Bpf2cCommand + " --bpf " + $ObjectFileWithPath + " --hash none"
         $Output = Invoke-Expression $RawCommand
         TrimAndExport-Output -InputBuffer $Output -OutputFile $ExpectedRawFileWithPath
     }

--- a/tests/bpf2c_tests/bpf2c_tests.vcxproj
+++ b/tests/bpf2c_tests/bpf2c_tests.vcxproj
@@ -110,7 +110,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -124,7 +124,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;BPF2C_VERBOSE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;BPF2C_VERBOSE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/tests/bpf2c_tests/bpf2c_tests.vcxproj
+++ b/tests/bpf2c_tests/bpf2c_tests.vcxproj
@@ -110,7 +110,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -124,7 +124,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;BPF2C_VERBOSE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;BPF2C_VERBOSE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/tests/bpf2c_tests/elf_bpf.cpp
+++ b/tests/bpf2c_tests/elf_bpf.cpp
@@ -75,6 +75,8 @@ run_test_elf(const std::string& elf_file, bool verify, bool expect_failure = fal
     }
     argv.push_back("--bpf");
     argv.push_back(elf_file.c_str());
+    argv.push_back("--hash");
+    argv.push_back("none");
 
     auto test = [&](const char* option, const char* suffix) {
         if (option) {

--- a/tests/bpf2c_tests/elf_bpf.cpp
+++ b/tests/bpf2c_tests/elf_bpf.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+
 #define CATCH_CONFIG_MAIN
 
 #include <string>

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 8, 68, 1024, 0, 0, 0, 0,  }, "process_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "limits_map" },
@@ -268,10 +273,10 @@ label_1:
 #line 59 "sample/bindmonitor.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor.c"
+#line 62 "sample/bindmonitor.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 59 "sample/bindmonitor.c"
+#line 62 "sample/bindmonitor.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
@@ -417,4 +422,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.txt
@@ -273,10 +273,10 @@ label_1:
 #line 59 "sample/bindmonitor.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor.c"
+#line 59 "sample/bindmonitor.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 62 "sample/bindmonitor.c"
+#line 59 "sample/bindmonitor.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.txt
@@ -231,10 +231,10 @@ label_1:
 #line 59 "sample/bindmonitor.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor.c"
+#line 59 "sample/bindmonitor.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 62 "sample/bindmonitor.c"
+#line 59 "sample/bindmonitor.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 8, 68, 1024, 0, 0, 0, 0,  }, "process_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "limits_map" },
@@ -226,10 +231,10 @@ label_1:
 #line 59 "sample/bindmonitor.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor.c"
+#line 62 "sample/bindmonitor.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 59 "sample/bindmonitor.c"
+#line 62 "sample/bindmonitor.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
@@ -375,4 +380,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 13, 0, 0, 262144, 0, 0, 0, 0,  }, "process_map" },
 };
@@ -147,4 +152,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_ringbuf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 13, 0, 0, 262144, 0, 0, 0, 0,  }, "process_map" },
 };
@@ -105,4 +110,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_ringbuf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 13, 0, 0, 262144, 0, 0, 0, 0,  }, "process_map" },
 };
@@ -272,4 +277,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_ringbuf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.txt
@@ -398,10 +398,10 @@ label_1:
 #line 59 "sample/bindmonitor.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor.c"
+#line 59 "sample/bindmonitor.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 62 "sample/bindmonitor.c"
+#line 59 "sample/bindmonitor.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 8, 68, 1024, 0, 0, 0, 0,  }, "process_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "limits_map" },
@@ -393,10 +398,10 @@ label_1:
 #line 59 "sample/bindmonitor.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor.c"
+#line 62 "sample/bindmonitor.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 59 "sample/bindmonitor.c"
+#line 62 "sample/bindmonitor.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
@@ -542,4 +547,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 8, 68, 1024, 0, 0, 0, 0,  }, "process_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "limits_map" },
@@ -463,10 +468,10 @@ label_1:
 #line 95 "sample/bindmonitor_tailcall.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 95 "sample/bindmonitor_tailcall.c"
+#line 98 "sample/bindmonitor_tailcall.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 95 "sample/bindmonitor_tailcall.c"
+#line 98 "sample/bindmonitor_tailcall.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
@@ -614,4 +619,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_tailcall_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_tailcall_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.txt
@@ -468,10 +468,10 @@ label_1:
 #line 95 "sample/bindmonitor_tailcall.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 98 "sample/bindmonitor_tailcall.c"
+#line 95 "sample/bindmonitor_tailcall.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 98 "sample/bindmonitor_tailcall.c"
+#line 95 "sample/bindmonitor_tailcall.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.txt
@@ -426,10 +426,10 @@ label_1:
 #line 95 "sample/bindmonitor_tailcall.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 98 "sample/bindmonitor_tailcall.c"
+#line 95 "sample/bindmonitor_tailcall.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 98 "sample/bindmonitor_tailcall.c"
+#line 95 "sample/bindmonitor_tailcall.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 8, 68, 1024, 0, 0, 0, 0,  }, "process_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "limits_map" },
@@ -421,10 +426,10 @@ label_1:
 #line 95 "sample/bindmonitor_tailcall.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 95 "sample/bindmonitor_tailcall.c"
+#line 98 "sample/bindmonitor_tailcall.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 95 "sample/bindmonitor_tailcall.c"
+#line 98 "sample/bindmonitor_tailcall.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
@@ -572,4 +577,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_tailcall_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_tailcall_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.txt
@@ -593,10 +593,10 @@ label_1:
 #line 95 "sample/bindmonitor_tailcall.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 98 "sample/bindmonitor_tailcall.c"
+#line 95 "sample/bindmonitor_tailcall.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 98 "sample/bindmonitor_tailcall.c"
+#line 95 "sample/bindmonitor_tailcall.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.txt
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 8, 68, 1024, 0, 0, 0, 0,  }, "process_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "limits_map" },
@@ -588,10 +593,10 @@ label_1:
 #line 95 "sample/bindmonitor_tailcall.c"
 	if (r0 == IMMEDIATE(0)) goto label_8;
 	// EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 95 "sample/bindmonitor_tailcall.c"
+#line 98 "sample/bindmonitor_tailcall.c"
 	r1 = r0;
 	// EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 95 "sample/bindmonitor_tailcall.c"
+#line 98 "sample/bindmonitor_tailcall.c"
 	r1 += IMMEDIATE(4);
 label_2:
 	// EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
@@ -739,4 +744,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bindmonitor_tailcall_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bindmonitor_tailcall_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bpf_call_dll.txt
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 2, 4, 512, 0, 0, 0, 0,  }, "map" },
 };
@@ -149,4 +154,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bpf_call_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bpf_call_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bpf_call_raw.txt
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 2, 4, 512, 0, 0, 0, 0,  }, "map" },
 };
@@ -107,4 +112,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bpf_call_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bpf_call_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bpf_call_sys.txt
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 2, 4, 512, 0, 0, 0, 0,  }, "map" },
 };
@@ -274,4 +279,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bpf_call_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bpf_call_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bpf_dll.txt
+++ b/tests/bpf2c_tests/expected/bpf_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -95,4 +100,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bpf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bpf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bpf_raw.txt
+++ b/tests/bpf2c_tests/expected/bpf_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -53,4 +58,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bpf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bpf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/bpf_sys.txt
+++ b/tests/bpf2c_tests/expected/bpf_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -220,4 +225,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t bpf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t bpf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.txt
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "ingress_connection_policy_map" },
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "egress_connection_policy_map" },
@@ -649,4 +654,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t cgroup_sock_addr_metadata_table = { _get_programs, _get_maps };
+metadata_table_t cgroup_sock_addr_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.txt
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "ingress_connection_policy_map" },
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "egress_connection_policy_map" },
@@ -607,4 +612,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t cgroup_sock_addr_metadata_table = { _get_programs, _get_maps };
+metadata_table_t cgroup_sock_addr_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.txt
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "ingress_connection_policy_map" },
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "egress_connection_policy_map" },
@@ -774,4 +779,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t cgroup_sock_addr_metadata_table = { _get_programs, _get_maps };
+metadata_table_t cgroup_sock_addr_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.txt
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.txt
@@ -67,389 +67,369 @@ static GUID decapsulate_permit_packet_program_type_guid = {0xf1832a85, 0x85d5, 0
 static GUID decapsulate_permit_packet_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
 static uint64_t decapsulate_permit_packet(void* context)
 {
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	// Prologue
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r0 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r1 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r2 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r3 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r4 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r5 = 0;
-#line 89 "sample/decap_permit_packet.c"
-	register uint64_t r6 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r10 = 0;
 
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	r1 = (uintptr_t)context;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-	// EBPF_OP_LDXDW pc=0 dst=r3 src=r1 offset=8 imm=0
+	// EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
+#line 83 "sample/decap_permit_packet.c"
+	r0 = IMMEDIATE(1);
+	// EBPF_OP_LDXDW pc=1 dst=r3 src=r1 offset=8 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r3 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(8));
-	// EBPF_OP_LDXDW pc=1 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 88 "sample/decap_permit_packet.c"
 	r2 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_MOV64_REG pc=2 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=3 dst=r4 src=r2 offset=0 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=3 dst=r4 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=4 dst=r4 src=r0 offset=0 imm=14
 #line 89 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(14);
-	// EBPF_OP_MOV64_IMM pc=4 dst=r6 src=r0 offset=0 imm=1
-#line 89 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=108 imm=0
+	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
 	// EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
 	r5 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=59 imm=56710
+	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 == IMMEDIATE(56710)) goto label_1;
-	// EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=1
-#line 93 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=9 dst=r5 src=r0 offset=104 imm=8
+	// EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(8)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=10 dst=r5 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	r5 = r2;
-	// EBPF_OP_ADD64_IMM pc=11 dst=r5 src=r0 offset=0 imm=34
+	// EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
 #line 94 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(34);
-	// EBPF_OP_MOV64_IMM pc=12 dst=r6 src=r0 offset=0 imm=1
-#line 94 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=13 dst=r5 src=r3 offset=100 imm=0
+	// EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=14 dst=r5 src=r2 offset=23 imm=0
+	// EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(23));
-	// EBPF_OP_MOV64_IMM pc=15 dst=r6 src=r0 offset=0 imm=1
-#line 99 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=16 dst=r5 src=r0 offset=97 imm=4
+	// EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
 #line 99 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(4)) goto label_3;
-	// EBPF_OP_LDXB pc=17 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r4 + OFFSET(0));
-	// EBPF_OP_LSH64_IMM pc=18 dst=r5 src=r0 offset=0 imm=2
+	// EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
 #line 98 "sample/decap_permit_packet.c"
 	r5 <<= IMMEDIATE(2);
-	// EBPF_OP_AND64_IMM pc=19 dst=r5 src=r0 offset=0 imm=60
+	// EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
 #line 98 "sample/decap_permit_packet.c"
 	r5 &= IMMEDIATE(60);
-	// EBPF_OP_MOV64_REG pc=20 dst=r0 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=17 dst=r4 src=r5 offset=0 imm=0
+#line 98 "sample/decap_permit_packet.c"
+	r4 += r5;
+	// EBPF_OP_ADD64_IMM pc=18 dst=r4 src=r0 offset=0 imm=20
 #line 100 "sample/decap_permit_packet.c"
-	r0 = r5;
-	// EBPF_OP_ADD64_REG pc=21 dst=r0 src=r4 offset=0 imm=0
+	r4 += IMMEDIATE(20);
+	// EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	r0 += r4;
-	// EBPF_OP_ADD64_IMM pc=22 dst=r0 src=r0 offset=0 imm=20
-#line 100 "sample/decap_permit_packet.c"
-	r0 += IMMEDIATE(20);
-	// EBPF_OP_MOV64_IMM pc=23 dst=r6 src=r0 offset=0 imm=1
-#line 100 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=24 dst=r0 src=r3 offset=89 imm=0
-#line 100 "sample/decap_permit_packet.c"
-	if (r0 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=25 dst=r4 src=r2 offset=0 imm=0
+	if (r4 > r3) goto label_3;
+	// EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_REG pc=26 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 += r5;
-	// EBPF_OP_MOV64_IMM pc=27 dst=r6 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=2
 #line 29 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(2);
-	// EBPF_OP_JGT_REG pc=28 dst=r4 src=r3 offset=85 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=29 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r5 = r4;
-	// EBPF_OP_ADD64_IMM pc=30 dst=r5 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
 #line 29 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=31 dst=r5 src=r3 offset=82 imm=0
+	// EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=32 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=33 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(13)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=34 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=29 dst=r3 src=r2 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=35 dst=r4 src=r3 offset=12 imm=0
+	// EBPF_OP_STXB pc=30 dst=r4 src=r3 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(12)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=36 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=31 dst=r3 src=r2 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=37 dst=r4 src=r3 offset=11 imm=0
+	// EBPF_OP_STXB pc=32 dst=r4 src=r3 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(11)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=38 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=33 dst=r3 src=r2 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=39 dst=r4 src=r3 offset=10 imm=0
+	// EBPF_OP_STXB pc=34 dst=r4 src=r3 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(10)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=40 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=35 dst=r3 src=r2 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=41 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_STXB pc=36 dst=r4 src=r3 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(9)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=42 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=37 dst=r3 src=r2 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=43 dst=r4 src=r3 offset=8 imm=0
+	// EBPF_OP_STXB pc=38 dst=r4 src=r3 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(8)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=44 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=39 dst=r3 src=r2 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=45 dst=r4 src=r3 offset=7 imm=0
+	// EBPF_OP_STXB pc=40 dst=r4 src=r3 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(7)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=46 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=41 dst=r3 src=r2 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=47 dst=r4 src=r3 offset=6 imm=0
+	// EBPF_OP_STXB pc=42 dst=r4 src=r3 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(6)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=48 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=43 dst=r3 src=r2 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=49 dst=r4 src=r3 offset=5 imm=0
+	// EBPF_OP_STXB pc=44 dst=r4 src=r3 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(5)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=50 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=45 dst=r3 src=r2 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=51 dst=r4 src=r3 offset=4 imm=0
+	// EBPF_OP_STXB pc=46 dst=r4 src=r3 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(4)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=52 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=47 dst=r3 src=r2 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=53 dst=r4 src=r3 offset=3 imm=0
+	// EBPF_OP_STXB pc=48 dst=r4 src=r3 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(3)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=54 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=49 dst=r3 src=r2 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=55 dst=r4 src=r3 offset=2 imm=0
+	// EBPF_OP_STXB pc=50 dst=r4 src=r3 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(2)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=56 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=51 dst=r3 src=r2 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=57 dst=r4 src=r3 offset=1 imm=0
+	// EBPF_OP_STXB pc=52 dst=r4 src=r3 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(1)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=58 dst=r2 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=53 dst=r2 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r2 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=59 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_STXB pc=54 dst=r4 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(0)) = (uint8_t)r2;
-	// EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_IMM pc=55 dst=r2 src=r0 offset=0 imm=20
 #line 39 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(20);
-	// EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 39 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 39 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 39 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_LSH64_IMM pc=62 dst=r0 src=r0 offset=0 imm=32
+	// EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r0 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=63 dst=r0 src=r0 offset=0 imm=32
+	r1 = r0;
+	// EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=0
+	r1 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=65 dst=r1 src=r0 offset=48 imm=0
+	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
 #line 39 "sample/decap_permit_packet.c"
-	if ((int64_t)r1 > (int64_t)r0) goto label_3;
-	// EBPF_OP_JA pc=66 dst=r0 src=r0 offset=46 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=0
+#line 39 "sample/decap_permit_packet.c"
+	r2 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
+#line 39 "sample/decap_permit_packet.c"
+	if ((int64_t)r2 > (int64_t)r1) goto label_3;
+	// EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 39 "sample/decap_permit_packet.c"
 	goto label_2;
 label_1:
+	// EBPF_OP_MOV64_REG pc=64 dst=r4 src=r2 offset=0 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	r4 = r2;
+	// EBPF_OP_ADD64_IMM pc=65 dst=r4 src=r0 offset=0 imm=54
+#line 106 "sample/decap_permit_packet.c"
+	r4 += IMMEDIATE(54);
+	// EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	if (r4 > r3) goto label_3;
 	// EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=54
+	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
 #line 106 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(54);
-	// EBPF_OP_MOV64_IMM pc=69 dst=r6 src=r0 offset=0 imm=1
-#line 106 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=70 dst=r4 src=r3 offset=43 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=71 dst=r4 src=r2 offset=20 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r4 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_MOV64_IMM pc=72 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=73 dst=r4 src=r0 offset=40 imm=41
-#line 111 "sample/decap_permit_packet.c"
-	if (r4 != IMMEDIATE(41)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=74 dst=r4 src=r2 offset=0 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=75 dst=r4 src=r0 offset=0 imm=94
-#line 111 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(94);
-	// EBPF_OP_MOV64_IMM pc=76 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=77 dst=r4 src=r3 offset=36 imm=0
+	// EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
 #line 111 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
+#line 111 "sample/decap_permit_packet.c"
+	if (r3 != IMMEDIATE(41)) goto label_3;
+	// EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=53 imm=0
+	// EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(53)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=74 dst=r3 src=r2 offset=12 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=52 imm=0
+	// EBPF_OP_STXB pc=75 dst=r2 src=r3 offset=52 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(52)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=76 dst=r3 src=r2 offset=11 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=51 imm=0
+	// EBPF_OP_STXB pc=77 dst=r2 src=r3 offset=51 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(51)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=10 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=50 imm=0
+	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=50 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(50)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=9 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=49 imm=0
+	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=49 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(49)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=8 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=48 imm=0
+	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=48 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(48)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=7 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=47 imm=0
+	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=47 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(47)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=6 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=46 imm=0
+	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=46 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(46)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=5 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=45 imm=0
+	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=45 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(45)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=4 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=44 imm=0
+	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=44 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(44)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=3 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=43 imm=0
+	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=43 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(43)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=100 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=2 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=101 dst=r2 src=r3 offset=42 imm=0
+	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=42 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(42)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=102 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=1 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=103 dst=r2 src=r3 offset=41 imm=0
+	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=41 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(41)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=104 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=0 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=105 dst=r2 src=r3 offset=40 imm=0
+	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=40 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(40)) = (uint8_t)r3;
-	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=40
+	// EBPF_OP_MOV64_IMM pc=100 dst=r2 src=r0 offset=0 imm=40
 #line 66 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(40);
-	// EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
 #line 66 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 66 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 66 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=108 dst=r6 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(2);
-	// EBPF_OP_LSH64_IMM pc=109 dst=r0 src=r0 offset=0 imm=32
+	r1 = r0;
+	// EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r0 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=32
+	r1 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=0
+	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
 #line 66 "sample/decap_permit_packet.c"
-	r1 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=112 dst=r1 src=r0 offset=1 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	if ((int64_t)r1 > (int64_t)r0) goto label_3;
+	r2 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
+#line 66 "sample/decap_permit_packet.c"
+	if ((int64_t)r2 > (int64_t)r1) goto label_3;
 label_2:
-	// EBPF_OP_MOV64_IMM pc=113 dst=r6 src=r0 offset=0 imm=1
+	// EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
 #line 66 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
+	r0 = IMMEDIATE(1);
 label_3:
-	// EBPF_OP_MOV64_REG pc=114 dst=r0 src=r6 offset=0 imm=0
-#line 121 "sample/decap_permit_packet.c"
-	r0 = r6;
-	// EBPF_OP_EXIT pc=115 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
 #line 121 "sample/decap_permit_packet.c"
 	return r0;
 #line 121 "sample/decap_permit_packet.c"
@@ -457,7 +437,7 @@ label_3:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 116, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
+	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 110, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.txt
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -62,369 +67,389 @@ static GUID decapsulate_permit_packet_program_type_guid = {0xf1832a85, 0x85d5, 0
 static GUID decapsulate_permit_packet_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
 static uint64_t decapsulate_permit_packet(void* context)
 {
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	// Prologue
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r0 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r1 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r2 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r3 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r4 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r5 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
+	register uint64_t r6 = 0;
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r10 = 0;
 
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	r1 = (uintptr_t)context;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-	// EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
-#line 83 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(1);
-	// EBPF_OP_LDXDW pc=1 dst=r3 src=r1 offset=8 imm=0
+	// EBPF_OP_LDXDW pc=0 dst=r3 src=r1 offset=8 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r3 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(8));
-	// EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=1 dst=r2 src=r1 offset=0 imm=0
 #line 88 "sample/decap_permit_packet.c"
 	r2 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_MOV64_REG pc=3 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=2 dst=r4 src=r2 offset=0 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=4 dst=r4 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=3 dst=r4 src=r0 offset=0 imm=14
 #line 89 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
+	// EBPF_OP_MOV64_IMM pc=4 dst=r6 src=r0 offset=0 imm=1
+#line 89 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=108 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
 	// EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
 	r5 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
+	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=59 imm=56710
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 == IMMEDIATE(56710)) goto label_1;
-	// EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+	// EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=1
+#line 93 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=9 dst=r5 src=r0 offset=104 imm=8
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(8)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=10 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	r5 = r2;
-	// EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
+	// EBPF_OP_ADD64_IMM pc=11 dst=r5 src=r0 offset=0 imm=34
 #line 94 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(34);
-	// EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
+	// EBPF_OP_MOV64_IMM pc=12 dst=r6 src=r0 offset=0 imm=1
+#line 94 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=13 dst=r5 src=r3 offset=100 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+	// EBPF_OP_LDXB pc=14 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(23));
-	// EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
+	// EBPF_OP_MOV64_IMM pc=15 dst=r6 src=r0 offset=0 imm=1
+#line 99 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=16 dst=r5 src=r0 offset=97 imm=4
 #line 99 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(4)) goto label_3;
-	// EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_LDXB pc=17 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r4 + OFFSET(0));
-	// EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
+	// EBPF_OP_LSH64_IMM pc=18 dst=r5 src=r0 offset=0 imm=2
 #line 98 "sample/decap_permit_packet.c"
 	r5 <<= IMMEDIATE(2);
-	// EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
+	// EBPF_OP_AND64_IMM pc=19 dst=r5 src=r0 offset=0 imm=60
 #line 98 "sample/decap_permit_packet.c"
 	r5 &= IMMEDIATE(60);
-	// EBPF_OP_ADD64_REG pc=17 dst=r4 src=r5 offset=0 imm=0
-#line 98 "sample/decap_permit_packet.c"
-	r4 += r5;
-	// EBPF_OP_ADD64_IMM pc=18 dst=r4 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_REG pc=20 dst=r0 src=r5 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(20);
-	// EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
+	r0 = r5;
+	// EBPF_OP_ADD64_REG pc=21 dst=r0 src=r4 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+	r0 += r4;
+	// EBPF_OP_ADD64_IMM pc=22 dst=r0 src=r0 offset=0 imm=20
+#line 100 "sample/decap_permit_packet.c"
+	r0 += IMMEDIATE(20);
+	// EBPF_OP_MOV64_IMM pc=23 dst=r6 src=r0 offset=0 imm=1
+#line 100 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=24 dst=r0 src=r3 offset=89 imm=0
+#line 100 "sample/decap_permit_packet.c"
+	if (r0 > r3) goto label_3;
+	// EBPF_OP_MOV64_REG pc=25 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=26 dst=r4 src=r5 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 += r5;
-	// EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_IMM pc=27 dst=r6 src=r0 offset=0 imm=2
 #line 29 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
+	r6 = IMMEDIATE(2);
+	// EBPF_OP_JGT_REG pc=28 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=29 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r5 = r4;
-	// EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=30 dst=r5 src=r0 offset=0 imm=14
 #line 29 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
+	// EBPF_OP_JGT_REG pc=31 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=32 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_STXB pc=33 dst=r4 src=r3 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(13)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=29 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=34 dst=r3 src=r2 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=30 dst=r4 src=r3 offset=12 imm=0
+	// EBPF_OP_STXB pc=35 dst=r4 src=r3 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(12)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=31 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=36 dst=r3 src=r2 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=32 dst=r4 src=r3 offset=11 imm=0
+	// EBPF_OP_STXB pc=37 dst=r4 src=r3 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(11)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=33 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=38 dst=r3 src=r2 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=34 dst=r4 src=r3 offset=10 imm=0
+	// EBPF_OP_STXB pc=39 dst=r4 src=r3 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(10)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=35 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=40 dst=r3 src=r2 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=36 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_STXB pc=41 dst=r4 src=r3 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(9)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=37 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=42 dst=r3 src=r2 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=38 dst=r4 src=r3 offset=8 imm=0
+	// EBPF_OP_STXB pc=43 dst=r4 src=r3 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(8)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=39 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=44 dst=r3 src=r2 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=40 dst=r4 src=r3 offset=7 imm=0
+	// EBPF_OP_STXB pc=45 dst=r4 src=r3 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(7)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=41 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=46 dst=r3 src=r2 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=42 dst=r4 src=r3 offset=6 imm=0
+	// EBPF_OP_STXB pc=47 dst=r4 src=r3 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(6)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=43 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=48 dst=r3 src=r2 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=44 dst=r4 src=r3 offset=5 imm=0
+	// EBPF_OP_STXB pc=49 dst=r4 src=r3 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(5)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=45 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=50 dst=r3 src=r2 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=46 dst=r4 src=r3 offset=4 imm=0
+	// EBPF_OP_STXB pc=51 dst=r4 src=r3 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(4)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=47 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=52 dst=r3 src=r2 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=48 dst=r4 src=r3 offset=3 imm=0
+	// EBPF_OP_STXB pc=53 dst=r4 src=r3 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(3)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=49 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=54 dst=r3 src=r2 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=50 dst=r4 src=r3 offset=2 imm=0
+	// EBPF_OP_STXB pc=55 dst=r4 src=r3 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(2)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=51 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=56 dst=r3 src=r2 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=52 dst=r4 src=r3 offset=1 imm=0
+	// EBPF_OP_STXB pc=57 dst=r4 src=r3 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(1)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=53 dst=r2 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=58 dst=r2 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r2 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=54 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_STXB pc=59 dst=r4 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(0)) = (uint8_t)r2;
-	// EBPF_OP_MOV64_IMM pc=55 dst=r2 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=20
 #line 39 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(20);
-	// EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=65536
 #line 39 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 39 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 39 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LSH64_IMM pc=62 dst=r0 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 = r0;
-	// EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
+	r0 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=63 dst=r0 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
+	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
+	r1 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=65 dst=r1 src=r0 offset=48 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=0
-#line 39 "sample/decap_permit_packet.c"
-	r2 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
-#line 39 "sample/decap_permit_packet.c"
-	if ((int64_t)r2 > (int64_t)r1) goto label_3;
-	// EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+	if ((int64_t)r1 > (int64_t)r0) goto label_3;
+	// EBPF_OP_JA pc=66 dst=r0 src=r0 offset=46 imm=0
 #line 39 "sample/decap_permit_packet.c"
 	goto label_2;
 label_1:
-	// EBPF_OP_MOV64_REG pc=64 dst=r4 src=r2 offset=0 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=65 dst=r4 src=r0 offset=0 imm=54
-#line 106 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(54);
-	// EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
 	// EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
+	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=54
 #line 106 "sample/decap_permit_packet.c"
+	r4 += IMMEDIATE(54);
+	// EBPF_OP_MOV64_IMM pc=69 dst=r6 src=r0 offset=0 imm=1
+#line 106 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=70 dst=r4 src=r3 offset=43 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	if (r4 > r3) goto label_3;
+	// EBPF_OP_LDXB pc=71 dst=r4 src=r2 offset=20 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r4 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_MOV64_IMM pc=72 dst=r6 src=r0 offset=0 imm=1
+#line 111 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=73 dst=r4 src=r0 offset=40 imm=41
+#line 111 "sample/decap_permit_packet.c"
+	if (r4 != IMMEDIATE(41)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=74 dst=r4 src=r2 offset=0 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r4 = r2;
+	// EBPF_OP_ADD64_IMM pc=75 dst=r4 src=r0 offset=0 imm=94
+#line 111 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(94);
-	// EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
+	// EBPF_OP_MOV64_IMM pc=76 dst=r6 src=r0 offset=0 imm=1
+#line 111 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=77 dst=r4 src=r3 offset=36 imm=0
 #line 111 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
-#line 111 "sample/decap_permit_packet.c"
-	if (r3 != IMMEDIATE(41)) goto label_3;
-	// EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
+	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=53 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(53)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=74 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=12 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=75 dst=r2 src=r3 offset=52 imm=0
+	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=52 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(52)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=76 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=11 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=77 dst=r2 src=r3 offset=51 imm=0
+	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=51 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(51)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=10 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=50 imm=0
+	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=50 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(50)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=9 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=49 imm=0
+	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=49 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(49)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=8 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=48 imm=0
+	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=48 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(48)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=7 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=47 imm=0
+	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=47 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(47)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=6 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=46 imm=0
+	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=46 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(46)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=5 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=45 imm=0
+	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=45 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(45)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=4 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=44 imm=0
+	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=44 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(44)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=3 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=43 imm=0
+	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=43 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(43)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=100 dst=r3 src=r2 offset=2 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=42 imm=0
+	// EBPF_OP_STXB pc=101 dst=r2 src=r3 offset=42 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(42)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=102 dst=r3 src=r2 offset=1 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=41 imm=0
+	// EBPF_OP_STXB pc=103 dst=r2 src=r3 offset=41 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(41)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=104 dst=r3 src=r2 offset=0 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=40 imm=0
+	// EBPF_OP_STXB pc=105 dst=r2 src=r3 offset=40 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(40)) = (uint8_t)r3;
-	// EBPF_OP_MOV64_IMM pc=100 dst=r2 src=r0 offset=0 imm=40
+	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=40
 #line 66 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(40);
-	// EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=65536
 #line 66 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 66 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 66 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=108 dst=r6 src=r0 offset=0 imm=2
 #line 66 "sample/decap_permit_packet.c"
-	r1 = r0;
-	// EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
+	r6 = IMMEDIATE(2);
+	// EBPF_OP_LSH64_IMM pc=109 dst=r0 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r1 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
+	r0 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
+	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=0
+	r1 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=112 dst=r1 src=r0 offset=1 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r2 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
-#line 66 "sample/decap_permit_packet.c"
-	if ((int64_t)r2 > (int64_t)r1) goto label_3;
+	if ((int64_t)r1 > (int64_t)r0) goto label_3;
 label_2:
-	// EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_MOV64_IMM pc=113 dst=r6 src=r0 offset=0 imm=1
 #line 66 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(1);
+	r6 = IMMEDIATE(1);
 label_3:
-	// EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=114 dst=r0 src=r6 offset=0 imm=0
+#line 121 "sample/decap_permit_packet.c"
+	r0 = r6;
+	// EBPF_OP_EXIT pc=115 dst=r0 src=r0 offset=0 imm=0
 #line 121 "sample/decap_permit_packet.c"
 	return r0;
 #line 121 "sample/decap_permit_packet.c"
@@ -432,7 +457,7 @@ label_3:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 110, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
+	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 116, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
@@ -442,4 +467,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t decap_permit_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t decap_permit_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.txt
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.txt
@@ -25,389 +25,369 @@ static GUID decapsulate_permit_packet_program_type_guid = {0xf1832a85, 0x85d5, 0
 static GUID decapsulate_permit_packet_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
 static uint64_t decapsulate_permit_packet(void* context)
 {
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	// Prologue
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r0 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r1 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r2 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r3 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r4 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r5 = 0;
-#line 89 "sample/decap_permit_packet.c"
-	register uint64_t r6 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r10 = 0;
 
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	r1 = (uintptr_t)context;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-	// EBPF_OP_LDXDW pc=0 dst=r3 src=r1 offset=8 imm=0
+	// EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
+#line 83 "sample/decap_permit_packet.c"
+	r0 = IMMEDIATE(1);
+	// EBPF_OP_LDXDW pc=1 dst=r3 src=r1 offset=8 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r3 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(8));
-	// EBPF_OP_LDXDW pc=1 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 88 "sample/decap_permit_packet.c"
 	r2 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_MOV64_REG pc=2 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=3 dst=r4 src=r2 offset=0 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=3 dst=r4 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=4 dst=r4 src=r0 offset=0 imm=14
 #line 89 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(14);
-	// EBPF_OP_MOV64_IMM pc=4 dst=r6 src=r0 offset=0 imm=1
-#line 89 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=108 imm=0
+	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
 	// EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
 	r5 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=59 imm=56710
+	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 == IMMEDIATE(56710)) goto label_1;
-	// EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=1
-#line 93 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=9 dst=r5 src=r0 offset=104 imm=8
+	// EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(8)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=10 dst=r5 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	r5 = r2;
-	// EBPF_OP_ADD64_IMM pc=11 dst=r5 src=r0 offset=0 imm=34
+	// EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
 #line 94 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(34);
-	// EBPF_OP_MOV64_IMM pc=12 dst=r6 src=r0 offset=0 imm=1
-#line 94 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=13 dst=r5 src=r3 offset=100 imm=0
+	// EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=14 dst=r5 src=r2 offset=23 imm=0
+	// EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(23));
-	// EBPF_OP_MOV64_IMM pc=15 dst=r6 src=r0 offset=0 imm=1
-#line 99 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=16 dst=r5 src=r0 offset=97 imm=4
+	// EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
 #line 99 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(4)) goto label_3;
-	// EBPF_OP_LDXB pc=17 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r4 + OFFSET(0));
-	// EBPF_OP_LSH64_IMM pc=18 dst=r5 src=r0 offset=0 imm=2
+	// EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
 #line 98 "sample/decap_permit_packet.c"
 	r5 <<= IMMEDIATE(2);
-	// EBPF_OP_AND64_IMM pc=19 dst=r5 src=r0 offset=0 imm=60
+	// EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
 #line 98 "sample/decap_permit_packet.c"
 	r5 &= IMMEDIATE(60);
-	// EBPF_OP_MOV64_REG pc=20 dst=r0 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=17 dst=r4 src=r5 offset=0 imm=0
+#line 98 "sample/decap_permit_packet.c"
+	r4 += r5;
+	// EBPF_OP_ADD64_IMM pc=18 dst=r4 src=r0 offset=0 imm=20
 #line 100 "sample/decap_permit_packet.c"
-	r0 = r5;
-	// EBPF_OP_ADD64_REG pc=21 dst=r0 src=r4 offset=0 imm=0
+	r4 += IMMEDIATE(20);
+	// EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	r0 += r4;
-	// EBPF_OP_ADD64_IMM pc=22 dst=r0 src=r0 offset=0 imm=20
-#line 100 "sample/decap_permit_packet.c"
-	r0 += IMMEDIATE(20);
-	// EBPF_OP_MOV64_IMM pc=23 dst=r6 src=r0 offset=0 imm=1
-#line 100 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=24 dst=r0 src=r3 offset=89 imm=0
-#line 100 "sample/decap_permit_packet.c"
-	if (r0 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=25 dst=r4 src=r2 offset=0 imm=0
+	if (r4 > r3) goto label_3;
+	// EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_REG pc=26 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 += r5;
-	// EBPF_OP_MOV64_IMM pc=27 dst=r6 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=2
 #line 29 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(2);
-	// EBPF_OP_JGT_REG pc=28 dst=r4 src=r3 offset=85 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=29 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r5 = r4;
-	// EBPF_OP_ADD64_IMM pc=30 dst=r5 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
 #line 29 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=31 dst=r5 src=r3 offset=82 imm=0
+	// EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=32 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=33 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(13)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=34 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=29 dst=r3 src=r2 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=35 dst=r4 src=r3 offset=12 imm=0
+	// EBPF_OP_STXB pc=30 dst=r4 src=r3 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(12)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=36 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=31 dst=r3 src=r2 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=37 dst=r4 src=r3 offset=11 imm=0
+	// EBPF_OP_STXB pc=32 dst=r4 src=r3 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(11)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=38 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=33 dst=r3 src=r2 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=39 dst=r4 src=r3 offset=10 imm=0
+	// EBPF_OP_STXB pc=34 dst=r4 src=r3 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(10)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=40 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=35 dst=r3 src=r2 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=41 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_STXB pc=36 dst=r4 src=r3 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(9)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=42 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=37 dst=r3 src=r2 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=43 dst=r4 src=r3 offset=8 imm=0
+	// EBPF_OP_STXB pc=38 dst=r4 src=r3 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(8)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=44 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=39 dst=r3 src=r2 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=45 dst=r4 src=r3 offset=7 imm=0
+	// EBPF_OP_STXB pc=40 dst=r4 src=r3 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(7)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=46 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=41 dst=r3 src=r2 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=47 dst=r4 src=r3 offset=6 imm=0
+	// EBPF_OP_STXB pc=42 dst=r4 src=r3 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(6)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=48 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=43 dst=r3 src=r2 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=49 dst=r4 src=r3 offset=5 imm=0
+	// EBPF_OP_STXB pc=44 dst=r4 src=r3 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(5)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=50 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=45 dst=r3 src=r2 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=51 dst=r4 src=r3 offset=4 imm=0
+	// EBPF_OP_STXB pc=46 dst=r4 src=r3 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(4)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=52 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=47 dst=r3 src=r2 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=53 dst=r4 src=r3 offset=3 imm=0
+	// EBPF_OP_STXB pc=48 dst=r4 src=r3 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(3)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=54 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=49 dst=r3 src=r2 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=55 dst=r4 src=r3 offset=2 imm=0
+	// EBPF_OP_STXB pc=50 dst=r4 src=r3 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(2)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=56 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=51 dst=r3 src=r2 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=57 dst=r4 src=r3 offset=1 imm=0
+	// EBPF_OP_STXB pc=52 dst=r4 src=r3 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(1)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=58 dst=r2 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=53 dst=r2 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r2 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=59 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_STXB pc=54 dst=r4 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(0)) = (uint8_t)r2;
-	// EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_IMM pc=55 dst=r2 src=r0 offset=0 imm=20
 #line 39 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(20);
-	// EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 39 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 39 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 39 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_LSH64_IMM pc=62 dst=r0 src=r0 offset=0 imm=32
+	// EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r0 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=63 dst=r0 src=r0 offset=0 imm=32
+	r1 = r0;
+	// EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=0
+	r1 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=65 dst=r1 src=r0 offset=48 imm=0
+	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
 #line 39 "sample/decap_permit_packet.c"
-	if ((int64_t)r1 > (int64_t)r0) goto label_3;
-	// EBPF_OP_JA pc=66 dst=r0 src=r0 offset=46 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=0
+#line 39 "sample/decap_permit_packet.c"
+	r2 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
+#line 39 "sample/decap_permit_packet.c"
+	if ((int64_t)r2 > (int64_t)r1) goto label_3;
+	// EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 39 "sample/decap_permit_packet.c"
 	goto label_2;
 label_1:
+	// EBPF_OP_MOV64_REG pc=64 dst=r4 src=r2 offset=0 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	r4 = r2;
+	// EBPF_OP_ADD64_IMM pc=65 dst=r4 src=r0 offset=0 imm=54
+#line 106 "sample/decap_permit_packet.c"
+	r4 += IMMEDIATE(54);
+	// EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	if (r4 > r3) goto label_3;
 	// EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=54
+	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
 #line 106 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(54);
-	// EBPF_OP_MOV64_IMM pc=69 dst=r6 src=r0 offset=0 imm=1
-#line 106 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=70 dst=r4 src=r3 offset=43 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=71 dst=r4 src=r2 offset=20 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r4 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_MOV64_IMM pc=72 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=73 dst=r4 src=r0 offset=40 imm=41
-#line 111 "sample/decap_permit_packet.c"
-	if (r4 != IMMEDIATE(41)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=74 dst=r4 src=r2 offset=0 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=75 dst=r4 src=r0 offset=0 imm=94
-#line 111 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(94);
-	// EBPF_OP_MOV64_IMM pc=76 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=77 dst=r4 src=r3 offset=36 imm=0
+	// EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
 #line 111 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
+#line 111 "sample/decap_permit_packet.c"
+	if (r3 != IMMEDIATE(41)) goto label_3;
+	// EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=53 imm=0
+	// EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(53)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=74 dst=r3 src=r2 offset=12 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=52 imm=0
+	// EBPF_OP_STXB pc=75 dst=r2 src=r3 offset=52 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(52)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=76 dst=r3 src=r2 offset=11 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=51 imm=0
+	// EBPF_OP_STXB pc=77 dst=r2 src=r3 offset=51 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(51)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=10 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=50 imm=0
+	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=50 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(50)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=9 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=49 imm=0
+	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=49 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(49)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=8 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=48 imm=0
+	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=48 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(48)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=7 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=47 imm=0
+	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=47 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(47)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=6 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=46 imm=0
+	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=46 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(46)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=5 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=45 imm=0
+	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=45 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(45)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=4 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=44 imm=0
+	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=44 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(44)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=3 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=43 imm=0
+	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=43 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(43)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=100 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=2 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=101 dst=r2 src=r3 offset=42 imm=0
+	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=42 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(42)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=102 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=1 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=103 dst=r2 src=r3 offset=41 imm=0
+	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=41 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(41)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=104 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=0 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=105 dst=r2 src=r3 offset=40 imm=0
+	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=40 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(40)) = (uint8_t)r3;
-	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=40
+	// EBPF_OP_MOV64_IMM pc=100 dst=r2 src=r0 offset=0 imm=40
 #line 66 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(40);
-	// EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
 #line 66 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 66 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 66 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=108 dst=r6 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(2);
-	// EBPF_OP_LSH64_IMM pc=109 dst=r0 src=r0 offset=0 imm=32
+	r1 = r0;
+	// EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r0 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=32
+	r1 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=0
+	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
 #line 66 "sample/decap_permit_packet.c"
-	r1 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=112 dst=r1 src=r0 offset=1 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	if ((int64_t)r1 > (int64_t)r0) goto label_3;
+	r2 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
+#line 66 "sample/decap_permit_packet.c"
+	if ((int64_t)r2 > (int64_t)r1) goto label_3;
 label_2:
-	// EBPF_OP_MOV64_IMM pc=113 dst=r6 src=r0 offset=0 imm=1
+	// EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
 #line 66 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
+	r0 = IMMEDIATE(1);
 label_3:
-	// EBPF_OP_MOV64_REG pc=114 dst=r0 src=r6 offset=0 imm=0
-#line 121 "sample/decap_permit_packet.c"
-	r0 = r6;
-	// EBPF_OP_EXIT pc=115 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
 #line 121 "sample/decap_permit_packet.c"
 	return r0;
 #line 121 "sample/decap_permit_packet.c"
@@ -415,7 +395,7 @@ label_3:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 116, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
+	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 110, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.txt
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -20,369 +25,389 @@ static GUID decapsulate_permit_packet_program_type_guid = {0xf1832a85, 0x85d5, 0
 static GUID decapsulate_permit_packet_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
 static uint64_t decapsulate_permit_packet(void* context)
 {
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	// Prologue
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r0 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r1 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r2 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r3 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r4 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r5 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
+	register uint64_t r6 = 0;
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r10 = 0;
 
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	r1 = (uintptr_t)context;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-	// EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
-#line 83 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(1);
-	// EBPF_OP_LDXDW pc=1 dst=r3 src=r1 offset=8 imm=0
+	// EBPF_OP_LDXDW pc=0 dst=r3 src=r1 offset=8 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r3 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(8));
-	// EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=1 dst=r2 src=r1 offset=0 imm=0
 #line 88 "sample/decap_permit_packet.c"
 	r2 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_MOV64_REG pc=3 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=2 dst=r4 src=r2 offset=0 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=4 dst=r4 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=3 dst=r4 src=r0 offset=0 imm=14
 #line 89 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
+	// EBPF_OP_MOV64_IMM pc=4 dst=r6 src=r0 offset=0 imm=1
+#line 89 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=108 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
 	// EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
 	r5 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
+	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=59 imm=56710
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 == IMMEDIATE(56710)) goto label_1;
-	// EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+	// EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=1
+#line 93 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=9 dst=r5 src=r0 offset=104 imm=8
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(8)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=10 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	r5 = r2;
-	// EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
+	// EBPF_OP_ADD64_IMM pc=11 dst=r5 src=r0 offset=0 imm=34
 #line 94 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(34);
-	// EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
+	// EBPF_OP_MOV64_IMM pc=12 dst=r6 src=r0 offset=0 imm=1
+#line 94 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=13 dst=r5 src=r3 offset=100 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+	// EBPF_OP_LDXB pc=14 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(23));
-	// EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
+	// EBPF_OP_MOV64_IMM pc=15 dst=r6 src=r0 offset=0 imm=1
+#line 99 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=16 dst=r5 src=r0 offset=97 imm=4
 #line 99 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(4)) goto label_3;
-	// EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_LDXB pc=17 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r4 + OFFSET(0));
-	// EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
+	// EBPF_OP_LSH64_IMM pc=18 dst=r5 src=r0 offset=0 imm=2
 #line 98 "sample/decap_permit_packet.c"
 	r5 <<= IMMEDIATE(2);
-	// EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
+	// EBPF_OP_AND64_IMM pc=19 dst=r5 src=r0 offset=0 imm=60
 #line 98 "sample/decap_permit_packet.c"
 	r5 &= IMMEDIATE(60);
-	// EBPF_OP_ADD64_REG pc=17 dst=r4 src=r5 offset=0 imm=0
-#line 98 "sample/decap_permit_packet.c"
-	r4 += r5;
-	// EBPF_OP_ADD64_IMM pc=18 dst=r4 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_REG pc=20 dst=r0 src=r5 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(20);
-	// EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
+	r0 = r5;
+	// EBPF_OP_ADD64_REG pc=21 dst=r0 src=r4 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+	r0 += r4;
+	// EBPF_OP_ADD64_IMM pc=22 dst=r0 src=r0 offset=0 imm=20
+#line 100 "sample/decap_permit_packet.c"
+	r0 += IMMEDIATE(20);
+	// EBPF_OP_MOV64_IMM pc=23 dst=r6 src=r0 offset=0 imm=1
+#line 100 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=24 dst=r0 src=r3 offset=89 imm=0
+#line 100 "sample/decap_permit_packet.c"
+	if (r0 > r3) goto label_3;
+	// EBPF_OP_MOV64_REG pc=25 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=26 dst=r4 src=r5 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 += r5;
-	// EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_IMM pc=27 dst=r6 src=r0 offset=0 imm=2
 #line 29 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
+	r6 = IMMEDIATE(2);
+	// EBPF_OP_JGT_REG pc=28 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=29 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r5 = r4;
-	// EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=30 dst=r5 src=r0 offset=0 imm=14
 #line 29 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
+	// EBPF_OP_JGT_REG pc=31 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=32 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_STXB pc=33 dst=r4 src=r3 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(13)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=29 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=34 dst=r3 src=r2 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=30 dst=r4 src=r3 offset=12 imm=0
+	// EBPF_OP_STXB pc=35 dst=r4 src=r3 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(12)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=31 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=36 dst=r3 src=r2 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=32 dst=r4 src=r3 offset=11 imm=0
+	// EBPF_OP_STXB pc=37 dst=r4 src=r3 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(11)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=33 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=38 dst=r3 src=r2 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=34 dst=r4 src=r3 offset=10 imm=0
+	// EBPF_OP_STXB pc=39 dst=r4 src=r3 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(10)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=35 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=40 dst=r3 src=r2 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=36 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_STXB pc=41 dst=r4 src=r3 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(9)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=37 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=42 dst=r3 src=r2 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=38 dst=r4 src=r3 offset=8 imm=0
+	// EBPF_OP_STXB pc=43 dst=r4 src=r3 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(8)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=39 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=44 dst=r3 src=r2 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=40 dst=r4 src=r3 offset=7 imm=0
+	// EBPF_OP_STXB pc=45 dst=r4 src=r3 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(7)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=41 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=46 dst=r3 src=r2 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=42 dst=r4 src=r3 offset=6 imm=0
+	// EBPF_OP_STXB pc=47 dst=r4 src=r3 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(6)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=43 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=48 dst=r3 src=r2 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=44 dst=r4 src=r3 offset=5 imm=0
+	// EBPF_OP_STXB pc=49 dst=r4 src=r3 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(5)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=45 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=50 dst=r3 src=r2 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=46 dst=r4 src=r3 offset=4 imm=0
+	// EBPF_OP_STXB pc=51 dst=r4 src=r3 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(4)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=47 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=52 dst=r3 src=r2 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=48 dst=r4 src=r3 offset=3 imm=0
+	// EBPF_OP_STXB pc=53 dst=r4 src=r3 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(3)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=49 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=54 dst=r3 src=r2 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=50 dst=r4 src=r3 offset=2 imm=0
+	// EBPF_OP_STXB pc=55 dst=r4 src=r3 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(2)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=51 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=56 dst=r3 src=r2 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=52 dst=r4 src=r3 offset=1 imm=0
+	// EBPF_OP_STXB pc=57 dst=r4 src=r3 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(1)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=53 dst=r2 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=58 dst=r2 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r2 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=54 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_STXB pc=59 dst=r4 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(0)) = (uint8_t)r2;
-	// EBPF_OP_MOV64_IMM pc=55 dst=r2 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=20
 #line 39 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(20);
-	// EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=65536
 #line 39 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 39 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 39 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LSH64_IMM pc=62 dst=r0 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 = r0;
-	// EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
+	r0 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=63 dst=r0 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
+	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
+	r1 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=65 dst=r1 src=r0 offset=48 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=0
-#line 39 "sample/decap_permit_packet.c"
-	r2 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
-#line 39 "sample/decap_permit_packet.c"
-	if ((int64_t)r2 > (int64_t)r1) goto label_3;
-	// EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+	if ((int64_t)r1 > (int64_t)r0) goto label_3;
+	// EBPF_OP_JA pc=66 dst=r0 src=r0 offset=46 imm=0
 #line 39 "sample/decap_permit_packet.c"
 	goto label_2;
 label_1:
-	// EBPF_OP_MOV64_REG pc=64 dst=r4 src=r2 offset=0 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=65 dst=r4 src=r0 offset=0 imm=54
-#line 106 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(54);
-	// EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
 	// EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
+	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=54
 #line 106 "sample/decap_permit_packet.c"
+	r4 += IMMEDIATE(54);
+	// EBPF_OP_MOV64_IMM pc=69 dst=r6 src=r0 offset=0 imm=1
+#line 106 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=70 dst=r4 src=r3 offset=43 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	if (r4 > r3) goto label_3;
+	// EBPF_OP_LDXB pc=71 dst=r4 src=r2 offset=20 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r4 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_MOV64_IMM pc=72 dst=r6 src=r0 offset=0 imm=1
+#line 111 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=73 dst=r4 src=r0 offset=40 imm=41
+#line 111 "sample/decap_permit_packet.c"
+	if (r4 != IMMEDIATE(41)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=74 dst=r4 src=r2 offset=0 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r4 = r2;
+	// EBPF_OP_ADD64_IMM pc=75 dst=r4 src=r0 offset=0 imm=94
+#line 111 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(94);
-	// EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
+	// EBPF_OP_MOV64_IMM pc=76 dst=r6 src=r0 offset=0 imm=1
+#line 111 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=77 dst=r4 src=r3 offset=36 imm=0
 #line 111 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
-#line 111 "sample/decap_permit_packet.c"
-	if (r3 != IMMEDIATE(41)) goto label_3;
-	// EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
+	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=53 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(53)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=74 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=12 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=75 dst=r2 src=r3 offset=52 imm=0
+	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=52 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(52)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=76 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=11 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=77 dst=r2 src=r3 offset=51 imm=0
+	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=51 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(51)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=10 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=50 imm=0
+	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=50 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(50)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=9 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=49 imm=0
+	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=49 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(49)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=8 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=48 imm=0
+	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=48 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(48)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=7 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=47 imm=0
+	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=47 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(47)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=6 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=46 imm=0
+	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=46 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(46)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=5 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=45 imm=0
+	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=45 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(45)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=4 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=44 imm=0
+	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=44 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(44)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=3 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=43 imm=0
+	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=43 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(43)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=100 dst=r3 src=r2 offset=2 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=42 imm=0
+	// EBPF_OP_STXB pc=101 dst=r2 src=r3 offset=42 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(42)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=102 dst=r3 src=r2 offset=1 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=41 imm=0
+	// EBPF_OP_STXB pc=103 dst=r2 src=r3 offset=41 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(41)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=104 dst=r3 src=r2 offset=0 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=40 imm=0
+	// EBPF_OP_STXB pc=105 dst=r2 src=r3 offset=40 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(40)) = (uint8_t)r3;
-	// EBPF_OP_MOV64_IMM pc=100 dst=r2 src=r0 offset=0 imm=40
+	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=40
 #line 66 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(40);
-	// EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=65536
 #line 66 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 66 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 66 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=108 dst=r6 src=r0 offset=0 imm=2
 #line 66 "sample/decap_permit_packet.c"
-	r1 = r0;
-	// EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
+	r6 = IMMEDIATE(2);
+	// EBPF_OP_LSH64_IMM pc=109 dst=r0 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r1 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
+	r0 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
+	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=0
+	r1 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=112 dst=r1 src=r0 offset=1 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r2 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
-#line 66 "sample/decap_permit_packet.c"
-	if ((int64_t)r2 > (int64_t)r1) goto label_3;
+	if ((int64_t)r1 > (int64_t)r0) goto label_3;
 label_2:
-	// EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_MOV64_IMM pc=113 dst=r6 src=r0 offset=0 imm=1
 #line 66 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(1);
+	r6 = IMMEDIATE(1);
 label_3:
-	// EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=114 dst=r0 src=r6 offset=0 imm=0
+#line 121 "sample/decap_permit_packet.c"
+	r0 = r6;
+	// EBPF_OP_EXIT pc=115 dst=r0 src=r0 offset=0 imm=0
 #line 121 "sample/decap_permit_packet.c"
 	return r0;
 #line 121 "sample/decap_permit_packet.c"
@@ -390,7 +415,7 @@ label_3:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 110, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
+	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 116, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
@@ -400,4 +425,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t decap_permit_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t decap_permit_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.txt
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.txt
@@ -192,389 +192,369 @@ static GUID decapsulate_permit_packet_program_type_guid = {0xf1832a85, 0x85d5, 0
 static GUID decapsulate_permit_packet_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
 static uint64_t decapsulate_permit_packet(void* context)
 {
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	// Prologue
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r0 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r1 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r2 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r3 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r4 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r5 = 0;
-#line 89 "sample/decap_permit_packet.c"
-	register uint64_t r6 = 0;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	register uint64_t r10 = 0;
 
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	r1 = (uintptr_t)context;
-#line 89 "sample/decap_permit_packet.c"
+#line 83 "sample/decap_permit_packet.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-	// EBPF_OP_LDXDW pc=0 dst=r3 src=r1 offset=8 imm=0
+	// EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
+#line 83 "sample/decap_permit_packet.c"
+	r0 = IMMEDIATE(1);
+	// EBPF_OP_LDXDW pc=1 dst=r3 src=r1 offset=8 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r3 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(8));
-	// EBPF_OP_LDXDW pc=1 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 88 "sample/decap_permit_packet.c"
 	r2 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_MOV64_REG pc=2 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=3 dst=r4 src=r2 offset=0 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=3 dst=r4 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=4 dst=r4 src=r0 offset=0 imm=14
 #line 89 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(14);
-	// EBPF_OP_MOV64_IMM pc=4 dst=r6 src=r0 offset=0 imm=1
-#line 89 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=108 imm=0
+	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
 	// EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
 	r5 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=59 imm=56710
+	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 == IMMEDIATE(56710)) goto label_1;
-	// EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=1
-#line 93 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=9 dst=r5 src=r0 offset=104 imm=8
+	// EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(8)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=10 dst=r5 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	r5 = r2;
-	// EBPF_OP_ADD64_IMM pc=11 dst=r5 src=r0 offset=0 imm=34
+	// EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
 #line 94 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(34);
-	// EBPF_OP_MOV64_IMM pc=12 dst=r6 src=r0 offset=0 imm=1
-#line 94 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=13 dst=r5 src=r3 offset=100 imm=0
+	// EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=14 dst=r5 src=r2 offset=23 imm=0
+	// EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(23));
-	// EBPF_OP_MOV64_IMM pc=15 dst=r6 src=r0 offset=0 imm=1
-#line 99 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=16 dst=r5 src=r0 offset=97 imm=4
+	// EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
 #line 99 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(4)) goto label_3;
-	// EBPF_OP_LDXB pc=17 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r4 + OFFSET(0));
-	// EBPF_OP_LSH64_IMM pc=18 dst=r5 src=r0 offset=0 imm=2
+	// EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
 #line 98 "sample/decap_permit_packet.c"
 	r5 <<= IMMEDIATE(2);
-	// EBPF_OP_AND64_IMM pc=19 dst=r5 src=r0 offset=0 imm=60
+	// EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
 #line 98 "sample/decap_permit_packet.c"
 	r5 &= IMMEDIATE(60);
-	// EBPF_OP_MOV64_REG pc=20 dst=r0 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=17 dst=r4 src=r5 offset=0 imm=0
+#line 98 "sample/decap_permit_packet.c"
+	r4 += r5;
+	// EBPF_OP_ADD64_IMM pc=18 dst=r4 src=r0 offset=0 imm=20
 #line 100 "sample/decap_permit_packet.c"
-	r0 = r5;
-	// EBPF_OP_ADD64_REG pc=21 dst=r0 src=r4 offset=0 imm=0
+	r4 += IMMEDIATE(20);
+	// EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	r0 += r4;
-	// EBPF_OP_ADD64_IMM pc=22 dst=r0 src=r0 offset=0 imm=20
-#line 100 "sample/decap_permit_packet.c"
-	r0 += IMMEDIATE(20);
-	// EBPF_OP_MOV64_IMM pc=23 dst=r6 src=r0 offset=0 imm=1
-#line 100 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=24 dst=r0 src=r3 offset=89 imm=0
-#line 100 "sample/decap_permit_packet.c"
-	if (r0 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=25 dst=r4 src=r2 offset=0 imm=0
+	if (r4 > r3) goto label_3;
+	// EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_REG pc=26 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 += r5;
-	// EBPF_OP_MOV64_IMM pc=27 dst=r6 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=2
 #line 29 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(2);
-	// EBPF_OP_JGT_REG pc=28 dst=r4 src=r3 offset=85 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=29 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r5 = r4;
-	// EBPF_OP_ADD64_IMM pc=30 dst=r5 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
 #line 29 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=31 dst=r5 src=r3 offset=82 imm=0
+	// EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=32 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=33 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(13)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=34 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=29 dst=r3 src=r2 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=35 dst=r4 src=r3 offset=12 imm=0
+	// EBPF_OP_STXB pc=30 dst=r4 src=r3 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(12)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=36 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=31 dst=r3 src=r2 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=37 dst=r4 src=r3 offset=11 imm=0
+	// EBPF_OP_STXB pc=32 dst=r4 src=r3 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(11)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=38 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=33 dst=r3 src=r2 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=39 dst=r4 src=r3 offset=10 imm=0
+	// EBPF_OP_STXB pc=34 dst=r4 src=r3 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(10)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=40 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=35 dst=r3 src=r2 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=41 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_STXB pc=36 dst=r4 src=r3 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(9)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=42 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=37 dst=r3 src=r2 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=43 dst=r4 src=r3 offset=8 imm=0
+	// EBPF_OP_STXB pc=38 dst=r4 src=r3 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(8)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=44 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=39 dst=r3 src=r2 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=45 dst=r4 src=r3 offset=7 imm=0
+	// EBPF_OP_STXB pc=40 dst=r4 src=r3 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(7)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=46 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=41 dst=r3 src=r2 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=47 dst=r4 src=r3 offset=6 imm=0
+	// EBPF_OP_STXB pc=42 dst=r4 src=r3 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(6)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=48 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=43 dst=r3 src=r2 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=49 dst=r4 src=r3 offset=5 imm=0
+	// EBPF_OP_STXB pc=44 dst=r4 src=r3 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(5)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=50 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=45 dst=r3 src=r2 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=51 dst=r4 src=r3 offset=4 imm=0
+	// EBPF_OP_STXB pc=46 dst=r4 src=r3 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(4)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=52 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=47 dst=r3 src=r2 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=53 dst=r4 src=r3 offset=3 imm=0
+	// EBPF_OP_STXB pc=48 dst=r4 src=r3 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(3)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=54 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=49 dst=r3 src=r2 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=55 dst=r4 src=r3 offset=2 imm=0
+	// EBPF_OP_STXB pc=50 dst=r4 src=r3 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(2)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=56 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=51 dst=r3 src=r2 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=57 dst=r4 src=r3 offset=1 imm=0
+	// EBPF_OP_STXB pc=52 dst=r4 src=r3 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(1)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=58 dst=r2 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=53 dst=r2 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r2 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=59 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_STXB pc=54 dst=r4 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(0)) = (uint8_t)r2;
-	// EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_IMM pc=55 dst=r2 src=r0 offset=0 imm=20
 #line 39 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(20);
-	// EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 39 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 39 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 39 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_LSH64_IMM pc=62 dst=r0 src=r0 offset=0 imm=32
+	// EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r0 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=63 dst=r0 src=r0 offset=0 imm=32
+	r1 = r0;
+	// EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=0
+	r1 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=65 dst=r1 src=r0 offset=48 imm=0
+	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
 #line 39 "sample/decap_permit_packet.c"
-	if ((int64_t)r1 > (int64_t)r0) goto label_3;
-	// EBPF_OP_JA pc=66 dst=r0 src=r0 offset=46 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=0
+#line 39 "sample/decap_permit_packet.c"
+	r2 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
+#line 39 "sample/decap_permit_packet.c"
+	if ((int64_t)r2 > (int64_t)r1) goto label_3;
+	// EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 39 "sample/decap_permit_packet.c"
 	goto label_2;
 label_1:
+	// EBPF_OP_MOV64_REG pc=64 dst=r4 src=r2 offset=0 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	r4 = r2;
+	// EBPF_OP_ADD64_IMM pc=65 dst=r4 src=r0 offset=0 imm=54
+#line 106 "sample/decap_permit_packet.c"
+	r4 += IMMEDIATE(54);
+	// EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	if (r4 > r3) goto label_3;
 	// EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=54
+	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
 #line 106 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(54);
-	// EBPF_OP_MOV64_IMM pc=69 dst=r6 src=r0 offset=0 imm=1
-#line 106 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=70 dst=r4 src=r3 offset=43 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=71 dst=r4 src=r2 offset=20 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r4 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_MOV64_IMM pc=72 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JNE_IMM pc=73 dst=r4 src=r0 offset=40 imm=41
-#line 111 "sample/decap_permit_packet.c"
-	if (r4 != IMMEDIATE(41)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=74 dst=r4 src=r2 offset=0 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=75 dst=r4 src=r0 offset=0 imm=94
-#line 111 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(94);
-	// EBPF_OP_MOV64_IMM pc=76 dst=r6 src=r0 offset=0 imm=1
-#line 111 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
-	// EBPF_OP_JGT_REG pc=77 dst=r4 src=r3 offset=36 imm=0
+	// EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
 #line 111 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
+#line 111 "sample/decap_permit_packet.c"
+	if (r3 != IMMEDIATE(41)) goto label_3;
+	// EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=53 imm=0
+	// EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(53)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=74 dst=r3 src=r2 offset=12 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=52 imm=0
+	// EBPF_OP_STXB pc=75 dst=r2 src=r3 offset=52 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(52)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=76 dst=r3 src=r2 offset=11 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=51 imm=0
+	// EBPF_OP_STXB pc=77 dst=r2 src=r3 offset=51 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(51)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=10 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=50 imm=0
+	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=50 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(50)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=9 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=49 imm=0
+	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=49 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(49)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=8 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=48 imm=0
+	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=48 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(48)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=7 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=47 imm=0
+	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=47 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(47)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=6 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=46 imm=0
+	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=46 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(46)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=5 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=45 imm=0
+	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=45 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(45)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=4 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=44 imm=0
+	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=44 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(44)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=3 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=43 imm=0
+	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=43 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(43)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=100 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=2 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=101 dst=r2 src=r3 offset=42 imm=0
+	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=42 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(42)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=102 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=1 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=103 dst=r2 src=r3 offset=41 imm=0
+	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=41 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(41)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=104 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=0 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=105 dst=r2 src=r3 offset=40 imm=0
+	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=40 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(40)) = (uint8_t)r3;
-	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=40
+	// EBPF_OP_MOV64_IMM pc=100 dst=r2 src=r0 offset=0 imm=40
 #line 66 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(40);
-	// EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
 #line 66 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 66 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 66 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=108 dst=r6 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(2);
-	// EBPF_OP_LSH64_IMM pc=109 dst=r0 src=r0 offset=0 imm=32
+	r1 = r0;
+	// EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r0 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=32
+	r1 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=0
+	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
 #line 66 "sample/decap_permit_packet.c"
-	r1 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=112 dst=r1 src=r0 offset=1 imm=0
+	r0 = IMMEDIATE(2);
+	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	if ((int64_t)r1 > (int64_t)r0) goto label_3;
+	r2 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
+#line 66 "sample/decap_permit_packet.c"
+	if ((int64_t)r2 > (int64_t)r1) goto label_3;
 label_2:
-	// EBPF_OP_MOV64_IMM pc=113 dst=r6 src=r0 offset=0 imm=1
+	// EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
 #line 66 "sample/decap_permit_packet.c"
-	r6 = IMMEDIATE(1);
+	r0 = IMMEDIATE(1);
 label_3:
-	// EBPF_OP_MOV64_REG pc=114 dst=r0 src=r6 offset=0 imm=0
-#line 121 "sample/decap_permit_packet.c"
-	r0 = r6;
-	// EBPF_OP_EXIT pc=115 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
 #line 121 "sample/decap_permit_packet.c"
 	return r0;
 #line 121 "sample/decap_permit_packet.c"
@@ -582,7 +562,7 @@ label_3:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 116, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
+	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 110, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.txt
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -187,369 +192,389 @@ static GUID decapsulate_permit_packet_program_type_guid = {0xf1832a85, 0x85d5, 0
 static GUID decapsulate_permit_packet_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
 static uint64_t decapsulate_permit_packet(void* context)
 {
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	// Prologue
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r0 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r1 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r2 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r3 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r4 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r5 = 0;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
+	register uint64_t r6 = 0;
+#line 89 "sample/decap_permit_packet.c"
 	register uint64_t r10 = 0;
 
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	r1 = (uintptr_t)context;
-#line 83 "sample/decap_permit_packet.c"
+#line 89 "sample/decap_permit_packet.c"
 	r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-	// EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=1
-#line 83 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(1);
-	// EBPF_OP_LDXDW pc=1 dst=r3 src=r1 offset=8 imm=0
+	// EBPF_OP_LDXDW pc=0 dst=r3 src=r1 offset=8 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r3 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(8));
-	// EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=1 dst=r2 src=r1 offset=0 imm=0
 #line 88 "sample/decap_permit_packet.c"
 	r2 = *(uint64_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_MOV64_REG pc=3 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=2 dst=r4 src=r2 offset=0 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=4 dst=r4 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=3 dst=r4 src=r0 offset=0 imm=14
 #line 89 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=103 imm=0
+	// EBPF_OP_MOV64_IMM pc=4 dst=r6 src=r0 offset=0 imm=1
+#line 89 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=5 dst=r4 src=r3 offset=108 imm=0
 #line 89 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
 	// EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
 	r5 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
+	// EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=59 imm=56710
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 == IMMEDIATE(56710)) goto label_1;
-	// EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+	// EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=1
+#line 93 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=9 dst=r5 src=r0 offset=104 imm=8
 #line 93 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(8)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=10 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	r5 = r2;
-	// EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
+	// EBPF_OP_ADD64_IMM pc=11 dst=r5 src=r0 offset=0 imm=34
 #line 94 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(34);
-	// EBPF_OP_JGT_REG pc=11 dst=r5 src=r3 offset=97 imm=0
+	// EBPF_OP_MOV64_IMM pc=12 dst=r6 src=r0 offset=0 imm=1
+#line 94 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=13 dst=r5 src=r3 offset=100 imm=0
 #line 94 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+	// EBPF_OP_LDXB pc=14 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(23));
-	// EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
+	// EBPF_OP_MOV64_IMM pc=15 dst=r6 src=r0 offset=0 imm=1
+#line 99 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=16 dst=r5 src=r0 offset=97 imm=4
 #line 99 "sample/decap_permit_packet.c"
 	if (r5 != IMMEDIATE(4)) goto label_3;
-	// EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_LDXB pc=17 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
 	r5 = *(uint8_t *)(uintptr_t)(r4 + OFFSET(0));
-	// EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
+	// EBPF_OP_LSH64_IMM pc=18 dst=r5 src=r0 offset=0 imm=2
 #line 98 "sample/decap_permit_packet.c"
 	r5 <<= IMMEDIATE(2);
-	// EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
+	// EBPF_OP_AND64_IMM pc=19 dst=r5 src=r0 offset=0 imm=60
 #line 98 "sample/decap_permit_packet.c"
 	r5 &= IMMEDIATE(60);
-	// EBPF_OP_ADD64_REG pc=17 dst=r4 src=r5 offset=0 imm=0
-#line 98 "sample/decap_permit_packet.c"
-	r4 += r5;
-	// EBPF_OP_ADD64_IMM pc=18 dst=r4 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_REG pc=20 dst=r0 src=r5 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(20);
-	// EBPF_OP_JGT_REG pc=19 dst=r4 src=r3 offset=89 imm=0
+	r0 = r5;
+	// EBPF_OP_ADD64_REG pc=21 dst=r0 src=r4 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+	r0 += r4;
+	// EBPF_OP_ADD64_IMM pc=22 dst=r0 src=r0 offset=0 imm=20
+#line 100 "sample/decap_permit_packet.c"
+	r0 += IMMEDIATE(20);
+	// EBPF_OP_MOV64_IMM pc=23 dst=r6 src=r0 offset=0 imm=1
+#line 100 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=24 dst=r0 src=r3 offset=89 imm=0
+#line 100 "sample/decap_permit_packet.c"
+	if (r0 > r3) goto label_3;
+	// EBPF_OP_MOV64_REG pc=25 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_ADD64_REG pc=26 dst=r4 src=r5 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r4 += r5;
-	// EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=2
+	// EBPF_OP_MOV64_IMM pc=27 dst=r6 src=r0 offset=0 imm=2
 #line 29 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_JGT_REG pc=23 dst=r4 src=r3 offset=85 imm=0
+	r6 = IMMEDIATE(2);
+	// EBPF_OP_JGT_REG pc=28 dst=r4 src=r3 offset=85 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=29 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	r5 = r4;
-	// EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
+	// EBPF_OP_ADD64_IMM pc=30 dst=r5 src=r0 offset=0 imm=14
 #line 29 "sample/decap_permit_packet.c"
 	r5 += IMMEDIATE(14);
-	// EBPF_OP_JGT_REG pc=26 dst=r5 src=r3 offset=82 imm=0
+	// EBPF_OP_JGT_REG pc=31 dst=r5 src=r3 offset=82 imm=0
 #line 29 "sample/decap_permit_packet.c"
 	if (r5 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=32 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_STXB pc=33 dst=r4 src=r3 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(13)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=29 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=34 dst=r3 src=r2 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=30 dst=r4 src=r3 offset=12 imm=0
+	// EBPF_OP_STXB pc=35 dst=r4 src=r3 offset=12 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(12)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=31 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=36 dst=r3 src=r2 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=32 dst=r4 src=r3 offset=11 imm=0
+	// EBPF_OP_STXB pc=37 dst=r4 src=r3 offset=11 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(11)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=33 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=38 dst=r3 src=r2 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=34 dst=r4 src=r3 offset=10 imm=0
+	// EBPF_OP_STXB pc=39 dst=r4 src=r3 offset=10 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(10)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=35 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=40 dst=r3 src=r2 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=36 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_STXB pc=41 dst=r4 src=r3 offset=9 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(9)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=37 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=42 dst=r3 src=r2 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=38 dst=r4 src=r3 offset=8 imm=0
+	// EBPF_OP_STXB pc=43 dst=r4 src=r3 offset=8 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(8)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=39 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=44 dst=r3 src=r2 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=40 dst=r4 src=r3 offset=7 imm=0
+	// EBPF_OP_STXB pc=45 dst=r4 src=r3 offset=7 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(7)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=41 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=46 dst=r3 src=r2 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=42 dst=r4 src=r3 offset=6 imm=0
+	// EBPF_OP_STXB pc=47 dst=r4 src=r3 offset=6 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(6)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=43 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=48 dst=r3 src=r2 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=44 dst=r4 src=r3 offset=5 imm=0
+	// EBPF_OP_STXB pc=49 dst=r4 src=r3 offset=5 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(5)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=45 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=50 dst=r3 src=r2 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=46 dst=r4 src=r3 offset=4 imm=0
+	// EBPF_OP_STXB pc=51 dst=r4 src=r3 offset=4 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(4)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=47 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=52 dst=r3 src=r2 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=48 dst=r4 src=r3 offset=3 imm=0
+	// EBPF_OP_STXB pc=53 dst=r4 src=r3 offset=3 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(3)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=49 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=54 dst=r3 src=r2 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=50 dst=r4 src=r3 offset=2 imm=0
+	// EBPF_OP_STXB pc=55 dst=r4 src=r3 offset=2 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(2)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=51 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=56 dst=r3 src=r2 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=52 dst=r4 src=r3 offset=1 imm=0
+	// EBPF_OP_STXB pc=57 dst=r4 src=r3 offset=1 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(1)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=53 dst=r2 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=58 dst=r2 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	r2 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=54 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_STXB pc=59 dst=r4 src=r2 offset=0 imm=0
 #line 36 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r4 + OFFSET(0)) = (uint8_t)r2;
-	// EBPF_OP_MOV64_IMM pc=55 dst=r2 src=r0 offset=0 imm=20
+	// EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=20
 #line 39 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(20);
-	// EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=65536
 #line 39 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 39 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 39 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LSH64_IMM pc=62 dst=r0 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 = r0;
-	// EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
+	r0 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=63 dst=r0 src=r0 offset=0 imm=32
 #line 39 "sample/decap_permit_packet.c"
-	r1 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
+	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
+	r1 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=65 dst=r1 src=r0 offset=48 imm=0
 #line 39 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=0
-#line 39 "sample/decap_permit_packet.c"
-	r2 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=62 dst=r2 src=r1 offset=46 imm=0
-#line 39 "sample/decap_permit_packet.c"
-	if ((int64_t)r2 > (int64_t)r1) goto label_3;
-	// EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+	if ((int64_t)r1 > (int64_t)r0) goto label_3;
+	// EBPF_OP_JA pc=66 dst=r0 src=r0 offset=46 imm=0
 #line 39 "sample/decap_permit_packet.c"
 	goto label_2;
 label_1:
-	// EBPF_OP_MOV64_REG pc=64 dst=r4 src=r2 offset=0 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=65 dst=r4 src=r0 offset=0 imm=54
-#line 106 "sample/decap_permit_packet.c"
-	r4 += IMMEDIATE(54);
-	// EBPF_OP_JGT_REG pc=66 dst=r4 src=r3 offset=42 imm=0
-#line 106 "sample/decap_permit_packet.c"
-	if (r4 > r3) goto label_3;
 	// EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
 	r4 = r2;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
+	// EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=54
 #line 106 "sample/decap_permit_packet.c"
+	r4 += IMMEDIATE(54);
+	// EBPF_OP_MOV64_IMM pc=69 dst=r6 src=r0 offset=0 imm=1
+#line 106 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=70 dst=r4 src=r3 offset=43 imm=0
+#line 106 "sample/decap_permit_packet.c"
+	if (r4 > r3) goto label_3;
+	// EBPF_OP_LDXB pc=71 dst=r4 src=r2 offset=20 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r4 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_MOV64_IMM pc=72 dst=r6 src=r0 offset=0 imm=1
+#line 111 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JNE_IMM pc=73 dst=r4 src=r0 offset=40 imm=41
+#line 111 "sample/decap_permit_packet.c"
+	if (r4 != IMMEDIATE(41)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=74 dst=r4 src=r2 offset=0 imm=0
+#line 111 "sample/decap_permit_packet.c"
+	r4 = r2;
+	// EBPF_OP_ADD64_IMM pc=75 dst=r4 src=r0 offset=0 imm=94
+#line 111 "sample/decap_permit_packet.c"
 	r4 += IMMEDIATE(94);
-	// EBPF_OP_JGT_REG pc=69 dst=r4 src=r3 offset=39 imm=0
+	// EBPF_OP_MOV64_IMM pc=76 dst=r6 src=r0 offset=0 imm=1
+#line 111 "sample/decap_permit_packet.c"
+	r6 = IMMEDIATE(1);
+	// EBPF_OP_JGT_REG pc=77 dst=r4 src=r3 offset=36 imm=0
 #line 111 "sample/decap_permit_packet.c"
 	if (r4 > r3) goto label_3;
-	// EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
-#line 111 "sample/decap_permit_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
-#line 111 "sample/decap_permit_packet.c"
-	if (r3 != IMMEDIATE(41)) goto label_3;
-	// EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(13));
-	// EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
+	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=53 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(53)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=74 dst=r3 src=r2 offset=12 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=12 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(12));
-	// EBPF_OP_STXB pc=75 dst=r2 src=r3 offset=52 imm=0
+	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=52 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(52)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=76 dst=r3 src=r2 offset=11 imm=0
+	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=11 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(11));
-	// EBPF_OP_STXB pc=77 dst=r2 src=r3 offset=51 imm=0
+	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=51 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(51)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=78 dst=r3 src=r2 offset=10 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=10 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(10));
-	// EBPF_OP_STXB pc=79 dst=r2 src=r3 offset=50 imm=0
+	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=50 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(50)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=80 dst=r3 src=r2 offset=9 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=9 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(9));
-	// EBPF_OP_STXB pc=81 dst=r2 src=r3 offset=49 imm=0
+	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=49 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(49)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=82 dst=r3 src=r2 offset=8 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=8 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(8));
-	// EBPF_OP_STXB pc=83 dst=r2 src=r3 offset=48 imm=0
+	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=48 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(48)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=84 dst=r3 src=r2 offset=7 imm=0
+	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=7 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(7));
-	// EBPF_OP_STXB pc=85 dst=r2 src=r3 offset=47 imm=0
+	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=47 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(47)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=86 dst=r3 src=r2 offset=6 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=6 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(6));
-	// EBPF_OP_STXB pc=87 dst=r2 src=r3 offset=46 imm=0
+	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=46 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(46)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=88 dst=r3 src=r2 offset=5 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=5 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(5));
-	// EBPF_OP_STXB pc=89 dst=r2 src=r3 offset=45 imm=0
+	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=45 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(45)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=90 dst=r3 src=r2 offset=4 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=4 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(4));
-	// EBPF_OP_STXB pc=91 dst=r2 src=r3 offset=44 imm=0
+	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=44 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(44)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=92 dst=r3 src=r2 offset=3 imm=0
+	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=3 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(3));
-	// EBPF_OP_STXB pc=93 dst=r2 src=r3 offset=43 imm=0
+	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=43 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(43)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=94 dst=r3 src=r2 offset=2 imm=0
+	// EBPF_OP_LDXB pc=100 dst=r3 src=r2 offset=2 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(2));
-	// EBPF_OP_STXB pc=95 dst=r2 src=r3 offset=42 imm=0
+	// EBPF_OP_STXB pc=101 dst=r2 src=r3 offset=42 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(42)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=96 dst=r3 src=r2 offset=1 imm=0
+	// EBPF_OP_LDXB pc=102 dst=r3 src=r2 offset=1 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(1));
-	// EBPF_OP_STXB pc=97 dst=r2 src=r3 offset=41 imm=0
+	// EBPF_OP_STXB pc=103 dst=r2 src=r3 offset=41 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(41)) = (uint8_t)r3;
-	// EBPF_OP_LDXB pc=98 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_LDXB pc=104 dst=r3 src=r2 offset=0 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(0));
-	// EBPF_OP_STXB pc=99 dst=r2 src=r3 offset=40 imm=0
+	// EBPF_OP_STXB pc=105 dst=r2 src=r3 offset=40 imm=0
 #line 63 "sample/decap_permit_packet.c"
 	*(uint8_t *)(uintptr_t)(r2 + OFFSET(40)) = (uint8_t)r3;
-	// EBPF_OP_MOV64_IMM pc=100 dst=r2 src=r0 offset=0 imm=40
+	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=40
 #line 66 "sample/decap_permit_packet.c"
 	r2 = IMMEDIATE(40);
-	// EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=65536
+	// EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=65536
 #line 66 "sample/decap_permit_packet.c"
 	r0 = decapsulate_permit_packet_helpers[0].address
 #line 66 "sample/decap_permit_packet.c"
 	(r1, r2, r3, r4, r5);
 #line 66 "sample/decap_permit_packet.c"
 	if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=108 dst=r6 src=r0 offset=0 imm=2
 #line 66 "sample/decap_permit_packet.c"
-	r1 = r0;
-	// EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
+	r6 = IMMEDIATE(2);
+	// EBPF_OP_LSH64_IMM pc=109 dst=r0 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r1 <<= IMMEDIATE(32);
-	// EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
+	r0 <<= IMMEDIATE(32);
+	// EBPF_OP_ARSH64_IMM pc=110 dst=r0 src=r0 offset=0 imm=32
 #line 66 "sample/decap_permit_packet.c"
-	r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-	// EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
+	r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(32);
+	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(2);
-	// EBPF_OP_MOV64_IMM pc=106 dst=r2 src=r0 offset=0 imm=0
+	r1 = IMMEDIATE(0);
+	// EBPF_OP_JSGT_REG pc=112 dst=r1 src=r0 offset=1 imm=0
 #line 66 "sample/decap_permit_packet.c"
-	r2 = IMMEDIATE(0);
-	// EBPF_OP_JSGT_REG pc=107 dst=r2 src=r1 offset=1 imm=0
-#line 66 "sample/decap_permit_packet.c"
-	if ((int64_t)r2 > (int64_t)r1) goto label_3;
+	if ((int64_t)r1 > (int64_t)r0) goto label_3;
 label_2:
-	// EBPF_OP_MOV64_IMM pc=108 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_MOV64_IMM pc=113 dst=r6 src=r0 offset=0 imm=1
 #line 66 "sample/decap_permit_packet.c"
-	r0 = IMMEDIATE(1);
+	r6 = IMMEDIATE(1);
 label_3:
-	// EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=114 dst=r0 src=r6 offset=0 imm=0
+#line 121 "sample/decap_permit_packet.c"
+	r0 = r6;
+	// EBPF_OP_EXIT pc=115 dst=r0 src=r0 offset=0 imm=0
 #line 121 "sample/decap_permit_packet.c"
 	return r0;
 #line 121 "sample/decap_permit_packet.c"
@@ -557,7 +582,7 @@ label_3:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 110, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
+	{ decapsulate_permit_packet, "xdp/decapsulate_reflect", "decapsulate_permit_packet", NULL, 0, decapsulate_permit_packet_helpers, 1, 116, &decapsulate_permit_packet_program_type_guid, &decapsulate_permit_packet_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
@@ -567,4 +592,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t decap_permit_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t decap_permit_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.txt
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "test_map" },
 };
@@ -154,4 +159,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t divide_by_zero_metadata_table = { _get_programs, _get_maps };
+metadata_table_t divide_by_zero_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.txt
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "test_map" },
 };
@@ -112,4 +117,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t divide_by_zero_metadata_table = { _get_programs, _get_maps };
+metadata_table_t divide_by_zero_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.txt
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "test_map" },
 };
@@ -279,4 +284,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t divide_by_zero_metadata_table = { _get_programs, _get_maps };
+metadata_table_t divide_by_zero_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/droppacket_dll.txt
+++ b/tests/bpf2c_tests/expected/droppacket_dll.txt
@@ -205,9 +205,9 @@ label_1:
 #line 69 "sample/droppacket.c"
 	r1 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 69 "sample/droppacket.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 69 "sample/droppacket.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 69 "sample/droppacket.c"

--- a/tests/bpf2c_tests/expected/droppacket_dll.txt
+++ b/tests/bpf2c_tests/expected/droppacket_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 8, 1, 0, 0, 0, 0,  }, "dropped_packet_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "interface_index_map" },
@@ -200,9 +205,9 @@ label_1:
 #line 69 "sample/droppacket.c"
 	r1 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
-#line 69 "sample/droppacket.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 69 "sample/droppacket.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 69 "sample/droppacket.c"
@@ -260,4 +265,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t droppacket_metadata_table = { _get_programs, _get_maps };
+metadata_table_t droppacket_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/droppacket_raw.txt
+++ b/tests/bpf2c_tests/expected/droppacket_raw.txt
@@ -163,9 +163,9 @@ label_1:
 #line 69 "sample/droppacket.c"
 	r1 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 69 "sample/droppacket.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 69 "sample/droppacket.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 69 "sample/droppacket.c"

--- a/tests/bpf2c_tests/expected/droppacket_raw.txt
+++ b/tests/bpf2c_tests/expected/droppacket_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 8, 1, 0, 0, 0, 0,  }, "dropped_packet_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "interface_index_map" },
@@ -158,9 +163,9 @@ label_1:
 #line 69 "sample/droppacket.c"
 	r1 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
-#line 69 "sample/droppacket.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 69 "sample/droppacket.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 69 "sample/droppacket.c"
@@ -218,4 +223,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t droppacket_metadata_table = { _get_programs, _get_maps };
+metadata_table_t droppacket_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/droppacket_sys.txt
+++ b/tests/bpf2c_tests/expected/droppacket_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 8, 1, 0, 0, 0, 0,  }, "dropped_packet_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "interface_index_map" },
@@ -325,9 +330,9 @@ label_1:
 #line 69 "sample/droppacket.c"
 	r1 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
-#line 69 "sample/droppacket.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 69 "sample/droppacket.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 69 "sample/droppacket.c"
@@ -385,4 +390,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t droppacket_metadata_table = { _get_programs, _get_maps };
+metadata_table_t droppacket_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/droppacket_sys.txt
+++ b/tests/bpf2c_tests/expected/droppacket_sys.txt
@@ -330,9 +330,9 @@ label_1:
 #line 69 "sample/droppacket.c"
 	r1 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(4));
 	// EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 69 "sample/droppacket.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 69 "sample/droppacket.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_JGT_IMM pc=34 dst=r1 src=r0 offset=11 imm=8
 #line 69 "sample/droppacket.c"

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.txt
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.txt
@@ -372,17 +372,17 @@ static uint64_t encap_reflect_packet(void* context)
 #line 64 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r6 + OFFSET(36));
 	// EBPF_OP_BE pc=92 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=93 dst=r1 src=r0 offset=0 imm=20
 #line 64 "sample/encap_reflect_packet.c"
 	r1 += IMMEDIATE(20);
 	// EBPF_OP_BE pc=94 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=95 dst=r6 src=r1 offset=16 imm=0
 #line 64 "sample/encap_reflect_packet.c"
@@ -455,21 +455,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=116 dst=r3 src=r1 offset=180 imm=0
 #line 164 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_LDXB pc=117 dst=r3 src=r2 offset=20 imm=0
-#line 169 "sample/encap_reflect_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=118 dst=r3 src=r0 offset=178 imm=17
-#line 169 "sample/encap_reflect_packet.c"
-	if (r3 != IMMEDIATE(17)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=119 dst=r3 src=r2 offset=0 imm=0
-#line 169 "sample/encap_reflect_packet.c"
+	// EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+#line 164 "sample/encap_reflect_packet.c"
 	r3 = r2;
-	// EBPF_OP_ADD64_IMM pc=120 dst=r3 src=r0 offset=0 imm=62
-#line 169 "sample/encap_reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
+#line 164 "sample/encap_reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=121 dst=r3 src=r1 offset=175 imm=0
+	// EBPF_OP_JGT_REG pc=119 dst=r3 src=r1 offset=177 imm=0
 #line 169 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
+	// EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+#line 169 "sample/encap_reflect_packet.c"
+	r1 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
+#line 169 "sample/encap_reflect_packet.c"
+	if (r1 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(56));
@@ -982,17 +982,17 @@ label_1:
 #line 123 "sample/encap_reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(58));
 	// EBPF_OP_BE pc=292 dst=r2 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 = htobe16((uint16_t)r2);
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=293 dst=r2 src=r0 offset=0 imm=40
 #line 123 "sample/encap_reflect_packet.c"
 	r2 += IMMEDIATE(40);
 	// EBPF_OP_BE pc=294 dst=r2 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 = htobe16((uint16_t)r2);
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=295 dst=r1 src=r2 offset=18 imm=0
 #line 123 "sample/encap_reflect_packet.c"

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.txt
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -367,17 +372,17 @@ static uint64_t encap_reflect_packet(void* context)
 #line 64 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r6 + OFFSET(36));
 	// EBPF_OP_BE pc=92 dst=r1 src=r0 offset=0 imm=16
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=93 dst=r1 src=r0 offset=0 imm=20
 #line 64 "sample/encap_reflect_packet.c"
 	r1 += IMMEDIATE(20);
 	// EBPF_OP_BE pc=94 dst=r1 src=r0 offset=0 imm=16
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=95 dst=r6 src=r1 offset=16 imm=0
 #line 64 "sample/encap_reflect_packet.c"
@@ -450,21 +455,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=116 dst=r3 src=r1 offset=180 imm=0
 #line 164 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
-#line 164 "sample/encap_reflect_packet.c"
+	// EBPF_OP_LDXB pc=117 dst=r3 src=r2 offset=20 imm=0
+#line 169 "sample/encap_reflect_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=118 dst=r3 src=r0 offset=178 imm=17
+#line 169 "sample/encap_reflect_packet.c"
+	if (r3 != IMMEDIATE(17)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=119 dst=r3 src=r2 offset=0 imm=0
+#line 169 "sample/encap_reflect_packet.c"
 	r3 = r2;
-	// EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
-#line 164 "sample/encap_reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=120 dst=r3 src=r0 offset=0 imm=62
+#line 169 "sample/encap_reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=119 dst=r3 src=r1 offset=177 imm=0
+	// EBPF_OP_JGT_REG pc=121 dst=r3 src=r1 offset=175 imm=0
 #line 169 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
-#line 169 "sample/encap_reflect_packet.c"
-	r1 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
-#line 169 "sample/encap_reflect_packet.c"
-	if (r1 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(56));
@@ -977,17 +982,17 @@ label_1:
 #line 123 "sample/encap_reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(58));
 	// EBPF_OP_BE pc=292 dst=r2 src=r0 offset=0 imm=16
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 = htobe16((uint16_t)r2);
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=293 dst=r2 src=r0 offset=0 imm=40
 #line 123 "sample/encap_reflect_packet.c"
 	r2 += IMMEDIATE(40);
 	// EBPF_OP_BE pc=294 dst=r2 src=r0 offset=0 imm=16
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 = htobe16((uint16_t)r2);
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=295 dst=r1 src=r2 offset=18 imm=0
 #line 123 "sample/encap_reflect_packet.c"
@@ -1015,4 +1020,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t encap_reflect_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t encap_reflect_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.txt
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -325,17 +330,17 @@ static uint64_t encap_reflect_packet(void* context)
 #line 64 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r6 + OFFSET(36));
 	// EBPF_OP_BE pc=92 dst=r1 src=r0 offset=0 imm=16
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=93 dst=r1 src=r0 offset=0 imm=20
 #line 64 "sample/encap_reflect_packet.c"
 	r1 += IMMEDIATE(20);
 	// EBPF_OP_BE pc=94 dst=r1 src=r0 offset=0 imm=16
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=95 dst=r6 src=r1 offset=16 imm=0
 #line 64 "sample/encap_reflect_packet.c"
@@ -408,21 +413,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=116 dst=r3 src=r1 offset=180 imm=0
 #line 164 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
-#line 164 "sample/encap_reflect_packet.c"
+	// EBPF_OP_LDXB pc=117 dst=r3 src=r2 offset=20 imm=0
+#line 169 "sample/encap_reflect_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=118 dst=r3 src=r0 offset=178 imm=17
+#line 169 "sample/encap_reflect_packet.c"
+	if (r3 != IMMEDIATE(17)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=119 dst=r3 src=r2 offset=0 imm=0
+#line 169 "sample/encap_reflect_packet.c"
 	r3 = r2;
-	// EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
-#line 164 "sample/encap_reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=120 dst=r3 src=r0 offset=0 imm=62
+#line 169 "sample/encap_reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=119 dst=r3 src=r1 offset=177 imm=0
+	// EBPF_OP_JGT_REG pc=121 dst=r3 src=r1 offset=175 imm=0
 #line 169 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
-#line 169 "sample/encap_reflect_packet.c"
-	r1 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
-#line 169 "sample/encap_reflect_packet.c"
-	if (r1 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(56));
@@ -935,17 +940,17 @@ label_1:
 #line 123 "sample/encap_reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(58));
 	// EBPF_OP_BE pc=292 dst=r2 src=r0 offset=0 imm=16
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 = htobe16((uint16_t)r2);
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=293 dst=r2 src=r0 offset=0 imm=40
 #line 123 "sample/encap_reflect_packet.c"
 	r2 += IMMEDIATE(40);
 	// EBPF_OP_BE pc=294 dst=r2 src=r0 offset=0 imm=16
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 = htobe16((uint16_t)r2);
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=295 dst=r1 src=r2 offset=18 imm=0
 #line 123 "sample/encap_reflect_packet.c"
@@ -973,4 +978,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t encap_reflect_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t encap_reflect_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.txt
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.txt
@@ -330,17 +330,17 @@ static uint64_t encap_reflect_packet(void* context)
 #line 64 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r6 + OFFSET(36));
 	// EBPF_OP_BE pc=92 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=93 dst=r1 src=r0 offset=0 imm=20
 #line 64 "sample/encap_reflect_packet.c"
 	r1 += IMMEDIATE(20);
 	// EBPF_OP_BE pc=94 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=95 dst=r6 src=r1 offset=16 imm=0
 #line 64 "sample/encap_reflect_packet.c"
@@ -413,21 +413,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=116 dst=r3 src=r1 offset=180 imm=0
 #line 164 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_LDXB pc=117 dst=r3 src=r2 offset=20 imm=0
-#line 169 "sample/encap_reflect_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=118 dst=r3 src=r0 offset=178 imm=17
-#line 169 "sample/encap_reflect_packet.c"
-	if (r3 != IMMEDIATE(17)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=119 dst=r3 src=r2 offset=0 imm=0
-#line 169 "sample/encap_reflect_packet.c"
+	// EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+#line 164 "sample/encap_reflect_packet.c"
 	r3 = r2;
-	// EBPF_OP_ADD64_IMM pc=120 dst=r3 src=r0 offset=0 imm=62
-#line 169 "sample/encap_reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
+#line 164 "sample/encap_reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=121 dst=r3 src=r1 offset=175 imm=0
+	// EBPF_OP_JGT_REG pc=119 dst=r3 src=r1 offset=177 imm=0
 #line 169 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
+	// EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+#line 169 "sample/encap_reflect_packet.c"
+	r1 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
+#line 169 "sample/encap_reflect_packet.c"
+	if (r1 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(56));
@@ -940,17 +940,17 @@ label_1:
 #line 123 "sample/encap_reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(58));
 	// EBPF_OP_BE pc=292 dst=r2 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 = htobe16((uint16_t)r2);
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=293 dst=r2 src=r0 offset=0 imm=40
 #line 123 "sample/encap_reflect_packet.c"
 	r2 += IMMEDIATE(40);
 	// EBPF_OP_BE pc=294 dst=r2 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 = htobe16((uint16_t)r2);
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=295 dst=r1 src=r2 offset=18 imm=0
 #line 123 "sample/encap_reflect_packet.c"

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.txt
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -492,17 +497,17 @@ static uint64_t encap_reflect_packet(void* context)
 #line 64 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r6 + OFFSET(36));
 	// EBPF_OP_BE pc=92 dst=r1 src=r0 offset=0 imm=16
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=93 dst=r1 src=r0 offset=0 imm=20
 #line 64 "sample/encap_reflect_packet.c"
 	r1 += IMMEDIATE(20);
 	// EBPF_OP_BE pc=94 dst=r1 src=r0 offset=0 imm=16
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 = htobe16((uint16_t)r1);
-#line 64 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=95 dst=r6 src=r1 offset=16 imm=0
 #line 64 "sample/encap_reflect_packet.c"
@@ -575,21 +580,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=116 dst=r3 src=r1 offset=180 imm=0
 #line 164 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
-#line 164 "sample/encap_reflect_packet.c"
+	// EBPF_OP_LDXB pc=117 dst=r3 src=r2 offset=20 imm=0
+#line 169 "sample/encap_reflect_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=118 dst=r3 src=r0 offset=178 imm=17
+#line 169 "sample/encap_reflect_packet.c"
+	if (r3 != IMMEDIATE(17)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=119 dst=r3 src=r2 offset=0 imm=0
+#line 169 "sample/encap_reflect_packet.c"
 	r3 = r2;
-	// EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
-#line 164 "sample/encap_reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=120 dst=r3 src=r0 offset=0 imm=62
+#line 169 "sample/encap_reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=119 dst=r3 src=r1 offset=177 imm=0
+	// EBPF_OP_JGT_REG pc=121 dst=r3 src=r1 offset=175 imm=0
 #line 169 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
-#line 169 "sample/encap_reflect_packet.c"
-	r1 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
-#line 169 "sample/encap_reflect_packet.c"
-	if (r1 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(56));
@@ -1102,17 +1107,17 @@ label_1:
 #line 123 "sample/encap_reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(58));
 	// EBPF_OP_BE pc=292 dst=r2 src=r0 offset=0 imm=16
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 = htobe16((uint16_t)r2);
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=293 dst=r2 src=r0 offset=0 imm=40
 #line 123 "sample/encap_reflect_packet.c"
 	r2 += IMMEDIATE(40);
 	// EBPF_OP_BE pc=294 dst=r2 src=r0 offset=0 imm=16
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 = htobe16((uint16_t)r2);
-#line 123 "sample/encap_reflect_packet.c"
+#line 10 "bpf_endian.h"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=295 dst=r1 src=r2 offset=18 imm=0
 #line 123 "sample/encap_reflect_packet.c"
@@ -1140,4 +1145,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t encap_reflect_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t encap_reflect_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.txt
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.txt
@@ -497,17 +497,17 @@ static uint64_t encap_reflect_packet(void* context)
 #line 64 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r6 + OFFSET(36));
 	// EBPF_OP_BE pc=92 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=93 dst=r1 src=r0 offset=0 imm=20
 #line 64 "sample/encap_reflect_packet.c"
 	r1 += IMMEDIATE(20);
 	// EBPF_OP_BE pc=94 dst=r1 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 = htobe16((uint16_t)r1);
-#line 10 "bpf_endian.h"
+#line 64 "sample/encap_reflect_packet.c"
 	r1 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=95 dst=r6 src=r1 offset=16 imm=0
 #line 64 "sample/encap_reflect_packet.c"
@@ -580,21 +580,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=116 dst=r3 src=r1 offset=180 imm=0
 #line 164 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
-	// EBPF_OP_LDXB pc=117 dst=r3 src=r2 offset=20 imm=0
-#line 169 "sample/encap_reflect_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=118 dst=r3 src=r0 offset=178 imm=17
-#line 169 "sample/encap_reflect_packet.c"
-	if (r3 != IMMEDIATE(17)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=119 dst=r3 src=r2 offset=0 imm=0
-#line 169 "sample/encap_reflect_packet.c"
+	// EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+#line 164 "sample/encap_reflect_packet.c"
 	r3 = r2;
-	// EBPF_OP_ADD64_IMM pc=120 dst=r3 src=r0 offset=0 imm=62
-#line 169 "sample/encap_reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
+#line 164 "sample/encap_reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=121 dst=r3 src=r1 offset=175 imm=0
+	// EBPF_OP_JGT_REG pc=119 dst=r3 src=r1 offset=177 imm=0
 #line 169 "sample/encap_reflect_packet.c"
 	if (r3 > r1) goto label_3;
+	// EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+#line 169 "sample/encap_reflect_packet.c"
+	r1 = *(uint8_t *)(uintptr_t)(r2 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
+#line 169 "sample/encap_reflect_packet.c"
+	if (r1 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
 	r1 = *(uint16_t *)(uintptr_t)(r2 + OFFSET(56));
@@ -1107,17 +1107,17 @@ label_1:
 #line 123 "sample/encap_reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(58));
 	// EBPF_OP_BE pc=292 dst=r2 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 = htobe16((uint16_t)r2);
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_ADD64_IMM pc=293 dst=r2 src=r0 offset=0 imm=40
 #line 123 "sample/encap_reflect_packet.c"
 	r2 += IMMEDIATE(40);
 	// EBPF_OP_BE pc=294 dst=r2 src=r0 offset=0 imm=16
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 = htobe16((uint16_t)r2);
-#line 10 "bpf_endian.h"
+#line 123 "sample/encap_reflect_packet.c"
 	r2 &= UINT32_MAX;
 	// EBPF_OP_STXH pc=295 dst=r1 src=r2 offset=18 imm=0
 #line 123 "sample/encap_reflect_packet.c"

--- a/tests/bpf2c_tests/expected/map_dll.txt
+++ b/tests/bpf2c_tests/expected/map_dll.txt
@@ -139,9 +139,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=4 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -151,9 +151,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_REG pc=6 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[1].address);
@@ -425,9 +425,9 @@ label_7:
 	// EBPF_OP_MOV64_IMM pc=106 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=108 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -437,9 +437,9 @@ label_7:
 	// EBPF_OP_MOV64_REG pc=110 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=112 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[2].address);
@@ -705,9 +705,9 @@ label_12:
 	// EBPF_OP_MOV64_IMM pc=211 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=213 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -717,9 +717,9 @@ label_12:
 	// EBPF_OP_MOV64_REG pc=215 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=217 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[3].address);
@@ -985,9 +985,9 @@ label_17:
 	// EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=317 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -997,9 +997,9 @@ label_17:
 	// EBPF_OP_MOV64_REG pc=319 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=321 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[4].address);
@@ -1265,9 +1265,9 @@ label_22:
 	// EBPF_OP_MOV64_IMM pc=420 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=422 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1277,9 +1277,9 @@ label_22:
 	// EBPF_OP_MOV64_REG pc=424 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=426 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1539,9 +1539,9 @@ label_27:
 	// EBPF_OP_MOV64_IMM pc=523 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=525 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1551,9 +1551,9 @@ label_27:
 	// EBPF_OP_MOV64_REG pc=527 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=529 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -1819,9 +1819,9 @@ label_32:
 	// EBPF_OP_MOV64_IMM pc=629 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-68 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=631 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1835,9 +1835,9 @@ label_33:
 	// EBPF_OP_MOV64_REG pc=634 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-68
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=636 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1893,9 +1893,9 @@ label_33:
 	// EBPF_OP_MOV64_IMM pc=653 dst=r1 src=r0 offset=0 imm=1
 #line 85 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-68 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=655 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1909,9 +1909,9 @@ label_34:
 	// EBPF_OP_MOV64_REG pc=658 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-68
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=660 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[6].address);

--- a/tests/bpf2c_tests/expected/map_dll.txt
+++ b/tests/bpf2c_tests/expected/map_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 12, 0, 4, 10, 0, 0, 0, 0,  }, "STACK_map" },
 { NULL, { 1, 4, 4, 10, 0, 0, 0, 0,  }, "HASH_map" },
@@ -134,9 +139,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=4 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -146,9 +151,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_REG pc=6 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[1].address);
@@ -420,9 +425,9 @@ label_7:
 	// EBPF_OP_MOV64_IMM pc=106 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=108 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -432,9 +437,9 @@ label_7:
 	// EBPF_OP_MOV64_REG pc=110 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=112 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[2].address);
@@ -700,9 +705,9 @@ label_12:
 	// EBPF_OP_MOV64_IMM pc=211 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=213 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -712,9 +717,9 @@ label_12:
 	// EBPF_OP_MOV64_REG pc=215 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=217 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[3].address);
@@ -980,9 +985,9 @@ label_17:
 	// EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=317 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -992,9 +997,9 @@ label_17:
 	// EBPF_OP_MOV64_REG pc=319 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=321 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[4].address);
@@ -1260,9 +1265,9 @@ label_22:
 	// EBPF_OP_MOV64_IMM pc=420 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=422 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1272,9 +1277,9 @@ label_22:
 	// EBPF_OP_MOV64_REG pc=424 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=426 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1534,9 +1539,9 @@ label_27:
 	// EBPF_OP_MOV64_IMM pc=523 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=525 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1546,9 +1551,9 @@ label_27:
 	// EBPF_OP_MOV64_REG pc=527 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=529 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -1814,9 +1819,9 @@ label_32:
 	// EBPF_OP_MOV64_IMM pc=629 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-8 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=631 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1830,9 +1835,9 @@ label_33:
 	// EBPF_OP_MOV64_REG pc=634 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-8
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=636 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1888,9 +1893,9 @@ label_33:
 	// EBPF_OP_MOV64_IMM pc=653 dst=r1 src=r0 offset=0 imm=1
 #line 85 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-8 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=655 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1904,9 +1909,9 @@ label_34:
 	// EBPF_OP_MOV64_REG pc=658 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-8
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=660 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -6085,4 +6090,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_in_map_dll.txt
+++ b/tests/bpf2c_tests/expected/map_in_map_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 1, 0, 0, 0,  }, "outer_map" },
 { NULL, { 1, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -176,4 +181,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_in_map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_in_map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_in_map_raw.txt
+++ b/tests/bpf2c_tests/expected/map_in_map_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 1, 0, 0, 0,  }, "outer_map" },
 { NULL, { 1, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -134,4 +139,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_in_map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_in_map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_in_map_sys.txt
+++ b/tests/bpf2c_tests/expected/map_in_map_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 1, 0, 0, 0,  }, "outer_map" },
 { NULL, { 1, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -301,4 +306,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_in_map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_in_map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_dll.txt
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 0, 0, 0, 10,  }, "outer_map" },
 { NULL, { 1, 4, 4, 1, 0, 0, 10, 0,  }, "inner_map" },
@@ -176,4 +181,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_in_map_v2_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_in_map_v2_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_raw.txt
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 0, 0, 0, 10,  }, "outer_map" },
 { NULL, { 1, 4, 4, 1, 0, 0, 10, 0,  }, "inner_map" },
@@ -134,4 +139,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_in_map_v2_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_in_map_v2_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_sys.txt
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 0, 0, 0, 10,  }, "outer_map" },
 { NULL, { 1, 4, 4, 1, 0, 0, 10, 0,  }, "inner_map" },
@@ -301,4 +306,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_in_map_v2_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_in_map_v2_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_raw.txt
+++ b/tests/bpf2c_tests/expected/map_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 12, 0, 4, 10, 0, 0, 0, 0,  }, "STACK_map" },
 { NULL, { 1, 4, 4, 10, 0, 0, 0, 0,  }, "HASH_map" },
@@ -92,9 +97,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=4 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -104,9 +109,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_REG pc=6 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[1].address);
@@ -378,9 +383,9 @@ label_7:
 	// EBPF_OP_MOV64_IMM pc=106 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=108 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -390,9 +395,9 @@ label_7:
 	// EBPF_OP_MOV64_REG pc=110 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=112 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[2].address);
@@ -658,9 +663,9 @@ label_12:
 	// EBPF_OP_MOV64_IMM pc=211 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=213 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -670,9 +675,9 @@ label_12:
 	// EBPF_OP_MOV64_REG pc=215 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=217 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[3].address);
@@ -938,9 +943,9 @@ label_17:
 	// EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=317 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -950,9 +955,9 @@ label_17:
 	// EBPF_OP_MOV64_REG pc=319 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=321 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[4].address);
@@ -1218,9 +1223,9 @@ label_22:
 	// EBPF_OP_MOV64_IMM pc=420 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=422 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1230,9 +1235,9 @@ label_22:
 	// EBPF_OP_MOV64_REG pc=424 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=426 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1492,9 +1497,9 @@ label_27:
 	// EBPF_OP_MOV64_IMM pc=523 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=525 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1504,9 +1509,9 @@ label_27:
 	// EBPF_OP_MOV64_REG pc=527 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=529 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -1772,9 +1777,9 @@ label_32:
 	// EBPF_OP_MOV64_IMM pc=629 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-8 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=631 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1788,9 +1793,9 @@ label_33:
 	// EBPF_OP_MOV64_REG pc=634 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-8
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=636 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1846,9 +1851,9 @@ label_33:
 	// EBPF_OP_MOV64_IMM pc=653 dst=r1 src=r0 offset=0 imm=1
 #line 85 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-8 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=655 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1862,9 +1867,9 @@ label_34:
 	// EBPF_OP_MOV64_REG pc=658 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-8
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=660 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -6043,4 +6048,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_raw.txt
+++ b/tests/bpf2c_tests/expected/map_raw.txt
@@ -97,9 +97,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=4 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -109,9 +109,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_REG pc=6 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[1].address);
@@ -383,9 +383,9 @@ label_7:
 	// EBPF_OP_MOV64_IMM pc=106 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=108 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -395,9 +395,9 @@ label_7:
 	// EBPF_OP_MOV64_REG pc=110 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=112 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[2].address);
@@ -663,9 +663,9 @@ label_12:
 	// EBPF_OP_MOV64_IMM pc=211 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=213 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -675,9 +675,9 @@ label_12:
 	// EBPF_OP_MOV64_REG pc=215 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=217 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[3].address);
@@ -943,9 +943,9 @@ label_17:
 	// EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=317 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -955,9 +955,9 @@ label_17:
 	// EBPF_OP_MOV64_REG pc=319 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=321 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[4].address);
@@ -1223,9 +1223,9 @@ label_22:
 	// EBPF_OP_MOV64_IMM pc=420 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=422 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1235,9 +1235,9 @@ label_22:
 	// EBPF_OP_MOV64_REG pc=424 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=426 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1497,9 +1497,9 @@ label_27:
 	// EBPF_OP_MOV64_IMM pc=523 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=525 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1509,9 +1509,9 @@ label_27:
 	// EBPF_OP_MOV64_REG pc=527 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=529 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -1777,9 +1777,9 @@ label_32:
 	// EBPF_OP_MOV64_IMM pc=629 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-68 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=631 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1793,9 +1793,9 @@ label_33:
 	// EBPF_OP_MOV64_REG pc=634 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-68
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=636 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1851,9 +1851,9 @@ label_33:
 	// EBPF_OP_MOV64_IMM pc=653 dst=r1 src=r0 offset=0 imm=1
 #line 85 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-68 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=655 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1867,9 +1867,9 @@ label_34:
 	// EBPF_OP_MOV64_REG pc=658 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-68
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=660 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[6].address);

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.txt
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 6, 4, 4, 1, 1, 2, 0, 0,  }, "outer_map" },
 { NULL, { 2, 4, 4, 1, 0, 2, 0, 0,  }, "inner_map" },
@@ -218,4 +223,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_reuse_2_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_reuse_2_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.txt
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 6, 4, 4, 1, 1, 2, 0, 0,  }, "outer_map" },
 { NULL, { 2, 4, 4, 1, 0, 2, 0, 0,  }, "inner_map" },
@@ -176,4 +181,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_reuse_2_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_reuse_2_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.txt
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 6, 4, 4, 1, 1, 2, 0, 0,  }, "outer_map" },
 { NULL, { 2, 4, 4, 1, 0, 2, 0, 0,  }, "inner_map" },
@@ -343,4 +348,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_reuse_2_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_reuse_2_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_reuse_dll.txt
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 6, 4, 4, 1, 1, 2, 0, 0,  }, "outer_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -218,4 +223,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_reuse_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_reuse_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_reuse_raw.txt
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 6, 4, 4, 1, 1, 2, 0, 0,  }, "outer_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -176,4 +181,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_reuse_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_reuse_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_reuse_sys.txt
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 6, 4, 4, 1, 1, 2, 0, 0,  }, "outer_map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -343,4 +348,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_reuse_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_reuse_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/map_sys.txt
+++ b/tests/bpf2c_tests/expected/map_sys.txt
@@ -264,9 +264,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=4 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -276,9 +276,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_REG pc=6 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[1].address);
@@ -550,9 +550,9 @@ label_7:
 	// EBPF_OP_MOV64_IMM pc=106 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=108 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -562,9 +562,9 @@ label_7:
 	// EBPF_OP_MOV64_REG pc=110 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=112 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[2].address);
@@ -830,9 +830,9 @@ label_12:
 	// EBPF_OP_MOV64_IMM pc=211 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=213 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -842,9 +842,9 @@ label_12:
 	// EBPF_OP_MOV64_REG pc=215 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=217 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[3].address);
@@ -1110,9 +1110,9 @@ label_17:
 	// EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=317 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1122,9 +1122,9 @@ label_17:
 	// EBPF_OP_MOV64_REG pc=319 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=321 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[4].address);
@@ -1390,9 +1390,9 @@ label_22:
 	// EBPF_OP_MOV64_IMM pc=420 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=422 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1402,9 +1402,9 @@ label_22:
 	// EBPF_OP_MOV64_REG pc=424 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=426 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1664,9 +1664,9 @@ label_27:
 	// EBPF_OP_MOV64_IMM pc=523 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-68 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=525 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1676,9 +1676,9 @@ label_27:
 	// EBPF_OP_MOV64_REG pc=527 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-68
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=529 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -1944,9 +1944,9 @@ label_32:
 	// EBPF_OP_MOV64_IMM pc=629 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-68 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=631 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1960,9 +1960,9 @@ label_33:
 	// EBPF_OP_MOV64_REG pc=634 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-68
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=636 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -2018,9 +2018,9 @@ label_33:
 	// EBPF_OP_MOV64_IMM pc=653 dst=r1 src=r0 offset=0 imm=1
 #line 85 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-68 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=655 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -2034,9 +2034,9 @@ label_34:
 	// EBPF_OP_MOV64_REG pc=658 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-8
+	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-68
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-8);
+	r3 += IMMEDIATE(-68);
 	// EBPF_OP_LDDW pc=660 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[6].address);

--- a/tests/bpf2c_tests/expected/map_sys.txt
+++ b/tests/bpf2c_tests/expected/map_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 12, 0, 4, 10, 0, 0, 0, 0,  }, "STACK_map" },
 { NULL, { 1, 4, 4, 10, 0, 0, 0, 0,  }, "HASH_map" },
@@ -259,9 +264,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_IMM pc=2 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=3 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=4 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -271,9 +276,9 @@ static uint64_t test_maps(void* context)
 	// EBPF_OP_MOV64_REG pc=6 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=7 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[1].address);
@@ -545,9 +550,9 @@ label_7:
 	// EBPF_OP_MOV64_IMM pc=106 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=107 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=108 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -557,9 +562,9 @@ label_7:
 	// EBPF_OP_MOV64_REG pc=110 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=111 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=112 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[2].address);
@@ -825,9 +830,9 @@ label_12:
 	// EBPF_OP_MOV64_IMM pc=211 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=212 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=213 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -837,9 +842,9 @@ label_12:
 	// EBPF_OP_MOV64_REG pc=215 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=216 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=217 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[3].address);
@@ -1105,9 +1110,9 @@ label_17:
 	// EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=317 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1117,9 +1122,9 @@ label_17:
 	// EBPF_OP_MOV64_REG pc=319 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=320 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=321 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[4].address);
@@ -1385,9 +1390,9 @@ label_22:
 	// EBPF_OP_MOV64_IMM pc=420 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=421 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=422 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1397,9 +1402,9 @@ label_22:
 	// EBPF_OP_MOV64_REG pc=424 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=425 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=426 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -1659,9 +1664,9 @@ label_27:
 	// EBPF_OP_MOV64_IMM pc=523 dst=r1 src=r0 offset=0 imm=1
 #line 52 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=524 dst=r10 src=r1 offset=-8 imm=0
 #line 53 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_REG pc=525 dst=r2 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r2 = r10;
@@ -1671,9 +1676,9 @@ label_27:
 	// EBPF_OP_MOV64_REG pc=527 dst=r3 src=r10 offset=0 imm=0
 #line 53 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=528 dst=r3 src=r0 offset=0 imm=-8
 #line 53 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=529 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -1939,9 +1944,9 @@ label_32:
 	// EBPF_OP_MOV64_IMM pc=629 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=630 dst=r10 src=r1 offset=-8 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=631 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -1955,9 +1960,9 @@ label_33:
 	// EBPF_OP_MOV64_REG pc=634 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=635 dst=r3 src=r0 offset=0 imm=-8
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=636 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[5].address);
@@ -2013,9 +2018,9 @@ label_33:
 	// EBPF_OP_MOV64_IMM pc=653 dst=r1 src=r0 offset=0 imm=1
 #line 85 "sample/map.c"
 	r1 = IMMEDIATE(1);
-	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-68 imm=0
+	// EBPF_OP_STXW pc=654 dst=r10 src=r1 offset=-8 imm=0
 #line 81 "sample/map.c"
-	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-68)) = (uint32_t)r1;
+	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
 	// EBPF_OP_MOV64_IMM pc=655 dst=r9 src=r0 offset=0 imm=11
 #line 81 "sample/map.c"
 	r9 = IMMEDIATE(11);
@@ -2029,9 +2034,9 @@ label_34:
 	// EBPF_OP_MOV64_REG pc=658 dst=r3 src=r10 offset=0 imm=0
 #line 81 "sample/map.c"
 	r3 = r10;
-	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-68
+	// EBPF_OP_ADD64_IMM pc=659 dst=r3 src=r0 offset=0 imm=-8
 #line 81 "sample/map.c"
-	r3 += IMMEDIATE(-68);
+	r3 += IMMEDIATE(-8);
 	// EBPF_OP_LDDW pc=660 dst=r1 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
 	r1 = POINTER(_maps[6].address);
@@ -6210,4 +6215,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/printk_dll.txt
+++ b/tests/bpf2c_tests/expected/printk_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -532,4 +537,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t printk_metadata_table = { _get_programs, _get_maps };
+metadata_table_t printk_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.txt
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -532,4 +537,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t printk_legacy_metadata_table = { _get_programs, _get_maps };
+metadata_table_t printk_legacy_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.txt
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -490,4 +495,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t printk_legacy_metadata_table = { _get_programs, _get_maps };
+metadata_table_t printk_legacy_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.txt
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -657,4 +662,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t printk_legacy_metadata_table = { _get_programs, _get_maps };
+metadata_table_t printk_legacy_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/printk_raw.txt
+++ b/tests/bpf2c_tests/expected/printk_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -490,4 +495,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t printk_metadata_table = { _get_programs, _get_maps };
+metadata_table_t printk_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/printk_sys.txt
+++ b/tests/bpf2c_tests/expected/printk_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -657,4 +662,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t printk_metadata_table = { _get_programs, _get_maps };
+metadata_table_t printk_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.txt
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.txt
@@ -289,21 +289,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=66 dst=r3 src=r2 offset=142 imm=0
 #line 52 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_LDXB pc=67 dst=r3 src=r1 offset=20 imm=0
-#line 57 "sample/reflect_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=68 dst=r3 src=r0 offset=140 imm=17
-#line 57 "sample/reflect_packet.c"
-	if (r3 != IMMEDIATE(17)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=69 dst=r3 src=r1 offset=0 imm=0
-#line 57 "sample/reflect_packet.c"
+	// EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+#line 52 "sample/reflect_packet.c"
 	r3 = r1;
-	// EBPF_OP_ADD64_IMM pc=70 dst=r3 src=r0 offset=0 imm=62
-#line 57 "sample/reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
+#line 52 "sample/reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=71 dst=r3 src=r2 offset=137 imm=0
+	// EBPF_OP_JGT_REG pc=69 dst=r3 src=r2 offset=139 imm=0
 #line 57 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
+	// EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+#line 57 "sample/reflect_packet.c"
+	r2 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
+#line 57 "sample/reflect_packet.c"
+	if (r2 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(56));
@@ -718,9 +718,9 @@ label_2:
 	r0 = IMMEDIATE(3);
 label_3:
 	// EBPF_OP_EXIT pc=209 dst=r0 src=r0 offset=0 imm=0
-#line 73 "sample/reflect_packet.c"
+#line 34 "sample/./xdp_common.h"
 	return r0;
-#line 73 "sample/reflect_packet.c"
+#line 34 "sample/./xdp_common.h"
 }
 #line __LINE__ __FILE__
 

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.txt
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -284,21 +289,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=66 dst=r3 src=r2 offset=142 imm=0
 #line 52 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
-#line 52 "sample/reflect_packet.c"
+	// EBPF_OP_LDXB pc=67 dst=r3 src=r1 offset=20 imm=0
+#line 57 "sample/reflect_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=68 dst=r3 src=r0 offset=140 imm=17
+#line 57 "sample/reflect_packet.c"
+	if (r3 != IMMEDIATE(17)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=69 dst=r3 src=r1 offset=0 imm=0
+#line 57 "sample/reflect_packet.c"
 	r3 = r1;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
-#line 52 "sample/reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=70 dst=r3 src=r0 offset=0 imm=62
+#line 57 "sample/reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=69 dst=r3 src=r2 offset=139 imm=0
+	// EBPF_OP_JGT_REG pc=71 dst=r3 src=r2 offset=137 imm=0
 #line 57 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
-#line 57 "sample/reflect_packet.c"
-	r2 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
-#line 57 "sample/reflect_packet.c"
-	if (r2 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(56));
@@ -713,9 +718,9 @@ label_2:
 	r0 = IMMEDIATE(3);
 label_3:
 	// EBPF_OP_EXIT pc=209 dst=r0 src=r0 offset=0 imm=0
-#line 34 "sample/./xdp_common.h"
+#line 73 "sample/reflect_packet.c"
 	return r0;
-#line 34 "sample/./xdp_common.h"
+#line 73 "sample/reflect_packet.c"
 }
 #line __LINE__ __FILE__
 
@@ -730,4 +735,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t reflect_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t reflect_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.txt
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -242,21 +247,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=66 dst=r3 src=r2 offset=142 imm=0
 #line 52 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
-#line 52 "sample/reflect_packet.c"
+	// EBPF_OP_LDXB pc=67 dst=r3 src=r1 offset=20 imm=0
+#line 57 "sample/reflect_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=68 dst=r3 src=r0 offset=140 imm=17
+#line 57 "sample/reflect_packet.c"
+	if (r3 != IMMEDIATE(17)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=69 dst=r3 src=r1 offset=0 imm=0
+#line 57 "sample/reflect_packet.c"
 	r3 = r1;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
-#line 52 "sample/reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=70 dst=r3 src=r0 offset=0 imm=62
+#line 57 "sample/reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=69 dst=r3 src=r2 offset=139 imm=0
+	// EBPF_OP_JGT_REG pc=71 dst=r3 src=r2 offset=137 imm=0
 #line 57 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
-#line 57 "sample/reflect_packet.c"
-	r2 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
-#line 57 "sample/reflect_packet.c"
-	if (r2 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(56));
@@ -671,9 +676,9 @@ label_2:
 	r0 = IMMEDIATE(3);
 label_3:
 	// EBPF_OP_EXIT pc=209 dst=r0 src=r0 offset=0 imm=0
-#line 34 "sample/./xdp_common.h"
+#line 73 "sample/reflect_packet.c"
 	return r0;
-#line 34 "sample/./xdp_common.h"
+#line 73 "sample/reflect_packet.c"
 }
 #line __LINE__ __FILE__
 
@@ -688,4 +693,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t reflect_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t reflect_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.txt
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.txt
@@ -247,21 +247,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=66 dst=r3 src=r2 offset=142 imm=0
 #line 52 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_LDXB pc=67 dst=r3 src=r1 offset=20 imm=0
-#line 57 "sample/reflect_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=68 dst=r3 src=r0 offset=140 imm=17
-#line 57 "sample/reflect_packet.c"
-	if (r3 != IMMEDIATE(17)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=69 dst=r3 src=r1 offset=0 imm=0
-#line 57 "sample/reflect_packet.c"
+	// EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+#line 52 "sample/reflect_packet.c"
 	r3 = r1;
-	// EBPF_OP_ADD64_IMM pc=70 dst=r3 src=r0 offset=0 imm=62
-#line 57 "sample/reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
+#line 52 "sample/reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=71 dst=r3 src=r2 offset=137 imm=0
+	// EBPF_OP_JGT_REG pc=69 dst=r3 src=r2 offset=139 imm=0
 #line 57 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
+	// EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+#line 57 "sample/reflect_packet.c"
+	r2 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
+#line 57 "sample/reflect_packet.c"
+	if (r2 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(56));
@@ -676,9 +676,9 @@ label_2:
 	r0 = IMMEDIATE(3);
 label_3:
 	// EBPF_OP_EXIT pc=209 dst=r0 src=r0 offset=0 imm=0
-#line 73 "sample/reflect_packet.c"
+#line 34 "sample/./xdp_common.h"
 	return r0;
-#line 73 "sample/reflect_packet.c"
+#line 34 "sample/./xdp_common.h"
 }
 #line __LINE__ __FILE__
 

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.txt
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static void _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
 {
 	*maps = NULL;
@@ -409,21 +414,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=66 dst=r3 src=r2 offset=142 imm=0
 #line 52 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
-#line 52 "sample/reflect_packet.c"
+	// EBPF_OP_LDXB pc=67 dst=r3 src=r1 offset=20 imm=0
+#line 57 "sample/reflect_packet.c"
+	r3 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=68 dst=r3 src=r0 offset=140 imm=17
+#line 57 "sample/reflect_packet.c"
+	if (r3 != IMMEDIATE(17)) goto label_3;
+	// EBPF_OP_MOV64_REG pc=69 dst=r3 src=r1 offset=0 imm=0
+#line 57 "sample/reflect_packet.c"
 	r3 = r1;
-	// EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
-#line 52 "sample/reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=70 dst=r3 src=r0 offset=0 imm=62
+#line 57 "sample/reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=69 dst=r3 src=r2 offset=139 imm=0
+	// EBPF_OP_JGT_REG pc=71 dst=r3 src=r2 offset=137 imm=0
 #line 57 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
-#line 57 "sample/reflect_packet.c"
-	r2 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
-#line 57 "sample/reflect_packet.c"
-	if (r2 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(56));
@@ -838,9 +843,9 @@ label_2:
 	r0 = IMMEDIATE(3);
 label_3:
 	// EBPF_OP_EXIT pc=209 dst=r0 src=r0 offset=0 imm=0
-#line 34 "sample/./xdp_common.h"
+#line 73 "sample/reflect_packet.c"
 	return r0;
-#line 34 "sample/./xdp_common.h"
+#line 73 "sample/reflect_packet.c"
 }
 #line __LINE__ __FILE__
 
@@ -855,4 +860,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t reflect_packet_metadata_table = { _get_programs, _get_maps };
+metadata_table_t reflect_packet_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.txt
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.txt
@@ -414,21 +414,21 @@ label_1:
 	// EBPF_OP_JGT_REG pc=66 dst=r3 src=r2 offset=142 imm=0
 #line 52 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
-	// EBPF_OP_LDXB pc=67 dst=r3 src=r1 offset=20 imm=0
-#line 57 "sample/reflect_packet.c"
-	r3 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
-	// EBPF_OP_JNE_IMM pc=68 dst=r3 src=r0 offset=140 imm=17
-#line 57 "sample/reflect_packet.c"
-	if (r3 != IMMEDIATE(17)) goto label_3;
-	// EBPF_OP_MOV64_REG pc=69 dst=r3 src=r1 offset=0 imm=0
-#line 57 "sample/reflect_packet.c"
+	// EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+#line 52 "sample/reflect_packet.c"
 	r3 = r1;
-	// EBPF_OP_ADD64_IMM pc=70 dst=r3 src=r0 offset=0 imm=62
-#line 57 "sample/reflect_packet.c"
+	// EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
+#line 52 "sample/reflect_packet.c"
 	r3 += IMMEDIATE(62);
-	// EBPF_OP_JGT_REG pc=71 dst=r3 src=r2 offset=137 imm=0
+	// EBPF_OP_JGT_REG pc=69 dst=r3 src=r2 offset=139 imm=0
 #line 57 "sample/reflect_packet.c"
 	if (r3 > r2) goto label_3;
+	// EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+#line 57 "sample/reflect_packet.c"
+	r2 = *(uint8_t *)(uintptr_t)(r1 + OFFSET(20));
+	// EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
+#line 57 "sample/reflect_packet.c"
+	if (r2 != IMMEDIATE(17)) goto label_3;
 	// EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
 	r2 = *(uint16_t *)(uintptr_t)(r1 + OFFSET(56));
@@ -843,9 +843,9 @@ label_2:
 	r0 = IMMEDIATE(3);
 label_3:
 	// EBPF_OP_EXIT pc=209 dst=r0 src=r0 offset=0 imm=0
-#line 73 "sample/reflect_packet.c"
+#line 34 "sample/./xdp_common.h"
 	return r0;
-#line 73 "sample/reflect_packet.c"
+#line 34 "sample/./xdp_common.h"
 }
 #line __LINE__ __FILE__
 

--- a/tests/bpf2c_tests/expected/sockops_dll.txt
+++ b/tests/bpf2c_tests/expected/sockops_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "connection_map" },
 { NULL, { 13, 0, 0, 262144, 0, 0, 0, 0,  }, "audit_map" },
@@ -123,7 +128,7 @@ static uint64_t connection_monitor(void* context)
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
-	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
+	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
 #line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
@@ -186,7 +191,7 @@ label_2:
 #line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 24 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
 #line 24 "sample/sockops.c"
@@ -211,7 +216,7 @@ label_3:
 #line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 25 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
 #line 25 "sample/sockops.c"
@@ -298,10 +303,10 @@ label_6:
 	(r1, r2, r3, r4, r5);
 #line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
+	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
 #line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
-	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
+	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
 #line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
@@ -329,465 +334,459 @@ label_7:
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
 #line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
-	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-80 imm=0
+	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
 #line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_REG pc=74 dst=r0 src=r1 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
+#line 46 "sample/sockops.c"
+	r1 += IMMEDIATE(8);
+	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r1;
-	// EBPF_OP_ADD64_IMM pc=75 dst=r0 src=r0 offset=0 imm=8
-#line 46 "sample/sockops.c"
-	r0 += IMMEDIATE(8);
-	// EBPF_OP_STXDW pc=76 dst=r10 src=r0 offset=-104 imm=0
-#line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-	// EBPF_OP_JNE_IMM pc=77 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
 #line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
-	// EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
-	// EBPF_OP_LDXB pc=79 dst=r2 src=r0 offset=13 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=81 dst=r1 src=r0 offset=12 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
 #line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
-	// EBPF_OP_STXDW pc=82 dst=r10 src=r1 offset=-64 imm=0
+	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
+	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_LDXB pc=83 dst=r8 src=r0 offset=15 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
+	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
 #line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=84 dst=r8 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=85 dst=r5 src=r0 offset=14 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=86 dst=r8 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r5;
-	// EBPF_OP_LDXB pc=87 dst=r6 src=r0 offset=9 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
 #line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=88 dst=r6 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=89 dst=r1 src=r0 offset=8 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
 #line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
-	// EBPF_OP_STXDW pc=90 dst=r10 src=r1 offset=-72 imm=0
+	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
+	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_LDXB pc=91 dst=r9 src=r0 offset=11 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
+	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
 #line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=92 dst=r9 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=93 dst=r5 src=r0 offset=10 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=94 dst=r9 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r9 |= r5;
-	// EBPF_OP_LDXB pc=95 dst=r5 src=r0 offset=1 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
-	// EBPF_OP_LDXB pc=96 dst=r7 src=r0 offset=0 imm=0
-#line 47 "sample/sockops.c"
-	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
-	// EBPF_OP_STXDW pc=97 dst=r10 src=r7 offset=-88 imm=0
-#line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r7;
-	// EBPF_OP_LDXB pc=98 dst=r7 src=r0 offset=3 imm=0
+	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
 #line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
-	// EBPF_OP_LDXB pc=99 dst=r1 src=r0 offset=2 imm=0
-#line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
-	// EBPF_OP_STXDW pc=100 dst=r10 src=r1 offset=-96 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-	// EBPF_OP_JNE_IMM pc=101 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_9;
-	// EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
-	r3 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-104));
+	r3 = r1;
 label_9:
-	// EBPF_OP_LDXDW pc=103 dst=r1 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_OR64_REG pc=104 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXDW pc=105 dst=r1 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
 #line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_OR64_REG pc=106 dst=r6 src=r1 offset=0 imm=0
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r6 |= r1;
-	// EBPF_OP_LSH64_IMM pc=107 dst=r9 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
 	r9 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=108 dst=r8 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
 	r8 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=109 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LSH64_IMM pc=110 dst=r7 src=r0 offset=0 imm=8
+	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
+	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
 	r7 <<= IMMEDIATE(8);
-	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
+	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=112 dst=r10 src=r1 offset=-72 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=113 dst=r1 src=r0 offset=0 imm=24
-#line 48 "sample/sockops.c"
-	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=114 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
 #line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_JNE_IMM pc=115 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
+#line 48 "sample/sockops.c"
+	r1 = IMMEDIATE(24);
+	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
-	// EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_10:
-	// EBPF_OP_OR64_REG pc=118 dst=r9 src=r6 offset=0 imm=0
+	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r9 |= r6;
-	// EBPF_OP_OR64_REG pc=119 dst=r8 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r8 |= r2;
-	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-88 imm=0
+	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
-	// EBPF_OP_OR64_REG pc=121 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXDW pc=122 dst=r1 src=r10 offset=-96 imm=0
+	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
-	// EBPF_OP_OR64_REG pc=123 dst=r7 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r7 |= r1;
-	// EBPF_OP_JNE_IMM pc=124 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
 #line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
-	// EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
+	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
+	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
 #line 51 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_11:
-	// EBPF_OP_LDXDW pc=127 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_OR64_REG pc=128 dst=r2 src=r4 offset=0 imm=0
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
+	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
 #line 53 "sample/sockops.c"
-	r2 |= r4;
-	// EBPF_OP_STXDW pc=129 dst=r10 src=r2 offset=-56 imm=0
+	r1 |= r4;
+	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
 #line 53 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
-	// EBPF_OP_LSH64_IMM pc=130 dst=r8 src=r0 offset=0 imm=32
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=131 dst=r8 src=r9 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r9;
-	// EBPF_OP_STXDW pc=132 dst=r10 src=r8 offset=-40 imm=0
+	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
-	// EBPF_OP_LSH64_IMM pc=133 dst=r7 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r7 |= r5;
-	// EBPF_OP_LDXB pc=135 dst=r1 src=r0 offset=5 imm=0
+	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
 #line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=136 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=4 imm=0
+	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=138 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=139 dst=r2 src=r0 offset=6 imm=0
+	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
-	// EBPF_OP_LDXB pc=140 dst=r4 src=r0 offset=7 imm=0
+	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
 #line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r2;
-	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LSH64_IMM pc=145 dst=r4 src=r0 offset=0 imm=32
+	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=146 dst=r4 src=r7 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r7;
-	// EBPF_OP_STXDW pc=147 dst=r10 src=r4 offset=-48 imm=0
+	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
-	// EBPF_OP_LDXDW pc=148 dst=r6 src=r10 offset=-80 imm=0
+	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
 #line 47 "sample/sockops.c"
-	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_MOV64_REG pc=149 dst=r1 src=r6 offset=0 imm=0
+	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=150 dst=r2 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
 #line 48 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_ADD64_REG pc=151 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=152 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=153 dst=r10 src=r1 offset=-32 imm=0
+	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
 #line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=154 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=155 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=156 dst=r1 src=r3 offset=12 imm=0
+	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
-	// EBPF_OP_OR64_REG pc=157 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LDXB pc=158 dst=r2 src=r3 offset=15 imm=0
+	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=159 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=160 dst=r1 src=r3 offset=14 imm=0
+	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXB pc=162 dst=r5 src=r3 offset=1 imm=0
+	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
-	// EBPF_OP_LSH64_IMM pc=163 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=0 imm=0
+	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
-	// EBPF_OP_OR64_REG pc=165 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXB pc=166 dst=r1 src=r3 offset=3 imm=0
+	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
-	// EBPF_OP_LSH64_IMM pc=167 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=168 dst=r0 src=r3 offset=2 imm=0
+	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
-	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r0;
-	// EBPF_OP_LSH64_IMM pc=170 dst=r1 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=171 dst=r1 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r5;
-	// EBPF_OP_LSH64_IMM pc=172 dst=r2 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=173 dst=r2 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r4;
-	// EBPF_OP_LDXB pc=174 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=175 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=8 imm=0
+	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
-	// EBPF_OP_OR64_REG pc=177 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r5;
-	// EBPF_OP_LDXB pc=178 dst=r5 src=r3 offset=11 imm=0
+	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=179 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=180 dst=r0 src=r3 offset=10 imm=0
+	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r0;
-	// EBPF_OP_LSH64_IMM pc=182 dst=r5 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=183 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r4;
-	// EBPF_OP_STXW pc=184 dst=r10 src=r5 offset=-20 imm=0
+	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
-	// EBPF_OP_STXW pc=185 dst=r10 src=r2 offset=-16 imm=0
+	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
-	// EBPF_OP_STXW pc=186 dst=r10 src=r1 offset=-28 imm=0
+	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
-	// EBPF_OP_LDXB pc=187 dst=r1 src=r3 offset=5 imm=0
+	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=188 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=4 imm=0
+	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=190 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=191 dst=r2 src=r3 offset=6 imm=0
+	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
-	// EBPF_OP_LDXB pc=192 dst=r3 src=r3 offset=7 imm=0
+	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
 #line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r2;
-	// EBPF_OP_LSH64_IMM pc=195 dst=r3 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=196 dst=r3 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r1;
-	// EBPF_OP_STXW pc=197 dst=r10 src=r3 offset=-24 imm=0
+	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-	// EBPF_OP_MOV64_REG pc=198 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=199 dst=r2 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_ADD64_REG pc=200 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=201 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=202 dst=r10 src=r1 offset=-12 imm=0
+	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
 #line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=203 dst=r1 src=r6 offset=48 imm=0
+	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
 #line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
-	// EBPF_OP_LDXDW pc=204 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
 #line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_STXB pc=205 dst=r10 src=r2 offset=-4 imm=0
+	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
 #line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
-	// EBPF_OP_STXW pc=206 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
 #line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-	// EBPF_OP_MOV64_REG pc=207 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
 #line 52 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=208 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
 #line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=209 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
-	// EBPF_OP_CALL pc=211 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
-	// EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
+	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
 #line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
-	// EBPF_OP_MOV64_REG pc=214 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=215 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
 #line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=216 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
-	// EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=48
+	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
 #line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
-	// EBPF_OP_MOV64_IMM pc=219 dst=r4 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
-	// EBPF_OP_CALL pc=220 dst=r0 src=r0 offset=0 imm=11
+	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
-	// EBPF_OP_MOV64_REG pc=222 dst=r0 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	r0 = r6;
-	// EBPF_OP_EXIT pc=223 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	return r0;
 #line 89 "sample/sockops.c"
@@ -795,7 +794,7 @@ label_13:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 224, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
+	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 222, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
@@ -805,4 +804,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t sockops_metadata_table = { _get_programs, _get_maps };
+metadata_table_t sockops_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/sockops_dll.txt
+++ b/tests/bpf2c_tests/expected/sockops_dll.txt
@@ -128,7 +128,7 @@ static uint64_t connection_monitor(void* context)
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
-	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
+	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
 #line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
@@ -191,7 +191,7 @@ label_2:
 #line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 22 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
 #line 24 "sample/sockops.c"
@@ -216,7 +216,7 @@ label_3:
 #line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 24 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
 #line 25 "sample/sockops.c"
@@ -303,10 +303,10 @@ label_6:
 	(r1, r2, r3, r4, r5);
 #line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
+	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
 #line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
-	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
+	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
 #line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
@@ -334,459 +334,465 @@ label_7:
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
 #line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
-	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
+	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-80 imm=0
 #line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
-#line 46 "sample/sockops.c"
-	r1 += IMMEDIATE(8);
-	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_REG pc=74 dst=r0 src=r1 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r1;
-	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_ADD64_IMM pc=75 dst=r0 src=r0 offset=0 imm=8
+#line 46 "sample/sockops.c"
+	r0 += IMMEDIATE(8);
+	// EBPF_OP_STXDW pc=76 dst=r10 src=r0 offset=-104 imm=0
+#line 46 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
+	// EBPF_OP_JNE_IMM pc=77 dst=r4 src=r0 offset=1 imm=0
 #line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
-	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
-	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
+	// EBPF_OP_LDXB pc=79 dst=r2 src=r0 offset=13 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
+	// EBPF_OP_LDXB pc=81 dst=r1 src=r0 offset=12 imm=0
 #line 47 "sample/sockops.c"
-	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
-	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
+	// EBPF_OP_STXDW pc=82 dst=r10 src=r1 offset=-64 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
-	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	// EBPF_OP_LDXB pc=83 dst=r8 src=r0 offset=15 imm=0
 #line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=84 dst=r8 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
+	// EBPF_OP_LDXB pc=85 dst=r5 src=r0 offset=14 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=86 dst=r8 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r5;
-	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
+	// EBPF_OP_LDXB pc=87 dst=r6 src=r0 offset=9 imm=0
 #line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=88 dst=r6 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
+	// EBPF_OP_LDXB pc=89 dst=r1 src=r0 offset=8 imm=0
 #line 47 "sample/sockops.c"
-	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
-	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
+	// EBPF_OP_STXDW pc=90 dst=r10 src=r1 offset=-72 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
-	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_LDXB pc=91 dst=r9 src=r0 offset=11 imm=0
 #line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=92 dst=r9 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
+	// EBPF_OP_LDXB pc=93 dst=r5 src=r0 offset=10 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=94 dst=r9 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r9 |= r5;
-	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
+	// EBPF_OP_LDXB pc=95 dst=r5 src=r0 offset=1 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
-	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r7 src=r0 offset=0 imm=0
+#line 47 "sample/sockops.c"
+	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
+	// EBPF_OP_STXDW pc=97 dst=r10 src=r7 offset=-88 imm=0
+#line 47 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r7;
+	// EBPF_OP_LDXB pc=98 dst=r7 src=r0 offset=3 imm=0
 #line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
-	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
-#line 48 "sample/sockops.c"
-	if (r4 != IMMEDIATE(0)) goto label_9;
-	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r3 = r1;
-label_9:
-	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r2 |= r1;
-	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r6 |= r1;
-	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
-#line 48 "sample/sockops.c"
-	r9 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
-#line 48 "sample/sockops.c"
-	r8 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
-#line 48 "sample/sockops.c"
-	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
-	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
-#line 48 "sample/sockops.c"
-	r7 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
-#line 48 "sample/sockops.c"
+	// EBPF_OP_LDXB pc=99 dst=r1 src=r0 offset=2 imm=0
+#line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
-	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
+	// EBPF_OP_STXDW pc=100 dst=r10 src=r1 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_JNE_IMM pc=101 dst=r4 src=r0 offset=1 imm=0
+#line 48 "sample/sockops.c"
+	if (r4 != IMMEDIATE(0)) goto label_9;
+	// EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+#line 48 "sample/sockops.c"
+	r3 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-104));
+label_9:
+	// EBPF_OP_LDXDW pc=103 dst=r1 src=r10 offset=-64 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_OR64_REG pc=104 dst=r2 src=r1 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r2 |= r1;
+	// EBPF_OP_LDXDW pc=105 dst=r1 src=r10 offset=-72 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_OR64_REG pc=106 dst=r6 src=r1 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r6 |= r1;
+	// EBPF_OP_LSH64_IMM pc=107 dst=r9 src=r0 offset=0 imm=16
+#line 48 "sample/sockops.c"
+	r9 <<= IMMEDIATE(16);
+	// EBPF_OP_LSH64_IMM pc=108 dst=r8 src=r0 offset=0 imm=16
+#line 48 "sample/sockops.c"
+	r8 <<= IMMEDIATE(16);
+	// EBPF_OP_LSH64_IMM pc=109 dst=r5 src=r0 offset=0 imm=8
+#line 48 "sample/sockops.c"
+	r5 <<= IMMEDIATE(8);
+	// EBPF_OP_LSH64_IMM pc=110 dst=r7 src=r0 offset=0 imm=8
+#line 48 "sample/sockops.c"
+	r7 <<= IMMEDIATE(8);
+	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=112 dst=r10 src=r1 offset=-72 imm=0
 #line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_IMM pc=113 dst=r1 src=r0 offset=0 imm=24
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_STXDW pc=114 dst=r10 src=r1 offset=-64 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	// EBPF_OP_JNE_IMM pc=115 dst=r4 src=r0 offset=2 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
-	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-label_10:
-	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
+	// EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
 #line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+label_10:
+	// EBPF_OP_OR64_REG pc=118 dst=r9 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r9 |= r6;
-	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=119 dst=r8 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r8 |= r2;
-	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
+	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-88 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
-	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=121 dst=r5 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
+	// EBPF_OP_LDXDW pc=122 dst=r1 src=r10 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
-	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=123 dst=r7 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r7 |= r1;
-	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_JNE_IMM pc=124 dst=r4 src=r0 offset=2 imm=0
 #line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
-	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
+	// EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
 #line 51 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
 label_11:
-	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=127 dst=r2 src=r10 offset=-56 imm=0
 #line 51 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
+	// EBPF_OP_OR64_REG pc=128 dst=r2 src=r4 offset=0 imm=0
 #line 53 "sample/sockops.c"
-	r1 |= r4;
-	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
+	r2 |= r4;
+	// EBPF_OP_STXDW pc=129 dst=r10 src=r2 offset=-56 imm=0
 #line 53 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
+	// EBPF_OP_LSH64_IMM pc=130 dst=r8 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=131 dst=r8 src=r9 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r9;
-	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
+	// EBPF_OP_STXDW pc=132 dst=r10 src=r8 offset=-40 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
-	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=133 dst=r7 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r7 |= r5;
-	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
+	// EBPF_OP_LDXB pc=135 dst=r1 src=r0 offset=5 imm=0
 #line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=136 dst=r1 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
+	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=4 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=138 dst=r1 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
+	// EBPF_OP_LDXB pc=139 dst=r2 src=r0 offset=6 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
-	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
+	// EBPF_OP_LDXB pc=140 dst=r4 src=r0 offset=7 imm=0
 #line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r2;
-	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r1 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
+	// EBPF_OP_LSH64_IMM pc=145 dst=r4 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=146 dst=r4 src=r7 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r7;
-	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
+	// EBPF_OP_STXDW pc=147 dst=r10 src=r4 offset=-48 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
-	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=148 dst=r6 src=r10 offset=-80 imm=0
 #line 47 "sample/sockops.c"
-	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
+	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_MOV64_REG pc=149 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
+	// EBPF_OP_LDXDW pc=150 dst=r2 src=r10 offset=-64 imm=0
 #line 48 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_ADD64_REG pc=151 dst=r1 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=152 dst=r1 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
+	// EBPF_OP_STXH pc=153 dst=r10 src=r1 offset=-32 imm=0
 #line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_LDXB pc=154 dst=r4 src=r3 offset=13 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=155 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
+	// EBPF_OP_LDXB pc=156 dst=r1 src=r3 offset=12 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
-	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=157 dst=r4 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
+	// EBPF_OP_LDXB pc=158 dst=r2 src=r3 offset=15 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=159 dst=r2 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
+	// EBPF_OP_LDXB pc=160 dst=r1 src=r3 offset=14 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
+	// EBPF_OP_LDXB pc=162 dst=r5 src=r3 offset=1 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
-	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=163 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
+	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
-	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=165 dst=r5 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
+	// EBPF_OP_LDXB pc=166 dst=r1 src=r3 offset=3 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
-	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=167 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
+	// EBPF_OP_LDXB pc=168 dst=r0 src=r3 offset=2 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
-	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r0;
-	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=170 dst=r1 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=171 dst=r1 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r5;
-	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=172 dst=r2 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=173 dst=r2 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r4;
-	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_LDXB pc=174 dst=r4 src=r3 offset=9 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=175 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
+	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=8 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
-	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=177 dst=r4 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r5;
-	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
+	// EBPF_OP_LDXB pc=178 dst=r5 src=r3 offset=11 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=179 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
+	// EBPF_OP_LDXB pc=180 dst=r0 src=r3 offset=10 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r0;
-	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=182 dst=r5 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=183 dst=r5 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r4;
-	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
+	// EBPF_OP_STXW pc=184 dst=r10 src=r5 offset=-20 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
-	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
+	// EBPF_OP_STXW pc=185 dst=r10 src=r2 offset=-16 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
-	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
+	// EBPF_OP_STXW pc=186 dst=r10 src=r1 offset=-28 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
-	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
+	// EBPF_OP_LDXB pc=187 dst=r1 src=r3 offset=5 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=188 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
+	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=4 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=190 dst=r1 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
+	// EBPF_OP_LDXB pc=191 dst=r2 src=r3 offset=6 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
-	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
+	// EBPF_OP_LDXB pc=192 dst=r3 src=r3 offset=7 imm=0
 #line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r2;
-	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=195 dst=r3 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=196 dst=r3 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r1;
-	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
+	// EBPF_OP_STXW pc=197 dst=r10 src=r3 offset=-24 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=198 dst=r1 src=r6 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=199 dst=r2 src=r10 offset=-72 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_ADD64_REG pc=200 dst=r1 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=201 dst=r1 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
+	// EBPF_OP_STXH pc=202 dst=r10 src=r1 offset=-12 imm=0
 #line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
+	// EBPF_OP_LDXB pc=203 dst=r1 src=r6 offset=48 imm=0
 #line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
-	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=204 dst=r2 src=r10 offset=-56 imm=0
 #line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
+	// EBPF_OP_STXB pc=205 dst=r10 src=r2 offset=-4 imm=0
 #line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
-	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=206 dst=r10 src=r1 offset=-8 imm=0
 #line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=207 dst=r2 src=r10 offset=0 imm=0
 #line 52 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=208 dst=r2 src=r0 offset=0 imm=-48
 #line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=209 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
-	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_CALL pc=211 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
-	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
+	// EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
 #line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
-	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=214 dst=r2 src=r10 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=215 dst=r2 src=r0 offset=0 imm=-48
 #line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=216 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
-	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
+	// EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=48
 #line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
-	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=219 dst=r4 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
-	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
+	// EBPF_OP_CALL pc=220 dst=r0 src=r0 offset=0 imm=11
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
-	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=222 dst=r0 src=r6 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	r0 = r6;
-	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=223 dst=r0 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	return r0;
 #line 89 "sample/sockops.c"
@@ -794,7 +800,7 @@ label_13:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 222, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
+	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 224, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)

--- a/tests/bpf2c_tests/expected/sockops_raw.txt
+++ b/tests/bpf2c_tests/expected/sockops_raw.txt
@@ -86,7 +86,7 @@ static uint64_t connection_monitor(void* context)
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
-	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
+	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
 #line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
@@ -149,7 +149,7 @@ label_2:
 #line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 22 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
 #line 24 "sample/sockops.c"
@@ -174,7 +174,7 @@ label_3:
 #line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 24 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
 #line 25 "sample/sockops.c"
@@ -261,10 +261,10 @@ label_6:
 	(r1, r2, r3, r4, r5);
 #line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
+	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
 #line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
-	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
+	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
 #line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
@@ -292,459 +292,465 @@ label_7:
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
 #line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
-	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
+	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-80 imm=0
 #line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
-#line 46 "sample/sockops.c"
-	r1 += IMMEDIATE(8);
-	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_REG pc=74 dst=r0 src=r1 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r1;
-	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_ADD64_IMM pc=75 dst=r0 src=r0 offset=0 imm=8
+#line 46 "sample/sockops.c"
+	r0 += IMMEDIATE(8);
+	// EBPF_OP_STXDW pc=76 dst=r10 src=r0 offset=-104 imm=0
+#line 46 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
+	// EBPF_OP_JNE_IMM pc=77 dst=r4 src=r0 offset=1 imm=0
 #line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
-	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
-	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
+	// EBPF_OP_LDXB pc=79 dst=r2 src=r0 offset=13 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
+	// EBPF_OP_LDXB pc=81 dst=r1 src=r0 offset=12 imm=0
 #line 47 "sample/sockops.c"
-	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
-	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
+	// EBPF_OP_STXDW pc=82 dst=r10 src=r1 offset=-64 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
-	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	// EBPF_OP_LDXB pc=83 dst=r8 src=r0 offset=15 imm=0
 #line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=84 dst=r8 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
+	// EBPF_OP_LDXB pc=85 dst=r5 src=r0 offset=14 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=86 dst=r8 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r5;
-	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
+	// EBPF_OP_LDXB pc=87 dst=r6 src=r0 offset=9 imm=0
 #line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=88 dst=r6 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
+	// EBPF_OP_LDXB pc=89 dst=r1 src=r0 offset=8 imm=0
 #line 47 "sample/sockops.c"
-	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
-	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
+	// EBPF_OP_STXDW pc=90 dst=r10 src=r1 offset=-72 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
-	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_LDXB pc=91 dst=r9 src=r0 offset=11 imm=0
 #line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=92 dst=r9 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
+	// EBPF_OP_LDXB pc=93 dst=r5 src=r0 offset=10 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=94 dst=r9 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r9 |= r5;
-	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
+	// EBPF_OP_LDXB pc=95 dst=r5 src=r0 offset=1 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
-	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r7 src=r0 offset=0 imm=0
+#line 47 "sample/sockops.c"
+	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
+	// EBPF_OP_STXDW pc=97 dst=r10 src=r7 offset=-88 imm=0
+#line 47 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r7;
+	// EBPF_OP_LDXB pc=98 dst=r7 src=r0 offset=3 imm=0
 #line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
-	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
-#line 48 "sample/sockops.c"
-	if (r4 != IMMEDIATE(0)) goto label_9;
-	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r3 = r1;
-label_9:
-	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r2 |= r1;
-	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r6 |= r1;
-	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
-#line 48 "sample/sockops.c"
-	r9 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
-#line 48 "sample/sockops.c"
-	r8 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
-#line 48 "sample/sockops.c"
-	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
-	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
-#line 48 "sample/sockops.c"
-	r7 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
-#line 48 "sample/sockops.c"
+	// EBPF_OP_LDXB pc=99 dst=r1 src=r0 offset=2 imm=0
+#line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
-	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
+	// EBPF_OP_STXDW pc=100 dst=r10 src=r1 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_JNE_IMM pc=101 dst=r4 src=r0 offset=1 imm=0
+#line 48 "sample/sockops.c"
+	if (r4 != IMMEDIATE(0)) goto label_9;
+	// EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+#line 48 "sample/sockops.c"
+	r3 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-104));
+label_9:
+	// EBPF_OP_LDXDW pc=103 dst=r1 src=r10 offset=-64 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_OR64_REG pc=104 dst=r2 src=r1 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r2 |= r1;
+	// EBPF_OP_LDXDW pc=105 dst=r1 src=r10 offset=-72 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_OR64_REG pc=106 dst=r6 src=r1 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r6 |= r1;
+	// EBPF_OP_LSH64_IMM pc=107 dst=r9 src=r0 offset=0 imm=16
+#line 48 "sample/sockops.c"
+	r9 <<= IMMEDIATE(16);
+	// EBPF_OP_LSH64_IMM pc=108 dst=r8 src=r0 offset=0 imm=16
+#line 48 "sample/sockops.c"
+	r8 <<= IMMEDIATE(16);
+	// EBPF_OP_LSH64_IMM pc=109 dst=r5 src=r0 offset=0 imm=8
+#line 48 "sample/sockops.c"
+	r5 <<= IMMEDIATE(8);
+	// EBPF_OP_LSH64_IMM pc=110 dst=r7 src=r0 offset=0 imm=8
+#line 48 "sample/sockops.c"
+	r7 <<= IMMEDIATE(8);
+	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=112 dst=r10 src=r1 offset=-72 imm=0
 #line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_IMM pc=113 dst=r1 src=r0 offset=0 imm=24
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_STXDW pc=114 dst=r10 src=r1 offset=-64 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	// EBPF_OP_JNE_IMM pc=115 dst=r4 src=r0 offset=2 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
-	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-label_10:
-	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
+	// EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
 #line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+label_10:
+	// EBPF_OP_OR64_REG pc=118 dst=r9 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r9 |= r6;
-	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=119 dst=r8 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r8 |= r2;
-	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
+	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-88 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
-	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=121 dst=r5 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
+	// EBPF_OP_LDXDW pc=122 dst=r1 src=r10 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
-	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=123 dst=r7 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r7 |= r1;
-	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_JNE_IMM pc=124 dst=r4 src=r0 offset=2 imm=0
 #line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
-	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
+	// EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
 #line 51 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
 label_11:
-	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=127 dst=r2 src=r10 offset=-56 imm=0
 #line 51 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
+	// EBPF_OP_OR64_REG pc=128 dst=r2 src=r4 offset=0 imm=0
 #line 53 "sample/sockops.c"
-	r1 |= r4;
-	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
+	r2 |= r4;
+	// EBPF_OP_STXDW pc=129 dst=r10 src=r2 offset=-56 imm=0
 #line 53 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
+	// EBPF_OP_LSH64_IMM pc=130 dst=r8 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=131 dst=r8 src=r9 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r9;
-	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
+	// EBPF_OP_STXDW pc=132 dst=r10 src=r8 offset=-40 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
-	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=133 dst=r7 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r7 |= r5;
-	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
+	// EBPF_OP_LDXB pc=135 dst=r1 src=r0 offset=5 imm=0
 #line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=136 dst=r1 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
+	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=4 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=138 dst=r1 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
+	// EBPF_OP_LDXB pc=139 dst=r2 src=r0 offset=6 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
-	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
+	// EBPF_OP_LDXB pc=140 dst=r4 src=r0 offset=7 imm=0
 #line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r2;
-	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r1 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
+	// EBPF_OP_LSH64_IMM pc=145 dst=r4 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=146 dst=r4 src=r7 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r7;
-	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
+	// EBPF_OP_STXDW pc=147 dst=r10 src=r4 offset=-48 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
-	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=148 dst=r6 src=r10 offset=-80 imm=0
 #line 47 "sample/sockops.c"
-	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
+	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_MOV64_REG pc=149 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
+	// EBPF_OP_LDXDW pc=150 dst=r2 src=r10 offset=-64 imm=0
 #line 48 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_ADD64_REG pc=151 dst=r1 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=152 dst=r1 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
+	// EBPF_OP_STXH pc=153 dst=r10 src=r1 offset=-32 imm=0
 #line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_LDXB pc=154 dst=r4 src=r3 offset=13 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=155 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
+	// EBPF_OP_LDXB pc=156 dst=r1 src=r3 offset=12 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
-	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=157 dst=r4 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
+	// EBPF_OP_LDXB pc=158 dst=r2 src=r3 offset=15 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=159 dst=r2 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
+	// EBPF_OP_LDXB pc=160 dst=r1 src=r3 offset=14 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
+	// EBPF_OP_LDXB pc=162 dst=r5 src=r3 offset=1 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
-	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=163 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
+	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
-	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=165 dst=r5 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
+	// EBPF_OP_LDXB pc=166 dst=r1 src=r3 offset=3 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
-	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=167 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
+	// EBPF_OP_LDXB pc=168 dst=r0 src=r3 offset=2 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
-	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r0;
-	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=170 dst=r1 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=171 dst=r1 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r5;
-	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=172 dst=r2 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=173 dst=r2 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r4;
-	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_LDXB pc=174 dst=r4 src=r3 offset=9 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=175 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
+	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=8 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
-	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=177 dst=r4 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r5;
-	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
+	// EBPF_OP_LDXB pc=178 dst=r5 src=r3 offset=11 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=179 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
+	// EBPF_OP_LDXB pc=180 dst=r0 src=r3 offset=10 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r0;
-	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=182 dst=r5 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=183 dst=r5 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r4;
-	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
+	// EBPF_OP_STXW pc=184 dst=r10 src=r5 offset=-20 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
-	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
+	// EBPF_OP_STXW pc=185 dst=r10 src=r2 offset=-16 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
-	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
+	// EBPF_OP_STXW pc=186 dst=r10 src=r1 offset=-28 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
-	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
+	// EBPF_OP_LDXB pc=187 dst=r1 src=r3 offset=5 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=188 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
+	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=4 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=190 dst=r1 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
+	// EBPF_OP_LDXB pc=191 dst=r2 src=r3 offset=6 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
-	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
+	// EBPF_OP_LDXB pc=192 dst=r3 src=r3 offset=7 imm=0
 #line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r2;
-	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=195 dst=r3 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=196 dst=r3 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r1;
-	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
+	// EBPF_OP_STXW pc=197 dst=r10 src=r3 offset=-24 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=198 dst=r1 src=r6 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=199 dst=r2 src=r10 offset=-72 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_ADD64_REG pc=200 dst=r1 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=201 dst=r1 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
+	// EBPF_OP_STXH pc=202 dst=r10 src=r1 offset=-12 imm=0
 #line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
+	// EBPF_OP_LDXB pc=203 dst=r1 src=r6 offset=48 imm=0
 #line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
-	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=204 dst=r2 src=r10 offset=-56 imm=0
 #line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
+	// EBPF_OP_STXB pc=205 dst=r10 src=r2 offset=-4 imm=0
 #line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
-	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=206 dst=r10 src=r1 offset=-8 imm=0
 #line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=207 dst=r2 src=r10 offset=0 imm=0
 #line 52 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=208 dst=r2 src=r0 offset=0 imm=-48
 #line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=209 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
-	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_CALL pc=211 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
-	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
+	// EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
 #line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
-	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=214 dst=r2 src=r10 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=215 dst=r2 src=r0 offset=0 imm=-48
 #line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=216 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
-	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
+	// EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=48
 #line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
-	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=219 dst=r4 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
-	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
+	// EBPF_OP_CALL pc=220 dst=r0 src=r0 offset=0 imm=11
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
-	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=222 dst=r0 src=r6 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	r0 = r6;
-	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=223 dst=r0 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	return r0;
 #line 89 "sample/sockops.c"
@@ -752,7 +758,7 @@ label_13:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 222, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
+	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 224, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)

--- a/tests/bpf2c_tests/expected/sockops_raw.txt
+++ b/tests/bpf2c_tests/expected/sockops_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "connection_map" },
 { NULL, { 13, 0, 0, 262144, 0, 0, 0, 0,  }, "audit_map" },
@@ -81,7 +86,7 @@ static uint64_t connection_monitor(void* context)
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
-	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
+	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
 #line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
@@ -144,7 +149,7 @@ label_2:
 #line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 24 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
 #line 24 "sample/sockops.c"
@@ -169,7 +174,7 @@ label_3:
 #line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 25 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
 #line 25 "sample/sockops.c"
@@ -256,10 +261,10 @@ label_6:
 	(r1, r2, r3, r4, r5);
 #line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
+	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
 #line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
-	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
+	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
 #line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
@@ -287,465 +292,459 @@ label_7:
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
 #line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
-	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-80 imm=0
+	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
 #line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_REG pc=74 dst=r0 src=r1 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
+#line 46 "sample/sockops.c"
+	r1 += IMMEDIATE(8);
+	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r1;
-	// EBPF_OP_ADD64_IMM pc=75 dst=r0 src=r0 offset=0 imm=8
-#line 46 "sample/sockops.c"
-	r0 += IMMEDIATE(8);
-	// EBPF_OP_STXDW pc=76 dst=r10 src=r0 offset=-104 imm=0
-#line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-	// EBPF_OP_JNE_IMM pc=77 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
 #line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
-	// EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
-	// EBPF_OP_LDXB pc=79 dst=r2 src=r0 offset=13 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=81 dst=r1 src=r0 offset=12 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
 #line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
-	// EBPF_OP_STXDW pc=82 dst=r10 src=r1 offset=-64 imm=0
+	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
+	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_LDXB pc=83 dst=r8 src=r0 offset=15 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
+	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
 #line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=84 dst=r8 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=85 dst=r5 src=r0 offset=14 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=86 dst=r8 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r5;
-	// EBPF_OP_LDXB pc=87 dst=r6 src=r0 offset=9 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
 #line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=88 dst=r6 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=89 dst=r1 src=r0 offset=8 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
 #line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
-	// EBPF_OP_STXDW pc=90 dst=r10 src=r1 offset=-72 imm=0
+	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
+	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_LDXB pc=91 dst=r9 src=r0 offset=11 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
+	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
 #line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=92 dst=r9 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=93 dst=r5 src=r0 offset=10 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=94 dst=r9 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r9 |= r5;
-	// EBPF_OP_LDXB pc=95 dst=r5 src=r0 offset=1 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
-	// EBPF_OP_LDXB pc=96 dst=r7 src=r0 offset=0 imm=0
-#line 47 "sample/sockops.c"
-	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
-	// EBPF_OP_STXDW pc=97 dst=r10 src=r7 offset=-88 imm=0
-#line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r7;
-	// EBPF_OP_LDXB pc=98 dst=r7 src=r0 offset=3 imm=0
+	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
 #line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
-	// EBPF_OP_LDXB pc=99 dst=r1 src=r0 offset=2 imm=0
-#line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
-	// EBPF_OP_STXDW pc=100 dst=r10 src=r1 offset=-96 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-	// EBPF_OP_JNE_IMM pc=101 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_9;
-	// EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
-	r3 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-104));
+	r3 = r1;
 label_9:
-	// EBPF_OP_LDXDW pc=103 dst=r1 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_OR64_REG pc=104 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXDW pc=105 dst=r1 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
 #line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_OR64_REG pc=106 dst=r6 src=r1 offset=0 imm=0
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r6 |= r1;
-	// EBPF_OP_LSH64_IMM pc=107 dst=r9 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
 	r9 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=108 dst=r8 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
 	r8 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=109 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LSH64_IMM pc=110 dst=r7 src=r0 offset=0 imm=8
+	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
+	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
 	r7 <<= IMMEDIATE(8);
-	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
+	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=112 dst=r10 src=r1 offset=-72 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=113 dst=r1 src=r0 offset=0 imm=24
-#line 48 "sample/sockops.c"
-	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=114 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
 #line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_JNE_IMM pc=115 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
+#line 48 "sample/sockops.c"
+	r1 = IMMEDIATE(24);
+	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
-	// EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_10:
-	// EBPF_OP_OR64_REG pc=118 dst=r9 src=r6 offset=0 imm=0
+	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r9 |= r6;
-	// EBPF_OP_OR64_REG pc=119 dst=r8 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r8 |= r2;
-	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-88 imm=0
+	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
-	// EBPF_OP_OR64_REG pc=121 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXDW pc=122 dst=r1 src=r10 offset=-96 imm=0
+	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
-	// EBPF_OP_OR64_REG pc=123 dst=r7 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r7 |= r1;
-	// EBPF_OP_JNE_IMM pc=124 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
 #line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
-	// EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
+	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
+	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
 #line 51 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_11:
-	// EBPF_OP_LDXDW pc=127 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_OR64_REG pc=128 dst=r2 src=r4 offset=0 imm=0
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
+	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
 #line 53 "sample/sockops.c"
-	r2 |= r4;
-	// EBPF_OP_STXDW pc=129 dst=r10 src=r2 offset=-56 imm=0
+	r1 |= r4;
+	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
 #line 53 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
-	// EBPF_OP_LSH64_IMM pc=130 dst=r8 src=r0 offset=0 imm=32
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=131 dst=r8 src=r9 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r9;
-	// EBPF_OP_STXDW pc=132 dst=r10 src=r8 offset=-40 imm=0
+	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
-	// EBPF_OP_LSH64_IMM pc=133 dst=r7 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r7 |= r5;
-	// EBPF_OP_LDXB pc=135 dst=r1 src=r0 offset=5 imm=0
+	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
 #line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=136 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=4 imm=0
+	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=138 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=139 dst=r2 src=r0 offset=6 imm=0
+	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
-	// EBPF_OP_LDXB pc=140 dst=r4 src=r0 offset=7 imm=0
+	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
 #line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r2;
-	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LSH64_IMM pc=145 dst=r4 src=r0 offset=0 imm=32
+	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=146 dst=r4 src=r7 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r7;
-	// EBPF_OP_STXDW pc=147 dst=r10 src=r4 offset=-48 imm=0
+	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
-	// EBPF_OP_LDXDW pc=148 dst=r6 src=r10 offset=-80 imm=0
+	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
 #line 47 "sample/sockops.c"
-	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_MOV64_REG pc=149 dst=r1 src=r6 offset=0 imm=0
+	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=150 dst=r2 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
 #line 48 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_ADD64_REG pc=151 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=152 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=153 dst=r10 src=r1 offset=-32 imm=0
+	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
 #line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=154 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=155 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=156 dst=r1 src=r3 offset=12 imm=0
+	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
-	// EBPF_OP_OR64_REG pc=157 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LDXB pc=158 dst=r2 src=r3 offset=15 imm=0
+	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=159 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=160 dst=r1 src=r3 offset=14 imm=0
+	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXB pc=162 dst=r5 src=r3 offset=1 imm=0
+	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
-	// EBPF_OP_LSH64_IMM pc=163 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=0 imm=0
+	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
-	// EBPF_OP_OR64_REG pc=165 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXB pc=166 dst=r1 src=r3 offset=3 imm=0
+	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
-	// EBPF_OP_LSH64_IMM pc=167 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=168 dst=r0 src=r3 offset=2 imm=0
+	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
-	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r0;
-	// EBPF_OP_LSH64_IMM pc=170 dst=r1 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=171 dst=r1 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r5;
-	// EBPF_OP_LSH64_IMM pc=172 dst=r2 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=173 dst=r2 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r4;
-	// EBPF_OP_LDXB pc=174 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=175 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=8 imm=0
+	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
-	// EBPF_OP_OR64_REG pc=177 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r5;
-	// EBPF_OP_LDXB pc=178 dst=r5 src=r3 offset=11 imm=0
+	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=179 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=180 dst=r0 src=r3 offset=10 imm=0
+	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r0;
-	// EBPF_OP_LSH64_IMM pc=182 dst=r5 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=183 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r4;
-	// EBPF_OP_STXW pc=184 dst=r10 src=r5 offset=-20 imm=0
+	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
-	// EBPF_OP_STXW pc=185 dst=r10 src=r2 offset=-16 imm=0
+	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
-	// EBPF_OP_STXW pc=186 dst=r10 src=r1 offset=-28 imm=0
+	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
-	// EBPF_OP_LDXB pc=187 dst=r1 src=r3 offset=5 imm=0
+	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=188 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=4 imm=0
+	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=190 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=191 dst=r2 src=r3 offset=6 imm=0
+	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
-	// EBPF_OP_LDXB pc=192 dst=r3 src=r3 offset=7 imm=0
+	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
 #line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r2;
-	// EBPF_OP_LSH64_IMM pc=195 dst=r3 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=196 dst=r3 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r1;
-	// EBPF_OP_STXW pc=197 dst=r10 src=r3 offset=-24 imm=0
+	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-	// EBPF_OP_MOV64_REG pc=198 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=199 dst=r2 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_ADD64_REG pc=200 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=201 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=202 dst=r10 src=r1 offset=-12 imm=0
+	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
 #line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=203 dst=r1 src=r6 offset=48 imm=0
+	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
 #line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
-	// EBPF_OP_LDXDW pc=204 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
 #line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_STXB pc=205 dst=r10 src=r2 offset=-4 imm=0
+	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
 #line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
-	// EBPF_OP_STXW pc=206 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
 #line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-	// EBPF_OP_MOV64_REG pc=207 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
 #line 52 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=208 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
 #line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=209 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
-	// EBPF_OP_CALL pc=211 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
-	// EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
+	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
 #line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
-	// EBPF_OP_MOV64_REG pc=214 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=215 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
 #line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=216 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
-	// EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=48
+	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
 #line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
-	// EBPF_OP_MOV64_IMM pc=219 dst=r4 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
-	// EBPF_OP_CALL pc=220 dst=r0 src=r0 offset=0 imm=11
+	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
-	// EBPF_OP_MOV64_REG pc=222 dst=r0 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	r0 = r6;
-	// EBPF_OP_EXIT pc=223 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	return r0;
 #line 89 "sample/sockops.c"
@@ -753,7 +752,7 @@ label_13:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 224, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
+	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 222, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
@@ -763,4 +762,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t sockops_metadata_table = { _get_programs, _get_maps };
+metadata_table_t sockops_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/sockops_sys.txt
+++ b/tests/bpf2c_tests/expected/sockops_sys.txt
@@ -253,7 +253,7 @@ static uint64_t connection_monitor(void* context)
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
-	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
+	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
 #line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
@@ -316,7 +316,7 @@ label_2:
 #line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 22 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
 #line 24 "sample/sockops.c"
@@ -341,7 +341,7 @@ label_3:
 #line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 24 "sample/sockops.c"
+#line 25 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
 #line 25 "sample/sockops.c"
@@ -428,10 +428,10 @@ label_6:
 	(r1, r2, r3, r4, r5);
 #line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
+	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
 #line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
-	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
+	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
 #line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
@@ -459,459 +459,465 @@ label_7:
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
 #line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
-	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
+	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-80 imm=0
 #line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
-#line 46 "sample/sockops.c"
-	r1 += IMMEDIATE(8);
-	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_REG pc=74 dst=r0 src=r1 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r1;
-	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_ADD64_IMM pc=75 dst=r0 src=r0 offset=0 imm=8
+#line 46 "sample/sockops.c"
+	r0 += IMMEDIATE(8);
+	// EBPF_OP_STXDW pc=76 dst=r10 src=r0 offset=-104 imm=0
+#line 46 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
+	// EBPF_OP_JNE_IMM pc=77 dst=r4 src=r0 offset=1 imm=0
 #line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
-	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
-	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
+	// EBPF_OP_LDXB pc=79 dst=r2 src=r0 offset=13 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
+	// EBPF_OP_LDXB pc=81 dst=r1 src=r0 offset=12 imm=0
 #line 47 "sample/sockops.c"
-	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
-	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
+	// EBPF_OP_STXDW pc=82 dst=r10 src=r1 offset=-64 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
-	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	// EBPF_OP_LDXB pc=83 dst=r8 src=r0 offset=15 imm=0
 #line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=84 dst=r8 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
+	// EBPF_OP_LDXB pc=85 dst=r5 src=r0 offset=14 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=86 dst=r8 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r5;
-	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
+	// EBPF_OP_LDXB pc=87 dst=r6 src=r0 offset=9 imm=0
 #line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=88 dst=r6 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
+	// EBPF_OP_LDXB pc=89 dst=r1 src=r0 offset=8 imm=0
 #line 47 "sample/sockops.c"
-	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
-	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
+	// EBPF_OP_STXDW pc=90 dst=r10 src=r1 offset=-72 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
-	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_LDXB pc=91 dst=r9 src=r0 offset=11 imm=0
 #line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=92 dst=r9 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
+	// EBPF_OP_LDXB pc=93 dst=r5 src=r0 offset=10 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=94 dst=r9 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r9 |= r5;
-	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
+	// EBPF_OP_LDXB pc=95 dst=r5 src=r0 offset=1 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
-	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
+	// EBPF_OP_LDXB pc=96 dst=r7 src=r0 offset=0 imm=0
+#line 47 "sample/sockops.c"
+	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
+	// EBPF_OP_STXDW pc=97 dst=r10 src=r7 offset=-88 imm=0
+#line 47 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r7;
+	// EBPF_OP_LDXB pc=98 dst=r7 src=r0 offset=3 imm=0
 #line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
-	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
-#line 48 "sample/sockops.c"
-	if (r4 != IMMEDIATE(0)) goto label_9;
-	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r3 = r1;
-label_9:
-	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r2 |= r1;
-	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r6 |= r1;
-	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
-#line 48 "sample/sockops.c"
-	r9 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
-#line 48 "sample/sockops.c"
-	r8 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
-#line 48 "sample/sockops.c"
-	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
-#line 48 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
-	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
-#line 48 "sample/sockops.c"
-	r7 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
-#line 48 "sample/sockops.c"
+	// EBPF_OP_LDXB pc=99 dst=r1 src=r0 offset=2 imm=0
+#line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
-	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
+	// EBPF_OP_STXDW pc=100 dst=r10 src=r1 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_JNE_IMM pc=101 dst=r4 src=r0 offset=1 imm=0
+#line 48 "sample/sockops.c"
+	if (r4 != IMMEDIATE(0)) goto label_9;
+	// EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+#line 48 "sample/sockops.c"
+	r3 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-104));
+label_9:
+	// EBPF_OP_LDXDW pc=103 dst=r1 src=r10 offset=-64 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_OR64_REG pc=104 dst=r2 src=r1 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r2 |= r1;
+	// EBPF_OP_LDXDW pc=105 dst=r1 src=r10 offset=-72 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_OR64_REG pc=106 dst=r6 src=r1 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r6 |= r1;
+	// EBPF_OP_LSH64_IMM pc=107 dst=r9 src=r0 offset=0 imm=16
+#line 48 "sample/sockops.c"
+	r9 <<= IMMEDIATE(16);
+	// EBPF_OP_LSH64_IMM pc=108 dst=r8 src=r0 offset=0 imm=16
+#line 48 "sample/sockops.c"
+	r8 <<= IMMEDIATE(16);
+	// EBPF_OP_LSH64_IMM pc=109 dst=r5 src=r0 offset=0 imm=8
+#line 48 "sample/sockops.c"
+	r5 <<= IMMEDIATE(8);
+	// EBPF_OP_LSH64_IMM pc=110 dst=r7 src=r0 offset=0 imm=8
+#line 48 "sample/sockops.c"
+	r7 <<= IMMEDIATE(8);
+	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=112 dst=r10 src=r1 offset=-72 imm=0
 #line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_IMM pc=113 dst=r1 src=r0 offset=0 imm=24
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_STXDW pc=114 dst=r10 src=r1 offset=-64 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	// EBPF_OP_JNE_IMM pc=115 dst=r4 src=r0 offset=2 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
-	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-label_10:
-	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
+	// EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
 #line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+label_10:
+	// EBPF_OP_OR64_REG pc=118 dst=r9 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r9 |= r6;
-	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=119 dst=r8 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r8 |= r2;
-	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
+	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-88 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
-	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=121 dst=r5 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
+	// EBPF_OP_LDXDW pc=122 dst=r1 src=r10 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
-	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=123 dst=r7 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r7 |= r1;
-	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_JNE_IMM pc=124 dst=r4 src=r0 offset=2 imm=0
 #line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
-	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
+	// EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
 #line 51 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
 label_11:
-	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=127 dst=r2 src=r10 offset=-56 imm=0
 #line 51 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
+	// EBPF_OP_OR64_REG pc=128 dst=r2 src=r4 offset=0 imm=0
 #line 53 "sample/sockops.c"
-	r1 |= r4;
-	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
+	r2 |= r4;
+	// EBPF_OP_STXDW pc=129 dst=r10 src=r2 offset=-56 imm=0
 #line 53 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
+	// EBPF_OP_LSH64_IMM pc=130 dst=r8 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=131 dst=r8 src=r9 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r9;
-	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
+	// EBPF_OP_STXDW pc=132 dst=r10 src=r8 offset=-40 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
-	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=133 dst=r7 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r7 |= r5;
-	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
+	// EBPF_OP_LDXB pc=135 dst=r1 src=r0 offset=5 imm=0
 #line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=136 dst=r1 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
+	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=4 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=138 dst=r1 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
+	// EBPF_OP_LDXB pc=139 dst=r2 src=r0 offset=6 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
-	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
+	// EBPF_OP_LDXB pc=140 dst=r4 src=r0 offset=7 imm=0
 #line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r2;
-	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r1 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
+	// EBPF_OP_LSH64_IMM pc=145 dst=r4 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=146 dst=r4 src=r7 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r7;
-	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
+	// EBPF_OP_STXDW pc=147 dst=r10 src=r4 offset=-48 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
-	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=148 dst=r6 src=r10 offset=-80 imm=0
 #line 47 "sample/sockops.c"
-	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
+	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_MOV64_REG pc=149 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
+	// EBPF_OP_LDXDW pc=150 dst=r2 src=r10 offset=-64 imm=0
 #line 48 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_ADD64_REG pc=151 dst=r1 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=152 dst=r1 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
+	// EBPF_OP_STXH pc=153 dst=r10 src=r1 offset=-32 imm=0
 #line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_LDXB pc=154 dst=r4 src=r3 offset=13 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=155 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
+	// EBPF_OP_LDXB pc=156 dst=r1 src=r3 offset=12 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
-	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=157 dst=r4 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
+	// EBPF_OP_LDXB pc=158 dst=r2 src=r3 offset=15 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=159 dst=r2 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
+	// EBPF_OP_LDXB pc=160 dst=r1 src=r3 offset=14 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
+	// EBPF_OP_LDXB pc=162 dst=r5 src=r3 offset=1 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
-	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=163 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
+	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
-	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=165 dst=r5 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
+	// EBPF_OP_LDXB pc=166 dst=r1 src=r3 offset=3 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
-	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=167 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
+	// EBPF_OP_LDXB pc=168 dst=r0 src=r3 offset=2 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
-	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r0;
-	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=170 dst=r1 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=171 dst=r1 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r5;
-	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=172 dst=r2 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=173 dst=r2 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r4;
-	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_LDXB pc=174 dst=r4 src=r3 offset=9 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=175 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
+	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=8 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
-	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=177 dst=r4 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r5;
-	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
+	// EBPF_OP_LDXB pc=178 dst=r5 src=r3 offset=11 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=179 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
+	// EBPF_OP_LDXB pc=180 dst=r0 src=r3 offset=10 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r0;
-	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=182 dst=r5 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=183 dst=r5 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r4;
-	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
+	// EBPF_OP_STXW pc=184 dst=r10 src=r5 offset=-20 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
-	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
+	// EBPF_OP_STXW pc=185 dst=r10 src=r2 offset=-16 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
-	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
+	// EBPF_OP_STXW pc=186 dst=r10 src=r1 offset=-28 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
-	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
+	// EBPF_OP_LDXB pc=187 dst=r1 src=r3 offset=5 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=188 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
+	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=4 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=190 dst=r1 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
+	// EBPF_OP_LDXB pc=191 dst=r2 src=r3 offset=6 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
-	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
+	// EBPF_OP_LDXB pc=192 dst=r3 src=r3 offset=7 imm=0
 #line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r2;
-	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=195 dst=r3 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=196 dst=r3 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r1;
-	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
+	// EBPF_OP_STXW pc=197 dst=r10 src=r3 offset=-24 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=198 dst=r1 src=r6 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=199 dst=r2 src=r10 offset=-72 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_ADD64_REG pc=200 dst=r1 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=201 dst=r1 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
+	// EBPF_OP_STXH pc=202 dst=r10 src=r1 offset=-12 imm=0
 #line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
+	// EBPF_OP_LDXB pc=203 dst=r1 src=r6 offset=48 imm=0
 #line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
-	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=204 dst=r2 src=r10 offset=-56 imm=0
 #line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
+	// EBPF_OP_STXB pc=205 dst=r10 src=r2 offset=-4 imm=0
 #line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
-	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=206 dst=r10 src=r1 offset=-8 imm=0
 #line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=207 dst=r2 src=r10 offset=0 imm=0
 #line 52 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=208 dst=r2 src=r0 offset=0 imm=-48
 #line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=209 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
-	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_CALL pc=211 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
-	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
+	// EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
 #line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
-	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=214 dst=r2 src=r10 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=215 dst=r2 src=r0 offset=0 imm=-48
 #line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=216 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
-	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
+	// EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=48
 #line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
-	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=219 dst=r4 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
-	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
+	// EBPF_OP_CALL pc=220 dst=r0 src=r0 offset=0 imm=11
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
-	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=222 dst=r0 src=r6 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	r0 = r6;
-	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=223 dst=r0 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	return r0;
 #line 89 "sample/sockops.c"
@@ -919,7 +925,7 @@ label_13:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 222, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
+	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 224, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)

--- a/tests/bpf2c_tests/expected/sockops_sys.txt
+++ b/tests/bpf2c_tests/expected/sockops_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 1, 44, 4, 1, 0, 0, 0, 0,  }, "connection_map" },
 { NULL, { 13, 0, 0, 262144, 0, 0, 0, 0,  }, "audit_map" },
@@ -248,7 +253,7 @@ static uint64_t connection_monitor(void* context)
 	// EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
 	r6 = (uint64_t)4294967295;
-	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
+	// EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=212 imm=1
 #line 70 "sample/sockops.c"
 	if (r2 != IMMEDIATE(1)) goto label_13;
 	// EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
@@ -311,7 +316,7 @@ label_2:
 #line 22 "sample/sockops.c"
 	r2 = IMMEDIATE(28);
 	// EBPF_OP_MOV64_IMM pc=27 dst=r5 src=r0 offset=0 imm=8
-#line 24 "sample/sockops.c"
+#line 22 "sample/sockops.c"
 	r5 = IMMEDIATE(8);
 	// EBPF_OP_JNE_IMM pc=28 dst=r4 src=r0 offset=1 imm=0
 #line 24 "sample/sockops.c"
@@ -336,7 +341,7 @@ label_3:
 #line 24 "sample/sockops.c"
 	r0 = IMMEDIATE(44);
 	// EBPF_OP_MOV64_IMM pc=35 dst=r3 src=r0 offset=0 imm=24
-#line 25 "sample/sockops.c"
+#line 24 "sample/sockops.c"
 	r3 = IMMEDIATE(24);
 	// EBPF_OP_JNE_IMM pc=36 dst=r4 src=r0 offset=1 imm=0
 #line 25 "sample/sockops.c"
@@ -423,10 +428,10 @@ label_6:
 	(r1, r2, r3, r4, r5);
 #line 32 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
+	// EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=156 imm=0
 #line 32 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
-	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
+	// EBPF_OP_JA pc=64 dst=r0 src=r0 offset=147 imm=0
 #line 32 "sample/sockops.c"
 	goto label_12;
 label_7:
@@ -454,465 +459,459 @@ label_7:
 	// EBPF_OP_ADD64_IMM pc=72 dst=r3 src=r0 offset=0 imm=28
 #line 46 "sample/sockops.c"
 	r3 += IMMEDIATE(28);
-	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-80 imm=0
+	// EBPF_OP_STXDW pc=73 dst=r10 src=r1 offset=-72 imm=0
 #line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_REG pc=74 dst=r0 src=r1 offset=0 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	// EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=8
+#line 46 "sample/sockops.c"
+	r1 += IMMEDIATE(8);
+	// EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r1;
-	// EBPF_OP_ADD64_IMM pc=75 dst=r0 src=r0 offset=0 imm=8
-#line 46 "sample/sockops.c"
-	r0 += IMMEDIATE(8);
-	// EBPF_OP_STXDW pc=76 dst=r10 src=r0 offset=-104 imm=0
-#line 46 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-	// EBPF_OP_JNE_IMM pc=77 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_JNE_IMM pc=76 dst=r4 src=r0 offset=1 imm=0
 #line 46 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_8;
-	// EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=77 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
 	r0 = r3;
 label_8:
-	// EBPF_OP_LDXB pc=79 dst=r2 src=r0 offset=13 imm=0
+	// EBPF_OP_LDXB pc=78 dst=r2 src=r0 offset=13 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=79 dst=r2 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=81 dst=r1 src=r0 offset=12 imm=0
+	// EBPF_OP_LDXB pc=80 dst=r5 src=r0 offset=12 imm=0
 #line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
-	// EBPF_OP_STXDW pc=82 dst=r10 src=r1 offset=-64 imm=0
+	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(12));
+	// EBPF_OP_STXDW pc=81 dst=r10 src=r5 offset=-64 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_LDXB pc=83 dst=r8 src=r0 offset=15 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r5;
+	// EBPF_OP_LDXB pc=82 dst=r8 src=r0 offset=15 imm=0
 #line 47 "sample/sockops.c"
 	r8 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=84 dst=r8 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=83 dst=r8 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=85 dst=r5 src=r0 offset=14 imm=0
+	// EBPF_OP_LDXB pc=84 dst=r5 src=r0 offset=14 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=86 dst=r8 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=85 dst=r8 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r5;
-	// EBPF_OP_LDXB pc=87 dst=r6 src=r0 offset=9 imm=0
+	// EBPF_OP_LDXB pc=86 dst=r6 src=r0 offset=9 imm=0
 #line 47 "sample/sockops.c"
 	r6 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=88 dst=r6 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=87 dst=r6 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r6 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=89 dst=r1 src=r0 offset=8 imm=0
+	// EBPF_OP_LDXB pc=88 dst=r5 src=r0 offset=8 imm=0
 #line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
-	// EBPF_OP_STXDW pc=90 dst=r10 src=r1 offset=-72 imm=0
+	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(8));
+	// EBPF_OP_STXDW pc=89 dst=r10 src=r5 offset=-80 imm=0
 #line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_LDXB pc=91 dst=r9 src=r0 offset=11 imm=0
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r5;
+	// EBPF_OP_LDXB pc=90 dst=r9 src=r0 offset=11 imm=0
 #line 47 "sample/sockops.c"
 	r9 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=92 dst=r9 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=91 dst=r9 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r9 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=93 dst=r5 src=r0 offset=10 imm=0
+	// EBPF_OP_LDXB pc=92 dst=r5 src=r0 offset=10 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=94 dst=r9 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=93 dst=r9 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r9 |= r5;
-	// EBPF_OP_LDXB pc=95 dst=r5 src=r0 offset=1 imm=0
+	// EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=1 imm=0
 #line 47 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(1));
-	// EBPF_OP_LDXB pc=96 dst=r7 src=r0 offset=0 imm=0
-#line 47 "sample/sockops.c"
-	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
-	// EBPF_OP_STXDW pc=97 dst=r10 src=r7 offset=-88 imm=0
-#line 47 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r7;
-	// EBPF_OP_LDXB pc=98 dst=r7 src=r0 offset=3 imm=0
+	// EBPF_OP_LDXB pc=95 dst=r7 src=r0 offset=3 imm=0
 #line 47 "sample/sockops.c"
 	r7 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(3));
-	// EBPF_OP_LDXB pc=99 dst=r1 src=r0 offset=2 imm=0
-#line 47 "sample/sockops.c"
-	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
-	// EBPF_OP_STXDW pc=100 dst=r10 src=r1 offset=-96 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-	// EBPF_OP_JNE_IMM pc=101 dst=r4 src=r0 offset=1 imm=0
+	// EBPF_OP_JNE_IMM pc=96 dst=r4 src=r0 offset=1 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_9;
-	// EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+	// EBPF_OP_MOV64_REG pc=97 dst=r3 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
-	r3 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-104));
+	r3 = r1;
 label_9:
-	// EBPF_OP_LDXDW pc=103 dst=r1 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=98 dst=r1 src=r10 offset=-64 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_OR64_REG pc=104 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=99 dst=r2 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXDW pc=105 dst=r1 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=100 dst=r1 src=r10 offset=-80 imm=0
 #line 48 "sample/sockops.c"
-	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_OR64_REG pc=106 dst=r6 src=r1 offset=0 imm=0
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_OR64_REG pc=101 dst=r6 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r6 |= r1;
-	// EBPF_OP_LSH64_IMM pc=107 dst=r9 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=102 dst=r9 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
 	r9 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=108 dst=r8 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=103 dst=r8 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
 	r8 <<= IMMEDIATE(16);
-	// EBPF_OP_LSH64_IMM pc=109 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LSH64_IMM pc=110 dst=r7 src=r0 offset=0 imm=8
+	// EBPF_OP_LDXB pc=105 dst=r1 src=r0 offset=0 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(0));
+	// EBPF_OP_STXDW pc=106 dst=r10 src=r1 offset=-88 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+	// EBPF_OP_LSH64_IMM pc=107 dst=r7 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
 	r7 <<= IMMEDIATE(8);
-	// EBPF_OP_MOV64_IMM pc=111 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_LDXB pc=108 dst=r1 src=r0 offset=2 imm=0
+#line 48 "sample/sockops.c"
+	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(2));
+	// EBPF_OP_STXDW pc=109 dst=r10 src=r1 offset=-96 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+	// EBPF_OP_MOV64_IMM pc=110 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=112 dst=r10 src=r1 offset=-72 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-	// EBPF_OP_MOV64_IMM pc=113 dst=r1 src=r0 offset=0 imm=24
-#line 48 "sample/sockops.c"
-	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=114 dst=r10 src=r1 offset=-64 imm=0
+	// EBPF_OP_STXDW pc=111 dst=r10 src=r1 offset=-64 imm=0
 #line 48 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-	// EBPF_OP_JNE_IMM pc=115 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=24
+#line 48 "sample/sockops.c"
+	r1 = IMMEDIATE(24);
+	// EBPF_OP_JNE_IMM pc=113 dst=r4 src=r0 offset=1 imm=0
 #line 48 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_10;
-	// EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
+	// EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
 	r1 = IMMEDIATE(44);
-	// EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
-#line 48 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_10:
-	// EBPF_OP_OR64_REG pc=118 dst=r9 src=r6 offset=0 imm=0
+	// EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
+#line 48 "sample/sockops.c"
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+	// EBPF_OP_OR64_REG pc=116 dst=r9 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r9 |= r6;
-	// EBPF_OP_OR64_REG pc=119 dst=r8 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=117 dst=r8 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r8 |= r2;
-	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-88 imm=0
+	// EBPF_OP_LDXDW pc=118 dst=r1 src=r10 offset=-88 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-88));
-	// EBPF_OP_OR64_REG pc=121 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=119 dst=r5 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXDW pc=122 dst=r1 src=r10 offset=-96 imm=0
+	// EBPF_OP_LDXDW pc=120 dst=r1 src=r10 offset=-96 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-96));
-	// EBPF_OP_OR64_REG pc=123 dst=r7 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=121 dst=r7 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r7 |= r1;
-	// EBPF_OP_JNE_IMM pc=124 dst=r4 src=r0 offset=2 imm=0
+	// EBPF_OP_JNE_IMM pc=122 dst=r4 src=r0 offset=2 imm=0
 #line 51 "sample/sockops.c"
 	if (r4 != IMMEDIATE(0)) goto label_11;
-	// EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
+	// EBPF_OP_MOV64_IMM pc=123 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
 	r1 = IMMEDIATE(24);
-	// EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
+	// EBPF_OP_STXDW pc=124 dst=r10 src=r1 offset=-64 imm=0
 #line 51 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
 label_11:
-	// EBPF_OP_LDXDW pc=127 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=125 dst=r1 src=r10 offset=-56 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_OR64_REG pc=128 dst=r2 src=r4 offset=0 imm=0
+	r1 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
+	// EBPF_OP_OR64_REG pc=126 dst=r1 src=r4 offset=0 imm=0
 #line 53 "sample/sockops.c"
-	r2 |= r4;
-	// EBPF_OP_STXDW pc=129 dst=r10 src=r2 offset=-56 imm=0
+	r1 |= r4;
+	// EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-56 imm=0
 #line 53 "sample/sockops.c"
-	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r2;
-	// EBPF_OP_LSH64_IMM pc=130 dst=r8 src=r0 offset=0 imm=32
+	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+	// EBPF_OP_LSH64_IMM pc=128 dst=r8 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r8 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=131 dst=r8 src=r9 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=129 dst=r8 src=r9 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r8 |= r9;
-	// EBPF_OP_STXDW pc=132 dst=r10 src=r8 offset=-40 imm=0
+	// EBPF_OP_STXDW pc=130 dst=r10 src=r8 offset=-40 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r8;
-	// EBPF_OP_LSH64_IMM pc=133 dst=r7 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=131 dst=r7 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r7 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=134 dst=r7 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=132 dst=r7 src=r5 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r7 |= r5;
-	// EBPF_OP_LDXB pc=135 dst=r1 src=r0 offset=5 imm=0
+	// EBPF_OP_LDXB pc=133 dst=r1 src=r0 offset=5 imm=0
 #line 47 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=136 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=134 dst=r1 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=4 imm=0
+	// EBPF_OP_LDXB pc=135 dst=r2 src=r0 offset=4 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=138 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=136 dst=r1 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=139 dst=r2 src=r0 offset=6 imm=0
+	// EBPF_OP_LDXB pc=137 dst=r2 src=r0 offset=6 imm=0
 #line 47 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(6));
-	// EBPF_OP_LDXB pc=140 dst=r4 src=r0 offset=7 imm=0
+	// EBPF_OP_LDXB pc=138 dst=r4 src=r0 offset=7 imm=0
 #line 47 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r0 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=139 dst=r4 src=r0 offset=0 imm=8
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=140 dst=r4 src=r2 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r2;
-	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=16
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=142 dst=r4 src=r1 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LSH64_IMM pc=145 dst=r4 src=r0 offset=0 imm=32
+	// EBPF_OP_LSH64_IMM pc=143 dst=r4 src=r0 offset=0 imm=32
 #line 47 "sample/sockops.c"
 	r4 <<= IMMEDIATE(32);
-	// EBPF_OP_OR64_REG pc=146 dst=r4 src=r7 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=144 dst=r4 src=r7 offset=0 imm=0
 #line 47 "sample/sockops.c"
 	r4 |= r7;
-	// EBPF_OP_STXDW pc=147 dst=r10 src=r4 offset=-48 imm=0
+	// EBPF_OP_STXDW pc=145 dst=r10 src=r4 offset=-48 imm=0
 #line 47 "sample/sockops.c"
 	*(uint64_t *)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
-	// EBPF_OP_LDXDW pc=148 dst=r6 src=r10 offset=-80 imm=0
+	// EBPF_OP_LDXDW pc=146 dst=r6 src=r10 offset=-72 imm=0
 #line 47 "sample/sockops.c"
-	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
-	// EBPF_OP_MOV64_REG pc=149 dst=r1 src=r6 offset=0 imm=0
+	r6 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
+	// EBPF_OP_MOV64_REG pc=147 dst=r1 src=r6 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=150 dst=r2 src=r10 offset=-64 imm=0
+	// EBPF_OP_LDXDW pc=148 dst=r2 src=r10 offset=-80 imm=0
 #line 48 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
-	// EBPF_OP_ADD64_REG pc=151 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-80));
+	// EBPF_OP_ADD64_REG pc=149 dst=r1 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=152 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=150 dst=r1 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=153 dst=r10 src=r1 offset=-32 imm=0
+	// EBPF_OP_STXH pc=151 dst=r10 src=r1 offset=-32 imm=0
 #line 48 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-32)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=154 dst=r4 src=r3 offset=13 imm=0
+	// EBPF_OP_LDXB pc=152 dst=r4 src=r3 offset=13 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(13));
-	// EBPF_OP_LSH64_IMM pc=155 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=156 dst=r1 src=r3 offset=12 imm=0
+	// EBPF_OP_LDXB pc=154 dst=r1 src=r3 offset=12 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(12));
-	// EBPF_OP_OR64_REG pc=157 dst=r4 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=155 dst=r4 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r1;
-	// EBPF_OP_LDXB pc=158 dst=r2 src=r3 offset=15 imm=0
+	// EBPF_OP_LDXB pc=156 dst=r2 src=r3 offset=15 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(15));
-	// EBPF_OP_LSH64_IMM pc=159 dst=r2 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=157 dst=r2 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=160 dst=r1 src=r3 offset=14 imm=0
+	// EBPF_OP_LDXB pc=158 dst=r1 src=r3 offset=14 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(14));
-	// EBPF_OP_OR64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=159 dst=r2 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r1;
-	// EBPF_OP_LDXB pc=162 dst=r5 src=r3 offset=1 imm=0
+	// EBPF_OP_LDXB pc=160 dst=r5 src=r3 offset=1 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(1));
-	// EBPF_OP_LSH64_IMM pc=163 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=161 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=0 imm=0
+	// EBPF_OP_LDXB pc=162 dst=r1 src=r3 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(0));
-	// EBPF_OP_OR64_REG pc=165 dst=r5 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=163 dst=r5 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r1;
-	// EBPF_OP_LDXB pc=166 dst=r1 src=r3 offset=3 imm=0
+	// EBPF_OP_LDXB pc=164 dst=r1 src=r3 offset=3 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(3));
-	// EBPF_OP_LSH64_IMM pc=167 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=165 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=168 dst=r0 src=r3 offset=2 imm=0
+	// EBPF_OP_LDXB pc=166 dst=r0 src=r3 offset=2 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(2));
-	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=167 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r0;
-	// EBPF_OP_LSH64_IMM pc=170 dst=r1 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=171 dst=r1 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=169 dst=r1 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r5;
-	// EBPF_OP_LSH64_IMM pc=172 dst=r2 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=170 dst=r2 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r2 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=173 dst=r2 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=171 dst=r2 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r2 |= r4;
-	// EBPF_OP_LDXB pc=174 dst=r4 src=r3 offset=9 imm=0
+	// EBPF_OP_LDXB pc=172 dst=r4 src=r3 offset=9 imm=0
 #line 50 "sample/sockops.c"
 	r4 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(9));
-	// EBPF_OP_LSH64_IMM pc=175 dst=r4 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=173 dst=r4 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r4 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=8 imm=0
+	// EBPF_OP_LDXB pc=174 dst=r5 src=r3 offset=8 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(8));
-	// EBPF_OP_OR64_REG pc=177 dst=r4 src=r5 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=175 dst=r4 src=r5 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r4 |= r5;
-	// EBPF_OP_LDXB pc=178 dst=r5 src=r3 offset=11 imm=0
+	// EBPF_OP_LDXB pc=176 dst=r5 src=r3 offset=11 imm=0
 #line 50 "sample/sockops.c"
 	r5 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(11));
-	// EBPF_OP_LSH64_IMM pc=179 dst=r5 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=177 dst=r5 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=180 dst=r0 src=r3 offset=10 imm=0
+	// EBPF_OP_LDXB pc=178 dst=r0 src=r3 offset=10 imm=0
 #line 50 "sample/sockops.c"
 	r0 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(10));
-	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r0 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=179 dst=r5 src=r0 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r0;
-	// EBPF_OP_LSH64_IMM pc=182 dst=r5 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r5 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=183 dst=r5 src=r4 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=181 dst=r5 src=r4 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r5 |= r4;
-	// EBPF_OP_STXW pc=184 dst=r10 src=r5 offset=-20 imm=0
+	// EBPF_OP_STXW pc=182 dst=r10 src=r5 offset=-20 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r5;
-	// EBPF_OP_STXW pc=185 dst=r10 src=r2 offset=-16 imm=0
+	// EBPF_OP_STXW pc=183 dst=r10 src=r2 offset=-16 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r2;
-	// EBPF_OP_STXW pc=186 dst=r10 src=r1 offset=-28 imm=0
+	// EBPF_OP_STXW pc=184 dst=r10 src=r1 offset=-28 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r1;
-	// EBPF_OP_LDXB pc=187 dst=r1 src=r3 offset=5 imm=0
+	// EBPF_OP_LDXB pc=185 dst=r1 src=r3 offset=5 imm=0
 #line 50 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(5));
-	// EBPF_OP_LSH64_IMM pc=188 dst=r1 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=186 dst=r1 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r1 <<= IMMEDIATE(8);
-	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=4 imm=0
+	// EBPF_OP_LDXB pc=187 dst=r2 src=r3 offset=4 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(4));
-	// EBPF_OP_OR64_REG pc=190 dst=r1 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=188 dst=r1 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r1 |= r2;
-	// EBPF_OP_LDXB pc=191 dst=r2 src=r3 offset=6 imm=0
+	// EBPF_OP_LDXB pc=189 dst=r2 src=r3 offset=6 imm=0
 #line 50 "sample/sockops.c"
 	r2 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(6));
-	// EBPF_OP_LDXB pc=192 dst=r3 src=r3 offset=7 imm=0
+	// EBPF_OP_LDXB pc=190 dst=r3 src=r3 offset=7 imm=0
 #line 50 "sample/sockops.c"
 	r3 = *(uint8_t *)(uintptr_t)(r3 + OFFSET(7));
-	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=8
+	// EBPF_OP_LSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=8
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(8);
-	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r2 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=192 dst=r3 src=r2 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r2;
-	// EBPF_OP_LSH64_IMM pc=195 dst=r3 src=r0 offset=0 imm=16
+	// EBPF_OP_LSH64_IMM pc=193 dst=r3 src=r0 offset=0 imm=16
 #line 50 "sample/sockops.c"
 	r3 <<= IMMEDIATE(16);
-	// EBPF_OP_OR64_REG pc=196 dst=r3 src=r1 offset=0 imm=0
+	// EBPF_OP_OR64_REG pc=194 dst=r3 src=r1 offset=0 imm=0
 #line 50 "sample/sockops.c"
 	r3 |= r1;
-	// EBPF_OP_STXW pc=197 dst=r10 src=r3 offset=-24 imm=0
+	// EBPF_OP_STXW pc=195 dst=r10 src=r3 offset=-24 imm=0
 #line 50 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
-	// EBPF_OP_MOV64_REG pc=198 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=196 dst=r1 src=r6 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = r6;
-	// EBPF_OP_LDXDW pc=199 dst=r2 src=r10 offset=-72 imm=0
+	// EBPF_OP_LDXDW pc=197 dst=r2 src=r10 offset=-64 imm=0
 #line 51 "sample/sockops.c"
-	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-72));
-	// EBPF_OP_ADD64_REG pc=200 dst=r1 src=r2 offset=0 imm=0
+	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-64));
+	// EBPF_OP_ADD64_REG pc=198 dst=r1 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 += r2;
-	// EBPF_OP_LDXW pc=201 dst=r1 src=r1 offset=0 imm=0
+	// EBPF_OP_LDXW pc=199 dst=r1 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
 	r1 = *(uint32_t *)(uintptr_t)(r1 + OFFSET(0));
-	// EBPF_OP_STXH pc=202 dst=r10 src=r1 offset=-12 imm=0
+	// EBPF_OP_STXH pc=200 dst=r10 src=r1 offset=-12 imm=0
 #line 51 "sample/sockops.c"
 	*(uint16_t *)(uintptr_t)(r10 + OFFSET(-12)) = (uint16_t)r1;
-	// EBPF_OP_LDXB pc=203 dst=r1 src=r6 offset=48 imm=0
+	// EBPF_OP_LDXB pc=201 dst=r1 src=r6 offset=48 imm=0
 #line 52 "sample/sockops.c"
 	r1 = *(uint8_t *)(uintptr_t)(r6 + OFFSET(48));
-	// EBPF_OP_LDXDW pc=204 dst=r2 src=r10 offset=-56 imm=0
+	// EBPF_OP_LDXDW pc=202 dst=r2 src=r10 offset=-56 imm=0
 #line 54 "sample/sockops.c"
 	r2 = *(uint64_t *)(uintptr_t)(r10 + OFFSET(-56));
-	// EBPF_OP_STXB pc=205 dst=r10 src=r2 offset=-4 imm=0
+	// EBPF_OP_STXB pc=203 dst=r10 src=r2 offset=-4 imm=0
 #line 54 "sample/sockops.c"
 	*(uint8_t *)(uintptr_t)(r10 + OFFSET(-4)) = (uint8_t)r2;
-	// EBPF_OP_STXW pc=206 dst=r10 src=r1 offset=-8 imm=0
+	// EBPF_OP_STXW pc=204 dst=r10 src=r1 offset=-8 imm=0
 #line 52 "sample/sockops.c"
 	*(uint32_t *)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-	// EBPF_OP_MOV64_REG pc=207 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=205 dst=r2 src=r10 offset=0 imm=0
 #line 52 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=208 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=206 dst=r2 src=r0 offset=0 imm=-48
 #line 53 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=209 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=207 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[0].address);
-	// EBPF_OP_CALL pc=211 dst=r0 src=r0 offset=0 imm=1
+	// EBPF_OP_CALL pc=209 dst=r0 src=r0 offset=0 imm=1
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[0].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[0].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=210 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = IMMEDIATE(0);
-	// EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
+	// EBPF_OP_JEQ_IMM pc=211 dst=r0 src=r0 offset=8 imm=0
 #line 56 "sample/sockops.c"
 	if (r0 == IMMEDIATE(0)) goto label_13;
 label_12:
-	// EBPF_OP_MOV64_REG pc=214 dst=r2 src=r10 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=212 dst=r2 src=r10 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r2 = r10;
-	// EBPF_OP_ADD64_IMM pc=215 dst=r2 src=r0 offset=0 imm=-48
+	// EBPF_OP_ADD64_IMM pc=213 dst=r2 src=r0 offset=0 imm=-48
 #line 56 "sample/sockops.c"
 	r2 += IMMEDIATE(-48);
-	// EBPF_OP_LDDW pc=216 dst=r1 src=r0 offset=0 imm=0
+	// EBPF_OP_LDDW pc=214 dst=r1 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r1 = POINTER(_maps[1].address);
-	// EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=48
+	// EBPF_OP_MOV64_IMM pc=216 dst=r3 src=r0 offset=0 imm=48
 #line 56 "sample/sockops.c"
 	r3 = IMMEDIATE(48);
-	// EBPF_OP_MOV64_IMM pc=219 dst=r4 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_IMM pc=217 dst=r4 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r4 = IMMEDIATE(0);
-	// EBPF_OP_CALL pc=220 dst=r0 src=r0 offset=0 imm=11
+	// EBPF_OP_CALL pc=218 dst=r0 src=r0 offset=0 imm=11
 #line 56 "sample/sockops.c"
 	r0 = connection_monitor_helpers[1].address
 #line 56 "sample/sockops.c"
 	(r1, r2, r3, r4, r5);
 #line 56 "sample/sockops.c"
 	if ((connection_monitor_helpers[1].tail_call) && (r0 == 0)) return 0;
-	// EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=219 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
 	r6 = r0;
 label_13:
-	// EBPF_OP_MOV64_REG pc=222 dst=r0 src=r6 offset=0 imm=0
+	// EBPF_OP_MOV64_REG pc=220 dst=r0 src=r6 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	r0 = r6;
-	// EBPF_OP_EXIT pc=223 dst=r0 src=r0 offset=0 imm=0
+	// EBPF_OP_EXIT pc=221 dst=r0 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
 	return r0;
 #line 89 "sample/sockops.c"
@@ -920,7 +919,7 @@ label_13:
 #line __LINE__ __FILE__
 
 static program_entry_t _programs[] = {
-	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 224, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
+	{ connection_monitor, "sockops", "connection_monitor", connection_monitor_maps, 2, connection_monitor_helpers, 2, 222, &connection_monitor_program_type_guid, &connection_monitor_attach_type_guid, },
 };
 
 static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
@@ -930,4 +929,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t sockops_metadata_table = { _get_programs, _get_maps };
+metadata_table_t sockops_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.txt
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "canary" },
@@ -205,4 +210,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_bad_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_bad_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.txt
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "canary" },
@@ -163,4 +168,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_bad_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_bad_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.txt
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "canary" },
@@ -330,4 +335,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_bad_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_bad_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_dll.txt
+++ b/tests/bpf2c_tests/expected/tail_call_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "canary" },
@@ -198,4 +203,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.txt
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 1, 0, 0, 0,  }, "outer_map" },
 { NULL, { 3, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -197,4 +202,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.txt
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 1, 0, 0, 0,  }, "outer_map" },
 { NULL, { 3, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -155,4 +160,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.txt
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 7, 4, 4, 1, 1, 0, 0, 0,  }, "outer_map" },
 { NULL, { 3, 4, 4, 1, 0, 0, 0, 0,  }, "inner_map" },
@@ -322,4 +327,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_map_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_map_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.txt
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 };
@@ -223,4 +228,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_multiple_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_multiple_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.txt
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 };
@@ -181,4 +186,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_multiple_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_multiple_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.txt
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 };
@@ -348,4 +353,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_multiple_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_multiple_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_raw.txt
+++ b/tests/bpf2c_tests/expected/tail_call_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "canary" },
@@ -156,4 +161,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/tail_call_sys.txt
+++ b/tests/bpf2c_tests/expected/tail_call_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 3, 4, 4, 10, 0, 0, 0, 0,  }, "map" },
 { NULL, { 2, 4, 4, 1, 0, 0, 0, 0,  }, "canary" },
@@ -323,4 +328,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t tail_call_metadata_table = { _get_programs, _get_maps };
+metadata_table_t tail_call_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.txt
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "test_map" },
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "utility_map" },
@@ -151,18 +156,18 @@ static uint64_t test_program_entry(void* context)
 	// EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
 	r7 = r0;
-	// EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	if (r8 == IMMEDIATE(0)) goto label_1;
-	// EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=16 dst=r1 src=r6 offset=0 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
-	// EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
+	// EBPF_OP_LDXDW pc=17 dst=r2 src=r6 offset=8 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
-	// EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
+	// EBPF_OP_JGE_REG pc=18 dst=r1 src=r2 offset=15 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	if (r1 >= r2) goto label_1;
+	// EBPF_OP_JEQ_IMM pc=19 dst=r8 src=r0 offset=14 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	if (r8 == IMMEDIATE(0)) goto label_1;
 	// EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
 	r2 -= r1;
@@ -449,4 +454,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t test_sample_ebpf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t test_sample_ebpf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.txt
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.txt
@@ -156,18 +156,18 @@ static uint64_t test_program_entry(void* context)
 	// EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
 	r7 = r0;
-	// EBPF_OP_LDXDW pc=16 dst=r1 src=r6 offset=0 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
-	// EBPF_OP_LDXDW pc=17 dst=r2 src=r6 offset=8 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
-	// EBPF_OP_JGE_REG pc=18 dst=r1 src=r2 offset=15 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	if (r1 >= r2) goto label_1;
-	// EBPF_OP_JEQ_IMM pc=19 dst=r8 src=r0 offset=14 imm=0
+	// EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	if (r8 == IMMEDIATE(0)) goto label_1;
+	// EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
+	// EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
+	// EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	if (r1 >= r2) goto label_1;
 	// EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
 	r2 -= r1;

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.txt
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "test_map" },
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "utility_map" },
@@ -109,18 +114,18 @@ static uint64_t test_program_entry(void* context)
 	// EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
 	r7 = r0;
-	// EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	if (r8 == IMMEDIATE(0)) goto label_1;
-	// EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=16 dst=r1 src=r6 offset=0 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
-	// EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
+	// EBPF_OP_LDXDW pc=17 dst=r2 src=r6 offset=8 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
-	// EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
+	// EBPF_OP_JGE_REG pc=18 dst=r1 src=r2 offset=15 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	if (r1 >= r2) goto label_1;
+	// EBPF_OP_JEQ_IMM pc=19 dst=r8 src=r0 offset=14 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	if (r8 == IMMEDIATE(0)) goto label_1;
 	// EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
 	r2 -= r1;
@@ -407,4 +412,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t test_sample_ebpf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t test_sample_ebpf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.txt
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.txt
@@ -114,18 +114,18 @@ static uint64_t test_program_entry(void* context)
 	// EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
 	r7 = r0;
-	// EBPF_OP_LDXDW pc=16 dst=r1 src=r6 offset=0 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
-	// EBPF_OP_LDXDW pc=17 dst=r2 src=r6 offset=8 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
-	// EBPF_OP_JGE_REG pc=18 dst=r1 src=r2 offset=15 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	if (r1 >= r2) goto label_1;
-	// EBPF_OP_JEQ_IMM pc=19 dst=r8 src=r0 offset=14 imm=0
+	// EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	if (r8 == IMMEDIATE(0)) goto label_1;
+	// EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
+	// EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
+	// EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	if (r1 >= r2) goto label_1;
 	// EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
 	r2 -= r1;

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.txt
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.txt
@@ -281,18 +281,18 @@ static uint64_t test_program_entry(void* context)
 	// EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
 	r7 = r0;
-	// EBPF_OP_LDXDW pc=16 dst=r1 src=r6 offset=0 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
-	// EBPF_OP_LDXDW pc=17 dst=r2 src=r6 offset=8 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
-	// EBPF_OP_JGE_REG pc=18 dst=r1 src=r2 offset=15 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	if (r1 >= r2) goto label_1;
-	// EBPF_OP_JEQ_IMM pc=19 dst=r8 src=r0 offset=14 imm=0
+	// EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	if (r8 == IMMEDIATE(0)) goto label_1;
+	// EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
+	// EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
+	// EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	if (r1 >= r2) goto label_1;
 	// EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
 	r2 -= r1;

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.txt
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "test_map" },
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "utility_map" },
@@ -276,18 +281,18 @@ static uint64_t test_program_entry(void* context)
 	// EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
 	r7 = r0;
-	// EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
-#line 38 "sample/test_sample_ebpf.c"
-	if (r8 == IMMEDIATE(0)) goto label_1;
-	// EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+	// EBPF_OP_LDXDW pc=16 dst=r1 src=r6 offset=0 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	r1 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(0));
-	// EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
+	// EBPF_OP_LDXDW pc=17 dst=r2 src=r6 offset=8 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	r2 = *(uint64_t *)(uintptr_t)(r6 + OFFSET(8));
-	// EBPF_OP_JGE_REG pc=19 dst=r1 src=r2 offset=14 imm=0
+	// EBPF_OP_JGE_REG pc=18 dst=r1 src=r2 offset=15 imm=0
 #line 38 "sample/test_sample_ebpf.c"
 	if (r1 >= r2) goto label_1;
+	// EBPF_OP_JEQ_IMM pc=19 dst=r8 src=r0 offset=14 imm=0
+#line 38 "sample/test_sample_ebpf.c"
+	if (r8 == IMMEDIATE(0)) goto label_1;
 	// EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
 	r2 -= r1;
@@ -574,4 +579,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t test_sample_ebpf_metadata_table = { _get_programs, _get_maps };
+metadata_table_t test_sample_ebpf_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.txt
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.txt
@@ -48,6 +48,11 @@ get_metadata_table()
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "utility_map" },
 };
@@ -261,4 +266,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t test_utility_helpers_metadata_table = { _get_programs, _get_maps };
+metadata_table_t test_utility_helpers_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.txt
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.txt
@@ -6,6 +6,11 @@
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "utility_map" },
 };
@@ -219,4 +224,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t test_utility_helpers_metadata_table = { _get_programs, _get_maps };
+metadata_table_t test_utility_helpers_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.txt
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.txt
@@ -173,6 +173,11 @@ division_by_zero(uint32_t address)
 
 #include "bpf2c.h"
 
+static void _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+	*hash = NULL;
+	*size = 0;
+}
 static map_entry_t _maps[] = {
 { NULL, { 2, 4, 32, 2, 0, 0, 0, 0,  }, "utility_map" },
 };
@@ -386,4 +391,4 @@ static void _get_programs(_Outptr_result_buffer_(*count) program_entry_t** progr
 }
 
 
-metadata_table_t test_utility_helpers_metadata_table = { _get_programs, _get_maps };
+metadata_table_t test_utility_helpers_metadata_table = { _get_programs, _get_maps, _get_hash };

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -1,10 +1,9 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING TRUE
-
 #include <Windows.h>
 #include <bcrypt.h>
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include <codecvt>
 #include <functional>
 #include <fstream>

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -193,8 +193,12 @@ main(int argc, char** argv)
         std::string c_name = file.substr(file.find_last_of("\\") + 1);
         c_name = c_name.substr(0, c_name.find("."));
         auto data = load_file_to_memory(file);
-        _hash hash(hash_algorithm);
-        auto hash_value = hash.hash_string(data);
+        std::optional<std::vector<uint8_t>> hash_value;
+        if (hash_algorithm != "none") {
+
+            _hash hash(hash_algorithm);
+            hash_value = hash.hash_string(data);
+        }
         auto stream = std::stringstream(data);
         // TODO: Issue #834 - validate the ELF is well formed
         bpf_code_generator generator(stream, c_name, {hash_value});

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -1,6 +1,11 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING TRUE
+
+#include <Windows.h>
+#include <bcrypt.h>
+#include <codecvt>
 #include <functional>
 #include <fstream>
 #include <iostream>
@@ -11,8 +16,11 @@
 #include <tuple>
 #include <vector>
 
+#undef max
 #include "bpf_code_generator.h"
 #include "ebpf_api.h"
+
+#pragma comment(lib, "Bcrypt.lib")
 
 const char copyright_notice[] = "// Copyright (c) Microsoft Corporation\n// SPDX-License-Identifier: MIT\n";
 
@@ -23,6 +31,71 @@ const char bpf2c_driver[] =
 const char bpf2c_dll[] =
 #include "bpf2c_dll.template"
     ;
+
+class _hash
+{
+  public:
+    _hash(const std::string& algorithm)
+    {
+        HRESULT hr;
+        std::wstring_convert<std::codecvt_utf8<wchar_t>, wchar_t> converter;
+        std::wstring wide_algorithm = converter.from_bytes(algorithm);
+
+        hr = BCryptOpenAlgorithmProvider(&algorithm_handle, wide_algorithm.c_str(), nullptr, BCRYPT_HASH_REUSABLE_FLAG);
+        if (!SUCCEEDED(hr)) {
+            throw std::runtime_error(
+                std::string("BCryptOpenAlgorithmProvider failed with algorithm: ") + algorithm +
+                " HR=" + std::to_string(hr));
+        }
+    }
+    ~_hash() { BCryptCloseAlgorithmProvider(algorithm_handle, 0); }
+
+    std::vector<uint8_t>
+    hash_string(const std::string& data)
+    {
+        uint32_t hash_length;
+        std::vector<uint8_t> hash;
+        BCRYPT_HASH_HANDLE hash_handle;
+        HRESULT hr;
+        hr = BCryptCreateHash(algorithm_handle, &hash_handle, nullptr, 0, nullptr, 0, 0);
+        if (!SUCCEEDED(hr)) {
+            throw std::runtime_error(std::string("BCryptCreateHash failed with HR=") + std::to_string(hr));
+        }
+        hr = BCryptHashData(
+            hash_handle,
+            reinterpret_cast<uint8_t*>(const_cast<char*>(data.data())),
+            static_cast<unsigned long>(data.size()),
+            0);
+        if (!SUCCEEDED(hr)) {
+            BCryptDestroyHash(hash_handle);
+            throw std::runtime_error(std::string("BCryptHashData failed with HR=") + std::to_string(hr));
+        }
+
+        unsigned long bytes_written;
+        hr = BCryptGetProperty(
+            algorithm_handle,
+            BCRYPT_HASH_LENGTH,
+            reinterpret_cast<uint8_t*>(&hash_length),
+            sizeof(hash_length),
+            &bytes_written,
+            0);
+        if (!SUCCEEDED(hr)) {
+            BCryptDestroyHash(hash_handle);
+            throw std::runtime_error(
+                std::string("BCryptGetProperty failed with BCRYPT_HASH_LENGTH  HR=") + std::to_string(hr));
+        }
+        hash.resize(hash_length);
+        hr = BCryptFinishHash(hash_handle, hash.data(), static_cast<unsigned long>(hash.size()), 0);
+        BCryptDestroyHash(hash_handle);
+        if (!SUCCEEDED(hr)) {
+            throw std::runtime_error(std::string("BCryptFinishHash failed with HR=") + std::to_string(hr));
+        }
+        return hash;
+    }
+
+  private:
+    BCRYPT_ALG_HANDLE algorithm_handle;
+};
 
 void
 emit_skeleton(const std::string& c_name, const std::string& code)
@@ -63,6 +136,7 @@ main(int argc, char** argv)
         std::string verifier_output_file;
         std::string file;
         std::vector<std::string> sections;
+        std::string hash_algorithm = "SHA256";
         bool verify_programs = true;
         std::map<std::string, std::tuple<std::string, std::function<void(std::vector<std::string>::iterator&)>>>
             options = {
@@ -80,6 +154,9 @@ main(int argc, char** argv)
                 {"--bpf",
                  {"Input ELF file containing BPF byte code",
                   [&](std::vector<std::string>::iterator& it) { file = *(++it); }}},
+                {"--hash",
+                 {"Algorithm used to hash ELF file",
+                  [&](std::vector<std::string>::iterator& it) { hash_algorithm = *(++it); }}},
                 {"--section",
                  {"Space separated list of sections to process ",
                   [&](std::vector<std::string>::iterator& it) {
@@ -116,9 +193,11 @@ main(int argc, char** argv)
         std::string c_name = file.substr(file.find_last_of("\\") + 1);
         c_name = c_name.substr(0, c_name.find("."));
         auto data = load_file_to_memory(file);
+        _hash hash(hash_algorithm);
+        auto hash_value = hash.hash_string(data);
         auto stream = std::stringstream(data);
         // TODO: Issue #834 - validate the ELF is well formed
-        bpf_code_generator generator(stream, c_name);
+        bpf_code_generator generator(stream, c_name, {hash_value});
 
         // Special case of no section name.
         if (sections.size() == 0) {

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -3,7 +3,6 @@
 
 #include <Windows.h>
 #include <bcrypt.h>
-#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
 #include <codecvt>
 #include <functional>
 #include <fstream>

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#define _SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING
+
 #include <Windows.h>
 #include <bcrypt.h>
 #include <codecvt>

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -113,7 +113,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;ENABLE_SKIP_VERIFY;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;ENABLE_SKIP_VERIFY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -125,7 +125,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -113,7 +113,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;ENABLE_SKIP_VERIFY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;ENABLE_SKIP_VERIFY;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
@@ -125,7 +125,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <FunctionLevelLinking>true</FunctionLevelLinking>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;_SILENCE_CXX17_CODECVT_HEADER_DEPRECATION_WARNING;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -4,6 +4,7 @@
 #pragma once
 #include <fstream>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
 #include <vector>
@@ -20,8 +21,10 @@ class bpf_code_generator
      *
      * @param[in] stream Input stream containing the eBPF file to parse.
      * @param[in] c_name C compatible name to export this as.
+     * @param[in] elf_file_hash Optional bytes containing hash of the ELF file.
      */
-    bpf_code_generator(std::istream& stream, const std::string& c_name);
+    bpf_code_generator(
+        std::istream& stream, const std::string& c_name, const std::optional<std::vector<uint8_t>>& elf_file_hash = {});
 
     /**
      * @brief Construct a new bpf code generator object from raw eBPF byte code.
@@ -230,4 +233,5 @@ class bpf_code_generator
     std::string c_name;
     std::string path;
     btf_section_to_instruction_to_line_info_t section_line_info;
+    std::optional<std::vector<uint8_t>> elf_file_hash;
 };


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Add a SHA256 hash of the ELF file that the native image was generated from.

## Testing

CI/CD

## Documentation

No.

Resolves: #1046 
