### PR TITLE
EX_PUSH_LOCK fix

### DIFF
--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
 
     - name: Harden Runner
-      uses: step-security/harden-runner@34cbc43f0b10c9dda284e663cf43c2ebaf83e956
+      uses: step-security/harden-runner@248ae51c2e8cc9622ecf50685c8bf7150c6e8813
       with:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -68,6 +68,34 @@ typedef struct _net_ebpf_extension_hook_provider
         LIST_ENTRY attached_clients_list; ///< Linked list of hook NPI clients that are attached to this provider.
 } net_ebpf_extension_hook_provider_t;
 
+static void
+_ebpf_ext_acquire_push_lock(_Inout_ PEX_PUSH_LOCK lock, bool exclusive)
+{
+    KeEnterCriticalRegion();
+    if (exclusive) {
+        ExAcquirePushLockExclusive(lock);
+    } else {
+        ExAcquirePushLockShared(lock);
+    }
+}
+
+static void
+_ebpf_ext_release_push_lock(_Inout_ PEX_PUSH_LOCK lock, bool exclusive)
+{
+    if (exclusive) {
+        ExReleasePushLockExclusive(lock);
+    } else {
+        ExReleasePushLockShared(lock);
+    }
+    KeLeaveCriticalRegion();
+}
+
+#define ACQUIRE_PUSH_LOCK_EXCLUSIVE(lock) _ebpf_ext_acquire_push_lock(lock, true)
+#define ACQUIRE_PUSH_LOCK_SHARED(lock) _ebpf_ext_acquire_push_lock(lock, false)
+
+#define RELEASE_PUSH_LOCK_EXCLUSIVE(lock) _ebpf_ext_release_push_lock(lock, true)
+#define RELEASE_PUSH_LOCK_SHARED(lock) _ebpf_ext_release_push_lock(lock, false)
+
 static _Function_class_(KDEFERRED_ROUTINE) _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_requires_min_(DISPATCH_LEVEL)
     _IRQL_requires_(DISPATCH_LEVEL) _IRQL_requires_same_ void _ebpf_ext_attach_rundown(
         _In_ KDPC* dpc,
@@ -133,8 +161,8 @@ _ebpf_ext_attach_wait_for_rundown(
 {
     rundown->rundown_occurred = TRUE;
     if (execution_type == EXECUTION_PASSIVE) {
-        ExAcquirePushLockExclusive(&rundown->passive.lock);
-        ExReleasePushLockExclusive(&rundown->passive.lock);
+        ACQUIRE_PUSH_LOCK_EXCLUSIVE(&rundown->passive.lock);
+        RELEASE_PUSH_LOCK_EXCLUSIVE(&rundown->passive.lock);
     } else {
         // Queue a DPC to each CPU and wait for it to run.
         // After it has run on each CPU we can be sure that no
@@ -185,7 +213,7 @@ _Acquires_lock_(hook_client) bool net_ebpf_extension_hook_client_enter_rundown(
 {
     net_ebpf_ext_hook_client_rundown_t* rundown = &hook_client->rundown;
     if (execution_type == EXECUTION_PASSIVE) {
-        ExAcquirePushLockShared(&rundown->passive.lock);
+        ACQUIRE_PUSH_LOCK_SHARED(&rundown->passive.lock);
     }
 
     return (rundown->rundown_occurred == FALSE);
@@ -249,7 +277,7 @@ net_ebpf_extension_hook_check_attach_parameter(
     if (memcmp(attach_parameter, wild_card_attach_parameter, attach_parameter_size) == 0)
         using_wild_card_attach_parameter = TRUE;
 
-    ExAcquirePushLockShared(&provider_context->lock);
+    ACQUIRE_PUSH_LOCK_SHARED(&provider_context->lock);
     lock_held = TRUE;
     if (using_wild_card_attach_parameter) {
         // Client requested wild card attach parameter. This will only be allowed if there are no other clients
@@ -353,9 +381,9 @@ _net_ebpf_extension_hook_provider_attach_client(
     if (result == EBPF_SUCCESS) {
         status = _ebpf_ext_attach_init_rundown(hook_client);
         if (status == STATUS_SUCCESS) {
-            ExAcquirePushLockExclusive(&local_provider_context->lock);
+            ACQUIRE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
             InsertTailList(&local_provider_context->attached_clients_list, &hook_client->link);
-            ExReleasePushLockExclusive(&local_provider_context->lock);
+            RELEASE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
         }
     } else {
         status = STATUS_ACCESS_DENIED;
@@ -399,9 +427,9 @@ _net_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_cont
     // Invoke hook specific handler for processing client detach.
     local_provider_context->detach_callback(local_client_context);
 
-    ExAcquirePushLockExclusive(&local_provider_context->lock);
+    ACQUIRE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
     RemoveEntryList(&local_client_context->link);
-    ExReleasePushLockExclusive(&local_provider_context->lock);
+    RELEASE_PUSH_LOCK_EXCLUSIVE(&local_provider_context->lock);
 
     IoQueueWorkItem(
         local_client_context->detach_work_item,
@@ -486,11 +514,11 @@ net_ebpf_extension_hook_client_t*
 net_ebpf_extension_hook_get_attached_client(_In_ net_ebpf_extension_hook_provider_t* provider_context)
 {
     net_ebpf_extension_hook_client_t* client_context = NULL;
-    ExAcquirePushLockShared(&provider_context->lock);
+    ACQUIRE_PUSH_LOCK_SHARED(&provider_context->lock);
     if (!IsListEmpty(&provider_context->attached_clients_list))
         client_context = (net_ebpf_extension_hook_client_t*)CONTAINING_RECORD(
             provider_context->attached_clients_list.Flink, net_ebpf_extension_hook_client_t, link);
-    ExReleasePushLockShared(&provider_context->lock);
+    RELEASE_PUSH_LOCK_SHARED(&provider_context->lock);
     return client_context;
 }
 
@@ -500,7 +528,7 @@ net_ebpf_extension_hook_get_next_attached_client(
     _In_opt_ const net_ebpf_extension_hook_client_t* client_context)
 {
     net_ebpf_extension_hook_client_t* next_client = NULL;
-    ExAcquirePushLockShared(&provider_context->lock);
+    ACQUIRE_PUSH_LOCK_SHARED(&provider_context->lock);
     if (client_context == NULL) {
         // Return the first attached client (if any).
         if (!IsListEmpty(&provider_context->attached_clients_list))
@@ -514,6 +542,6 @@ net_ebpf_extension_hook_get_next_attached_client(
                 client_context->link.Flink, net_ebpf_extension_hook_client_t, link);
         }
     }
-    ExReleasePushLockShared(&provider_context->lock);
+    RELEASE_PUSH_LOCK_SHARED(&provider_context->lock);
     return next_client;
 }


### PR DESCRIPTION
## Description

**Issue:**
MSDN (https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/wdm/nf-wdm-exacquirepushlockexclusive) says that the caller should call `KeEnterCriticalRegion()` before acquiring push lock (both shared and exclusive).

This PR fixes that by calling `KeEnterCriticalRegion` / `KeLeaveCriticalRegion` at appropriate places.

## Testing

Existing tests cover it.

## Documentation

NA
