### PR TITLE
Build self-contained Convert-BpfToNative.ps1

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -40,6 +40,7 @@ jobs:
     with:
       build_artifact: Build-x64-vcxproj
       generate_release_package: true
+      build_nuget: true
 
   cmake:
     # Always run this job.

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -22,6 +22,9 @@ on:
       build_codeql:
         required: false
         type: boolean
+      build_nuget:
+        required: false
+        type: boolean
 
 permissions:
   contents: read
@@ -165,6 +168,18 @@ jobs:
       with:
         name: ebpf-for-windows.msi
         path: ${{ steps.packages.outputs.REL_MSI_PACKAGE_PATH }}
+
+    - name: Build nuget package
+      if: matrix.configurations == 'Release' && inputs.build_nuget == true
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} ${{env.BUILD_OPTIONS}} /t:tools\nuget
+
+    - name: Upload the nuget package
+      if: matrix.configurations == 'Release' && inputs.build_nuget == true
+      uses: actions/upload-artifact@6673cd052c4cd6fcf4b4e6e60ea986c889389535
+      with:
+        name: ebpf-for-windows nuget
+        path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/*.nupkg
 
     - name: Perform CodeQL Analysis
       if: inputs.build_codeql == true

--- a/cmake/process_bpf_source_file.cmake
+++ b/cmake/process_bpf_source_file.cmake
@@ -11,7 +11,7 @@ function(add_bpftonative_command file_name kernel_mode unsafe_program)
     set (output_file ${output_dir}/${file_name}_um.dll)
   endif()
 
-  set(command_line ${powershell_path} -NonInteractive -ExecutionPolicy Unrestricted ${CMAKE_SOURCE_DIR}/scripts/Convert-BpfToNative.ps1 -ProgramName ${file_name} -SolutionDir ${CMAKE_SOURCE_DIR} -OutputDir ${output_dir} -Platform x64 -Configuration $(Configuration) -KernelMode ${kernel_mode})
+  set(command_line ${powershell_path} -NonInteractive -ExecutionPolicy Unrestricted ${output_dir}/Convert-BpfToNative.ps1 -IncludeDir ${CMAKE_SOURCE_DIR}/include -ProgramName ${file_name} -OutDir ${output_dir} -Platform x64 -Configuration $(Configuration) -KernelMode ${kernel_mode})
 
   set (input_file ${output_dir}/${file_name}.o)
   if (${unsafe_program})

--- a/scripts/Convert-BpfToNative.ps1.template
+++ b/scripts/Convert-BpfToNative.ps1.template
@@ -2,12 +2,15 @@
 # SPDX-License-Identifier: MIT
 
 param([parameter(Mandatory = $true)] [string] $ProgramName,
-    [parameter(Mandatory = $false)] [string] $SolutionDir = $Pwd,
-    [parameter(Mandatory = $false)] [string] $OutputDir = $Pwd,
+    [parameter(Mandatory = $false)] [string] $IncludeDir = "$PSScriptRoot\..\include",
+    [parameter(Mandatory = $false)] [string] $BinDir = "$PSScriptRoot",
     [parameter(Mandatory = $false)] [string] $Platform = "x64",
     [ValidateSet("Release", "Debug")][parameter(Mandatory = $false)] [string] $Configuration = "Release",
     [parameter(Mandatory = $false)] [bool] $SkipVerification = $false,
     [parameter(Mandatory = $false)] [bool] $KernelMode = $true)
+
+$KernelModeProject = '___KERNEL_MODE_VCXPROJ___'
+$UserModeProject = '___USER_MODE_VCXPROJ___'
 
 # If program name ends with .o, remove the suffix
 if ($ProgramName.EndsWith(".o")) {
@@ -23,22 +26,25 @@ if ($null -eq (Get-Command 'msbuild.exe' -ErrorAction SilentlyContinue)) {
     throw "Unable to locate msbuild.exe. This command needs to run within a 'Developer Command Prompt'"
 }
 
-$fileExists = Test-Path -Path ("$OutputDir\$ProgramName.o")
+$fileExists = Test-Path -Path ("$ProgramName.o")
 if (!$fileExists) {
-    $errorString = "Can't find program file: " + "$OutputDir\$ProgramName.o"
+    $errorString = "Can't find program file: " + "$ProgramName.o"
     throw $errorString
 }
 
-Push-Location $SolutionDir
 
-$ProjectFile = "$SolutionDir\tools\bpf2c\templates\kernel_mode_bpf2c.vcxproj"
-if (!$KernelMode) {
-    $ProjectFile = "$SolutionDir\tools\bpf2c\templates\user_mode_bpf2c.vcxproj"
+if ($KernelMode) {
+    $ProjectFile = "$ProgramName.vcxproj"
+    Set-Content -Path $ProjectFile -Value $KernelModeProject
+}
+else {
+    $ProjectFile = "$ProgramName_um.vcxproj"
+    Set-Content -Path $ProjectFile -Value $UserModeProject
 }
 
 $AdditionalOptions = If ($SkipVerification) {"--no-verify"} Else {""}
 
-msbuild /p:SolutionDir="$SolutionDir\" /p:OutDir="$OutputDir" /p:Configuration="$Configuration" /p:Platform="$Platform" /p:ProgramName="$ProgramName" /p:AdditionalOptions="$AdditionalOptions" $ProjectFile
+msbuild /p:BinDir="$BinDir\" /p:OutDir="$PWD\" /p:IncludeDir="$IncludeDir" /p:Configuration="$Configuration" /p:Platform="$Platform" /p:ProgramName="$ProgramName" /p:AdditionalOptions="$AdditionalOptions" $ProjectFile
 
 if ($LASTEXITCODE -ne 0) {
     throw "Build failed for $ProgramName.o"

--- a/scripts/Process-File.ps1
+++ b/scripts/Process-File.ps1
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# Process-File Reads $InputFile and $ConfigFile and performs replacement of strings in the content of $InputFile based
+# on the Files key in the $ConfigFile.
+# $ConfigFile is a json document containing the following elements:
+# Array called "Files" that contains objects with properties "Symbol" and "Filename".
+# Array called "EscapeCharacters" that contains objects with properties "Char" and "Escape".
+#
+# Each string with the value from "Symbol" is replaced with the contents from the corresponding "FileName" after
+# each occurence of "Char" in the file is replaced with "Escape".
+
+param ([Parameter(Mandatory=$True)] [string] $InputFile,
+       [Parameter(Mandatory=$True)] [string] $OutputFile,
+       [Parameter(Mandatory=$True)] [string] $ConfigFile)
+
+$Config = Get-Content -Path $ConfigFile | ConvertFrom-Json
+$Data = Get-Content -Path $InputFile
+
+$Config.Files | ForEach-Object {
+    $InsertString = Get-Content -Path $_.FileName
+    $Config.EscapeCharacters | ForEach-Object {
+        $InsertString = $InsertString.Replace($_.Char, $_.Escape)
+    }
+
+    $Data = $Data.Replace($_.Symbol, $InsertString)
+}
+
+Set-Content -Path $OutputFile -Value $Data

--- a/scripts/Replace-Text.ps1
+++ b/scripts/Replace-Text.ps1
@@ -1,0 +1,10 @@
+﻿# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+param ($InputFile, $OutputFile, $TemplateText, $Replacement)
+
+$lines = Get-Content $InputFile
+
+
+
+$lines | Out-File $OutputFile

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_in_map_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 

--- a/tests/sample/sample.vcxproj
+++ b/tests/sample/sample.vcxproj
@@ -97,8 +97,10 @@
       <FileType>CppCode</FileType>
       <Command>
         clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -c %(Filename).c -o $(OutputPath)%(Filename).o
-        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Convert-BpfToNative.ps1 -ProgramName %(Filename) -SolutionDir $(SolutionDir) -OutputDir $(OutDir) -Platform $(Platform) -Configuration $(Configuration) -KernelMode $true
-        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Convert-BpfToNative.ps1 -ProgramName %(Filename) -SolutionDir $(SolutionDir) -OutputDir $(OutDir) -Platform $(Platform) -Configuration $(Configuration) -KernelMode $false
+        pushd $(OutDir)
+        powershell -NonInteractive -ExecutionPolicy Unrestricted .\Convert-BpfToNative.ps1 -ProgramName %(Filename) -IncludeDir $(SolutionDir)\include -Platform $(Platform) -Configuration $(Configuration) -KernelMode $true
+        powershell -NonInteractive -ExecutionPolicy Unrestricted .\Convert-BpfToNative.ps1 -ProgramName %(Filename) -IncludeDir $(SolutionDir)\include -Platform $(Platform) -Configuration $(Configuration) -KernelMode $false
+        popd
       </Command>
       <Outputs>$(OutputPath)%(Filename).o;$(OutputPath)%(Filename)_um.dll;$(OutputPath)%(Filename).sys</Outputs>
     </CustomBuild>
@@ -110,8 +112,10 @@
       <Command>clang $(ClangFlags) -c %(Filename).c -o $(OutputPath)%(Filename).o</Command>
       <Command>
         clang $(ClangFlags) -I../xdp -I../socket -I./ext/inc -c unsafe\%(Filename).c -o $(OutputPath)%(Filename).o
-        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Convert-BpfToNative.ps1 -ProgramName %(Filename) -SolutionDir $(SolutionDir) -OutputDir $(OutDir) -Platform $(Platform) -Configuration $(Configuration) -KernelMode $true -SkipVerification $true
-        powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Convert-BpfToNative.ps1 -ProgramName %(Filename) -SolutionDir $(SolutionDir) -OutputDir $(OutDir) -Platform $(Platform) -Configuration $(Configuration) -KernelMode $false -SkipVerification $true
+        pushd $(OutDir)
+        powershell -NonInteractive -ExecutionPolicy Unrestricted .\Convert-BpfToNative.ps1 -ProgramName %(Filename) -IncludeDir $(SolutionDir)\include -Platform $(Platform) -Configuration $(Configuration) -KernelMode $true -SkipVerification $true
+        powershell -NonInteractive -ExecutionPolicy Unrestricted .\Convert-BpfToNative.ps1 -ProgramName %(Filename) -IncludeDir $(SolutionDir)\include -Platform $(Platform) -Configuration $(Configuration) -KernelMode $false -SkipVerification $true
+        popd
       </Command>
       <Outputs>$(OutputPath)%(Filename).o</Outputs>
     </CustomBuild>

--- a/tools/bpf2c/CMakeLists.txt
+++ b/tools/bpf2c/CMakeLists.txt
@@ -65,6 +65,44 @@ function(generateTemplate source_file_name)
   )
 endfunction()
 
+function(processFile source_file_name config_file)
+  find_program(powershell_path "powershell" REQUIRED)
+
+  set(input_file_name "${CMAKE_CURRENT_LIST_DIR}/${source_file_name}.ps1.template")
+  set(output_file_name "${output_dir}/${source_file_name}.ps1")
+  set(config_file_name "${CMAKE_CURRENT_LIST_DIR}/${config_file}")
+
+  add_custom_command(
+    OUTPUT
+      "${output_file_name}"
+
+    COMMAND
+      "${powershell_path}" powershell -NonInteractive -ExecutionPolicy Unrestricted "${CMAKE_SOURCE_DIR}/scripts/Process-File.ps1" -InputFile "${input_file_name}" -OutputFile "${output_file_name}" -ConfigFile "${config_file_name}"
+
+    VERBATIM
+
+    COMMENT
+      "ebpf-for-windows - Generating: ${source_file_name}.ps1"
+
+    WORKING_DIRECTORY
+      "${CMAKE_CURRENT_LIST_DIR}"
+
+  )
+
+  add_custom_target("${source_file_name}_builder"
+    DEPENDS "${output_file_name}"
+  )
+
+  add_library("${source_file_name}" INTERFACE)
+  target_include_directories("${source_file_name}" INTERFACE
+    "${CMAKE_CURRENT_BINARY_DIR}"
+  )
+
+  add_dependencies("${source_file_name}"
+    "${source_file_name}_builder"
+  )
+endfunction()
+
 generateTemplate("bpf2c_driver")
 target_link_libraries("bpf2c" PRIVATE
   "bpf2c_driver"
@@ -75,9 +113,14 @@ target_link_libraries("bpf2c" PRIVATE
   "bpf2c_dll"
 )
 
+processFile("Convert-BpfToNative" "replacements.json")
+target_link_libraries("bpf2c" PRIVATE
+  "Convert-BpfToNative"
+)
+
 if(EBPFFORWINDOWS_ENABLE_INSTALL)
   install(
-    TARGETS "bpf2c"
+    TARGETS "bpf2c" "Convert-BpfToNative"
     DESTINATION "."
   )
 endif()

--- a/tools/bpf2c/Convert-BpfToNative.ps1.template
+++ b/tools/bpf2c/Convert-BpfToNative.ps1.template
@@ -4,10 +4,13 @@
 param([parameter(Mandatory = $true)] [string] $ProgramName,
     [parameter(Mandatory = $false)] [string] $IncludeDir = "$PSScriptRoot\..\include",
     [parameter(Mandatory = $false)] [string] $BinDir = "$PSScriptRoot",
+    [parameter(Mandatory = $false)] [string] $OutDir = "$PWD",
     [parameter(Mandatory = $false)] [string] $Platform = "x64",
     [ValidateSet("Release", "Debug")][parameter(Mandatory = $false)] [string] $Configuration = "Release",
     [parameter(Mandatory = $false)] [bool] $SkipVerification = $false,
     [parameter(Mandatory = $false)] [bool] $KernelMode = $true)
+
+Push-Location $OutDir
 
 $KernelModeProject = '___KERNEL_MODE_VCXPROJ___'
 $UserModeProject = '___USER_MODE_VCXPROJ___'

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -121,6 +121,13 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <PreBuildEvent>
+      <!--
+      This powershell command is base64 encoded to solve the use of | in the command which breaks the command processing.
+      (Get-Content .\scripts\Convert-BpfToNative.ps1.template).Replace('___KERNEL_MODE_VCXPROJ___', (Get-Content .\tools\bpf2c\templates\kernel_mode_bpf2c.vcxproj).Replace("'", "''")).Replace('___USER_MODE_VCXPROJ___', (Get-Content .\tools\bpf2c\templates\user_mode_bpf2c.vcxproj).Replace("'", "''")) | Set-Content .\x64\debug\Convert-BpfToNative.ps1
+      -->
+      <Command>pushd $(SolutionDir) &amp;&amp; powershell -EncodedCommand KABHAGUAdAAtAEMAbwBuAHQAZQBuAHQAIAAuAFwAcwBjAHIAaQBwAHQAcwBcAEMAbwBuAHYAZQByAHQALQBCAHAAZgBUAG8ATgBhAHQAaQB2AGUALgBwAHMAMQAuAHQAZQBtAHAAbABhAHQAZQApAC4AUgBlAHAAbABhAGMAZQAoACcAXwBfAF8ASwBFAFIATgBFAEwAXwBNAE8ARABFAF8AVgBDAFgAUABSAE8ASgBfAF8AXwAnACwAIAAoAEcAZQB0AC0AQwBvAG4AdABlAG4AdAAgAC4AXAB0AG8AbwBsAHMAXABiAHAAZgAyAGMAXAB0AGUAbQBwAGwAYQB0AGUAcwBcAGsAZQByAG4AZQBsAF8AbQBvAGQAZQBfAGIAcABmADIAYwAuAHYAYwB4AHAAcgBvAGoAKQAuAFIAZQBwAGwAYQBjAGUAKAAiACcAIgAsACAAIgAnACcAIgApACkALgBSAGUAcABsAGEAYwBlACgAJwBfAF8AXwBVAFMARQBSAF8ATQBPAEQARQBfAFYAQwBYAFAAUgBPAEoAXwBfAF8AJwAsACAAKABHAGUAdAAtAEMAbwBuAHQAZQBuAHQAIAAuAFwAdABvAG8AbABzAFwAYgBwAGYAMgBjAFwAdABlAG0AcABsAGEAdABlAHMAXAB1AHMAZQByAF8AbQBvAGQAZQBfAGIAcABmADIAYwAuAHYAYwB4AHAAcgBvAGoAKQAuAFIAZQBwAGwAYQBjAGUAKAAiACcAIgAsACAAIgAnACcAIgApACkAIAB8ACAAUwBlAHQALQBDAG8AbgB0AGUAbgB0ACAALgBcAHgANgA0AFwAZABlAGIAdQBnAFwAQwBvAG4AdgBlAHIAdAAtAEIAcABmAFQAbwBOAGEAdABpAHYAZQAuAHAAcwAxAA== &amp;&amp; popd</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -135,6 +142,13 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+    <PreBuildEvent>
+      <!--
+      This powershell command is base64 encoded to solve the use of | in the command which breaks the command processing.
+      (Get-Content .\scripts\Convert-BpfToNative.ps1.template).Replace('___KERNEL_MODE_VCXPROJ___', (Get-Content .\tools\bpf2c\templates\kernel_mode_bpf2c.vcxproj).Replace("'", "''")).Replace('___USER_MODE_VCXPROJ___', (Get-Content .\tools\bpf2c\templates\user_mode_bpf2c.vcxproj).Replace("'", "''")) | Set-Content .\x64\release\Convert-BpfToNative.ps1
+      -->
+      <Command>pushd $(SolutionDir) &amp;&amp; powershell -EncodedCommand KABHAGUAdAAtAEMAbwBuAHQAZQBuAHQAIAAuAFwAcwBjAHIAaQBwAHQAcwBcAEMAbwBuAHYAZQByAHQALQBCAHAAZgBUAG8ATgBhAHQAaQB2AGUALgBwAHMAMQAuAHQAZQBtAHAAbABhAHQAZQApAC4AUgBlAHAAbABhAGMAZQAoACcAXwBfAF8ASwBFAFIATgBFAEwAXwBNAE8ARABFAF8AVgBDAFgAUABSAE8ASgBfAF8AXwAnACwAIAAoAEcAZQB0AC0AQwBvAG4AdABlAG4AdAAgAC4AXAB0AG8AbwBsAHMAXABiAHAAZgAyAGMAXAB0AGUAbQBwAGwAYQB0AGUAcwBcAGsAZQByAG4AZQBsAF8AbQBvAGQAZQBfAGIAcABmADIAYwAuAHYAYwB4AHAAcgBvAGoAKQAuAFIAZQBwAGwAYQBjAGUAKAAiACcAIgAsACAAIgAnACcAIgApACkALgBSAGUAcABsAGEAYwBlACgAJwBfAF8AXwBVAFMARQBSAF8ATQBPAEQARQBfAFYAQwBYAFAAUgBPAEoAXwBfAF8AJwAsACAAKABHAGUAdAAtAEMAbwBuAHQAZQBuAHQAIAAuAFwAdABvAG8AbABzAFwAYgBwAGYAMgBjAFwAdABlAG0AcABsAGEAdABlAHMAXAB1AHMAZQByAF8AbQBvAGQAZQBfAGIAcABmADIAYwAuAHYAYwB4AHAAcgBvAGoAKQAuAFIAZQBwAGwAYQBjAGUAKAAiACcAIgAsACAAIgAnACcAIgApACkAIAB8ACAAUwBlAHQALQBDAG8AbgB0AGUAbgB0ACAALgBcAHgANgA0AFwAcgBlAGwAZQBhAHMAZQBcAEMAbwBuAHYAZQByAHQALQBCAHAAZgBUAG8ATgBhAHQAaQB2AGUALgBwAHMAMQA= &amp;&amp; popd</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="bpf2c.cpp" />
@@ -190,13 +204,13 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="templates\kernel_mode_bpf2c.vcxproj">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <FileType>Document</FileType>
     </None>
     <None Include="templates\sources.def">
       <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
     </None>
     <None Include="templates\user_mode_bpf2c.vcxproj">
-      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <FileType>Document</FileType>
     </None>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -122,11 +122,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <!--
-      This powershell command is base64 encoded to solve the use of | in the command which breaks the command processing.
-      (Get-Content .\scripts\Convert-BpfToNative.ps1.template).Replace('___KERNEL_MODE_VCXPROJ___', (Get-Content .\tools\bpf2c\templates\kernel_mode_bpf2c.vcxproj).Replace("'", "''")).Replace('___USER_MODE_VCXPROJ___', (Get-Content .\tools\bpf2c\templates\user_mode_bpf2c.vcxproj).Replace("'", "''")) | Set-Content .\x64\debug\Convert-BpfToNative.ps1
-      -->
-      <Command>pushd $(SolutionDir) &amp;&amp; powershell -EncodedCommand KABHAGUAdAAtAEMAbwBuAHQAZQBuAHQAIAAuAFwAcwBjAHIAaQBwAHQAcwBcAEMAbwBuAHYAZQByAHQALQBCAHAAZgBUAG8ATgBhAHQAaQB2AGUALgBwAHMAMQAuAHQAZQBtAHAAbABhAHQAZQApAC4AUgBlAHAAbABhAGMAZQAoACcAXwBfAF8ASwBFAFIATgBFAEwAXwBNAE8ARABFAF8AVgBDAFgAUABSAE8ASgBfAF8AXwAnACwAIAAoAEcAZQB0AC0AQwBvAG4AdABlAG4AdAAgAC4AXAB0AG8AbwBsAHMAXABiAHAAZgAyAGMAXAB0AGUAbQBwAGwAYQB0AGUAcwBcAGsAZQByAG4AZQBsAF8AbQBvAGQAZQBfAGIAcABmADIAYwAuAHYAYwB4AHAAcgBvAGoAKQAuAFIAZQBwAGwAYQBjAGUAKAAiACcAIgAsACAAIgAnACcAIgApACkALgBSAGUAcABsAGEAYwBlACgAJwBfAF8AXwBVAFMARQBSAF8ATQBPAEQARQBfAFYAQwBYAFAAUgBPAEoAXwBfAF8AJwAsACAAKABHAGUAdAAtAEMAbwBuAHQAZQBuAHQAIAAuAFwAdABvAG8AbABzAFwAYgBwAGYAMgBjAFwAdABlAG0AcABsAGEAdABlAHMAXAB1AHMAZQByAF8AbQBvAGQAZQBfAGIAcABmADIAYwAuAHYAYwB4AHAAcgBvAGoAKQAuAFIAZQBwAGwAYQBjAGUAKAAiACcAIgAsACAAIgAnACcAIgApACkAIAB8ACAAUwBlAHQALQBDAG8AbgB0AGUAbgB0ACAALgBcAHgANgA0AFwAZABlAGIAdQBnAFwAQwBvAG4AdgBlAHIAdAAtAEIAcABmAFQAbwBOAGEAdABpAHYAZQAuAHAAcwAxAA== &amp;&amp; popd</Command>
+      <Command>powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Process-File.ps1 -InputFile Convert-BpfToNative.ps1.template -OutputFile $(OutDir)Convert-BpfToNative.ps1 -ConfigFile replacements.json</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -143,11 +139,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PreBuildEvent>
-      <!--
-      This powershell command is base64 encoded to solve the use of | in the command which breaks the command processing.
-      (Get-Content .\scripts\Convert-BpfToNative.ps1.template).Replace('___KERNEL_MODE_VCXPROJ___', (Get-Content .\tools\bpf2c\templates\kernel_mode_bpf2c.vcxproj).Replace("'", "''")).Replace('___USER_MODE_VCXPROJ___', (Get-Content .\tools\bpf2c\templates\user_mode_bpf2c.vcxproj).Replace("'", "''")) | Set-Content .\x64\release\Convert-BpfToNative.ps1
-      -->
-      <Command>pushd $(SolutionDir) &amp;&amp; powershell -EncodedCommand KABHAGUAdAAtAEMAbwBuAHQAZQBuAHQAIAAuAFwAcwBjAHIAaQBwAHQAcwBcAEMAbwBuAHYAZQByAHQALQBCAHAAZgBUAG8ATgBhAHQAaQB2AGUALgBwAHMAMQAuAHQAZQBtAHAAbABhAHQAZQApAC4AUgBlAHAAbABhAGMAZQAoACcAXwBfAF8ASwBFAFIATgBFAEwAXwBNAE8ARABFAF8AVgBDAFgAUABSAE8ASgBfAF8AXwAnACwAIAAoAEcAZQB0AC0AQwBvAG4AdABlAG4AdAAgAC4AXAB0AG8AbwBsAHMAXABiAHAAZgAyAGMAXAB0AGUAbQBwAGwAYQB0AGUAcwBcAGsAZQByAG4AZQBsAF8AbQBvAGQAZQBfAGIAcABmADIAYwAuAHYAYwB4AHAAcgBvAGoAKQAuAFIAZQBwAGwAYQBjAGUAKAAiACcAIgAsACAAIgAnACcAIgApACkALgBSAGUAcABsAGEAYwBlACgAJwBfAF8AXwBVAFMARQBSAF8ATQBPAEQARQBfAFYAQwBYAFAAUgBPAEoAXwBfAF8AJwAsACAAKABHAGUAdAAtAEMAbwBuAHQAZQBuAHQAIAAuAFwAdABvAG8AbABzAFwAYgBwAGYAMgBjAFwAdABlAG0AcABsAGEAdABlAHMAXAB1AHMAZQByAF8AbQBvAGQAZQBfAGIAcABmADIAYwAuAHYAYwB4AHAAcgBvAGoAKQAuAFIAZQBwAGwAYQBjAGUAKAAiACcAIgAsACAAIgAnACcAIgApACkAIAB8ACAAUwBlAHQALQBDAG8AbgB0AGUAbgB0ACAALgBcAHgANgA0AFwAcgBlAGwAZQBhAHMAZQBcAEMAbwBuAHYAZQByAHQALQBCAHAAZgBUAG8ATgBhAHQAaQB2AGUALgBwAHMAMQA= &amp;&amp; popd</Command>
+      <Command>powershell -NonInteractive -ExecutionPolicy Unrestricted $(SolutionDir)scripts\Process-File.ps1 -InputFile Convert-BpfToNative.ps1.template -OutputFile $(OutDir)Convert-BpfToNative.ps1 -ConfigFile replacements.json</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/tools/bpf2c/bpf2c_dll.c
+++ b/tools/bpf2c/bpf2c_dll.c
@@ -37,8 +37,4 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }

--- a/tools/bpf2c/replacements.json
+++ b/tools/bpf2c/replacements.json
@@ -1,0 +1,23 @@
+{
+    "Copyright Notice" : [
+        "Copyright (c) Microsoft Corporation",
+        "SPDX-License-Identifier: MIT"
+    ],
+    "Description" : "This file controls the replacement of symbols with escaped strings",
+    "Files": [
+        {
+            "Symbol": "___KERNEL_MODE_VCXPROJ___",
+            "FileName": "templates\\kernel_mode_bpf2c.vcxproj"
+        },
+        {
+            "Symbol": "___USER_MODE_VCXPROJ___",
+            "FileName": "templates\\user_mode_bpf2c.vcxproj"
+        }
+    ],
+    "EscapeCharacters": [
+        {
+            "Char": "'",
+            "Escape": "''"
+        }
+    ]
+}

--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -72,10 +72,10 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <PreBuildEvent>
-      <Command>$(OutDir)bpf2c --bpf $(OutDir)$(ProgramName).o --sys $(AdditionalOptions) &gt;$(OutDir)$(ProgramName)_driver.c</Command>
+      <Command>$(BinDir)bpf2c --bpf $(ProgramName).o --sys $(AdditionalOptions) &gt;$(ProgramName)_driver.c</Command>
     </PreBuildEvent>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(IncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -89,7 +89,7 @@
     <FilesToPackage Include="$(TargetPath)" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="$(OutDir)$(ProgramName)_driver.c" />
+    <ClCompile Include="$(ProgramName)_driver.c" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/tools/bpf2c/templates/sources.def
+++ b/tools/bpf2c/templates/sources.def
@@ -1,8 +1,0 @@
-;
-;  Copyright (c) Microsoft Corporation
-;  SPDX-License-Identifier: MIT
-;
-
-LIBRARY
-EXPORTS
-	get_metadata_table

--- a/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
@@ -23,7 +23,7 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="$(OutDir)$(ProgramName)_dll.c" />
+    <ClCompile Include="$(ProgramName)_dll.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>
@@ -59,17 +59,16 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(IncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <ModuleDefinitionFile>$(SolutionDir)tools\bpf2c\templates\sources.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(OutDir)bpf2c.exe --bpf $(OutDir)$(ProgramName).o --dll $(AdditionalOptions) &gt;$(OutDir)$(ProgramName)_dll.c</Command>
+      <Command>$(BinDir)bpf2c.exe --bpf $(ProgramName).o --dll $(AdditionalOptions) &gt;$(ProgramName)_dll.c</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -78,7 +77,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(IncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -87,10 +86,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <ModuleDefinitionFile>$(SolutionDir)tools\bpf2c\templates\sources.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(OutDir)bpf2c.exe --bpf $(OutDir)$(ProgramName).o --dll $(AdditionalOptions) &gt;$(OutDir)$(ProgramName)_dll.c</Command>
+      <Command>$(BinDir)bpf2c.exe --bpf $(ProgramName).o --dll $(AdditionalOptions) &gt;$(ProgramName)_dll.c</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -99,17 +97,16 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(IncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <ModuleDefinitionFile>$(SolutionDir)tools\bpf2c\templates\sources.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(OutDir)bpf2c.exe --bpf $(OutDir)$(ProgramName).o --dll $(AdditionalOptions) &gt;$(OutDir)$(ProgramName)_dll.c</Command>
+      <Command>$(BinDir)bpf2c.exe --bpf $(ProgramName).o --dll $(AdditionalOptions) &gt;$(ProgramName)_dll.c</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -118,7 +115,7 @@
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(IncludeDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <DisableSpecificWarnings>4189;4245;%(DisableSpecificWarnings)</DisableSpecificWarnings>
     </ClCompile>
     <Link>
@@ -127,10 +124,9 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <EnableUAC>false</EnableUAC>
-      <ModuleDefinitionFile>$(SolutionDir)tools\bpf2c\templates\sources.def</ModuleDefinitionFile>
     </Link>
     <PreBuildEvent>
-      <Command>$(OutDir)bpf2c.exe --bpf $(OutDir)$(ProgramName).o --dll $(AdditionalOptions) &gt;$(OutDir)$(ProgramName)_dll.c</Command>
+      <Command>$(BinDir)bpf2c.exe --bpf $(ProgramName).o --dll $(AdditionalOptions) &gt;$(ProgramName)_dll.c</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/tools/nuget/ebpf-for-windows.nuspec
+++ b/tools/nuget/ebpf-for-windows.nuspec
@@ -6,7 +6,7 @@
   <metadata>
     <title>eBPF for Windows SDK</title>
     <id>eBPF-for-Windows</id>
-    <version>0.1.3</version>
+    <version>0.1.4</version>
     <authors>eBPF for Windows Contributors</authors>
     <owners>eBPF for Windows Contributors</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -18,8 +18,9 @@
   </metadata>
 
   <files>
-    <file src="..\..\scripts\Convert-BpfToNative.ps1"         target="build\native\bin"                    />
+    <file src="..\..\x64\Release\Convert-BpfToNative.ps1"     target="build\native\bin"                    />
     <file src="..\..\x64\Release\bpf2c.exe"                   target="build\native\bin"                    />
+    <file src="..\..\x64\Release\ebpfapi.dll"                 target="build\native\bin"                    />
     <file src="..\..\x64\Release\ebpfapi.lib"                 target="build\native\lib"                    />
     <file src="..\..\include\**\*.*"                          target="build\native\include"                />
     <file src="..\..\external\bpftool\libbpf\include\**\*.*"  target="build\native\include\libbpf\include" />

--- a/tools/nuget/ebpf-for-windows.props
+++ b/tools/nuget/ebpf-for-windows.props
@@ -14,6 +14,8 @@
   <PropertyGroup>
     <EbpfLibraries>@(EbpfLibs)</EbpfLibraries>
     <ClangIncludes>-I $(MSBuildThisFileDirectory)include -I $(MSBuildThisFileDirectory)include/uapi</ClangIncludes>
+    <EbpfBinPath>$(MSBuildThisFileDirectory)bin</EbpfBinPath>
+    <EbpfIncludePath>$(MSBuildThisFileDirectory)include</EbpfIncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

1) Make Convert-BpfToNative.ps1 fully self-contained (except for bpf2c.exe).
2) Update nuget package to include ebpfapi.dll (bpf2c.exe depends on it).

## Testing

CI/CD

## Documentation

No.
