### PR TITLE
Added support for host-process container installation

### DIFF
--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -40,7 +40,7 @@ Start an admin Powershell on the Windows Host and run `.\images\build-images.ps1
    
     b.  To build the image on a Linux machine (e.g. Ubuntu), make sure docker is installed. [install docker on Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
 
-    * Run the following powershell command on Windows Host to create zip files containing the binaries.
+    * Run the following Powershell command on the Windows Host to create zip files containing the binaries.
       ```
       Compress-Archive -Update -Path C:\temp -DestinationPath ebpf-for-windows-c-temp.zip
       ```

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -27,7 +27,7 @@ Copy the build output to the host of the test VM and run the following.
 
 ## Installing eBPF with host-process container 
 
-The following instructions will build ebpf-for-windows image and deploy a daemonset referencing the image. This is the easiest way
+The following instructions will build an ebpf-for-windows image and deploy a daemonset referencing the image. This is the easiest way
 to install eBPF on all Windows nodes in a Kubernetes cluster. 
 
 1. Deploy the binaries to `C:\Temp` on the machine (Windows Host) where you built the binaries.

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -31,7 +31,7 @@ The following instructions will build an ebpf-for-windows image and deploy a dae
 to install eBPF on all Windows nodes in a Kubernetes cluster. 
 
 1. Deploy the binaries to `C:\Temp` on the machine (Windows Host) where you built the binaries.
-   Start an admin Powershell on Windows Host and do `.\scripts\deploy-ebpf`.
+   Start an admin Powershell on the Windows Host and do `.\scripts\deploy-ebpf`.
    
 2. Build ebpf-for-windows image. 
      

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -45,7 +45,7 @@ Start an admin Powershell on the Windows Host and run `.\images\build-images.ps1
       Compress-Archive -Update -Path C:\temp -DestinationPath ebpf-for-windows-c-temp.zip
       ```
       
-   * Copy `images\*` and `ebpf-for-windows-c-temp.zip` from Windows Host to a directory on the Linux machine (e.g. `$HOME/ebpf-for-windows-image`).
+   * Copy `images\*` and `ebpf-for-windows-c-temp.zip` from the Windows Host to a directory on the Linux machine (e.g. `$HOME/ebpf-for-windows-image`).
    
    * Run `$HOME/ebpf-for-windows-image/build-images.sh` and provide parameters for `repositry`, `tag` and `OSVersion`.
    

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -36,7 +36,7 @@ to install eBPF on all Windows nodes in a Kubernetes cluster.
 2. Build ebpf-for-windows image. 
      
     a.  To build the image on Windows Host, make sure docker is installed. [install docker on Windows Server](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server/).
-Start an admin Powershell on Windows Host and run `.\images\build-images.ps1` and provide parameters for `repositry`, `tag` and `OSVersion`.
+Start an admin Powershell on the Windows Host and run `.\images\build-images.ps1` and provide parameters for `repository`, `tag` and `OSVersion`.
    
     b.  To build the image on a Linux machine (e.g. Ubuntu), make sure docker is installed. [install docker on Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
 

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -35,19 +35,19 @@ to install eBPF on all Windows nodes in a Kubernetes cluster.
    
 2. Build ebpf-for-windows image. 
      
-    a. To build the image on Windows Host, make sure docker is installed. [install docker on Windows Server] (https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server).
+    a.  To build the image on Windows Host, make sure docker is installed. [install docker on Windows Server](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server/).
 Start an admin Powershell on Windows Host and run `.\images\build-images.ps1` and provide parameters for `repositry`, `tag` and `OSVersion`.
    
-    b.To build the image on a Linux machine (e.g. Ubuntu), make sure docker is installed. [install docker on Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
+    b.  To build the image on a Linux machine (e.g. Ubuntu), make sure docker is installed. [install docker on Ubuntu](https://docs.docker.com/engine/install/ubuntu/).
 
-        i. Run following powershell command on Windows Host to create zip files containing the binaries.
-```
-Compress-Archive -Update -Path C:\temp -DestinationPath ebpf-for-windows-c-temp.zip
-```
-
-        ii.Copy `images\build-images.sh`, `images\Dockerfile.install` and `ebpf-for-windows-c-temp.zip` from Windows Host to a directory on the Linux machine, e.g. `$HOME/ebpf-for-windows-image`.
-
-        iii.Run `$HOME/ebpf-for-windows-image/build-images.sh` and provide parameters for `repositry`, `tag` and `OSVersion`.
+    * Run the following powershell command on Windows Host to create zip files containing the binaries.
+      ```
+      Compress-Archive -Update -Path C:\temp -DestinationPath ebpf-for-windows-c-temp.zip
+      ```
+      
+   * Copy `images\build-images.sh`, `images\Dockerfile.install` and `ebpf-for-windows-c-temp.zip` from Windows Host to a directory on the Linux machine (e.g. `$HOME/ebpf-for-windows-image`).
+   
+   * Run `$HOME/ebpf-for-windows-image/build-images.sh` and provide parameters for `repositry`, `tag` and `OSVersion`.
    
 3. Push ebpf-for-windows image to your repositry.
 

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -49,7 +49,7 @@ Start an admin Powershell on the Windows Host and run `.\images\build-images.ps1
    
    * Run `$HOME/ebpf-for-windows-image/build-images.sh` and provide parameters for `repositry`, `tag` and `OSVersion`.
    
-3. Push ebpf-for-windows image to your repositry.
+3. Push the ebpf-for-windows image to your repository.
 
 4. Update `manifests/Kubernetes/ebpf-for-windows-daemonset.yaml` with the container image pointing to your image path. Run the following command:
 ```

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -45,7 +45,7 @@ Start an admin Powershell on Windows Host and run `.\images\build-images.ps1` an
       Compress-Archive -Update -Path C:\temp -DestinationPath ebpf-for-windows-c-temp.zip
       ```
       
-   * Copy `images\build-images.sh`, `images\Dockerfile.install` and `ebpf-for-windows-c-temp.zip` from Windows Host to a directory on the Linux machine (e.g. `$HOME/ebpf-for-windows-image`).
+   * Copy `images\*` and `ebpf-for-windows-c-temp.zip` from Windows Host to a directory on the Linux machine (e.g. `$HOME/ebpf-for-windows-image`).
    
    * Run `$HOME/ebpf-for-windows-image/build-images.sh` and provide parameters for `repositry`, `tag` and `OSVersion`.
    

--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -35,7 +35,7 @@ to install eBPF on all Windows nodes in a Kubernetes cluster.
    
 2. Build ebpf-for-windows image. 
      
-    a.  To build the image on Windows Host, make sure docker is installed. [install docker on Windows Server](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server/).
+    a.  To build the image on the Windows Host, make sure docker is installed. [install docker on Windows Server](https://docs.microsoft.com/en-us/virtualization/windowscontainers/quick-start/set-up-environment?tabs=Windows-Server/).
 Start an admin Powershell on the Windows Host and run `.\images\build-images.ps1` and provide parameters for `repository`, `tag` and `OSVersion`.
    
     b.  To build the image on a Linux machine (e.g. Ubuntu), make sure docker is installed. [install docker on Ubuntu](https://docs.docker.com/engine/install/ubuntu/).

--- a/images/Dockerfile.install
+++ b/images/Dockerfile.install
@@ -1,15 +1,16 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 
-ARG RELEASE_ZIP="ebpf-for-windows-c-temp.zip"
-ARG WINDOWS_VERSION="1809"
+ARG WINDOWS_VERSION=1809
 
 # The files in this image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host.
 FROM mcr.microsoft.com/windows/nanoserver:${WINDOWS_VERSION}
 
 ENV PATH="C:\Program Files\PowerShell;C:\utils;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0;"
 
-COPY  ${RELEASE_ZIP} /ebpf-for-windows-c-temp.zip
-COPY  install-ebpf-for-windows.ps1 /
+ARG RELEASE_ZIP=ebpf-for-windows-c-temp.zip
+
+COPY ${RELEASE_ZIP} /ebpf-for-windows-c-temp.zip
+COPY install-ebpf-for-windows.ps1 /
 
 ENTRYPOINT ["powershell"]

--- a/images/Dockerfile.install
+++ b/images/Dockerfile.install
@@ -1,0 +1,15 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+ARG RELEASE_ZIP="ebpf-for-windows-c-temp.zip"
+ARG WINDOWS_VERSION="1809"
+
+# The files in this image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host.
+FROM mcr.microsoft.com/windows/nanoserver:${WINDOWS_VERSION}
+
+ENV PATH="C:\Program Files\PowerShell;C:\utils;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0;"
+
+COPY  ${RELEASE_ZIP} /ebpf-for-windows-c-temp.zip
+COPY  install-ebpf-for-windows.ps1 /
+
+ENTRYPOINT ["powershell"]

--- a/images/build-images.ps1
+++ b/images/build-images.ps1
@@ -1,0 +1,19 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+param ([parameter(Mandatory=$false)][string] $TEMPDir = "c:\temp",
+    [parameter(Mandatory=$true)][string] $Repositry = "",
+    [parameter(Mandatory=$true)][string] $Tag = "",
+    [parameter(Mandatory=$true)][string] $OSVersion = "1809")
+
+$svc = Get-Service | where Name -EQ 'docker'
+if ($svc -EQ $null) {
+    throw "Docker service is not installed."
+}
+if ($svc.Status -NE 'Running') {
+    throw "Docker service is not running."
+}
+
+Compress-Archive -Update -Path $TEMPDir -DestinationPath ebpf-for-windows-c-temp.zip
+
+docker build -t $Repositry/ebpfwin-install:$Tag  -f .\Dockerfile.install --build-arg WINDOWS_VERSION=$OSVersion .

--- a/images/build-images.ps1
+++ b/images/build-images.ps1
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 param ([parameter(Mandatory=$false)][string] $TEMPDir = "c:\temp",
-    [parameter(Mandatory=$true)][string] $Repositry = "",
+    [parameter(Mandatory=$true)][string] $Repository = "",
     [parameter(Mandatory=$true)][string] $Tag = "",
     [parameter(Mandatory=$true)][string] $OSVersion = "1809")
 

--- a/images/build-images.ps1
+++ b/images/build-images.ps1
@@ -16,4 +16,4 @@ if ($svc.Status -NE 'Running') {
 
 Compress-Archive -Update -Path $TEMPDir -DestinationPath ebpf-for-windows-c-temp.zip
 
-docker build -t $Repositry/ebpfwin-install:$Tag  -f .\Dockerfile.install --build-arg WINDOWS_VERSION=$OSVersion .
+docker build -t $Repository/ebpfwin-install:$Tag  -f .\Dockerfile.install --build-arg WINDOWS_VERSION=$OSVersion .

--- a/images/build-images.sh
+++ b/images/build-images.sh
@@ -5,5 +5,6 @@
 
 repository=${repository:-"your repository"}
 tag=${tag:-"your tag"}
+OSVersion=${OSVersion:-"1809"}
 
-docker buildx build --platform windows/amd64 --output=type=registry --pull -f Dockerfile.install -t $repository/ebpfwin-install:$tag .
+docker buildx build --platform windows/amd64 --output=type=registry --pull -f Dockerfile.install -t $repository/ebpfwin-install:$tag --build-arg WINDOWS_VERSION=$OSVersion .

--- a/images/build-images.sh
+++ b/images/build-images.sh
@@ -1,0 +1,9 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# Copy release archive to local directory as ebpf-for-windows-c-temp.zip before running this script.
+
+repository=${repository:-"your repository"}
+tag=${tag:-"your tag"}
+
+docker buildx build --platform windows/amd64 --output=type=registry --pull -f Dockerfile.install -t $repository/ebpfwin-install:$tag .

--- a/images/install-ebpf-for-windows.ps1
+++ b/images/install-ebpf-for-windows.ps1
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# Make sure the script is running in a HostProcess container.
+if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
+    $ns = $env:CONTAINER_SANDBOX_MOUNT_POINT
+    write-host ("Install script is running in a HostProcess container. This sandbox mount point is {0}" -f $ns)
+} else {
+    throw "Install script is NOT running in a HostProcess container."
+}
+
+# Unzip release archive to c:\temp.
+$EbpfWindowsZip = "ebpf-for-windows-c-temp.zip"
+if (!(Test-Path $EbpfWindowsZip))
+{
+    throw "$EbpfWindowsZip not found..."
+}
+Write-Host "Unzip ebpf-for-windows release..."
+Expand-Archive -Force $EbpfWindowsZip c:\
+
+# Run install-ebpf.bat
+cd c:\temp
+Write-Host "Install ebpf-for-windows ..."
+.\install-ebpf.bat
+
+# Make sure netsh ebpf works.
+Write-Host "ebpf-for-windows installation completed. Show program..."
+netsh ebpf show program
+
+# Sleep until the container is required to exit explicitly. This is for dev only.
+# TODO: If this container is running as an init container of a daemonset, 
+# this section is not required.
+$filePath = 'C:\exit-ebpfwin-install-container.txt'
+while (-not (Test-Path -Path $filePath)) {
+    Start-Sleep -Seconds 30
+}
+
+write-host "All done."
+exit 0

--- a/manifests/Kubernetes/ebpf-for-windows-daemonset.yaml
+++ b/manifests/Kubernetes/ebpf-for-windows-daemonset.yaml
@@ -1,0 +1,31 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ebpf-for-windows
+  namespace: kube-system
+  labels:
+    k8s-app: ebpf-for-windows
+spec:
+  selector:
+    matchLabels:
+      k8s-app: ebpf-for-windows
+  template:
+    metadata:
+      labels:
+        k8s-app: ebpf-for-windows
+    spec:
+      tolerations:
+      - operator: Exists
+      securityContext:
+        windowsOptions:
+          hostProcess: true
+          runAsUserName: "NT AUTHORITY\\system"
+      hostNetwork: true
+      containers:
+      - name: ebpf-for-windows
+        image: docker.io/songtjiang/ebpfwin-install:01
+        imagePullPolicy: Always
+        args:
+        - ".\\install-ebpf-for-windows.ps1"
+      nodeSelector:
+        kubernetes.io/os: windows

--- a/manifests/Kubernetes/ebpf-for-windows-daemonset.yaml
+++ b/manifests/Kubernetes/ebpf-for-windows-daemonset.yaml
@@ -23,7 +23,7 @@ spec:
       hostNetwork: true
       containers:
       - name: ebpf-for-windows
-        image: docker.io/songtjiang/ebpfwin-install:01
+        image: <your ebpf-for-windows image path>
         imagePullPolicy: Always
         args:
         - ".\\install-ebpf-for-windows.ps1"


### PR DESCRIPTION
## Description

This PR is the first step for https://github.com/microsoft/ebpf-for-windows/issues/996 which adds scripts/dockerfile to build host-process container image. It also added manifests which can be deployed in a Kubernetes cluster. 

Note:
- The scripts need to be updated once the release process is finalised. 
- Which repository should the image been pushed?

## Testing

_Do any existing tests cover this change? Are new tests needed?_

- Need CI pipeline for building the images and deploy them. 
- Need CD pipeline to push the verified images to the repository.  

## Documentation

_Is there any documentation impact for this change?_
Yes. We would need update the doc on how to install ebpf-for-windows with host-process container.
