### PR TITLE
Add comments for map declarations

### DIFF
--- a/include/ebpf_structs.h
+++ b/include/ebpf_structs.h
@@ -12,6 +12,8 @@
 #endif
 #include "ebpf_windows.h"
 
+#define BPF_ENUM_TO_STRING(X) #X
+
 typedef enum bpf_map_type
 {
     BPF_MAP_TYPE_UNSPEC = 0, ///< Unspecified map type.
@@ -31,6 +33,40 @@ typedef enum bpf_map_type
     BPF_MAP_TYPE_RINGBUF = 13          ///< Ring buffer.
 } ebpf_map_type_t;
 
+static const char* const _ebpf_map_type_names[] = {
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_UNSPEC),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_HASH),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_ARRAY),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_PROG_ARRAY),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_PERCPU_HASH),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_PERCPU_ARRAY),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_HASH_OF_MAPS),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_ARRAY_OF_MAPS),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_LRU_HASH),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_LPM_TRIE),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_QUEUE),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_LRU_PERCPU_HASH),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_STACK),
+    BPF_ENUM_TO_STRING(BPF_MAP_TYPE_RINGBUF),
+};
+
+static const char* const _ebpf_map_display_names[] = {
+    "Other",
+    "Hash",
+    "Array",
+    "Program array",
+    "Per-CPU hash table",
+    "Per-CPU array",
+    "Hash of maps",
+    "Array of maps",
+    "LRU hash table",
+    "LPM trie",
+    "Queue",
+    "LRU Per-CPU hash table",
+    "Stack",
+    "Ring-buffer",
+};
+
 typedef enum ebpf_map_option
 {
     EBPF_ANY,     ///< Create a new element or update an existing element.
@@ -45,6 +81,13 @@ typedef enum ebpf_pin_type
     PIN_GLOBAL_NS, ///< Pinning with a global namespace.
     PIN_CUSTOM_NS  ///< Pinning with a custom path given as section parameter.
 } ebpf_pin_type_t;
+
+static const char* const _ebpf_pin_type_names[] = {
+    BPF_ENUM_TO_STRING(PIN_NONE),
+    BPF_ENUM_TO_STRING(PIN_OBJECT_NS),
+    BPF_ENUM_TO_STRING(PIN_GLOBAL_NS),
+    BPF_ENUM_TO_STRING(PIN_CUSTOM_NS),
+};
 
 typedef uint32_t ebpf_id_t;
 #define EBPF_ID_NONE UINT32_MAX

--- a/libs/ebpfnetsh/maps.cpp
+++ b/libs/ebpfnetsh/maps.cpp
@@ -16,14 +16,11 @@
 #include "maps.h"
 #include "tokens.h"
 
-static PCSTR _map_type_names[] = {
-    "Other", "Hash", "Array", "Program array", "Per-CPU hash table", "Per-CPU array", "Hash of maps", "Array of maps"};
-
 static PCSTR
 _get_map_type_name(ebpf_map_type_t type)
 {
-    int index = (type >= _countof(_map_type_names)) ? 0 : type;
-    return _map_type_names[index];
+    int index = (type >= _countof(_ebpf_map_display_names)) ? 0 : type;
+    return _ebpf_map_display_names[index];
 }
 
 DWORD

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,    // Type of map.
-         8,    // Size in bytes of a map key.
-         68,   // Size in bytes of a map value.
-         1024, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         8,                 // Size in bytes of a map key.
+         68,                // Size in bytes of a map value.
+         1024,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "limits_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         8,
-         68,
-         1024,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         8,    // Size in bytes of a map key.
+         68,   // Size in bytes of a map value.
+         1024, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "limits_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,    // Type of map.
-         8,    // Size in bytes of a map key.
-         68,   // Size in bytes of a map value.
-         1024, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         8,                 // Size in bytes of a map key.
+         68,                // Size in bytes of a map value.
+         1024,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "limits_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         8,
-         68,
-         1024,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         8,    // Size in bytes of a map key.
+         68,   // Size in bytes of a map value.
+         1024, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "limits_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         13,     // Type of map.
-         0,      // Size in bytes of a map key.
-         0,      // Size in bytes of a map value.
-         262144, // Maximum number of entries allowed in the map.
-         0,      // Inner map index.
-         0,      // Pinning type for the map.
-         0,      // Identifier for a map template.
-         0,      // The id of the inner map template.
+         BPF_MAP_TYPE_RINGBUF, // Type of map.
+         0,                    // Size in bytes of a map key.
+         0,                    // Size in bytes of a map value.
+         262144,               // Maximum number of entries allowed in the map.
+         0,                    // Inner map index.
+         PIN_NONE,             // Pinning type for the map.
+         0,                    // Identifier for a map template.
+         0,                    // The id of the inner map template.
      },
      "process_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         13,
-         0,
-         0,
-         262144,
-         0,
-         0,
-         0,
-         0,
+         13,     // Type of map.
+         0,      // Size in bytes of a map key.
+         0,      // Size in bytes of a map value.
+         262144, // Maximum number of entries allowed in the map.
+         0,      // Inner map index.
+         0,      // Pinning type for the map.
+         0,      // Identifier for a map template.
+         0,      // The id of the inner map template.
      },
      "process_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         13,
-         0,
-         0,
-         262144,
-         0,
-         0,
-         0,
-         0,
+         13,     // Type of map.
+         0,      // Size in bytes of a map key.
+         0,      // Size in bytes of a map value.
+         262144, // Maximum number of entries allowed in the map.
+         0,      // Inner map index.
+         0,      // Pinning type for the map.
+         0,      // Identifier for a map template.
+         0,      // The id of the inner map template.
      },
      "process_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         13,     // Type of map.
-         0,      // Size in bytes of a map key.
-         0,      // Size in bytes of a map value.
-         262144, // Maximum number of entries allowed in the map.
-         0,      // Inner map index.
-         0,      // Pinning type for the map.
-         0,      // Identifier for a map template.
-         0,      // The id of the inner map template.
+         BPF_MAP_TYPE_RINGBUF, // Type of map.
+         0,                    // Size in bytes of a map key.
+         0,                    // Size in bytes of a map value.
+         262144,               // Maximum number of entries allowed in the map.
+         0,                    // Inner map index.
+         PIN_NONE,             // Pinning type for the map.
+         0,                    // Identifier for a map template.
+         0,                    // The id of the inner map template.
      },
      "process_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         13,
-         0,
-         0,
-         262144,
-         0,
-         0,
-         0,
-         0,
+         13,     // Type of map.
+         0,      // Size in bytes of a map key.
+         0,      // Size in bytes of a map value.
+         262144, // Maximum number of entries allowed in the map.
+         0,      // Inner map index.
+         0,      // Pinning type for the map.
+         0,      // Identifier for a map template.
+         0,      // The id of the inner map template.
      },
      "process_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         13,     // Type of map.
-         0,      // Size in bytes of a map key.
-         0,      // Size in bytes of a map value.
-         262144, // Maximum number of entries allowed in the map.
-         0,      // Inner map index.
-         0,      // Pinning type for the map.
-         0,      // Identifier for a map template.
-         0,      // The id of the inner map template.
+         BPF_MAP_TYPE_RINGBUF, // Type of map.
+         0,                    // Size in bytes of a map key.
+         0,                    // Size in bytes of a map value.
+         262144,               // Maximum number of entries allowed in the map.
+         0,                    // Inner map index.
+         PIN_NONE,             // Pinning type for the map.
+         0,                    // Identifier for a map template.
+         0,                    // The id of the inner map template.
      },
      "process_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,    // Type of map.
-         8,    // Size in bytes of a map key.
-         68,   // Size in bytes of a map value.
-         1024, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         8,                 // Size in bytes of a map key.
+         68,                // Size in bytes of a map value.
+         1024,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "limits_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         8,
-         68,
-         1024,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         8,    // Size in bytes of a map key.
+         68,   // Size in bytes of a map value.
+         1024, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "limits_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -57,86 +57,86 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         8,
-         68,
-         1024,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         8,    // Size in bytes of a map key.
+         68,   // Size in bytes of a map value.
+         1024, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "limits_map"},
     {NULL,
      {
-         3,
-         4,
-         4,
-         2,
-         0,
-         0,
-         0,
-         0,
+         3, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         2, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "prog_array_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1000,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         4,    // Size in bytes of a map key.
+         4,    // Size in bytes of a map value.
+         1000, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "dummy_map"},
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         10,
+         7,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         10, // The id of the inner map template.
      },
      "dummy_outer_map"},
     {NULL,
      {
-         6,
-         4,
-         4,
-         10,
-         6,
-         0,
-         0,
-         0,
+         6,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         6,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "dummy_outer_idx_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         10,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         10, // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "dummy_inner_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -57,86 +57,86 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,    // Type of map.
-         8,    // Size in bytes of a map key.
-         68,   // Size in bytes of a map value.
-         1024, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         8,                 // Size in bytes of a map key.
+         68,                // Size in bytes of a map value.
+         1024,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "limits_map"},
     {NULL,
      {
-         3, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         2, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         2,                       // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "prog_array_map"},
     {NULL,
      {
-         1,    // Type of map.
-         4,    // Size in bytes of a map key.
-         4,    // Size in bytes of a map value.
-         1000, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1000,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "dummy_map"},
     {NULL,
      {
-         7,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         10, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         0,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         10,                         // The id of the inner map template.
      },
      "dummy_outer_map"},
     {NULL,
      {
-         6,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         6,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         10,                        // Maximum number of entries allowed in the map.
+         6,                         // Inner map index.
+         PIN_NONE,                  // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "dummy_outer_idx_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         10, // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         10,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "dummy_inner_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -15,86 +15,86 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         8,
-         68,
-         1024,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         8,    // Size in bytes of a map key.
+         68,   // Size in bytes of a map value.
+         1024, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "limits_map"},
     {NULL,
      {
-         3,
-         4,
-         4,
-         2,
-         0,
-         0,
-         0,
-         0,
+         3, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         2, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "prog_array_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1000,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         4,    // Size in bytes of a map key.
+         4,    // Size in bytes of a map value.
+         1000, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "dummy_map"},
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         10,
+         7,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         10, // The id of the inner map template.
      },
      "dummy_outer_map"},
     {NULL,
      {
-         6,
-         4,
-         4,
-         10,
-         6,
-         0,
-         0,
-         0,
+         6,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         6,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "dummy_outer_idx_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         10,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         10, // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "dummy_inner_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -15,86 +15,86 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,    // Type of map.
-         8,    // Size in bytes of a map key.
-         68,   // Size in bytes of a map value.
-         1024, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         8,                 // Size in bytes of a map key.
+         68,                // Size in bytes of a map value.
+         1024,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "limits_map"},
     {NULL,
      {
-         3, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         2, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         2,                       // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "prog_array_map"},
     {NULL,
      {
-         1,    // Type of map.
-         4,    // Size in bytes of a map key.
-         4,    // Size in bytes of a map value.
-         1000, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1000,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "dummy_map"},
     {NULL,
      {
-         7,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         10, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         0,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         10,                         // The id of the inner map template.
      },
      "dummy_outer_map"},
     {NULL,
      {
-         6,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         6,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         10,                        // Maximum number of entries allowed in the map.
+         6,                         // Inner map index.
+         PIN_NONE,                  // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "dummy_outer_idx_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         10, // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         10,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "dummy_inner_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -182,86 +182,86 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         8,
-         68,
-         1024,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         8,    // Size in bytes of a map key.
+         68,   // Size in bytes of a map value.
+         1024, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "limits_map"},
     {NULL,
      {
-         3,
-         4,
-         4,
-         2,
-         0,
-         0,
-         0,
-         0,
+         3, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         2, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "prog_array_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1000,
-         0,
-         0,
-         0,
-         0,
+         1,    // Type of map.
+         4,    // Size in bytes of a map key.
+         4,    // Size in bytes of a map value.
+         1000, // Maximum number of entries allowed in the map.
+         0,    // Inner map index.
+         0,    // Pinning type for the map.
+         0,    // Identifier for a map template.
+         0,    // The id of the inner map template.
      },
      "dummy_map"},
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         10,
+         7,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         10, // The id of the inner map template.
      },
      "dummy_outer_map"},
     {NULL,
      {
-         6,
-         4,
-         4,
-         10,
-         6,
-         0,
-         0,
-         0,
+         6,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         6,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "dummy_outer_idx_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         10,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         10, // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "dummy_inner_map"},
 };

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -182,86 +182,86 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,    // Type of map.
-         8,    // Size in bytes of a map key.
-         68,   // Size in bytes of a map value.
-         1024, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         8,                 // Size in bytes of a map key.
+         68,                // Size in bytes of a map value.
+         1024,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "process_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "limits_map"},
     {NULL,
      {
-         3, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         2, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         2,                       // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "prog_array_map"},
     {NULL,
      {
-         1,    // Type of map.
-         4,    // Size in bytes of a map key.
-         4,    // Size in bytes of a map value.
-         1000, // Maximum number of entries allowed in the map.
-         0,    // Inner map index.
-         0,    // Pinning type for the map.
-         0,    // Identifier for a map template.
-         0,    // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1000,              // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "dummy_map"},
     {NULL,
      {
-         7,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         10, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         0,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         10,                         // The id of the inner map template.
      },
      "dummy_outer_map"},
     {NULL,
      {
-         6,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         6,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         10,                        // Maximum number of entries allowed in the map.
+         6,                         // Inner map index.
+         PIN_NONE,                  // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "dummy_outer_idx_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         10, // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         10,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "dummy_inner_map"},
 };

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         2,
-         4,
-         512,
-         0,
-         0,
-         0,
-         0,
+         2,   // Type of map.
+         2,   // Size in bytes of a map key.
+         4,   // Size in bytes of a map value.
+         512, // Maximum number of entries allowed in the map.
+         0,   // Inner map index.
+         0,   // Pinning type for the map.
+         0,   // Identifier for a map template.
+         0,   // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,   // Type of map.
-         2,   // Size in bytes of a map key.
-         4,   // Size in bytes of a map value.
-         512, // Maximum number of entries allowed in the map.
-         0,   // Inner map index.
-         0,   // Pinning type for the map.
-         0,   // Identifier for a map template.
-         0,   // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         2,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         512,                // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,   // Type of map.
-         2,   // Size in bytes of a map key.
-         4,   // Size in bytes of a map value.
-         512, // Maximum number of entries allowed in the map.
-         0,   // Inner map index.
-         0,   // Pinning type for the map.
-         0,   // Identifier for a map template.
-         0,   // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         2,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         512,                // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         2,
-         4,
-         512,
-         0,
-         0,
-         0,
-         0,
+         2,   // Type of map.
+         2,   // Size in bytes of a map key.
+         4,   // Size in bytes of a map value.
+         512, // Maximum number of entries allowed in the map.
+         0,   // Inner map index.
+         0,   // Pinning type for the map.
+         0,   // Identifier for a map template.
+         0,   // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,   // Type of map.
-         2,   // Size in bytes of a map key.
-         4,   // Size in bytes of a map value.
-         512, // Maximum number of entries allowed in the map.
-         0,   // Inner map index.
-         0,   // Pinning type for the map.
-         0,   // Identifier for a map template.
-         0,   // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         2,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         512,                // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         2,
-         4,
-         512,
-         0,
-         0,
-         0,
-         0,
+         2,   // Type of map.
+         2,   // Size in bytes of a map key.
+         4,   // Size in bytes of a map value.
+         512, // Maximum number of entries allowed in the map.
+         0,   // Inner map index.
+         0,   // Pinning type for the map.
+         0,   // Identifier for a map template.
+         0,   // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "ingress_connection_policy_map"},
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "egress_connection_policy_map"},
 };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "ingress_connection_policy_map"},
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "egress_connection_policy_map"},
 };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "ingress_connection_policy_map"},
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "egress_connection_policy_map"},
 };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "ingress_connection_policy_map"},
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "egress_connection_policy_map"},
 };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "ingress_connection_policy_map"},
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "egress_connection_policy_map"},
 };

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "ingress_connection_policy_map"},
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "egress_connection_policy_map"},
 };

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "test_map"},
 };

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "test_map"},
 };

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "test_map"},
 };

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "test_map"},
 };

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "test_map"},
 };

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "test_map"},
 };

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         8, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         8,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "dropped_packet_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "interface_index_map"},
 };

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         8,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         8, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "dropped_packet_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "interface_index_map"},
 };

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         8,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         8, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "dropped_packet_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "interface_index_map"},
 };

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         8, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         8,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "dropped_packet_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "interface_index_map"},
 };

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         8,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         8, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "dropped_packet_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "interface_index_map"},
 };

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         8, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         8,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "dropped_packet_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "interface_index_map"},
 };

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -57,98 +57,98 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         12, // Type of map.
-         0,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_STACK, // Type of map.
+         0,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "STACK_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         10,                // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "HASH_map"},
     {NULL,
      {
-         4,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PERCPU_HASH, // Type of map.
+         4,                        // Size in bytes of a map key.
+         4,                        // Size in bytes of a map value.
+         10,                       // Maximum number of entries allowed in the map.
+         0,                        // Inner map index.
+         PIN_NONE,                 // Pinning type for the map.
+         0,                        // Identifier for a map template.
+         0,                        // The id of the inner map template.
      },
      "PERCPU_HASH_map"},
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "ARRAY_map"},
     {NULL,
      {
-         5,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PERCPU_ARRAY, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         10,                        // Maximum number of entries allowed in the map.
+         0,                         // Inner map index.
+         PIN_NONE,                  // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "PERCPU_ARRAY_map"},
     {NULL,
      {
-         8,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_LRU_HASH, // Type of map.
+         4,                     // Size in bytes of a map key.
+         4,                     // Size in bytes of a map value.
+         10,                    // Maximum number of entries allowed in the map.
+         0,                     // Inner map index.
+         PIN_NONE,              // Pinning type for the map.
+         0,                     // Identifier for a map template.
+         0,                     // The id of the inner map template.
      },
      "LRU_HASH_map"},
     {NULL,
      {
-         11, // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_LRU_PERCPU_HASH, // Type of map.
+         4,                            // Size in bytes of a map key.
+         4,                            // Size in bytes of a map value.
+         10,                           // Maximum number of entries allowed in the map.
+         0,                            // Inner map index.
+         PIN_NONE,                     // Pinning type for the map.
+         0,                            // Identifier for a map template.
+         0,                            // The id of the inner map template.
      },
      "LRU_PERCPU_HASH_map"},
     {NULL,
      {
-         10, // Type of map.
-         0,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_QUEUE, // Type of map.
+         0,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "QUEUE_map"},
 };

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -57,98 +57,98 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         12,
-         0,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         12, // Type of map.
+         0,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "STACK_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "HASH_map"},
     {NULL,
      {
-         4,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         4,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "PERCPU_HASH_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "ARRAY_map"},
     {NULL,
      {
-         5,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         5,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "PERCPU_ARRAY_map"},
     {NULL,
      {
-         8,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         8,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "LRU_HASH_map"},
     {NULL,
      {
-         11,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         11, // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "LRU_PERCPU_HASH_map"},
     {NULL,
      {
-         10,
-         0,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         10, // Type of map.
+         0,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "QUEUE_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         1,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         0,                          // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         1,
-         0,
-         0,
-         0,
+         7, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         1,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         0,                          // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         1,
-         0,
-         0,
-         0,
+         7, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         1,
-         0,
-         0,
-         0,
+         7, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         1,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         0,                          // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         10,
+         7,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         10, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         10,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         10, // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         10, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         0,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         10,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         10, // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         10,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         10,
+         7,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         10, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         10,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         10, // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         10, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         0,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         10,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         10, // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         10,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         10,
+         7,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         10, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         1,
-         0,
-         0,
-         10,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         10, // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         10, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         0,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         10,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         10, // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         10,                // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -15,98 +15,98 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         12,
-         0,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         12, // Type of map.
+         0,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "STACK_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "HASH_map"},
     {NULL,
      {
-         4,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         4,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "PERCPU_HASH_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "ARRAY_map"},
     {NULL,
      {
-         5,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         5,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "PERCPU_ARRAY_map"},
     {NULL,
      {
-         8,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         8,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "LRU_HASH_map"},
     {NULL,
      {
-         11,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         11, // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "LRU_PERCPU_HASH_map"},
     {NULL,
      {
-         10,
-         0,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         10, // Type of map.
+         0,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "QUEUE_map"},
 };

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -15,98 +15,98 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         12, // Type of map.
-         0,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_STACK, // Type of map.
+         0,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "STACK_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         10,                // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "HASH_map"},
     {NULL,
      {
-         4,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PERCPU_HASH, // Type of map.
+         4,                        // Size in bytes of a map key.
+         4,                        // Size in bytes of a map value.
+         10,                       // Maximum number of entries allowed in the map.
+         0,                        // Inner map index.
+         PIN_NONE,                 // Pinning type for the map.
+         0,                        // Identifier for a map template.
+         0,                        // The id of the inner map template.
      },
      "PERCPU_HASH_map"},
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "ARRAY_map"},
     {NULL,
      {
-         5,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PERCPU_ARRAY, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         10,                        // Maximum number of entries allowed in the map.
+         0,                         // Inner map index.
+         PIN_NONE,                  // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "PERCPU_ARRAY_map"},
     {NULL,
      {
-         8,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_LRU_HASH, // Type of map.
+         4,                     // Size in bytes of a map key.
+         4,                     // Size in bytes of a map value.
+         10,                    // Maximum number of entries allowed in the map.
+         0,                     // Inner map index.
+         PIN_NONE,              // Pinning type for the map.
+         0,                     // Identifier for a map template.
+         0,                     // The id of the inner map template.
      },
      "LRU_HASH_map"},
     {NULL,
      {
-         11, // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_LRU_PERCPU_HASH, // Type of map.
+         4,                            // Size in bytes of a map key.
+         4,                            // Size in bytes of a map value.
+         10,                           // Maximum number of entries allowed in the map.
+         0,                            // Inner map index.
+         PIN_NONE,                     // Pinning type for the map.
+         0,                            // Identifier for a map template.
+         0,                            // The id of the inner map template.
      },
      "LRU_PERCPU_HASH_map"},
     {NULL,
      {
-         10, // Type of map.
-         0,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_QUEUE, // Type of map.
+         0,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "QUEUE_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -57,38 +57,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6,
-         4,
-         4,
-         1,
-         1,
-         2,
-         0,
-         0,
+         6, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -57,38 +57,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         1,                         // Maximum number of entries allowed in the map.
+         1,                         // Inner map index.
+         PIN_GLOBAL_NS,             // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -15,38 +15,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         1,                         // Maximum number of entries allowed in the map.
+         1,                         // Inner map index.
+         PIN_GLOBAL_NS,             // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -15,38 +15,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6,
-         4,
-         4,
-         1,
-         1,
-         2,
-         0,
-         0,
+         6, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -182,38 +182,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6,
-         4,
-         4,
-         1,
-         1,
-         2,
-         0,
-         0,
+         6, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -182,38 +182,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         1,                         // Maximum number of entries allowed in the map.
+         1,                         // Inner map index.
+         PIN_GLOBAL_NS,             // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -57,38 +57,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6,
-         4,
-         4,
-         1,
-         1,
-         2,
-         0,
-         0,
+         6, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -57,38 +57,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         1,                         // Maximum number of entries allowed in the map.
+         1,                         // Inner map index.
+         PIN_GLOBAL_NS,             // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -15,38 +15,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6,
-         4,
-         4,
-         1,
-         1,
-         2,
-         0,
-         0,
+         6, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -15,38 +15,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         1,                         // Maximum number of entries allowed in the map.
+         1,                         // Inner map index.
+         PIN_GLOBAL_NS,             // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -182,38 +182,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         1,                         // Maximum number of entries allowed in the map.
+         1,                         // Inner map index.
+         PIN_GLOBAL_NS,             // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         2, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_GLOBAL_NS,      // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -182,38 +182,38 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         6,
-         4,
-         4,
-         1,
-         1,
-         2,
-         0,
-         0,
+         6, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         2,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         2, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "port_map"},
 };

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -182,98 +182,98 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         12,
-         0,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         12, // Type of map.
+         0,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "STACK_map"},
     {NULL,
      {
-         1,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "HASH_map"},
     {NULL,
      {
-         4,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         4,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "PERCPU_HASH_map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "ARRAY_map"},
     {NULL,
      {
-         5,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         5,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "PERCPU_ARRAY_map"},
     {NULL,
      {
-         8,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         8,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "LRU_HASH_map"},
     {NULL,
      {
-         11,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         11, // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "LRU_PERCPU_HASH_map"},
     {NULL,
      {
-         10,
-         0,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         10, // Type of map.
+         0,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "QUEUE_map"},
 };

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -182,98 +182,98 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         12, // Type of map.
-         0,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_STACK, // Type of map.
+         0,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "STACK_map"},
     {NULL,
      {
-         1,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         10,                // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "HASH_map"},
     {NULL,
      {
-         4,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PERCPU_HASH, // Type of map.
+         4,                        // Size in bytes of a map key.
+         4,                        // Size in bytes of a map value.
+         10,                       // Maximum number of entries allowed in the map.
+         0,                        // Inner map index.
+         PIN_NONE,                 // Pinning type for the map.
+         0,                        // Identifier for a map template.
+         0,                        // The id of the inner map template.
      },
      "PERCPU_HASH_map"},
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "ARRAY_map"},
     {NULL,
      {
-         5,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PERCPU_ARRAY, // Type of map.
+         4,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         10,                        // Maximum number of entries allowed in the map.
+         0,                         // Inner map index.
+         PIN_NONE,                  // Pinning type for the map.
+         0,                         // Identifier for a map template.
+         0,                         // The id of the inner map template.
      },
      "PERCPU_ARRAY_map"},
     {NULL,
      {
-         8,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_LRU_HASH, // Type of map.
+         4,                     // Size in bytes of a map key.
+         4,                     // Size in bytes of a map value.
+         10,                    // Maximum number of entries allowed in the map.
+         0,                     // Inner map index.
+         PIN_NONE,              // Pinning type for the map.
+         0,                     // Identifier for a map template.
+         0,                     // The id of the inner map template.
      },
      "LRU_HASH_map"},
     {NULL,
      {
-         11, // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_LRU_PERCPU_HASH, // Type of map.
+         4,                            // Size in bytes of a map key.
+         4,                            // Size in bytes of a map value.
+         10,                           // Maximum number of entries allowed in the map.
+         0,                            // Inner map index.
+         PIN_NONE,                     // Pinning type for the map.
+         0,                            // Identifier for a map template.
+         0,                            // The id of the inner map template.
      },
      "LRU_PERCPU_HASH_map"},
     {NULL,
      {
-         10, // Type of map.
-         0,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_QUEUE, // Type of map.
+         0,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         10,                 // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "QUEUE_map"},
 };

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "connection_map"},
     {NULL,
      {
-         13,     // Type of map.
-         0,      // Size in bytes of a map key.
-         0,      // Size in bytes of a map value.
-         262144, // Maximum number of entries allowed in the map.
-         0,      // Inner map index.
-         0,      // Pinning type for the map.
-         0,      // Identifier for a map template.
-         0,      // The id of the inner map template.
+         BPF_MAP_TYPE_RINGBUF, // Type of map.
+         0,                    // Size in bytes of a map key.
+         0,                    // Size in bytes of a map value.
+         262144,               // Maximum number of entries allowed in the map.
+         0,                    // Inner map index.
+         PIN_NONE,             // Pinning type for the map.
+         0,                    // Identifier for a map template.
+         0,                    // The id of the inner map template.
      },
      "audit_map"},
 };

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "connection_map"},
     {NULL,
      {
-         13,
-         0,
-         0,
-         262144,
-         0,
-         0,
-         0,
-         0,
+         13,     // Type of map.
+         0,      // Size in bytes of a map key.
+         0,      // Size in bytes of a map value.
+         262144, // Maximum number of entries allowed in the map.
+         0,      // Inner map index.
+         0,      // Pinning type for the map.
+         0,      // Identifier for a map template.
+         0,      // The id of the inner map template.
      },
      "audit_map"},
 };

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "connection_map"},
     {NULL,
      {
-         13,     // Type of map.
-         0,      // Size in bytes of a map key.
-         0,      // Size in bytes of a map value.
-         262144, // Maximum number of entries allowed in the map.
-         0,      // Inner map index.
-         0,      // Pinning type for the map.
-         0,      // Identifier for a map template.
-         0,      // The id of the inner map template.
+         BPF_MAP_TYPE_RINGBUF, // Type of map.
+         0,                    // Size in bytes of a map key.
+         0,                    // Size in bytes of a map value.
+         262144,               // Maximum number of entries allowed in the map.
+         0,                    // Inner map index.
+         PIN_NONE,             // Pinning type for the map.
+         0,                    // Identifier for a map template.
+         0,                    // The id of the inner map template.
      },
      "audit_map"},
 };

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "connection_map"},
     {NULL,
      {
-         13,
-         0,
-         0,
-         262144,
-         0,
-         0,
-         0,
-         0,
+         13,     // Type of map.
+         0,      // Size in bytes of a map key.
+         0,      // Size in bytes of a map value.
+         262144, // Maximum number of entries allowed in the map.
+         0,      // Inner map index.
+         0,      // Pinning type for the map.
+         0,      // Identifier for a map template.
+         0,      // The id of the inner map template.
      },
      "audit_map"},
 };

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,
-         44,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         1,  // Type of map.
+         44, // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         1,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "connection_map"},
     {NULL,
      {
-         13,
-         0,
-         0,
-         262144,
-         0,
-         0,
-         0,
-         0,
+         13,     // Type of map.
+         0,      // Size in bytes of a map key.
+         0,      // Size in bytes of a map value.
+         262144, // Maximum number of entries allowed in the map.
+         0,      // Inner map index.
+         0,      // Pinning type for the map.
+         0,      // Identifier for a map template.
+         0,      // The id of the inner map template.
      },
      "audit_map"},
 };

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         1,  // Type of map.
-         44, // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         1,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_HASH, // Type of map.
+         44,                // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
      },
      "connection_map"},
     {NULL,
      {
-         13,     // Type of map.
-         0,      // Size in bytes of a map key.
-         0,      // Size in bytes of a map value.
-         262144, // Maximum number of entries allowed in the map.
-         0,      // Inner map index.
-         0,      // Pinning type for the map.
-         0,      // Identifier for a map template.
-         0,      // The id of the inner map template.
+         BPF_MAP_TYPE_RINGBUF, // Type of map.
+         0,                    // Size in bytes of a map key.
+         0,                    // Size in bytes of a map value.
+         262144,               // Maximum number of entries allowed in the map.
+         0,                    // Inner map index.
+         PIN_NONE,             // Pinning type for the map.
+         0,                    // Identifier for a map template.
+         0,                    // The id of the inner map template.
      },
      "audit_map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         1,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         0,                          // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         3, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         1,                       // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         1,
-         0,
-         0,
-         0,
+         7, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         3,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         3, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         1,
-         0,
-         0,
-         0,
+         7, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         3,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         3, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         1,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         0,                          // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         3, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         1,                       // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7,
-         4,
-         4,
-         1,
-         1,
-         0,
-         0,
-         0,
+         7, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         1, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         3,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         3, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         7, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         1, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY_OF_MAPS, // Type of map.
+         4,                          // Size in bytes of a map key.
+         4,                          // Size in bytes of a map value.
+         1,                          // Maximum number of entries allowed in the map.
+         1,                          // Inner map index.
+         PIN_NONE,                   // Pinning type for the map.
+         0,                          // Identifier for a map template.
+         0,                          // The id of the inner map template.
      },
      "outer_map"},
     {NULL,
      {
-         3, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         1,                       // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "inner_map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,
-         4,
-         4,
-         10,
-         0,
-         0,
-         0,
-         0,
+         3,  // Type of map.
+         4,  // Size in bytes of a map key.
+         4,  // Size in bytes of a map value.
+         10, // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2,
-         4,
-         4,
-         1,
-         0,
-         0,
-         0,
-         0,
+         2, // Type of map.
+         4, // Size in bytes of a map key.
+         4, // Size in bytes of a map value.
+         1, // Maximum number of entries allowed in the map.
+         0, // Inner map index.
+         0, // Pinning type for the map.
+         0, // Identifier for a map template.
+         0, // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         3,  // Type of map.
-         4,  // Size in bytes of a map key.
-         4,  // Size in bytes of a map value.
-         10, // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
+         4,                       // Size in bytes of a map key.
+         4,                       // Size in bytes of a map value.
+         10,                      // Maximum number of entries allowed in the map.
+         0,                       // Inner map index.
+         PIN_NONE,                // Pinning type for the map.
+         0,                       // Identifier for a map template.
+         0,                       // The id of the inner map template.
      },
      "map"},
     {NULL,
      {
-         2, // Type of map.
-         4, // Size in bytes of a map key.
-         4, // Size in bytes of a map value.
-         1, // Maximum number of entries allowed in the map.
-         0, // Inner map index.
-         0, // Pinning type for the map.
-         0, // Identifier for a map template.
-         0, // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "canary"},
 };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "test_map"},
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -57,26 +57,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "test_map"},
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "test_map"},
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -15,26 +15,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "test_map"},
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "test_map"},
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -182,26 +182,26 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "test_map"},
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -57,14 +57,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -15,14 +15,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,  // Type of map.
-         4,  // Size in bytes of a map key.
-         32, // Size in bytes of a map value.
-         2,  // Maximum number of entries allowed in the map.
-         0,  // Inner map index.
-         0,  // Pinning type for the map.
-         0,  // Identifier for a map template.
-         0,  // The id of the inner map template.
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         32,                 // Size in bytes of a map value.
+         2,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         PIN_NONE,           // Pinning type for the map.
+         0,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -182,14 +182,14 @@ _get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ si
 static map_entry_t _maps[] = {
     {NULL,
      {
-         2,
-         4,
-         32,
-         2,
-         0,
-         0,
-         0,
-         0,
+         2,  // Type of map.
+         4,  // Size in bytes of a map key.
+         32, // Size in bytes of a map value.
+         2,  // Maximum number of entries allowed in the map.
+         0,  // Inner map index.
+         0,  // Pinning type for the map.
+         0,  // Identifier for a map template.
+         0,  // The id of the inner map template.
      },
      "utility_map"},
 };

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -744,19 +744,25 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         while (current_index < map_size) {
             for (const auto& [name, entry] : map_definitions) {
                 if (entry.index == current_index) {
-                    if (entry.definition.type > _countof(_map_type_names)) {
-                        throw std::runtime_error("Unknown map type");
+                    std::string map_type;
+                    std::string map_pinning;
+                    if (entry.definition.type < _countof(_map_type_names)) {
+                        map_type = _map_type_names[entry.definition.type];
+                    } else {
+                        map_type = std::to_string(entry.definition.type);
                     }
-                    if (entry.definition.pinning > _countof(_pin_enum_names)) {
-                        throw std::runtime_error("Unknown pinning type");
+                    if (entry.definition.pinning < _countof(_pin_enum_names)) {
+                        map_pinning = _pin_enum_names[entry.definition.pinning];
+                    } else {
+                        map_pinning = std::to_string(entry.definition.pinning);
                     }
                     double width = 0;
-                    width = std::max(width, (double)_map_type_names[entry.definition.type].size() - 1);
+                    width = std::max(width, (double)map_type.size() - 1);
                     width = std::max(width, std::log10((size_t)entry.definition.key_size));
                     width = std::max(width, std::log10((size_t)entry.definition.value_size));
                     width = std::max(width, std::log10((size_t)entry.definition.max_entries));
                     width = std::max(width, std::log10((size_t)entry.definition.inner_map_idx));
-                    width = std::max(width, (double)_pin_enum_names[entry.definition.pinning].size() - 1);
+                    width = std::max(width, (double)map_pinning.size() - 1);
                     width = std::max(width, std::log10((size_t)entry.definition.id));
 
                     width = std::max(width, std::log10((size_t)entry.definition.inner_id));
@@ -765,8 +771,7 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
 
                     output_stream << INDENT "{NULL," << std::endl;
                     output_stream << INDENT " {" << std::endl;
-                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
-                                  << _map_type_names[entry.definition.type] + ","
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width) << map_type + ","
                                   << "// Type of map." << std::endl;
                     output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
                                   << std::to_string(entry.definition.key_size) + ","
@@ -780,8 +785,7 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
                     output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
                                   << std::to_string(entry.definition.inner_map_idx) + ","
                                   << "// Inner map index." << std::endl;
-                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
-                                  << _pin_enum_names[entry.definition.pinning] + ","
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width) << map_pinning + ","
                                   << "// Pinning type for the map." << std::endl;
                     output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
                                   << std::to_string(entry.definition.id) + ","

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -112,25 +112,6 @@ static std::map<uint8_t, std::string> _opcode_name_strings = {
     ADD_OPCODE(EBPF_OP_JSLT_REG),   ADD_OPCODE(EBPF_OP_JSLE_IMM),  ADD_OPCODE(EBPF_OP_JSLE_REG),
 };
 
-static const std::string _map_type_names[]{
-    "BPF_MAP_TYPE_UNSPEC",
-    "BPF_MAP_TYPE_HASH",
-    "BPF_MAP_TYPE_ARRAY",
-    "BPF_MAP_TYPE_PROG_ARRAY",
-    "BPF_MAP_TYPE_PERCPU_HASH",
-    "BPF_MAP_TYPE_PERCPU_ARRAY",
-    "BPF_MAP_TYPE_HASH_OF_MAPS",
-    "BPF_MAP_TYPE_ARRAY_OF_MAPS",
-    "BPF_MAP_TYPE_LRU_HASH",
-    "BPF_MAP_TYPE_LPM_TRIE",
-    "BPF_MAP_TYPE_QUEUE",
-    "BPF_MAP_TYPE_LRU_PERCPU_HASH",
-    "BPF_MAP_TYPE_STACK",
-    "BPF_MAP_TYPE_RINGBUF",
-};
-
-static const std::string _pin_enum_names[]{"PIN_NONE", "PIN_OBJECT_NS", "PIN_GLOBAL_NS", "PIN_CUSTOM_NS"};
-
 std::string
 bpf_code_generator::get_register_name(uint8_t id)
 {
@@ -746,13 +727,13 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
                 if (entry.index == current_index) {
                     std::string map_type;
                     std::string map_pinning;
-                    if (entry.definition.type < _countof(_map_type_names)) {
-                        map_type = _map_type_names[entry.definition.type];
+                    if (entry.definition.type < _countof(_ebpf_map_type_names)) {
+                        map_type = _ebpf_map_type_names[entry.definition.type];
                     } else {
                         map_type = std::to_string(entry.definition.type);
                     }
-                    if (entry.definition.pinning < _countof(_pin_enum_names)) {
-                        map_pinning = _pin_enum_names[entry.definition.pinning];
+                    if (entry.definition.pinning < _countof(_ebpf_pin_type_names)) {
+                        map_pinning = _ebpf_pin_type_names[entry.definition.pinning];
                     } else {
                         map_pinning = std::to_string(entry.definition.pinning);
                     }

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -21,6 +21,7 @@
 #define _countof(array) (sizeof(array) / sizeof(array[0]))
 #endif
 #include <cassert>
+#include <iomanip>
 
 #define INDENT "    "
 #define LINE_BREAK_WIDTH 120
@@ -724,16 +725,43 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         while (current_index < map_size) {
             for (const auto& [name, entry] : map_definitions) {
                 if (entry.index == current_index) {
+                    double width = 0;
+                    width = std::max(width, std::log10((size_t)entry.definition.type));
+                    width = std::max(width, std::log10((size_t)entry.definition.key_size));
+                    width = std::max(width, std::log10((size_t)entry.definition.value_size));
+                    width = std::max(width, std::log10((size_t)entry.definition.max_entries));
+                    width = std::max(width, std::log10((size_t)entry.definition.inner_map_idx));
+                    width = std::max(width, std::log10((size_t)entry.definition.id));
+                    width = std::max(width, std::log10((size_t)entry.definition.inner_id));
+                    auto stream_width = static_cast<std::streamsize>(std::floor(width) + 1);
+                    stream_width += 2; // Add space for the trailing ", "
+
                     output_stream << INDENT "{NULL," << std::endl;
                     output_stream << INDENT " {" << std::endl;
-                    output_stream << INDENT INDENT " " << entry.definition.type << "," << std::endl;
-                    output_stream << INDENT INDENT " " << entry.definition.key_size << "," << std::endl;
-                    output_stream << INDENT INDENT " " << entry.definition.value_size << "," << std::endl;
-                    output_stream << INDENT INDENT " " << entry.definition.max_entries << "," << std::endl;
-                    output_stream << INDENT INDENT " " << entry.definition.inner_map_idx << "," << std::endl;
-                    output_stream << INDENT INDENT " " << entry.definition.pinning << "," << std::endl;
-                    output_stream << INDENT INDENT " " << entry.definition.id << "," << std::endl;
-                    output_stream << INDENT INDENT " " << entry.definition.inner_id << "," << std::endl;
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
+                                  << std::to_string(entry.definition.type) + ","
+                                  << "// Type of map." << std::endl;
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
+                                  << std::to_string(entry.definition.key_size) + ","
+                                  << "// Size in bytes of a map key." << std::endl;
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
+                                  << std::to_string(entry.definition.value_size) + ","
+                                  << "// Size in bytes of a map value." << std::endl;
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
+                                  << std::to_string(entry.definition.max_entries) + ","
+                                  << "// Maximum number of entries allowed in the map." << std::endl;
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
+                                  << std::to_string(entry.definition.inner_map_idx) + ","
+                                  << "// Inner map index." << std::endl;
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
+                                  << std::to_string(entry.definition.pinning) + ","
+                                  << "// Pinning type for the map." << std::endl;
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
+                                  << std::to_string(entry.definition.id) + ","
+                                  << "// Identifier for a map template." << std::endl;
+                    output_stream << INDENT INDENT " " << std::left << std::setw(stream_width)
+                                  << std::to_string(entry.definition.inner_id) + ","
+                                  << "// The id of the inner map template." << std::endl;
                     output_stream << INDENT " }," << std::endl;
                     output_stream << INDENT " \"" << name.c_str() << "\"}," << std::endl;
 
@@ -795,7 +823,6 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         std::string program_type_name = program_name + "_program_type_guid";
         std::string attach_type_name = program_name + "_attach_type_guid";
 
-#if defined(_MSC_VER)
         auto guid_declaration = format_string(
             "static GUID %s = %s;", sanitize_name(program_type_name), format_guid(&section.program_type, false));
 
@@ -819,7 +846,6 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
                                  format_guid(&section.expected_attach_type, true))
                           << std::endl;
         }
-#endif
 
         if (section.referenced_map_indices.size() > 0) {
             // Emit the array for the maps used.
@@ -900,13 +926,8 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         size_t helper_count = program.helper_functions.size();
         auto map_array_name = map_count ? (program_name + "_maps") : std::string("NULL");
         auto helper_array_name = helper_count ? (program_name + "_helpers") : std::string("NULL");
-#if defined(_MSC_VER)
         auto program_type_guid_name = program_name + "_program_type_guid";
         auto attach_type_guid_name = program_name + "_attach_type_guid";
-#else
-        auto program_type_guid_name = std::string("NULL");
-        auto attach_type_guid_name = std::string("NULL");
-#endif
         output_stream << INDENT "{" << std::endl;
         output_stream << INDENT INDENT << sanitize_name(program_name) << "," << std::endl;
         output_stream << INDENT INDENT "\"" << name.c_str() << "\"," << std::endl;
@@ -916,12 +937,8 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         output_stream << INDENT INDENT << helper_array_name.c_str() << "," << std::endl;
         output_stream << INDENT INDENT << program.helper_functions.size() << "," << std::endl;
         output_stream << INDENT INDENT << program.output.size() << "," << std::endl;
-#if defined(_MSC_VER)
         output_stream << INDENT INDENT "&" << sanitize_name(program_type_guid_name) << "," << std::endl;
         output_stream << INDENT INDENT "&" << sanitize_name(attach_type_guid_name) << "," << std::endl;
-#else
-        << sanitize_name(program_type_guid_name) << ", " << sanitize_name(attach_type_guid_name) << ", "
-#endif
         output_stream << INDENT "}," << std::endl;
     }
     output_stream << "};" << std::endl;
@@ -940,7 +957,6 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         c_name.c_str() + std::string("_metadata_table"));
 }
 
-#if defined(_MSC_VER)
 std::string
 bpf_code_generator::format_guid(const GUID* guid, bool split)
 {
@@ -974,7 +990,6 @@ bpf_code_generator::format_guid(const GUID* guid, bool split)
     output.resize(strlen(output.c_str()));
     return output;
 }
-#endif
 
 std::string
 bpf_code_generator::format_string(


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Modify bpf2c to emit a comment for each entry in the map definition.

## Testing

CI/CD.

## Documentation

No.

Resolves: #1063