### PR TITLE
Move expected output to subfolder

### DIFF
--- a/tests/bpf2c_tests/bpf2c_tests.vcxproj
+++ b/tests/bpf2c_tests/bpf2c_tests.vcxproj
@@ -119,7 +119,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>copy $(ProjectDir)expected\* $(OutDir)</Command>
+      <Command>xcopy /y $(ProjectDir)expected\* $(OutDir)\expected\*</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -135,7 +135,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <Command>copy $(ProjectDir)expected\* $(OutDir)</Command>
+      <Command>xcopy /y $(ProjectDir)expected\* $(OutDir)\expected\*</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/tests/bpf2c_tests/elf_bpf.cpp
+++ b/tests/bpf2c_tests/elf_bpf.cpp
@@ -116,8 +116,8 @@ run_test_elf(const std::string& elf_file, _test_mode test_mode)
         switch (test_mode) {
         case _test_mode::Verify:
         case _test_mode::NoVerify: {
-            auto raw_output =
-                read_contents<std::ifstream>(name + suffix, {transform_line_directives, transform_fix_opcode_comment});
+            auto raw_output = read_contents<std::ifstream>(
+                std::string("expected\\") + name + suffix, {transform_line_directives, transform_fix_opcode_comment});
             auto raw_result = read_contents<std::istringstream>(out, {transform_line_directives});
 
             REQUIRE(raw_result.size() == raw_output.size());


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Some of the expected output is overwritten during the build, invalidating the test.

## Testing

CI/CD

## Documentation

No.
