### PR TITLE
Add support for bpf_program__type

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -69,7 +69,7 @@ EXPORTS
     bpf_program__attach_xdp
     bpf_program__fd
     bpf_program__get_expected_attach_type
-    bpf_program__get_type
+    bpf_program__get_type=bpf_program__type
     bpf_program__name
     bpf_program__next
     bpf_program__pin
@@ -77,6 +77,7 @@ EXPORTS
     bpf_program__section_name
     bpf_program__set_expected_attach_type
     bpf_program__set_type
+    bpf_program__type
     bpf_program__unload
     bpf_program__unpin
     bpf_set_link_xdp_fd

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -619,7 +619,10 @@ bpf_program__get_expected_attach_type(const struct bpf_program* prog);
  *
  * @returns Program type.
  *
+ * @deprecated Use bpf_program__type() instead.
+ *
  * @sa bpf_program__get_expected_attach_type
+ * @sa bpf_program__type
  */
 enum bpf_prog_type
 bpf_program__get_type(const struct bpf_program* prog);
@@ -713,9 +716,22 @@ bpf_program__set_expected_attach_type(struct bpf_program* prog, enum bpf_attach_
  * @param[in] type Program type to set.
  *
  * @sa bpf_program__set_expected_attach_type
+ * @sa bpf_program__type
  */
 void
 bpf_program__set_type(struct bpf_program* prog, enum bpf_prog_type type);
+
+/**
+ * @brief Get the program type for an eBPF program.
+ *
+ * @param[in] prog Program to check.
+ *
+ * @returns Program type.
+ *
+ * @sa bpf_program__get_expected_attach_type
+ */
+enum bpf_prog_type
+bpf_program__type(const struct bpf_program* prog);
 
 /**
  * @brief Unload a program.

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -408,7 +408,7 @@ bpf_program__set_expected_attach_type(struct bpf_program* program, enum bpf_atta
 }
 
 enum bpf_prog_type
-bpf_program__get_type(const struct bpf_program* program)
+bpf_program__type(const struct bpf_program* program)
 {
     return _get_bpf_program_type(&program->program_type);
 }

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -190,7 +190,7 @@ handle_ebpf_add_program(
     void* attach_parameters = nullptr;
     size_t attach_parameters_size = 0;
     if (interface_parameter != nullptr) {
-        result = _process_interface_parameter(interface_parameter, bpf_program__get_type(program), &if_index);
+        result = _process_interface_parameter(interface_parameter, bpf_program__type(program), &if_index);
         if (result == EBPF_SUCCESS) {
             attach_parameters = &if_index;
             attach_parameters_size = sizeof(if_index);

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -460,6 +460,9 @@ TEST_CASE("tailcall_load_test", "[tailcall_load_test]")
     fd_t callee1_fd = bpf_program__fd(callee1);
     REQUIRE(callee1_fd > 0);
 
+    // Test a legacy libbpf api alias.
+    REQUIRE(bpf_program__get_type(callee0) == BPF_PROG_TYPE_XDP);
+
     fd_t prog_map_fd = bpf_object__find_map_fd_by_name(object, "map");
     REQUIRE(prog_map_fd > 0);
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1604,11 +1604,11 @@ TEST_CASE("bpf_object__load", "[libbpf]")
     REQUIRE(program != nullptr);
 
     REQUIRE(bpf_program__fd(program) == ebpf_fd_invalid);
-    REQUIRE(bpf_program__get_type(program) == BPF_PROG_TYPE_XDP);
+    REQUIRE(bpf_program__type(program) == BPF_PROG_TYPE_XDP);
 
     // Make sure we can override the program type if desired.
     bpf_program__set_type(program, BPF_PROG_TYPE_BIND);
-    REQUIRE(bpf_program__get_type(program) == BPF_PROG_TYPE_BIND);
+    REQUIRE(bpf_program__type(program) == BPF_PROG_TYPE_BIND);
 
     bpf_program__set_type(program, BPF_PROG_TYPE_XDP);
 


### PR DESCRIPTION
Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

In libbpf APIs, bpf_program__get_type() is a legacy alias for bpf_program__type().  We only supported the legacy alias and not the modern api.  This PR adds the modern api.

## Testing

Tests are updated in this PR.

## Documentation

Documentation is updated in this PR.
