### PR TITLE
Skip checkout of repo for ossar scan

### DIFF
--- a/.github/workflows/ossar-scan.yml
+++ b/.github/workflows/ossar-scan.yml
@@ -38,13 +38,6 @@ jobs:
       BUILD_CONFIGURATION: ${{matrix.configurations}}
       BUILD_PLATFORM: x64
 
-    # Checking out the branch is needed to gather correct code coverage data.
-    steps:
-    - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415
-      with:
-        submodules: 'recursive'
-        ref: ${{ github.event.workflow_run.head_branch }}
-
     - name: Wait for build to succeed
       uses: fountainhead/action-wait-for-check@507b029e31edbe1a72d4de429476e1f4efe98869
       id: wait_for_build

--- a/.github/workflows/ossar-scan.yml
+++ b/.github/workflows/ossar-scan.yml
@@ -38,6 +38,7 @@ jobs:
       BUILD_CONFIGURATION: ${{matrix.configurations}}
       BUILD_PLATFORM: x64
 
+    steps:
     - name: Wait for build to succeed
       uses: fountainhead/action-wait-for-check@507b029e31edbe1a72d4de429476e1f4efe98869
       id: wait_for_build

--- a/.github/workflows/ossar-scan.yml
+++ b/.github/workflows/ossar-scan.yml
@@ -39,6 +39,12 @@ jobs:
       BUILD_PLATFORM: x64
 
     steps:
+    # Checking out the branch is needed to correctly log security alerts.
+    - uses: actions/checkout@b0e28b5ac45a892f91e7d036f8200cf5ed489415
+      with:
+        # Only check out main repo, not submodules.
+        ref: ${{ github.event.workflow_run.head_branch }}
+
     - name: Wait for build to succeed
       uses: fountainhead/action-wait-for-check@507b029e31edbe1a72d4de429476e1f4efe98869
       id: wait_for_build


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

PE submodule contains invalid PE images that break the ossar tool. Skip checking out repo as it's not needed for the ossar scan.

## Testing

CI/Cd

## Documentation

No.
