### PR TITLE
Emit line directive for first line of BPF program

### DIFF
--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -108,6 +108,7 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
+#line 78 "sample/bindmonitor.c"
 {
 #line 78 "sample/bindmonitor.c"
     // Prologue
@@ -168,7 +169,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 82 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 82 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -176,7 +177,7 @@ BindMonitor(void* context)
     if (r7 == IMMEDIATE(0))
 #line 83 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -184,7 +185,7 @@ BindMonitor(void* context)
     if (r1 == IMMEDIATE(0))
 #line 83 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 42 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -238,12 +239,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 47 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 48 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 48 "sample/bindmonitor.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 48 "sample/bindmonitor.c"
     goto label_3;
 label_1:
@@ -255,7 +256,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 51 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 54 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -263,7 +264,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 54 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 54 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -271,7 +272,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 54 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 54 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -304,7 +305,7 @@ label_1:
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
 #line 57 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 58 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -319,12 +320,12 @@ label_1:
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 58 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 59 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 59 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/bindmonitor.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -345,7 +346,7 @@ label_2:
     if (r2 >= r3)
 #line 63 "sample/bindmonitor.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 66 "sample/bindmonitor.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -374,12 +375,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 92 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(2))
 #line 92 "sample/bindmonitor.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 108 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -400,7 +401,7 @@ label_4:
     if (r1 >= r2)
 #line 94 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 98 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -418,7 +419,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/bindmonitor.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 102 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -66,6 +66,7 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
+#line 78 "sample/bindmonitor.c"
 {
 #line 78 "sample/bindmonitor.c"
     // Prologue
@@ -126,7 +127,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 82 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 82 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -134,7 +135,7 @@ BindMonitor(void* context)
     if (r7 == IMMEDIATE(0))
 #line 83 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -142,7 +143,7 @@ BindMonitor(void* context)
     if (r1 == IMMEDIATE(0))
 #line 83 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 42 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -196,12 +197,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 47 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 48 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 48 "sample/bindmonitor.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 48 "sample/bindmonitor.c"
     goto label_3;
 label_1:
@@ -213,7 +214,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 51 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 54 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -221,7 +222,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 54 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 54 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -229,7 +230,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 54 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 54 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -262,7 +263,7 @@ label_1:
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
 #line 57 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 58 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -277,12 +278,12 @@ label_1:
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 58 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 59 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 59 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/bindmonitor.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -303,7 +304,7 @@ label_2:
     if (r2 >= r3)
 #line 63 "sample/bindmonitor.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 66 "sample/bindmonitor.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -332,12 +333,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 92 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(2))
 #line 92 "sample/bindmonitor.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 108 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -358,7 +359,7 @@ label_4:
     if (r1 >= r2)
 #line 94 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 98 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -376,7 +377,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/bindmonitor.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 102 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -93,6 +93,7 @@ static uint16_t bind_monitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 bind_monitor(void* context)
+#line 23 "sample/bindmonitor_ringbuf.c"
 {
 #line 23 "sample/bindmonitor_ringbuf.c"
     // Prologue
@@ -126,7 +127,7 @@ bind_monitor(void* context)
     if (r2 != IMMEDIATE(0))
 #line 23 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 25 "sample/bindmonitor_ringbuf.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LDXDW pc=3 dst=r3 src=r1 offset=8 imm=0
@@ -137,7 +138,7 @@ bind_monitor(void* context)
     if (r2 >= r3)
 #line 25 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-    // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
 #line 26 "sample/bindmonitor_ringbuf.c"
     r3 -= r2;
     // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -51,6 +51,7 @@ static uint16_t bind_monitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 bind_monitor(void* context)
+#line 23 "sample/bindmonitor_ringbuf.c"
 {
 #line 23 "sample/bindmonitor_ringbuf.c"
     // Prologue
@@ -84,7 +85,7 @@ bind_monitor(void* context)
     if (r2 != IMMEDIATE(0))
 #line 23 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 25 "sample/bindmonitor_ringbuf.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LDXDW pc=3 dst=r3 src=r1 offset=8 imm=0
@@ -95,7 +96,7 @@ bind_monitor(void* context)
     if (r2 >= r3)
 #line 25 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-    // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
 #line 26 "sample/bindmonitor_ringbuf.c"
     r3 -= r2;
     // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -218,6 +218,7 @@ static uint16_t bind_monitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 bind_monitor(void* context)
+#line 23 "sample/bindmonitor_ringbuf.c"
 {
 #line 23 "sample/bindmonitor_ringbuf.c"
     // Prologue
@@ -251,7 +252,7 @@ bind_monitor(void* context)
     if (r2 != IMMEDIATE(0))
 #line 23 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=2 dst=r2 src=r1 offset=0 imm=0
 #line 25 "sample/bindmonitor_ringbuf.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LDXDW pc=3 dst=r3 src=r1 offset=8 imm=0
@@ -262,7 +263,7 @@ bind_monitor(void* context)
     if (r2 >= r3)
 #line 25 "sample/bindmonitor_ringbuf.c"
         goto label_1;
-    // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_SUB64_REG pc=5 dst=r3 src=r2 offset=0 imm=0
 #line 26 "sample/bindmonitor_ringbuf.c"
     r3 -= r2;
     // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -233,6 +233,7 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
+#line 78 "sample/bindmonitor.c"
 {
 #line 78 "sample/bindmonitor.c"
     // Prologue
@@ -293,7 +294,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 82 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 82 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -301,7 +302,7 @@ BindMonitor(void* context)
     if (r7 == IMMEDIATE(0))
 #line 83 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -309,7 +310,7 @@ BindMonitor(void* context)
     if (r1 == IMMEDIATE(0))
 #line 83 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 42 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -363,12 +364,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 47 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 48 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 48 "sample/bindmonitor.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 48 "sample/bindmonitor.c"
     goto label_3;
 label_1:
@@ -380,7 +381,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 51 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 54 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -388,7 +389,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 54 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 54 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -396,7 +397,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 54 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 54 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -429,7 +430,7 @@ label_1:
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
 #line 57 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 58 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -444,12 +445,12 @@ label_1:
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 58 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 59 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 59 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/bindmonitor.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -470,7 +471,7 @@ label_2:
     if (r2 >= r3)
 #line 63 "sample/bindmonitor.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 66 "sample/bindmonitor.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -499,12 +500,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 92 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(2))
 #line 92 "sample/bindmonitor.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 108 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -525,7 +526,7 @@ label_4:
     if (r1 >= r2)
 #line 94 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 98 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -543,7 +544,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/bindmonitor.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 102 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -167,6 +167,7 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
+#line 114 "sample/bindmonitor_tailcall.c"
 {
 #line 114 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -221,12 +222,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 117 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 119 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 119 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 122 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -273,6 +274,7 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
+#line 130 "sample/bindmonitor_tailcall.c"
 {
 #line 130 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -327,12 +329,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 133 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 135 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 135 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 138 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -380,6 +382,7 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
+#line 146 "sample/bindmonitor_tailcall.c"
 {
 #line 146 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -440,7 +443,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 150 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -448,7 +451,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 151 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -456,7 +459,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -510,12 +513,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     goto label_3;
 label_1:
@@ -527,7 +530,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -535,7 +538,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -543,7 +546,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -576,7 +579,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 93 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -591,12 +594,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 94 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -617,7 +620,7 @@ label_2:
     if (r2 >= r3)
 #line 99 "sample/bindmonitor_tailcall.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 102 "sample/bindmonitor_tailcall.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -646,12 +649,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 160 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(2))
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -672,7 +675,7 @@ label_4:
     if (r1 >= r2)
 #line 162 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 166 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -690,7 +693,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 170 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -125,6 +125,7 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
+#line 114 "sample/bindmonitor_tailcall.c"
 {
 #line 114 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -179,12 +180,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 117 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 119 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 119 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 122 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -231,6 +232,7 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
+#line 130 "sample/bindmonitor_tailcall.c"
 {
 #line 130 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -285,12 +287,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 133 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 135 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 135 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 138 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -338,6 +340,7 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
+#line 146 "sample/bindmonitor_tailcall.c"
 {
 #line 146 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -398,7 +401,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 150 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -406,7 +409,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 151 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -414,7 +417,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -468,12 +471,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     goto label_3;
 label_1:
@@ -485,7 +488,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -493,7 +496,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -501,7 +504,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -534,7 +537,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 93 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -549,12 +552,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 94 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -575,7 +578,7 @@ label_2:
     if (r2 >= r3)
 #line 99 "sample/bindmonitor_tailcall.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 102 "sample/bindmonitor_tailcall.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -604,12 +607,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 160 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(2))
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -630,7 +633,7 @@ label_4:
     if (r1 >= r2)
 #line 162 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 166 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -648,7 +651,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 170 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -292,6 +292,7 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
+#line 114 "sample/bindmonitor_tailcall.c"
 {
 #line 114 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -346,12 +347,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 117 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 119 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 119 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 122 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -398,6 +399,7 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
+#line 130 "sample/bindmonitor_tailcall.c"
 {
 #line 130 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -452,12 +454,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 133 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 135 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 135 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 138 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -505,6 +507,7 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
+#line 146 "sample/bindmonitor_tailcall.c"
 {
 #line 146 "sample/bindmonitor_tailcall.c"
     // Prologue
@@ -565,7 +568,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 150 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -573,7 +576,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 151 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -581,7 +584,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -635,12 +638,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     goto label_3;
 label_1:
@@ -652,7 +655,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -660,7 +663,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -668,7 +671,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -701,7 +704,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 93 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -716,12 +719,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 94 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -742,7 +745,7 @@ label_2:
     if (r2 >= r3)
 #line 99 "sample/bindmonitor_tailcall.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 102 "sample/bindmonitor_tailcall.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -771,12 +774,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 160 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(2))
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -797,7 +800,7 @@ label_4:
     if (r1 >= r2)
 #line 162 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 166 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -815,7 +818,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 170 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -91,6 +91,7 @@ static uint16_t func_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 func(void* context)
+#line 18 "sample/bpf_call.c"
 {
 #line 18 "sample/bpf_call.c"
     // Prologue
@@ -155,7 +156,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/bpf_call.c"
         return 0;
-    // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
 #line 23 "sample/bpf_call.c"
     return r0;
 #line 23 "sample/bpf_call.c"

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -49,6 +49,7 @@ static uint16_t func_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 func(void* context)
+#line 18 "sample/bpf_call.c"
 {
 #line 18 "sample/bpf_call.c"
     // Prologue
@@ -113,7 +114,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/bpf_call.c"
         return 0;
-    // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
 #line 23 "sample/bpf_call.c"
     return r0;
 #line 23 "sample/bpf_call.c"

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -216,6 +216,7 @@ static uint16_t func_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 func(void* context)
+#line 18 "sample/bpf_call.c"
 {
 #line 18 "sample/bpf_call.c"
     // Prologue
@@ -280,7 +281,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/bpf_call.c"
         return 0;
-    // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_EXIT pc=12 dst=r0 src=r0 offset=0 imm=0
 #line 23 "sample/bpf_call.c"
     return r0;
 #line 23 "sample/bpf_call.c"

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -66,6 +66,7 @@ static GUID func_attach_type_guid = {0x00000000, 0x0000, 0x0000, {0x00, 0x00, 0x
 #pragma code_seg(push, ".text")
 static uint64_t
 func(void* context)
+#line 17 "sample/bpf.c"
 {
 #line 17 "sample/bpf.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_raw.c
@@ -24,6 +24,7 @@ static GUID func_attach_type_guid = {0x00000000, 0x0000, 0x0000, {0x00, 0x00, 0x
 #pragma code_seg(push, ".text")
 static uint64_t
 func(void* context)
+#line 17 "sample/bpf.c"
 {
 #line 17 "sample/bpf.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -191,6 +191,7 @@ static GUID func_attach_type_guid = {0x00000000, 0x0000, 0x0000, {0x00, 0x00, 0x
 #pragma code_seg(push, ".text")
 static uint64_t
 func(void* context)
+#line 17 "sample/bpf.c"
 {
 #line 17 "sample/bpf.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -105,6 +105,7 @@ static uint16_t authorize_connect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 authorize_connect4(void* context)
+#line 66 "sample/cgroup_sock_addr.c"
 {
 #line 66 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -208,7 +209,7 @@ authorize_connect4(void* context)
     if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
@@ -219,7 +220,7 @@ authorize_connect4(void* context)
     if (r1 == IMMEDIATE(0))
 #line 45 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -246,6 +247,7 @@ static uint16_t authorize_connect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 authorize_connect6(void* context)
+#line 73 "sample/cgroup_sock_addr.c"
 {
 #line 73 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -373,7 +375,7 @@ authorize_connect6(void* context)
     if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0))
 #line 59 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=1
@@ -384,7 +386,7 @@ authorize_connect6(void* context)
     if (r1 == IMMEDIATE(0))
 #line 61 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -411,6 +413,7 @@ static uint16_t authorize_recv_accept4_maps[] = {
 #pragma code_seg(push, "cgroup~3")
 static uint64_t
 authorize_recv_accept4(void* context)
+#line 80 "sample/cgroup_sock_addr.c"
 {
 #line 80 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -514,7 +517,7 @@ authorize_recv_accept4(void* context)
     if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
@@ -525,7 +528,7 @@ authorize_recv_accept4(void* context)
     if (r1 == IMMEDIATE(0))
 #line 45 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -552,6 +555,7 @@ static uint16_t authorize_recv_accept6_maps[] = {
 #pragma code_seg(push, "cgroup~4")
 static uint64_t
 authorize_recv_accept6(void* context)
+#line 87 "sample/cgroup_sock_addr.c"
 {
 #line 87 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -679,7 +683,7 @@ authorize_recv_accept6(void* context)
     if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0))
 #line 59 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=1
@@ -690,7 +694,7 @@ authorize_recv_accept6(void* context)
     if (r1 == IMMEDIATE(0))
 #line 61 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -63,6 +63,7 @@ static uint16_t authorize_connect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 authorize_connect4(void* context)
+#line 66 "sample/cgroup_sock_addr.c"
 {
 #line 66 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -166,7 +167,7 @@ authorize_connect4(void* context)
     if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
@@ -177,7 +178,7 @@ authorize_connect4(void* context)
     if (r1 == IMMEDIATE(0))
 #line 45 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -204,6 +205,7 @@ static uint16_t authorize_connect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 authorize_connect6(void* context)
+#line 73 "sample/cgroup_sock_addr.c"
 {
 #line 73 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -331,7 +333,7 @@ authorize_connect6(void* context)
     if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0))
 #line 59 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=1
@@ -342,7 +344,7 @@ authorize_connect6(void* context)
     if (r1 == IMMEDIATE(0))
 #line 61 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -369,6 +371,7 @@ static uint16_t authorize_recv_accept4_maps[] = {
 #pragma code_seg(push, "cgroup~3")
 static uint64_t
 authorize_recv_accept4(void* context)
+#line 80 "sample/cgroup_sock_addr.c"
 {
 #line 80 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -472,7 +475,7 @@ authorize_recv_accept4(void* context)
     if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
@@ -483,7 +486,7 @@ authorize_recv_accept4(void* context)
     if (r1 == IMMEDIATE(0))
 #line 45 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -510,6 +513,7 @@ static uint16_t authorize_recv_accept6_maps[] = {
 #pragma code_seg(push, "cgroup~4")
 static uint64_t
 authorize_recv_accept6(void* context)
+#line 87 "sample/cgroup_sock_addr.c"
 {
 #line 87 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -637,7 +641,7 @@ authorize_recv_accept6(void* context)
     if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0))
 #line 59 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=1
@@ -648,7 +652,7 @@ authorize_recv_accept6(void* context)
     if (r1 == IMMEDIATE(0))
 #line 61 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -230,6 +230,7 @@ static uint16_t authorize_connect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 authorize_connect4(void* context)
+#line 66 "sample/cgroup_sock_addr.c"
 {
 #line 66 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -333,7 +334,7 @@ authorize_connect4(void* context)
     if ((authorize_connect4_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
@@ -344,7 +345,7 @@ authorize_connect4(void* context)
     if (r1 == IMMEDIATE(0))
 #line 45 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -371,6 +372,7 @@ static uint16_t authorize_connect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 authorize_connect6(void* context)
+#line 73 "sample/cgroup_sock_addr.c"
 {
 #line 73 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -498,7 +500,7 @@ authorize_connect6(void* context)
     if ((authorize_connect6_helpers[0].tail_call) && (r0 == 0))
 #line 59 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=1
@@ -509,7 +511,7 @@ authorize_connect6(void* context)
     if (r1 == IMMEDIATE(0))
 #line 61 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -536,6 +538,7 @@ static uint16_t authorize_recv_accept4_maps[] = {
 #pragma code_seg(push, "cgroup~3")
 static uint64_t
 authorize_recv_accept4(void* context)
+#line 80 "sample/cgroup_sock_addr.c"
 {
 #line 80 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -639,7 +642,7 @@ authorize_recv_accept4(void* context)
     if ((authorize_recv_accept4_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
@@ -650,7 +653,7 @@ authorize_recv_accept4(void* context)
     if (r1 == IMMEDIATE(0))
 #line 45 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r0 src=r1 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:
@@ -677,6 +680,7 @@ static uint16_t authorize_recv_accept6_maps[] = {
 #pragma code_seg(push, "cgroup~4")
 static uint64_t
 authorize_recv_accept6(void* context)
+#line 87 "sample/cgroup_sock_addr.c"
 {
 #line 87 "sample/cgroup_sock_addr.c"
     // Prologue
@@ -804,7 +808,7 @@ authorize_recv_accept6(void* context)
     if ((authorize_recv_accept6_helpers[0].tail_call) && (r0 == 0))
 #line 59 "sample/cgroup_sock_addr.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=33 dst=r1 src=r0 offset=0 imm=0
 #line 59 "sample/cgroup_sock_addr.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=34 dst=r0 src=r0 offset=0 imm=1
@@ -815,7 +819,7 @@ authorize_recv_accept6(void* context)
     if (r1 == IMMEDIATE(0))
 #line 61 "sample/cgroup_sock_addr.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXW pc=36 dst=r0 src=r1 offset=0 imm=0
 #line 61 "sample/cgroup_sock_addr.c"
     r0 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
 label_1:

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -72,6 +72,7 @@ static GUID decapsulate_permit_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/de~1")
 static uint64_t
 decapsulate_permit_packet(void* context)
+#line 83 "sample/decap_permit_packet.c"
 {
 #line 83 "sample/decap_permit_packet.c"
     // Prologue
@@ -117,7 +118,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 89 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
@@ -125,12 +126,12 @@ decapsulate_permit_packet(void* context)
     if (r5 == IMMEDIATE(56710))
 #line 93 "sample/decap_permit_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 93 "sample/decap_permit_packet.c"
     if (r5 != IMMEDIATE(8))
 #line 93 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -141,7 +142,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
@@ -149,7 +150,7 @@ decapsulate_permit_packet(void* context)
     if (r5 != IMMEDIATE(4))
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
@@ -169,7 +170,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -183,7 +184,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -194,7 +195,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -290,7 +291,7 @@ decapsulate_permit_packet(void* context)
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 39 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
@@ -310,7 +311,7 @@ decapsulate_permit_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 39 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 39 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -325,7 +326,7 @@ label_1:
     if (r4 > r3)
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -336,7 +337,7 @@ label_1:
     if (r4 > r3)
 #line 111 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 111 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
@@ -344,7 +345,7 @@ label_1:
     if (r3 != IMMEDIATE(41))
 #line 111 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -440,7 +441,7 @@ label_1:
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 66 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
@@ -30,6 +30,7 @@ static GUID decapsulate_permit_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/de~1")
 static uint64_t
 decapsulate_permit_packet(void* context)
+#line 83 "sample/decap_permit_packet.c"
 {
 #line 83 "sample/decap_permit_packet.c"
     // Prologue
@@ -75,7 +76,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 89 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
@@ -83,12 +84,12 @@ decapsulate_permit_packet(void* context)
     if (r5 == IMMEDIATE(56710))
 #line 93 "sample/decap_permit_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 93 "sample/decap_permit_packet.c"
     if (r5 != IMMEDIATE(8))
 #line 93 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -99,7 +100,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
@@ -107,7 +108,7 @@ decapsulate_permit_packet(void* context)
     if (r5 != IMMEDIATE(4))
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
@@ -127,7 +128,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -141,7 +142,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -152,7 +153,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -248,7 +249,7 @@ decapsulate_permit_packet(void* context)
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 39 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
@@ -268,7 +269,7 @@ decapsulate_permit_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 39 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 39 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -283,7 +284,7 @@ label_1:
     if (r4 > r3)
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -294,7 +295,7 @@ label_1:
     if (r4 > r3)
 #line 111 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 111 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
@@ -302,7 +303,7 @@ label_1:
     if (r3 != IMMEDIATE(41))
 #line 111 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -398,7 +399,7 @@ label_1:
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 66 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
@@ -197,6 +197,7 @@ static GUID decapsulate_permit_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/de~1")
 static uint64_t
 decapsulate_permit_packet(void* context)
+#line 83 "sample/decap_permit_packet.c"
 {
 #line 83 "sample/decap_permit_packet.c"
     // Prologue
@@ -242,7 +243,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 89 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 93 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
@@ -250,12 +251,12 @@ decapsulate_permit_packet(void* context)
     if (r5 == IMMEDIATE(56710))
 #line 93 "sample/decap_permit_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 93 "sample/decap_permit_packet.c"
     if (r5 != IMMEDIATE(8))
 #line 93 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 94 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -266,7 +267,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
@@ -274,7 +275,7 @@ decapsulate_permit_packet(void* context)
     if (r5 != IMMEDIATE(4))
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 98 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
@@ -294,7 +295,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -308,7 +309,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -319,7 +320,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 36 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -415,7 +416,7 @@ decapsulate_permit_packet(void* context)
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 39 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 39 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
@@ -435,7 +436,7 @@ decapsulate_permit_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 39 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 39 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -450,7 +451,7 @@ label_1:
     if (r4 > r3)
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -461,7 +462,7 @@ label_1:
     if (r4 > r3)
 #line 111 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 111 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
@@ -469,7 +470,7 @@ label_1:
     if (r3 != IMMEDIATE(41))
 #line 111 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 63 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -565,7 +566,7 @@ label_1:
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 66 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 66 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -93,6 +93,7 @@ static uint16_t divide_by_zero_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 divide_by_zero(void* context)
+#line 27 "sample/divide_by_zero.c"
 {
 #line 27 "sample/divide_by_zero.c"
     // Prologue
@@ -144,12 +145,12 @@ divide_by_zero(void* context)
     if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0))
 #line 30 "sample/divide_by_zero.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
 #line 31 "sample/divide_by_zero.c"
     if (r0 == IMMEDIATE(0))
 #line 31 "sample/divide_by_zero.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 32 "sample/divide_by_zero.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_MOV64_IMM pc=9 dst=r6 src=r0 offset=0 imm=100000

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -51,6 +51,7 @@ static uint16_t divide_by_zero_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 divide_by_zero(void* context)
+#line 27 "sample/divide_by_zero.c"
 {
 #line 27 "sample/divide_by_zero.c"
     // Prologue
@@ -102,12 +103,12 @@ divide_by_zero(void* context)
     if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0))
 #line 30 "sample/divide_by_zero.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
 #line 31 "sample/divide_by_zero.c"
     if (r0 == IMMEDIATE(0))
 #line 31 "sample/divide_by_zero.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 32 "sample/divide_by_zero.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_MOV64_IMM pc=9 dst=r6 src=r0 offset=0 imm=100000

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -218,6 +218,7 @@ static uint16_t divide_by_zero_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 divide_by_zero(void* context)
+#line 27 "sample/divide_by_zero.c"
 {
 #line 27 "sample/divide_by_zero.c"
     // Prologue
@@ -269,12 +270,12 @@ divide_by_zero(void* context)
     if ((divide_by_zero_helpers[0].tail_call) && (r0 == 0))
 #line 30 "sample/divide_by_zero.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=3 imm=0
 #line 31 "sample/divide_by_zero.c"
     if (r0 == IMMEDIATE(0))
 #line 31 "sample/divide_by_zero.c"
         goto label_1;
-    // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 32 "sample/divide_by_zero.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_MOV64_IMM pc=9 dst=r6 src=r0 offset=0 imm=100000

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -106,6 +106,7 @@ static uint16_t DropPacket_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 DropPacket(void* context)
+#line 35 "sample/droppacket.c"
 {
 #line 35 "sample/droppacket.c"
     // Prologue
@@ -160,7 +161,7 @@ DropPacket(void* context)
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 48 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
@@ -168,7 +169,7 @@ DropPacket(void* context)
     if (r1 == IMMEDIATE(0))
 #line 49 "sample/droppacket.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 49 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -203,7 +204,7 @@ label_1:
     if (r3 > r2)
 #line 56 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 60 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
@@ -211,7 +212,7 @@ label_1:
     if (r3 != IMMEDIATE(8))
 #line 60 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 63 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
@@ -219,7 +220,7 @@ label_1:
     if (r3 != IMMEDIATE(17))
 #line 63 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 63 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -245,7 +246,7 @@ label_1:
     if (r3 > r2)
 #line 66 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 69 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -258,7 +259,7 @@ label_1:
     if (r1 > IMMEDIATE(8))
 #line 69 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 69 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -276,7 +277,7 @@ label_1:
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 70 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -287,7 +288,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 71 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 72 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -64,6 +64,7 @@ static uint16_t DropPacket_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 DropPacket(void* context)
+#line 35 "sample/droppacket.c"
 {
 #line 35 "sample/droppacket.c"
     // Prologue
@@ -118,7 +119,7 @@ DropPacket(void* context)
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 48 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
@@ -126,7 +127,7 @@ DropPacket(void* context)
     if (r1 == IMMEDIATE(0))
 #line 49 "sample/droppacket.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 49 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -161,7 +162,7 @@ label_1:
     if (r3 > r2)
 #line 56 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 60 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
@@ -169,7 +170,7 @@ label_1:
     if (r3 != IMMEDIATE(8))
 #line 60 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 63 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
@@ -177,7 +178,7 @@ label_1:
     if (r3 != IMMEDIATE(17))
 #line 63 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 63 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -203,7 +204,7 @@ label_1:
     if (r3 > r2)
 #line 66 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 69 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -216,7 +217,7 @@ label_1:
     if (r1 > IMMEDIATE(8))
 #line 69 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 69 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -234,7 +235,7 @@ label_1:
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 70 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -245,7 +246,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 71 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 72 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -231,6 +231,7 @@ static uint16_t DropPacket_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 DropPacket(void* context)
+#line 35 "sample/droppacket.c"
 {
 #line 35 "sample/droppacket.c"
     // Prologue
@@ -285,7 +286,7 @@ DropPacket(void* context)
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 48 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
@@ -293,7 +294,7 @@ DropPacket(void* context)
     if (r1 == IMMEDIATE(0))
 #line 49 "sample/droppacket.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 49 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -328,7 +329,7 @@ label_1:
     if (r3 > r2)
 #line 56 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 60 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
@@ -336,7 +337,7 @@ label_1:
     if (r3 != IMMEDIATE(8))
 #line 60 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 63 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
@@ -344,7 +345,7 @@ label_1:
     if (r3 != IMMEDIATE(17))
 #line 63 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 63 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -370,7 +371,7 @@ label_1:
     if (r3 > r2)
 #line 66 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 69 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -383,7 +384,7 @@ label_1:
     if (r1 > IMMEDIATE(8))
 #line 69 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 69 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -401,7 +402,7 @@ label_1:
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 70 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -412,7 +413,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 71 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 72 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -73,6 +73,7 @@ static GUID encap_reflect_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/en~1")
 static uint64_t
 encap_reflect_packet(void* context)
+#line 139 "sample/encap_reflect_packet.c"
 {
 #line 139 "sample/encap_reflect_packet.c"
     // Prologue
@@ -123,7 +124,7 @@ encap_reflect_packet(void* context)
     if (r3 > r1)
 #line 145 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 149 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=105 imm=56710
@@ -131,12 +132,12 @@ encap_reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 149 "sample/encap_reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
+        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
 #line 149 "sample/encap_reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 149 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 150 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -147,7 +148,7 @@ encap_reflect_packet(void* context)
     if (r4 > r1)
 #line 150 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 155 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=282 imm=17
@@ -155,7 +156,7 @@ encap_reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 155 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
@@ -178,7 +179,7 @@ encap_reflect_packet(void* context)
     if (r2 > r1)
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 160 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=273 imm=7459
@@ -186,7 +187,7 @@ encap_reflect_packet(void* context)
     if (r1 != IMMEDIATE(7459))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -201,7 +202,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -221,7 +222,7 @@ encap_reflect_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 22 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 27 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r6 src=r6 offset=0 imm=0
@@ -238,7 +239,7 @@ encap_reflect_packet(void* context)
     if (r3 > r4)
 #line 27 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
 #line 33 "sample/encap_reflect_packet.c"
     r2 = r6;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -249,7 +250,7 @@ encap_reflect_packet(void* context)
     if (r2 > r4)
 #line 33 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
 #line 40 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -260,7 +261,7 @@ encap_reflect_packet(void* context)
     if (r1 > r4)
 #line 40 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
 #line 40 "sample/encap_reflect_packet.c"
     r5 = r6;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -271,7 +272,7 @@ encap_reflect_packet(void* context)
     if (r5 > r4)
 #line 40 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 51 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r6 src=r4 offset=4 imm=0
@@ -446,7 +447,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
 #line 68 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=104 dst=r1 src=r0 offset=0 imm=65535
@@ -491,7 +492,7 @@ label_1:
     if (r3 > r1)
 #line 164 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
 #line 164 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
@@ -502,7 +503,7 @@ label_1:
     if (r3 > r1)
 #line 169 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
 #line 169 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
@@ -510,7 +511,7 @@ label_1:
     if (r1 != IMMEDIATE(17))
 #line 169 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
+        // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=123 dst=r1 src=r0 offset=173 imm=7459
@@ -518,7 +519,7 @@ label_1:
     if (r1 != IMMEDIATE(7459))
 #line 174 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
 #line 82 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=125 dst=r2 src=r0 offset=0 imm=-40
@@ -533,7 +534,7 @@ label_1:
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 82 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
 #line 82 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=129 dst=r0 src=r0 offset=0 imm=2
@@ -553,7 +554,7 @@ label_1:
     if ((int64_t)r2 > (int64_t)r1)
 #line 82 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=135 dst=r1 src=r6 offset=0 imm=0
@@ -570,7 +571,7 @@ label_1:
     if (r2 > r5)
 #line 87 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
 #line 93 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=140 dst=r4 src=r0 offset=0 imm=40
@@ -581,7 +582,7 @@ label_1:
     if (r4 > r5)
 #line 93 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=143 dst=r3 src=r0 offset=0 imm=54
@@ -592,7 +593,7 @@ label_1:
     if (r3 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r6 = r1;
     // EBPF_OP_ADD64_IMM pc=146 dst=r6 src=r0 offset=0 imm=94
@@ -603,7 +604,7 @@ label_1:
     if (r6 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
+        // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
 #line 111 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=149 dst=r1 src=r5 offset=4 imm=0

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
@@ -31,6 +31,7 @@ static GUID encap_reflect_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/en~1")
 static uint64_t
 encap_reflect_packet(void* context)
+#line 139 "sample/encap_reflect_packet.c"
 {
 #line 139 "sample/encap_reflect_packet.c"
     // Prologue
@@ -81,7 +82,7 @@ encap_reflect_packet(void* context)
     if (r3 > r1)
 #line 145 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 149 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=105 imm=56710
@@ -89,12 +90,12 @@ encap_reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 149 "sample/encap_reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
+        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
 #line 149 "sample/encap_reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 149 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 150 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -105,7 +106,7 @@ encap_reflect_packet(void* context)
     if (r4 > r1)
 #line 150 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 155 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=282 imm=17
@@ -113,7 +114,7 @@ encap_reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 155 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
@@ -136,7 +137,7 @@ encap_reflect_packet(void* context)
     if (r2 > r1)
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 160 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=273 imm=7459
@@ -144,7 +145,7 @@ encap_reflect_packet(void* context)
     if (r1 != IMMEDIATE(7459))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -159,7 +160,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -179,7 +180,7 @@ encap_reflect_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 22 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 27 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r6 src=r6 offset=0 imm=0
@@ -196,7 +197,7 @@ encap_reflect_packet(void* context)
     if (r3 > r4)
 #line 27 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
 #line 33 "sample/encap_reflect_packet.c"
     r2 = r6;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -207,7 +208,7 @@ encap_reflect_packet(void* context)
     if (r2 > r4)
 #line 33 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
 #line 40 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -218,7 +219,7 @@ encap_reflect_packet(void* context)
     if (r1 > r4)
 #line 40 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
 #line 40 "sample/encap_reflect_packet.c"
     r5 = r6;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -229,7 +230,7 @@ encap_reflect_packet(void* context)
     if (r5 > r4)
 #line 40 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 51 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r6 src=r4 offset=4 imm=0
@@ -404,7 +405,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
 #line 68 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=104 dst=r1 src=r0 offset=0 imm=65535
@@ -449,7 +450,7 @@ label_1:
     if (r3 > r1)
 #line 164 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
 #line 164 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
@@ -460,7 +461,7 @@ label_1:
     if (r3 > r1)
 #line 169 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
 #line 169 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
@@ -468,7 +469,7 @@ label_1:
     if (r1 != IMMEDIATE(17))
 #line 169 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
+        // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=123 dst=r1 src=r0 offset=173 imm=7459
@@ -476,7 +477,7 @@ label_1:
     if (r1 != IMMEDIATE(7459))
 #line 174 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
 #line 82 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=125 dst=r2 src=r0 offset=0 imm=-40
@@ -491,7 +492,7 @@ label_1:
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 82 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
 #line 82 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=129 dst=r0 src=r0 offset=0 imm=2
@@ -511,7 +512,7 @@ label_1:
     if ((int64_t)r2 > (int64_t)r1)
 #line 82 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=135 dst=r1 src=r6 offset=0 imm=0
@@ -528,7 +529,7 @@ label_1:
     if (r2 > r5)
 #line 87 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
 #line 93 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=140 dst=r4 src=r0 offset=0 imm=40
@@ -539,7 +540,7 @@ label_1:
     if (r4 > r5)
 #line 93 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=143 dst=r3 src=r0 offset=0 imm=54
@@ -550,7 +551,7 @@ label_1:
     if (r3 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r6 = r1;
     // EBPF_OP_ADD64_IMM pc=146 dst=r6 src=r0 offset=0 imm=94
@@ -561,7 +562,7 @@ label_1:
     if (r6 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
+        // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
 #line 111 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=149 dst=r1 src=r5 offset=4 imm=0

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
@@ -198,6 +198,7 @@ static GUID encap_reflect_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/en~1")
 static uint64_t
 encap_reflect_packet(void* context)
+#line 139 "sample/encap_reflect_packet.c"
 {
 #line 139 "sample/encap_reflect_packet.c"
     // Prologue
@@ -248,7 +249,7 @@ encap_reflect_packet(void* context)
     if (r3 > r1)
 #line 145 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 149 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=105 imm=56710
@@ -256,12 +257,12 @@ encap_reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 149 "sample/encap_reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
+        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
 #line 149 "sample/encap_reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 149 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 150 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -272,7 +273,7 @@ encap_reflect_packet(void* context)
     if (r4 > r1)
 #line 150 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 155 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=282 imm=17
@@ -280,7 +281,7 @@ encap_reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 155 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
@@ -303,7 +304,7 @@ encap_reflect_packet(void* context)
     if (r2 > r1)
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 160 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=273 imm=7459
@@ -311,7 +312,7 @@ encap_reflect_packet(void* context)
     if (r1 != IMMEDIATE(7459))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -326,7 +327,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -346,7 +347,7 @@ encap_reflect_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 22 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 27 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r6 src=r6 offset=0 imm=0
@@ -363,7 +364,7 @@ encap_reflect_packet(void* context)
     if (r3 > r4)
 #line 27 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
 #line 33 "sample/encap_reflect_packet.c"
     r2 = r6;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -374,7 +375,7 @@ encap_reflect_packet(void* context)
     if (r2 > r4)
 #line 33 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
 #line 40 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -385,7 +386,7 @@ encap_reflect_packet(void* context)
     if (r1 > r4)
 #line 40 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
 #line 40 "sample/encap_reflect_packet.c"
     r5 = r6;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -396,7 +397,7 @@ encap_reflect_packet(void* context)
     if (r5 > r4)
 #line 40 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 51 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r6 src=r4 offset=4 imm=0
@@ -571,7 +572,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
 #line 68 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=104 dst=r1 src=r0 offset=0 imm=65535
@@ -616,7 +617,7 @@ label_1:
     if (r3 > r1)
 #line 164 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
 #line 164 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
@@ -627,7 +628,7 @@ label_1:
     if (r3 > r1)
 #line 169 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
 #line 169 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
@@ -635,7 +636,7 @@ label_1:
     if (r1 != IMMEDIATE(17))
 #line 169 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
+        // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 174 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=123 dst=r1 src=r0 offset=173 imm=7459
@@ -643,7 +644,7 @@ label_1:
     if (r1 != IMMEDIATE(7459))
 #line 174 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
 #line 82 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=125 dst=r2 src=r0 offset=0 imm=-40
@@ -658,7 +659,7 @@ label_1:
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 82 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
 #line 82 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=129 dst=r0 src=r0 offset=0 imm=2
@@ -678,7 +679,7 @@ label_1:
     if ((int64_t)r2 > (int64_t)r1)
 #line 82 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=135 dst=r1 src=r6 offset=0 imm=0
@@ -695,7 +696,7 @@ label_1:
     if (r2 > r5)
 #line 87 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
 #line 93 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=140 dst=r4 src=r0 offset=0 imm=40
@@ -706,7 +707,7 @@ label_1:
     if (r4 > r5)
 #line 93 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=143 dst=r3 src=r0 offset=0 imm=54
@@ -717,7 +718,7 @@ label_1:
     if (r3 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r6 = r1;
     // EBPF_OP_ADD64_IMM pc=146 dst=r6 src=r0 offset=0 imm=94
@@ -728,7 +729,7 @@ label_1:
     if (r6 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
+        // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
 #line 111 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=149 dst=r1 src=r5 offset=4 imm=0

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -192,6 +192,7 @@ static uint16_t test_maps_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 test_maps(void* context)
+#line 173 "sample/map.c"
 {
 #line 173 "sample/map.c"
     // Prologue
@@ -264,7 +265,7 @@ test_maps(void* context)
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r6 offset=0 imm=0
@@ -281,7 +282,7 @@ test_maps(void* context)
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=19 dst=r10 src=r1 offset=-40 imm=0
@@ -318,12 +319,12 @@ label_1:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=33 dst=r10 src=r1 offset=-32 imm=0
@@ -371,7 +372,7 @@ label_1:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=26 imm=0
@@ -396,7 +397,7 @@ label_2:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=59 dst=r3 src=r6 offset=0 imm=0
@@ -413,7 +414,7 @@ label_2:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_7;
-    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-40 imm=0
@@ -568,7 +569,7 @@ label_7:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=116 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=116 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r6 offset=0 imm=0
@@ -585,7 +586,7 @@ label_7:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_8;
-    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-40 imm=0
@@ -622,12 +623,12 @@ label_8:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=135 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=135 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_9;
-    // EBPF_OP_MOV64_IMM pc=136 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=136 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=137 dst=r10 src=r1 offset=-32 imm=0
@@ -675,7 +676,7 @@ label_8:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=154 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=154 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=156 dst=r0 src=r0 offset=26 imm=0
@@ -700,7 +701,7 @@ label_9:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=162 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=162 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=163 dst=r3 src=r6 offset=0 imm=0
@@ -717,7 +718,7 @@ label_9:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_12;
-    // EBPF_OP_LDDW pc=167 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=167 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=169 dst=r10 src=r1 offset=-40 imm=0
@@ -864,7 +865,7 @@ label_12:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=222 dst=r3 src=r6 offset=0 imm=0
@@ -881,7 +882,7 @@ label_12:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_13;
-    // EBPF_OP_LDDW pc=226 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=226 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=228 dst=r10 src=r1 offset=-40 imm=0
@@ -918,12 +919,12 @@ label_13:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=240 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=240 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_14;
-    // EBPF_OP_MOV64_IMM pc=241 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=241 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=242 dst=r10 src=r1 offset=-32 imm=0
@@ -971,7 +972,7 @@ label_13:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=259 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=259 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=261 dst=r0 src=r0 offset=26 imm=0
@@ -996,7 +997,7 @@ label_14:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=267 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=267 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=268 dst=r3 src=r6 offset=0 imm=0
@@ -1013,7 +1014,7 @@ label_14:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_17;
-    // EBPF_OP_LDDW pc=272 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=272 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=274 dst=r10 src=r1 offset=-40 imm=0
@@ -1160,7 +1161,7 @@ label_17:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=325 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=325 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=326 dst=r3 src=r6 offset=0 imm=0
@@ -1177,7 +1178,7 @@ label_17:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_18;
-    // EBPF_OP_LDDW pc=330 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=330 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=332 dst=r10 src=r1 offset=-40 imm=0
@@ -1214,12 +1215,12 @@ label_18:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=344 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=344 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_19;
-    // EBPF_OP_MOV64_IMM pc=345 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=345 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=346 dst=r10 src=r1 offset=-32 imm=0
@@ -1267,7 +1268,7 @@ label_18:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=363 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=363 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=365 dst=r0 src=r0 offset=26 imm=0
@@ -1292,7 +1293,7 @@ label_19:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=371 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=371 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=372 dst=r3 src=r6 offset=0 imm=0
@@ -1309,7 +1310,7 @@ label_19:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_22;
-    // EBPF_OP_LDDW pc=376 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=376 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=378 dst=r10 src=r1 offset=-40 imm=0
@@ -1456,7 +1457,7 @@ label_22:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=430 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=430 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=431 dst=r3 src=r6 offset=0 imm=0
@@ -1473,7 +1474,7 @@ label_22:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_23;
-    // EBPF_OP_LDDW pc=435 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=435 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=437 dst=r10 src=r1 offset=-40 imm=0
@@ -1510,12 +1511,12 @@ label_23:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=449 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=449 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_24;
-    // EBPF_OP_MOV64_IMM pc=450 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=450 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=451 dst=r10 src=r1 offset=-32 imm=0
@@ -1563,7 +1564,7 @@ label_23:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=468 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=468 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=470 dst=r0 src=r0 offset=26 imm=0
@@ -1588,7 +1589,7 @@ label_24:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=476 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=476 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=477 dst=r3 src=r6 offset=0 imm=0
@@ -1605,7 +1606,7 @@ label_24:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_27;
-    // EBPF_OP_LDDW pc=481 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=481 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=483 dst=r10 src=r1 offset=-40 imm=0
@@ -1746,7 +1747,7 @@ label_27:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=533 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=533 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=534 dst=r3 src=r6 offset=0 imm=0
@@ -1763,7 +1764,7 @@ label_27:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_28;
-    // EBPF_OP_LDDW pc=538 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=538 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=540 dst=r10 src=r1 offset=-40 imm=0
@@ -1800,12 +1801,12 @@ label_28:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=552 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=552 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_29;
-    // EBPF_OP_MOV64_IMM pc=553 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=553 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=554 dst=r10 src=r1 offset=-32 imm=0
@@ -1853,7 +1854,7 @@ label_28:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=571 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=571 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=573 dst=r0 src=r0 offset=26 imm=0
@@ -1878,7 +1879,7 @@ label_29:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=579 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=579 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=580 dst=r3 src=r6 offset=0 imm=0
@@ -1895,7 +1896,7 @@ label_29:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_32;
-    // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=586 dst=r10 src=r1 offset=-40 imm=0
@@ -2046,7 +2047,7 @@ label_33:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 86 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=640 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=640 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=641 dst=r7 src=r6 offset=0 imm=0
@@ -2063,7 +2064,7 @@ label_33:
     if ((int64_t)r8 > (int64_t)r7)
 #line 87 "sample/map.c"
         goto label_37;
-    // EBPF_OP_LDXW pc=645 dst=r1 src=r10 offset=-4 imm=0
+        // EBPF_OP_LDXW pc=645 dst=r1 src=r10 offset=-4 imm=0
 #line 85 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ADD64_IMM pc=646 dst=r1 src=r0 offset=0 imm=1
@@ -2083,7 +2084,7 @@ label_33:
     if (r9 > r1)
 #line 85 "sample/map.c"
         goto label_33;
-    // EBPF_OP_MOV64_IMM pc=651 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=651 dst=r8 src=r0 offset=0 imm=0
 #line 85 "sample/map.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=652 dst=r10 src=r8 offset=-4 imm=0
@@ -2126,7 +2127,7 @@ label_34:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 86 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=664 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=664 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=665 dst=r7 src=r6 offset=0 imm=0
@@ -2143,7 +2144,7 @@ label_34:
     if ((int64_t)r8 > (int64_t)r7)
 #line 87 "sample/map.c"
         goto label_38;
-    // EBPF_OP_LDXW pc=669 dst=r1 src=r10 offset=-4 imm=0
+        // EBPF_OP_LDXW pc=669 dst=r1 src=r10 offset=-4 imm=0
 #line 85 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ADD64_IMM pc=670 dst=r1 src=r0 offset=0 imm=1
@@ -2163,7 +2164,7 @@ label_34:
     if (r9 > r1)
 #line 85 "sample/map.c"
         goto label_34;
-    // EBPF_OP_MOV64_IMM pc=675 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=675 dst=r1 src=r0 offset=0 imm=0
 #line 85 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=676 dst=r10 src=r1 offset=-4 imm=0
@@ -2187,7 +2188,7 @@ label_34:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=682 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=682 dst=r6 src=r0 offset=0 imm=0
 #line 137 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=683 dst=r4 src=r6 offset=0 imm=0
@@ -2278,7 +2279,7 @@ label_36:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=716 dst=r0 src=r0 offset=104 imm=0
+        // EBPF_OP_JA pc=716 dst=r0 src=r0 offset=104 imm=0
 #line 137 "sample/map.c"
     goto label_44;
 label_37:
@@ -2327,7 +2328,7 @@ label_37:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 88 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=734 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=734 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=735 dst=r10 src=r1 offset=-28 imm=0
@@ -2421,7 +2422,7 @@ label_38:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 88 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=771 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=771 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=772 dst=r10 src=r1 offset=-20 imm=0
@@ -2548,7 +2549,7 @@ label_43:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=819 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=819 dst=r6 src=r0 offset=0 imm=-1
 #line 137 "sample/map.c"
     r6 = (uint64_t)4294967295;
 label_44:
@@ -2566,7 +2567,7 @@ label_44:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 186 "sample/map.c"
         goto label_68;
-    // EBPF_OP_LDDW pc=825 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=825 dst=r1 src=r0 offset=0 imm=1684369010
 #line 186 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=827 dst=r10 src=r1 offset=-32 imm=0
@@ -2633,7 +2634,7 @@ label_45:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 138 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=851 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=851 dst=r6 src=r0 offset=0 imm=0
 #line 138 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=852 dst=r4 src=r6 offset=0 imm=0
@@ -2791,7 +2792,7 @@ label_49:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=912 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=912 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=913 dst=r1 src=r6 offset=0 imm=0
@@ -2895,7 +2896,7 @@ label_52:
     if ((test_maps_helpers[9].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=-129 imm=0
+        // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=-129 imm=0
 #line 141 "sample/map.c"
     goto label_44;
 label_53:
@@ -2926,7 +2927,7 @@ label_53:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=958 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=958 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=959 dst=r1 src=r6 offset=0 imm=0
@@ -2943,7 +2944,7 @@ label_53:
     if (r1 == IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_54;
-    // EBPF_OP_JA pc=963 dst=r0 src=r0 offset=-47 imm=0
+        // EBPF_OP_JA pc=963 dst=r0 src=r0 offset=-47 imm=0
 #line 141 "sample/map.c"
     goto label_50;
 label_54:
@@ -2974,7 +2975,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=972 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=972 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=973 dst=r1 src=r6 offset=0 imm=0
@@ -2991,7 +2992,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=977 dst=r1 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=977 dst=r1 src=r0 offset=0 imm=3
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=978 dst=r10 src=r1 offset=-4 imm=0
@@ -3018,7 +3019,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=985 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=985 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=986 dst=r1 src=r6 offset=0 imm=0
@@ -3035,7 +3036,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=990 dst=r1 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=990 dst=r1 src=r0 offset=0 imm=4
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=991 dst=r10 src=r1 offset=-4 imm=0
@@ -3062,7 +3063,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=998 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=998 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=999 dst=r1 src=r6 offset=0 imm=0
@@ -3079,7 +3080,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1003 dst=r1 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1003 dst=r1 src=r0 offset=0 imm=5
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=1004 dst=r10 src=r1 offset=-4 imm=0
@@ -3106,7 +3107,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1011 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1011 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1012 dst=r1 src=r6 offset=0 imm=0
@@ -3123,7 +3124,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1016 dst=r1 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1016 dst=r1 src=r0 offset=0 imm=6
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=1017 dst=r10 src=r1 offset=-4 imm=0
@@ -3150,7 +3151,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1024 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1024 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1025 dst=r1 src=r6 offset=0 imm=0
@@ -3167,7 +3168,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=7
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=1030 dst=r10 src=r1 offset=-4 imm=0
@@ -3194,7 +3195,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1037 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1037 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1038 dst=r1 src=r6 offset=0 imm=0
@@ -3211,7 +3212,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=8
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=1043 dst=r10 src=r1 offset=-4 imm=0
@@ -3238,7 +3239,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1050 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1050 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1051 dst=r1 src=r6 offset=0 imm=0
@@ -3255,7 +3256,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1055 dst=r1 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1055 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=1056 dst=r10 src=r1 offset=-4 imm=0
@@ -3282,7 +3283,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1063 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1063 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1064 dst=r1 src=r6 offset=0 imm=0
@@ -3299,7 +3300,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1068 dst=r7 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1068 dst=r7 src=r0 offset=0 imm=10
 #line 141 "sample/map.c"
     r7 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=1069 dst=r10 src=r7 offset=-4 imm=0
@@ -3329,7 +3330,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 144 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1077 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1077 dst=r6 src=r0 offset=0 imm=0
 #line 144 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1078 dst=r5 src=r6 offset=0 imm=0
@@ -3352,7 +3353,7 @@ label_54:
     if (r1 == r2)
 #line 144 "sample/map.c"
         goto label_55;
-    // EBPF_OP_STXB pc=1085 dst=r10 src=r8 offset=-10 imm=0
+        // EBPF_OP_STXB pc=1085 dst=r10 src=r8 offset=-10 imm=0
 #line 144 "sample/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1086 dst=r1 src=r0 offset=0 imm=25637
@@ -3449,7 +3450,7 @@ label_55:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 145 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1122 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1122 dst=r6 src=r0 offset=0 imm=0
 #line 145 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1123 dst=r5 src=r6 offset=0 imm=0
@@ -3469,7 +3470,7 @@ label_55:
     if (r1 == IMMEDIATE(0))
 #line 145 "sample/map.c"
         goto label_56;
-    // EBPF_OP_MOV64_IMM pc=1128 dst=r1 src=r0 offset=0 imm=25637
+        // EBPF_OP_MOV64_IMM pc=1128 dst=r1 src=r0 offset=0 imm=25637
 #line 145 "sample/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1129 dst=r10 src=r1 offset=-12 imm=0
@@ -3554,7 +3555,7 @@ label_56:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1161 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1161 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1162 dst=r4 src=r6 offset=0 imm=0
@@ -3574,7 +3575,7 @@ label_56:
     if (r1 == IMMEDIATE(0))
 #line 147 "sample/map.c"
         goto label_58;
-    // EBPF_OP_MOV64_IMM pc=1167 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=1167 dst=r1 src=r0 offset=0 imm=100
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1168 dst=r10 src=r1 offset=-16 imm=0
@@ -3641,7 +3642,7 @@ label_57:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1193 dst=r0 src=r0 offset=-373 imm=0
+        // EBPF_OP_JA pc=1193 dst=r0 src=r0 offset=-373 imm=0
 #line 147 "sample/map.c"
     goto label_44;
 label_58:
@@ -3653,7 +3654,7 @@ label_58:
     if (r3 == IMMEDIATE(1))
 #line 147 "sample/map.c"
         goto label_59;
-    // EBPF_OP_MOV64_IMM pc=1196 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1196 dst=r1 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1197 dst=r10 src=r1 offset=-24 imm=0
@@ -3729,7 +3730,7 @@ label_59:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1225 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1225 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1226 dst=r1 src=r6 offset=0 imm=0
@@ -3887,7 +3888,7 @@ label_63:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1285 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1285 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1286 dst=r1 src=r6 offset=0 imm=0
@@ -3904,7 +3905,7 @@ label_63:
     if (r1 == IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_64;
-    // EBPF_OP_JA pc=1290 dst=r0 src=r0 offset=-61 imm=0
+        // EBPF_OP_JA pc=1290 dst=r0 src=r0 offset=-61 imm=0
 #line 150 "sample/map.c"
     goto label_60;
 label_64:
@@ -3919,7 +3920,7 @@ label_64:
     if (r3 != IMMEDIATE(2))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1294 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1294 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1295 dst=r10 src=r1 offset=-4 imm=0
@@ -3943,7 +3944,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1301 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1301 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1302 dst=r1 src=r6 offset=0 imm=0
@@ -3960,7 +3961,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1306 dst=r4 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=1306 dst=r4 src=r0 offset=0 imm=3
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(3);
     // EBPF_OP_LDXW pc=1307 dst=r3 src=r10 offset=-4 imm=0
@@ -3971,7 +3972,7 @@ label_64:
     if (r3 != IMMEDIATE(3))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1309 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1309 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1310 dst=r10 src=r1 offset=-4 imm=0
@@ -3995,7 +3996,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1316 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1316 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1317 dst=r1 src=r6 offset=0 imm=0
@@ -4012,7 +4013,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1321 dst=r4 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=1321 dst=r4 src=r0 offset=0 imm=4
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(4);
     // EBPF_OP_LDXW pc=1322 dst=r3 src=r10 offset=-4 imm=0
@@ -4023,7 +4024,7 @@ label_64:
     if (r3 != IMMEDIATE(4))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1324 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1324 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1325 dst=r10 src=r1 offset=-4 imm=0
@@ -4047,7 +4048,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1331 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1331 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1332 dst=r1 src=r6 offset=0 imm=0
@@ -4064,7 +4065,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1336 dst=r4 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1336 dst=r4 src=r0 offset=0 imm=5
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(5);
     // EBPF_OP_LDXW pc=1337 dst=r3 src=r10 offset=-4 imm=0
@@ -4075,7 +4076,7 @@ label_64:
     if (r3 != IMMEDIATE(5))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1340 dst=r10 src=r1 offset=-4 imm=0
@@ -4099,7 +4100,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1346 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1346 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1347 dst=r1 src=r6 offset=0 imm=0
@@ -4116,7 +4117,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1351 dst=r4 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1351 dst=r4 src=r0 offset=0 imm=6
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(6);
     // EBPF_OP_LDXW pc=1352 dst=r3 src=r10 offset=-4 imm=0
@@ -4127,7 +4128,7 @@ label_64:
     if (r3 != IMMEDIATE(6))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1354 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1354 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1355 dst=r10 src=r1 offset=-4 imm=0
@@ -4151,7 +4152,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1361 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1361 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1362 dst=r1 src=r6 offset=0 imm=0
@@ -4168,7 +4169,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1366 dst=r4 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1366 dst=r4 src=r0 offset=0 imm=7
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(7);
     // EBPF_OP_LDXW pc=1367 dst=r3 src=r10 offset=-4 imm=0
@@ -4179,7 +4180,7 @@ label_64:
     if (r3 != IMMEDIATE(7))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1369 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1369 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1370 dst=r10 src=r1 offset=-4 imm=0
@@ -4203,7 +4204,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1376 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1376 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1377 dst=r1 src=r6 offset=0 imm=0
@@ -4220,7 +4221,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1381 dst=r4 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1381 dst=r4 src=r0 offset=0 imm=8
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(8);
     // EBPF_OP_LDXW pc=1382 dst=r3 src=r10 offset=-4 imm=0
@@ -4231,7 +4232,7 @@ label_64:
     if (r3 != IMMEDIATE(8))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1384 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1384 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1385 dst=r10 src=r1 offset=-4 imm=0
@@ -4255,7 +4256,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1391 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1391 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1392 dst=r1 src=r6 offset=0 imm=0
@@ -4272,7 +4273,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1396 dst=r4 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1396 dst=r4 src=r0 offset=0 imm=9
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(9);
     // EBPF_OP_LDXW pc=1397 dst=r3 src=r10 offset=-4 imm=0
@@ -4283,7 +4284,7 @@ label_64:
     if (r3 != IMMEDIATE(9))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1399 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1399 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1400 dst=r10 src=r1 offset=-4 imm=0
@@ -4307,7 +4308,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1406 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1406 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1407 dst=r1 src=r6 offset=0 imm=0
@@ -4324,7 +4325,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1411 dst=r4 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1411 dst=r4 src=r0 offset=0 imm=10
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(10);
     // EBPF_OP_LDXW pc=1412 dst=r3 src=r10 offset=-4 imm=0
@@ -4335,7 +4336,7 @@ label_64:
     if (r3 != IMMEDIATE(10))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1414 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1414 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1415 dst=r10 src=r1 offset=-4 imm=0
@@ -4359,7 +4360,7 @@ label_64:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 153 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1421 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1421 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1422 dst=r4 src=r6 offset=0 imm=0
@@ -4382,7 +4383,7 @@ label_64:
     if (r1 == r2)
 #line 153 "sample/map.c"
         goto label_65;
-    // EBPF_OP_JA pc=1429 dst=r0 src=r0 offset=-740 imm=0
+        // EBPF_OP_JA pc=1429 dst=r0 src=r0 offset=-740 imm=0
 #line 153 "sample/map.c"
     goto label_35;
 label_65:
@@ -4394,7 +4395,7 @@ label_65:
     if (r3 == IMMEDIATE(0))
 #line 153 "sample/map.c"
         goto label_66;
-    // EBPF_OP_JA pc=1432 dst=r0 src=r0 offset=-636 imm=0
+        // EBPF_OP_JA pc=1432 dst=r0 src=r0 offset=-636 imm=0
 #line 153 "sample/map.c"
     goto label_41;
 label_66:
@@ -4422,7 +4423,7 @@ label_66:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 154 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1440 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1440 dst=r6 src=r0 offset=0 imm=0
 #line 154 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1441 dst=r4 src=r6 offset=0 imm=0
@@ -4445,7 +4446,7 @@ label_66:
     if (r1 == r2)
 #line 154 "sample/map.c"
         goto label_67;
-    // EBPF_OP_JA pc=1448 dst=r0 src=r0 offset=-590 imm=0
+        // EBPF_OP_JA pc=1448 dst=r0 src=r0 offset=-590 imm=0
 #line 154 "sample/map.c"
     goto label_46;
 label_67:
@@ -4457,7 +4458,7 @@ label_67:
     if (r3 == IMMEDIATE(0))
 #line 154 "sample/map.c"
         goto label_68;
-    // EBPF_OP_JA pc=1451 dst=r0 src=r0 offset=-567 imm=0
+        // EBPF_OP_JA pc=1451 dst=r0 src=r0 offset=-567 imm=0
 #line 154 "sample/map.c"
     goto label_48;
 label_68:
@@ -4485,7 +4486,7 @@ label_68:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
 #line 137 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1460 dst=r4 src=r7 offset=0 imm=0
@@ -4576,7 +4577,7 @@ label_70:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1493 dst=r0 src=r0 offset=26 imm=0
+        // EBPF_OP_JA pc=1493 dst=r0 src=r0 offset=26 imm=0
 #line 137 "sample/map.c"
     goto label_75;
 label_71:
@@ -4648,7 +4649,7 @@ label_74:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=1518 dst=r7 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=1518 dst=r7 src=r0 offset=0 imm=-1
 #line 137 "sample/map.c"
     r7 = (uint64_t)4294967295;
 label_75:
@@ -4669,7 +4670,7 @@ label_75:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 187 "sample/map.c"
         goto label_6;
-    // EBPF_OP_LDDW pc=1525 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=1525 dst=r1 src=r0 offset=0 imm=1684369010
 #line 187 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=1527 dst=r10 src=r1 offset=-32 imm=0
@@ -4717,7 +4718,7 @@ label_75:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 187 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1544 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1544 dst=r6 src=r7 offset=0 imm=0
 #line 187 "sample/map.c"
     r6 = r7;
     // EBPF_OP_JA pc=1545 dst=r0 src=r0 offset=-1444 imm=0
@@ -4748,7 +4749,7 @@ label_76:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 138 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1553 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1553 dst=r7 src=r0 offset=0 imm=0
 #line 138 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1554 dst=r4 src=r7 offset=0 imm=0
@@ -4906,7 +4907,7 @@ label_80:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1614 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1614 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1615 dst=r1 src=r7 offset=0 imm=0
@@ -5010,7 +5011,7 @@ label_83:
     if ((test_maps_helpers[9].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1651 dst=r0 src=r0 offset=-132 imm=0
+        // EBPF_OP_JA pc=1651 dst=r0 src=r0 offset=-132 imm=0
 #line 141 "sample/map.c"
     goto label_75;
 label_84:
@@ -5041,7 +5042,7 @@ label_84:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1660 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1660 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1661 dst=r1 src=r7 offset=0 imm=0
@@ -5058,7 +5059,7 @@ label_84:
     if (r1 == IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_85;
-    // EBPF_OP_JA pc=1665 dst=r0 src=r0 offset=-47 imm=0
+        // EBPF_OP_JA pc=1665 dst=r0 src=r0 offset=-47 imm=0
 #line 141 "sample/map.c"
     goto label_81;
 label_85:
@@ -5089,7 +5090,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1674 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1674 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1675 dst=r1 src=r7 offset=0 imm=0
@@ -5106,7 +5107,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1679 dst=r1 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=1679 dst=r1 src=r0 offset=0 imm=3
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=1680 dst=r10 src=r1 offset=-4 imm=0
@@ -5133,7 +5134,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1687 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1687 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1688 dst=r1 src=r7 offset=0 imm=0
@@ -5150,7 +5151,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1692 dst=r1 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=1692 dst=r1 src=r0 offset=0 imm=4
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=1693 dst=r10 src=r1 offset=-4 imm=0
@@ -5177,7 +5178,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1700 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1700 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1701 dst=r1 src=r7 offset=0 imm=0
@@ -5194,7 +5195,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1705 dst=r1 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1705 dst=r1 src=r0 offset=0 imm=5
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=1706 dst=r10 src=r1 offset=-4 imm=0
@@ -5221,7 +5222,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1713 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1713 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1714 dst=r1 src=r7 offset=0 imm=0
@@ -5238,7 +5239,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1718 dst=r1 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1718 dst=r1 src=r0 offset=0 imm=6
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=1719 dst=r10 src=r1 offset=-4 imm=0
@@ -5265,7 +5266,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1726 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1726 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1727 dst=r1 src=r7 offset=0 imm=0
@@ -5282,7 +5283,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1731 dst=r1 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1731 dst=r1 src=r0 offset=0 imm=7
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=1732 dst=r10 src=r1 offset=-4 imm=0
@@ -5309,7 +5310,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1739 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1739 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1740 dst=r1 src=r7 offset=0 imm=0
@@ -5326,7 +5327,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1744 dst=r1 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1744 dst=r1 src=r0 offset=0 imm=8
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=1745 dst=r10 src=r1 offset=-4 imm=0
@@ -5353,7 +5354,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1752 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1752 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1753 dst=r1 src=r7 offset=0 imm=0
@@ -5370,7 +5371,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1757 dst=r1 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1757 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=1758 dst=r10 src=r1 offset=-4 imm=0
@@ -5397,7 +5398,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1765 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1765 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1766 dst=r1 src=r7 offset=0 imm=0
@@ -5414,7 +5415,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1770 dst=r6 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1770 dst=r6 src=r0 offset=0 imm=10
 #line 141 "sample/map.c"
     r6 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=1771 dst=r10 src=r6 offset=-4 imm=0
@@ -5444,7 +5445,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 144 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1779 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1779 dst=r7 src=r0 offset=0 imm=0
 #line 144 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1780 dst=r5 src=r7 offset=0 imm=0
@@ -5467,7 +5468,7 @@ label_85:
     if (r1 == r2)
 #line 144 "sample/map.c"
         goto label_86;
-    // EBPF_OP_STXB pc=1787 dst=r10 src=r8 offset=-10 imm=0
+        // EBPF_OP_STXB pc=1787 dst=r10 src=r8 offset=-10 imm=0
 #line 144 "sample/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1788 dst=r1 src=r0 offset=0 imm=25637
@@ -5564,7 +5565,7 @@ label_86:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 145 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1824 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1824 dst=r7 src=r0 offset=0 imm=0
 #line 145 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1825 dst=r5 src=r7 offset=0 imm=0
@@ -5584,7 +5585,7 @@ label_86:
     if (r1 == IMMEDIATE(0))
 #line 145 "sample/map.c"
         goto label_87;
-    // EBPF_OP_MOV64_IMM pc=1830 dst=r1 src=r0 offset=0 imm=25637
+        // EBPF_OP_MOV64_IMM pc=1830 dst=r1 src=r0 offset=0 imm=25637
 #line 145 "sample/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1831 dst=r10 src=r1 offset=-12 imm=0
@@ -5669,7 +5670,7 @@ label_87:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1863 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1863 dst=r7 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1864 dst=r4 src=r7 offset=0 imm=0
@@ -5689,7 +5690,7 @@ label_87:
     if (r1 == IMMEDIATE(0))
 #line 147 "sample/map.c"
         goto label_89;
-    // EBPF_OP_MOV64_IMM pc=1869 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=1869 dst=r1 src=r0 offset=0 imm=100
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1870 dst=r10 src=r1 offset=-16 imm=0
@@ -5756,7 +5757,7 @@ label_88:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1895 dst=r0 src=r0 offset=-376 imm=0
+        // EBPF_OP_JA pc=1895 dst=r0 src=r0 offset=-376 imm=0
 #line 147 "sample/map.c"
     goto label_75;
 label_89:
@@ -5768,7 +5769,7 @@ label_89:
     if (r3 == IMMEDIATE(10))
 #line 147 "sample/map.c"
         goto label_90;
-    // EBPF_OP_MOV64_IMM pc=1898 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1898 dst=r1 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1899 dst=r10 src=r1 offset=-24 imm=0
@@ -5844,7 +5845,7 @@ label_90:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1927 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1927 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1928 dst=r1 src=r7 offset=0 imm=0
@@ -6002,7 +6003,7 @@ label_94:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1987 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1987 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1988 dst=r1 src=r7 offset=0 imm=0
@@ -6019,7 +6020,7 @@ label_94:
     if (r1 == IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_95;
-    // EBPF_OP_JA pc=1992 dst=r0 src=r0 offset=-61 imm=0
+        // EBPF_OP_JA pc=1992 dst=r0 src=r0 offset=-61 imm=0
 #line 150 "sample/map.c"
     goto label_91;
 label_95:
@@ -6034,7 +6035,7 @@ label_95:
     if (r3 != IMMEDIATE(9))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=1996 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1996 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1997 dst=r10 src=r1 offset=-4 imm=0
@@ -6058,7 +6059,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2003 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2003 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2004 dst=r1 src=r7 offset=0 imm=0
@@ -6075,7 +6076,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2008 dst=r4 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=2008 dst=r4 src=r0 offset=0 imm=8
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(8);
     // EBPF_OP_LDXW pc=2009 dst=r3 src=r10 offset=-4 imm=0
@@ -6086,7 +6087,7 @@ label_95:
     if (r3 != IMMEDIATE(8))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2011 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2011 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2012 dst=r10 src=r1 offset=-4 imm=0
@@ -6110,7 +6111,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2018 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2018 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2019 dst=r1 src=r7 offset=0 imm=0
@@ -6127,7 +6128,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2023 dst=r4 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=2023 dst=r4 src=r0 offset=0 imm=7
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(7);
     // EBPF_OP_LDXW pc=2024 dst=r3 src=r10 offset=-4 imm=0
@@ -6138,7 +6139,7 @@ label_95:
     if (r3 != IMMEDIATE(7))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2026 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2026 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2027 dst=r10 src=r1 offset=-4 imm=0
@@ -6162,7 +6163,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2033 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2033 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2034 dst=r1 src=r7 offset=0 imm=0
@@ -6179,7 +6180,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2038 dst=r4 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=2038 dst=r4 src=r0 offset=0 imm=6
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(6);
     // EBPF_OP_LDXW pc=2039 dst=r3 src=r10 offset=-4 imm=0
@@ -6190,7 +6191,7 @@ label_95:
     if (r3 != IMMEDIATE(6))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2041 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2041 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2042 dst=r10 src=r1 offset=-4 imm=0
@@ -6214,7 +6215,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2048 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2048 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2049 dst=r1 src=r7 offset=0 imm=0
@@ -6231,7 +6232,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2053 dst=r4 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=2053 dst=r4 src=r0 offset=0 imm=5
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(5);
     // EBPF_OP_LDXW pc=2054 dst=r3 src=r10 offset=-4 imm=0
@@ -6242,7 +6243,7 @@ label_95:
     if (r3 != IMMEDIATE(5))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2056 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2056 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2057 dst=r10 src=r1 offset=-4 imm=0
@@ -6266,7 +6267,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2063 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2063 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2064 dst=r1 src=r7 offset=0 imm=0
@@ -6283,7 +6284,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2068 dst=r4 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=2068 dst=r4 src=r0 offset=0 imm=4
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(4);
     // EBPF_OP_LDXW pc=2069 dst=r3 src=r10 offset=-4 imm=0
@@ -6294,7 +6295,7 @@ label_95:
     if (r3 != IMMEDIATE(4))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2071 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2071 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2072 dst=r10 src=r1 offset=-4 imm=0
@@ -6318,7 +6319,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2078 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2078 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2079 dst=r1 src=r7 offset=0 imm=0
@@ -6335,7 +6336,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2083 dst=r4 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=2083 dst=r4 src=r0 offset=0 imm=3
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(3);
     // EBPF_OP_LDXW pc=2084 dst=r3 src=r10 offset=-4 imm=0
@@ -6346,7 +6347,7 @@ label_95:
     if (r3 != IMMEDIATE(3))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2086 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2086 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2087 dst=r10 src=r1 offset=-4 imm=0
@@ -6370,7 +6371,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2093 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2093 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2094 dst=r1 src=r7 offset=0 imm=0
@@ -6387,7 +6388,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=2
+        // EBPF_OP_MOV64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=2
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(2);
     // EBPF_OP_LDXW pc=2099 dst=r3 src=r10 offset=-4 imm=0
@@ -6398,7 +6399,7 @@ label_95:
     if (r3 != IMMEDIATE(2))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2101 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2101 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2102 dst=r10 src=r1 offset=-4 imm=0
@@ -6422,7 +6423,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2108 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2108 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2109 dst=r1 src=r7 offset=0 imm=0
@@ -6439,7 +6440,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2113 dst=r4 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=2113 dst=r4 src=r0 offset=0 imm=1
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=2114 dst=r3 src=r10 offset=-4 imm=0
@@ -6450,7 +6451,7 @@ label_95:
     if (r3 != IMMEDIATE(1))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2116 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2116 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2117 dst=r10 src=r1 offset=-4 imm=0
@@ -6474,7 +6475,7 @@ label_95:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 153 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2123 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2123 dst=r7 src=r0 offset=0 imm=0
 #line 153 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2124 dst=r4 src=r7 offset=0 imm=0
@@ -6497,7 +6498,7 @@ label_95:
     if (r1 == r2)
 #line 153 "sample/map.c"
         goto label_96;
-    // EBPF_OP_JA pc=2131 dst=r0 src=r0 offset=-665 imm=0
+        // EBPF_OP_JA pc=2131 dst=r0 src=r0 offset=-665 imm=0
 #line 153 "sample/map.c"
     goto label_69;
 label_96:
@@ -6509,7 +6510,7 @@ label_96:
     if (r3 == IMMEDIATE(0))
 #line 153 "sample/map.c"
         goto label_97;
-    // EBPF_OP_JA pc=2134 dst=r0 src=r0 offset=-639 imm=0
+        // EBPF_OP_JA pc=2134 dst=r0 src=r0 offset=-639 imm=0
 #line 153 "sample/map.c"
     goto label_72;
 label_97:
@@ -6537,7 +6538,7 @@ label_97:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 154 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2142 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2142 dst=r7 src=r0 offset=0 imm=0
 #line 154 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2143 dst=r4 src=r7 offset=0 imm=0
@@ -6560,7 +6561,7 @@ label_97:
     if (r1 == r2)
 #line 154 "sample/map.c"
         goto label_98;
-    // EBPF_OP_JA pc=2150 dst=r0 src=r0 offset=-590 imm=0
+        // EBPF_OP_JA pc=2150 dst=r0 src=r0 offset=-590 imm=0
 #line 154 "sample/map.c"
     goto label_77;
 label_98:
@@ -6572,7 +6573,7 @@ label_98:
     if (r3 == IMMEDIATE(0))
 #line 154 "sample/map.c"
         goto label_99;
-    // EBPF_OP_JA pc=2153 dst=r0 src=r0 offset=-567 imm=0
+        // EBPF_OP_JA pc=2153 dst=r0 src=r0 offset=-567 imm=0
 #line 154 "sample/map.c"
     goto label_79;
 label_99:

--- a/tests/bpf2c_tests/expected/map_in_map_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_dll.c
@@ -103,6 +103,7 @@ static uint16_t lookup_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup(void* context)
+#line 29 "sample/map_in_map.c"
 {
 #line 29 "sample/map_in_map.c"
     // Prologue
@@ -154,12 +155,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/map_in_map.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 33 "sample/map_in_map.c"
     if (r0 == IMMEDIATE(0))
 #line 33 "sample/map_in_map.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 33 "sample/map_in_map.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -183,12 +184,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/map_in_map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 36 "sample/map_in_map.c"
     if (r0 != IMMEDIATE(0))
 #line 36 "sample/map_in_map.c"
         goto label_1;
-    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 36 "sample/map_in_map.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_raw.c
@@ -61,6 +61,7 @@ static uint16_t lookup_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup(void* context)
+#line 29 "sample/map_in_map.c"
 {
 #line 29 "sample/map_in_map.c"
     // Prologue
@@ -112,12 +113,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/map_in_map.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 33 "sample/map_in_map.c"
     if (r0 == IMMEDIATE(0))
 #line 33 "sample/map_in_map.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 33 "sample/map_in_map.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -141,12 +142,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/map_in_map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 36 "sample/map_in_map.c"
     if (r0 != IMMEDIATE(0))
 #line 36 "sample/map_in_map.c"
         goto label_1;
-    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 36 "sample/map_in_map.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_sys.c
@@ -228,6 +228,7 @@ static uint16_t lookup_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup(void* context)
+#line 29 "sample/map_in_map.c"
 {
 #line 29 "sample/map_in_map.c"
     // Prologue
@@ -279,12 +280,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/map_in_map.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 33 "sample/map_in_map.c"
     if (r0 == IMMEDIATE(0))
 #line 33 "sample/map_in_map.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 33 "sample/map_in_map.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -308,12 +309,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/map_in_map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 36 "sample/map_in_map.c"
     if (r0 != IMMEDIATE(0))
 #line 36 "sample/map_in_map.c"
         goto label_1;
-    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 36 "sample/map_in_map.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
@@ -103,6 +103,7 @@ static uint16_t lookup_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup(void* context)
+#line 35 "sample/map_in_map_v2.c"
 {
 #line 35 "sample/map_in_map_v2.c"
     // Prologue
@@ -154,12 +155,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 38 "sample/map_in_map_v2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 39 "sample/map_in_map_v2.c"
     if (r0 == IMMEDIATE(0))
 #line 39 "sample/map_in_map_v2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 39 "sample/map_in_map_v2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -183,12 +184,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 41 "sample/map_in_map_v2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 42 "sample/map_in_map_v2.c"
     if (r0 != IMMEDIATE(0))
 #line 42 "sample/map_in_map_v2.c"
         goto label_1;
-    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 42 "sample/map_in_map_v2.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
@@ -61,6 +61,7 @@ static uint16_t lookup_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup(void* context)
+#line 35 "sample/map_in_map_v2.c"
 {
 #line 35 "sample/map_in_map_v2.c"
     // Prologue
@@ -112,12 +113,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 38 "sample/map_in_map_v2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 39 "sample/map_in_map_v2.c"
     if (r0 == IMMEDIATE(0))
 #line 39 "sample/map_in_map_v2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 39 "sample/map_in_map_v2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -141,12 +142,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 41 "sample/map_in_map_v2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 42 "sample/map_in_map_v2.c"
     if (r0 != IMMEDIATE(0))
 #line 42 "sample/map_in_map_v2.c"
         goto label_1;
-    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 42 "sample/map_in_map_v2.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
@@ -228,6 +228,7 @@ static uint16_t lookup_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup(void* context)
+#line 35 "sample/map_in_map_v2.c"
 {
 #line 35 "sample/map_in_map_v2.c"
     // Prologue
@@ -279,12 +280,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 38 "sample/map_in_map_v2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
 #line 39 "sample/map_in_map_v2.c"
     if (r0 == IMMEDIATE(0))
 #line 39 "sample/map_in_map_v2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 39 "sample/map_in_map_v2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -308,12 +309,12 @@ lookup(void* context)
     if ((lookup_helpers[0].tail_call) && (r0 == 0))
 #line 41 "sample/map_in_map_v2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
 #line 42 "sample/map_in_map_v2.c"
     if (r0 != IMMEDIATE(0))
 #line 42 "sample/map_in_map_v2.c"
         goto label_1;
-    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
 #line 42 "sample/map_in_map_v2.c"
     goto label_2;
 label_1:

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -150,6 +150,7 @@ static uint16_t test_maps_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 test_maps(void* context)
+#line 173 "sample/map.c"
 {
 #line 173 "sample/map.c"
     // Prologue
@@ -222,7 +223,7 @@ test_maps(void* context)
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r6 offset=0 imm=0
@@ -239,7 +240,7 @@ test_maps(void* context)
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=19 dst=r10 src=r1 offset=-40 imm=0
@@ -276,12 +277,12 @@ label_1:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=33 dst=r10 src=r1 offset=-32 imm=0
@@ -329,7 +330,7 @@ label_1:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=26 imm=0
@@ -354,7 +355,7 @@ label_2:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=59 dst=r3 src=r6 offset=0 imm=0
@@ -371,7 +372,7 @@ label_2:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_7;
-    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-40 imm=0
@@ -526,7 +527,7 @@ label_7:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=116 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=116 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r6 offset=0 imm=0
@@ -543,7 +544,7 @@ label_7:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_8;
-    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-40 imm=0
@@ -580,12 +581,12 @@ label_8:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=135 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=135 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_9;
-    // EBPF_OP_MOV64_IMM pc=136 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=136 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=137 dst=r10 src=r1 offset=-32 imm=0
@@ -633,7 +634,7 @@ label_8:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=154 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=154 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=156 dst=r0 src=r0 offset=26 imm=0
@@ -658,7 +659,7 @@ label_9:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=162 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=162 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=163 dst=r3 src=r6 offset=0 imm=0
@@ -675,7 +676,7 @@ label_9:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_12;
-    // EBPF_OP_LDDW pc=167 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=167 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=169 dst=r10 src=r1 offset=-40 imm=0
@@ -822,7 +823,7 @@ label_12:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=222 dst=r3 src=r6 offset=0 imm=0
@@ -839,7 +840,7 @@ label_12:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_13;
-    // EBPF_OP_LDDW pc=226 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=226 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=228 dst=r10 src=r1 offset=-40 imm=0
@@ -876,12 +877,12 @@ label_13:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=240 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=240 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_14;
-    // EBPF_OP_MOV64_IMM pc=241 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=241 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=242 dst=r10 src=r1 offset=-32 imm=0
@@ -929,7 +930,7 @@ label_13:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=259 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=259 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=261 dst=r0 src=r0 offset=26 imm=0
@@ -954,7 +955,7 @@ label_14:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=267 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=267 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=268 dst=r3 src=r6 offset=0 imm=0
@@ -971,7 +972,7 @@ label_14:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_17;
-    // EBPF_OP_LDDW pc=272 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=272 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=274 dst=r10 src=r1 offset=-40 imm=0
@@ -1118,7 +1119,7 @@ label_17:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=325 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=325 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=326 dst=r3 src=r6 offset=0 imm=0
@@ -1135,7 +1136,7 @@ label_17:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_18;
-    // EBPF_OP_LDDW pc=330 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=330 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=332 dst=r10 src=r1 offset=-40 imm=0
@@ -1172,12 +1173,12 @@ label_18:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=344 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=344 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_19;
-    // EBPF_OP_MOV64_IMM pc=345 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=345 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=346 dst=r10 src=r1 offset=-32 imm=0
@@ -1225,7 +1226,7 @@ label_18:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=363 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=363 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=365 dst=r0 src=r0 offset=26 imm=0
@@ -1250,7 +1251,7 @@ label_19:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=371 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=371 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=372 dst=r3 src=r6 offset=0 imm=0
@@ -1267,7 +1268,7 @@ label_19:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_22;
-    // EBPF_OP_LDDW pc=376 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=376 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=378 dst=r10 src=r1 offset=-40 imm=0
@@ -1414,7 +1415,7 @@ label_22:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=430 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=430 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=431 dst=r3 src=r6 offset=0 imm=0
@@ -1431,7 +1432,7 @@ label_22:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_23;
-    // EBPF_OP_LDDW pc=435 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=435 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=437 dst=r10 src=r1 offset=-40 imm=0
@@ -1468,12 +1469,12 @@ label_23:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=449 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=449 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_24;
-    // EBPF_OP_MOV64_IMM pc=450 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=450 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=451 dst=r10 src=r1 offset=-32 imm=0
@@ -1521,7 +1522,7 @@ label_23:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=468 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=468 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=470 dst=r0 src=r0 offset=26 imm=0
@@ -1546,7 +1547,7 @@ label_24:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=476 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=476 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=477 dst=r3 src=r6 offset=0 imm=0
@@ -1563,7 +1564,7 @@ label_24:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_27;
-    // EBPF_OP_LDDW pc=481 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=481 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=483 dst=r10 src=r1 offset=-40 imm=0
@@ -1704,7 +1705,7 @@ label_27:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=533 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=533 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=534 dst=r3 src=r6 offset=0 imm=0
@@ -1721,7 +1722,7 @@ label_27:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_28;
-    // EBPF_OP_LDDW pc=538 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=538 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=540 dst=r10 src=r1 offset=-40 imm=0
@@ -1758,12 +1759,12 @@ label_28:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=552 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=552 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_29;
-    // EBPF_OP_MOV64_IMM pc=553 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=553 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=554 dst=r10 src=r1 offset=-32 imm=0
@@ -1811,7 +1812,7 @@ label_28:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=571 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=571 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=573 dst=r0 src=r0 offset=26 imm=0
@@ -1836,7 +1837,7 @@ label_29:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=579 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=579 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=580 dst=r3 src=r6 offset=0 imm=0
@@ -1853,7 +1854,7 @@ label_29:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_32;
-    // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=586 dst=r10 src=r1 offset=-40 imm=0
@@ -2004,7 +2005,7 @@ label_33:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 86 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=640 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=640 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=641 dst=r7 src=r6 offset=0 imm=0
@@ -2021,7 +2022,7 @@ label_33:
     if ((int64_t)r8 > (int64_t)r7)
 #line 87 "sample/map.c"
         goto label_37;
-    // EBPF_OP_LDXW pc=645 dst=r1 src=r10 offset=-4 imm=0
+        // EBPF_OP_LDXW pc=645 dst=r1 src=r10 offset=-4 imm=0
 #line 85 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ADD64_IMM pc=646 dst=r1 src=r0 offset=0 imm=1
@@ -2041,7 +2042,7 @@ label_33:
     if (r9 > r1)
 #line 85 "sample/map.c"
         goto label_33;
-    // EBPF_OP_MOV64_IMM pc=651 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=651 dst=r8 src=r0 offset=0 imm=0
 #line 85 "sample/map.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=652 dst=r10 src=r8 offset=-4 imm=0
@@ -2084,7 +2085,7 @@ label_34:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 86 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=664 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=664 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=665 dst=r7 src=r6 offset=0 imm=0
@@ -2101,7 +2102,7 @@ label_34:
     if ((int64_t)r8 > (int64_t)r7)
 #line 87 "sample/map.c"
         goto label_38;
-    // EBPF_OP_LDXW pc=669 dst=r1 src=r10 offset=-4 imm=0
+        // EBPF_OP_LDXW pc=669 dst=r1 src=r10 offset=-4 imm=0
 #line 85 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ADD64_IMM pc=670 dst=r1 src=r0 offset=0 imm=1
@@ -2121,7 +2122,7 @@ label_34:
     if (r9 > r1)
 #line 85 "sample/map.c"
         goto label_34;
-    // EBPF_OP_MOV64_IMM pc=675 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=675 dst=r1 src=r0 offset=0 imm=0
 #line 85 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=676 dst=r10 src=r1 offset=-4 imm=0
@@ -2145,7 +2146,7 @@ label_34:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=682 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=682 dst=r6 src=r0 offset=0 imm=0
 #line 137 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=683 dst=r4 src=r6 offset=0 imm=0
@@ -2236,7 +2237,7 @@ label_36:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=716 dst=r0 src=r0 offset=104 imm=0
+        // EBPF_OP_JA pc=716 dst=r0 src=r0 offset=104 imm=0
 #line 137 "sample/map.c"
     goto label_44;
 label_37:
@@ -2285,7 +2286,7 @@ label_37:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 88 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=734 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=734 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=735 dst=r10 src=r1 offset=-28 imm=0
@@ -2379,7 +2380,7 @@ label_38:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 88 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=771 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=771 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=772 dst=r10 src=r1 offset=-20 imm=0
@@ -2506,7 +2507,7 @@ label_43:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=819 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=819 dst=r6 src=r0 offset=0 imm=-1
 #line 137 "sample/map.c"
     r6 = (uint64_t)4294967295;
 label_44:
@@ -2524,7 +2525,7 @@ label_44:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 186 "sample/map.c"
         goto label_68;
-    // EBPF_OP_LDDW pc=825 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=825 dst=r1 src=r0 offset=0 imm=1684369010
 #line 186 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=827 dst=r10 src=r1 offset=-32 imm=0
@@ -2591,7 +2592,7 @@ label_45:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 138 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=851 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=851 dst=r6 src=r0 offset=0 imm=0
 #line 138 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=852 dst=r4 src=r6 offset=0 imm=0
@@ -2749,7 +2750,7 @@ label_49:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=912 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=912 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=913 dst=r1 src=r6 offset=0 imm=0
@@ -2853,7 +2854,7 @@ label_52:
     if ((test_maps_helpers[9].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=-129 imm=0
+        // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=-129 imm=0
 #line 141 "sample/map.c"
     goto label_44;
 label_53:
@@ -2884,7 +2885,7 @@ label_53:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=958 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=958 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=959 dst=r1 src=r6 offset=0 imm=0
@@ -2901,7 +2902,7 @@ label_53:
     if (r1 == IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_54;
-    // EBPF_OP_JA pc=963 dst=r0 src=r0 offset=-47 imm=0
+        // EBPF_OP_JA pc=963 dst=r0 src=r0 offset=-47 imm=0
 #line 141 "sample/map.c"
     goto label_50;
 label_54:
@@ -2932,7 +2933,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=972 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=972 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=973 dst=r1 src=r6 offset=0 imm=0
@@ -2949,7 +2950,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=977 dst=r1 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=977 dst=r1 src=r0 offset=0 imm=3
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=978 dst=r10 src=r1 offset=-4 imm=0
@@ -2976,7 +2977,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=985 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=985 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=986 dst=r1 src=r6 offset=0 imm=0
@@ -2993,7 +2994,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=990 dst=r1 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=990 dst=r1 src=r0 offset=0 imm=4
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=991 dst=r10 src=r1 offset=-4 imm=0
@@ -3020,7 +3021,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=998 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=998 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=999 dst=r1 src=r6 offset=0 imm=0
@@ -3037,7 +3038,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1003 dst=r1 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1003 dst=r1 src=r0 offset=0 imm=5
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=1004 dst=r10 src=r1 offset=-4 imm=0
@@ -3064,7 +3065,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1011 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1011 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1012 dst=r1 src=r6 offset=0 imm=0
@@ -3081,7 +3082,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1016 dst=r1 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1016 dst=r1 src=r0 offset=0 imm=6
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=1017 dst=r10 src=r1 offset=-4 imm=0
@@ -3108,7 +3109,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1024 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1024 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1025 dst=r1 src=r6 offset=0 imm=0
@@ -3125,7 +3126,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=7
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=1030 dst=r10 src=r1 offset=-4 imm=0
@@ -3152,7 +3153,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1037 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1037 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1038 dst=r1 src=r6 offset=0 imm=0
@@ -3169,7 +3170,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=8
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=1043 dst=r10 src=r1 offset=-4 imm=0
@@ -3196,7 +3197,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1050 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1050 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1051 dst=r1 src=r6 offset=0 imm=0
@@ -3213,7 +3214,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1055 dst=r1 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1055 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=1056 dst=r10 src=r1 offset=-4 imm=0
@@ -3240,7 +3241,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1063 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1063 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1064 dst=r1 src=r6 offset=0 imm=0
@@ -3257,7 +3258,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1068 dst=r7 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1068 dst=r7 src=r0 offset=0 imm=10
 #line 141 "sample/map.c"
     r7 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=1069 dst=r10 src=r7 offset=-4 imm=0
@@ -3287,7 +3288,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 144 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1077 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1077 dst=r6 src=r0 offset=0 imm=0
 #line 144 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1078 dst=r5 src=r6 offset=0 imm=0
@@ -3310,7 +3311,7 @@ label_54:
     if (r1 == r2)
 #line 144 "sample/map.c"
         goto label_55;
-    // EBPF_OP_STXB pc=1085 dst=r10 src=r8 offset=-10 imm=0
+        // EBPF_OP_STXB pc=1085 dst=r10 src=r8 offset=-10 imm=0
 #line 144 "sample/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1086 dst=r1 src=r0 offset=0 imm=25637
@@ -3407,7 +3408,7 @@ label_55:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 145 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1122 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1122 dst=r6 src=r0 offset=0 imm=0
 #line 145 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1123 dst=r5 src=r6 offset=0 imm=0
@@ -3427,7 +3428,7 @@ label_55:
     if (r1 == IMMEDIATE(0))
 #line 145 "sample/map.c"
         goto label_56;
-    // EBPF_OP_MOV64_IMM pc=1128 dst=r1 src=r0 offset=0 imm=25637
+        // EBPF_OP_MOV64_IMM pc=1128 dst=r1 src=r0 offset=0 imm=25637
 #line 145 "sample/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1129 dst=r10 src=r1 offset=-12 imm=0
@@ -3512,7 +3513,7 @@ label_56:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1161 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1161 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1162 dst=r4 src=r6 offset=0 imm=0
@@ -3532,7 +3533,7 @@ label_56:
     if (r1 == IMMEDIATE(0))
 #line 147 "sample/map.c"
         goto label_58;
-    // EBPF_OP_MOV64_IMM pc=1167 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=1167 dst=r1 src=r0 offset=0 imm=100
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1168 dst=r10 src=r1 offset=-16 imm=0
@@ -3599,7 +3600,7 @@ label_57:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1193 dst=r0 src=r0 offset=-373 imm=0
+        // EBPF_OP_JA pc=1193 dst=r0 src=r0 offset=-373 imm=0
 #line 147 "sample/map.c"
     goto label_44;
 label_58:
@@ -3611,7 +3612,7 @@ label_58:
     if (r3 == IMMEDIATE(1))
 #line 147 "sample/map.c"
         goto label_59;
-    // EBPF_OP_MOV64_IMM pc=1196 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1196 dst=r1 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1197 dst=r10 src=r1 offset=-24 imm=0
@@ -3687,7 +3688,7 @@ label_59:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1225 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1225 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1226 dst=r1 src=r6 offset=0 imm=0
@@ -3845,7 +3846,7 @@ label_63:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1285 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1285 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1286 dst=r1 src=r6 offset=0 imm=0
@@ -3862,7 +3863,7 @@ label_63:
     if (r1 == IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_64;
-    // EBPF_OP_JA pc=1290 dst=r0 src=r0 offset=-61 imm=0
+        // EBPF_OP_JA pc=1290 dst=r0 src=r0 offset=-61 imm=0
 #line 150 "sample/map.c"
     goto label_60;
 label_64:
@@ -3877,7 +3878,7 @@ label_64:
     if (r3 != IMMEDIATE(2))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1294 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1294 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1295 dst=r10 src=r1 offset=-4 imm=0
@@ -3901,7 +3902,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1301 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1301 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1302 dst=r1 src=r6 offset=0 imm=0
@@ -3918,7 +3919,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1306 dst=r4 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=1306 dst=r4 src=r0 offset=0 imm=3
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(3);
     // EBPF_OP_LDXW pc=1307 dst=r3 src=r10 offset=-4 imm=0
@@ -3929,7 +3930,7 @@ label_64:
     if (r3 != IMMEDIATE(3))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1309 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1309 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1310 dst=r10 src=r1 offset=-4 imm=0
@@ -3953,7 +3954,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1316 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1316 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1317 dst=r1 src=r6 offset=0 imm=0
@@ -3970,7 +3971,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1321 dst=r4 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=1321 dst=r4 src=r0 offset=0 imm=4
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(4);
     // EBPF_OP_LDXW pc=1322 dst=r3 src=r10 offset=-4 imm=0
@@ -3981,7 +3982,7 @@ label_64:
     if (r3 != IMMEDIATE(4))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1324 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1324 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1325 dst=r10 src=r1 offset=-4 imm=0
@@ -4005,7 +4006,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1331 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1331 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1332 dst=r1 src=r6 offset=0 imm=0
@@ -4022,7 +4023,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1336 dst=r4 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1336 dst=r4 src=r0 offset=0 imm=5
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(5);
     // EBPF_OP_LDXW pc=1337 dst=r3 src=r10 offset=-4 imm=0
@@ -4033,7 +4034,7 @@ label_64:
     if (r3 != IMMEDIATE(5))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1340 dst=r10 src=r1 offset=-4 imm=0
@@ -4057,7 +4058,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1346 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1346 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1347 dst=r1 src=r6 offset=0 imm=0
@@ -4074,7 +4075,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1351 dst=r4 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1351 dst=r4 src=r0 offset=0 imm=6
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(6);
     // EBPF_OP_LDXW pc=1352 dst=r3 src=r10 offset=-4 imm=0
@@ -4085,7 +4086,7 @@ label_64:
     if (r3 != IMMEDIATE(6))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1354 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1354 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1355 dst=r10 src=r1 offset=-4 imm=0
@@ -4109,7 +4110,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1361 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1361 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1362 dst=r1 src=r6 offset=0 imm=0
@@ -4126,7 +4127,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1366 dst=r4 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1366 dst=r4 src=r0 offset=0 imm=7
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(7);
     // EBPF_OP_LDXW pc=1367 dst=r3 src=r10 offset=-4 imm=0
@@ -4137,7 +4138,7 @@ label_64:
     if (r3 != IMMEDIATE(7))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1369 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1369 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1370 dst=r10 src=r1 offset=-4 imm=0
@@ -4161,7 +4162,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1376 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1376 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1377 dst=r1 src=r6 offset=0 imm=0
@@ -4178,7 +4179,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1381 dst=r4 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1381 dst=r4 src=r0 offset=0 imm=8
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(8);
     // EBPF_OP_LDXW pc=1382 dst=r3 src=r10 offset=-4 imm=0
@@ -4189,7 +4190,7 @@ label_64:
     if (r3 != IMMEDIATE(8))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1384 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1384 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1385 dst=r10 src=r1 offset=-4 imm=0
@@ -4213,7 +4214,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1391 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1391 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1392 dst=r1 src=r6 offset=0 imm=0
@@ -4230,7 +4231,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1396 dst=r4 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1396 dst=r4 src=r0 offset=0 imm=9
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(9);
     // EBPF_OP_LDXW pc=1397 dst=r3 src=r10 offset=-4 imm=0
@@ -4241,7 +4242,7 @@ label_64:
     if (r3 != IMMEDIATE(9))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1399 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1399 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1400 dst=r10 src=r1 offset=-4 imm=0
@@ -4265,7 +4266,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1406 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1406 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1407 dst=r1 src=r6 offset=0 imm=0
@@ -4282,7 +4283,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1411 dst=r4 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1411 dst=r4 src=r0 offset=0 imm=10
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(10);
     // EBPF_OP_LDXW pc=1412 dst=r3 src=r10 offset=-4 imm=0
@@ -4293,7 +4294,7 @@ label_64:
     if (r3 != IMMEDIATE(10))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1414 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1414 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1415 dst=r10 src=r1 offset=-4 imm=0
@@ -4317,7 +4318,7 @@ label_64:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 153 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1421 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1421 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1422 dst=r4 src=r6 offset=0 imm=0
@@ -4340,7 +4341,7 @@ label_64:
     if (r1 == r2)
 #line 153 "sample/map.c"
         goto label_65;
-    // EBPF_OP_JA pc=1429 dst=r0 src=r0 offset=-740 imm=0
+        // EBPF_OP_JA pc=1429 dst=r0 src=r0 offset=-740 imm=0
 #line 153 "sample/map.c"
     goto label_35;
 label_65:
@@ -4352,7 +4353,7 @@ label_65:
     if (r3 == IMMEDIATE(0))
 #line 153 "sample/map.c"
         goto label_66;
-    // EBPF_OP_JA pc=1432 dst=r0 src=r0 offset=-636 imm=0
+        // EBPF_OP_JA pc=1432 dst=r0 src=r0 offset=-636 imm=0
 #line 153 "sample/map.c"
     goto label_41;
 label_66:
@@ -4380,7 +4381,7 @@ label_66:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 154 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1440 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1440 dst=r6 src=r0 offset=0 imm=0
 #line 154 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1441 dst=r4 src=r6 offset=0 imm=0
@@ -4403,7 +4404,7 @@ label_66:
     if (r1 == r2)
 #line 154 "sample/map.c"
         goto label_67;
-    // EBPF_OP_JA pc=1448 dst=r0 src=r0 offset=-590 imm=0
+        // EBPF_OP_JA pc=1448 dst=r0 src=r0 offset=-590 imm=0
 #line 154 "sample/map.c"
     goto label_46;
 label_67:
@@ -4415,7 +4416,7 @@ label_67:
     if (r3 == IMMEDIATE(0))
 #line 154 "sample/map.c"
         goto label_68;
-    // EBPF_OP_JA pc=1451 dst=r0 src=r0 offset=-567 imm=0
+        // EBPF_OP_JA pc=1451 dst=r0 src=r0 offset=-567 imm=0
 #line 154 "sample/map.c"
     goto label_48;
 label_68:
@@ -4443,7 +4444,7 @@ label_68:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
 #line 137 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1460 dst=r4 src=r7 offset=0 imm=0
@@ -4534,7 +4535,7 @@ label_70:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1493 dst=r0 src=r0 offset=26 imm=0
+        // EBPF_OP_JA pc=1493 dst=r0 src=r0 offset=26 imm=0
 #line 137 "sample/map.c"
     goto label_75;
 label_71:
@@ -4606,7 +4607,7 @@ label_74:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=1518 dst=r7 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=1518 dst=r7 src=r0 offset=0 imm=-1
 #line 137 "sample/map.c"
     r7 = (uint64_t)4294967295;
 label_75:
@@ -4627,7 +4628,7 @@ label_75:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 187 "sample/map.c"
         goto label_6;
-    // EBPF_OP_LDDW pc=1525 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=1525 dst=r1 src=r0 offset=0 imm=1684369010
 #line 187 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=1527 dst=r10 src=r1 offset=-32 imm=0
@@ -4675,7 +4676,7 @@ label_75:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 187 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1544 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1544 dst=r6 src=r7 offset=0 imm=0
 #line 187 "sample/map.c"
     r6 = r7;
     // EBPF_OP_JA pc=1545 dst=r0 src=r0 offset=-1444 imm=0
@@ -4706,7 +4707,7 @@ label_76:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 138 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1553 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1553 dst=r7 src=r0 offset=0 imm=0
 #line 138 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1554 dst=r4 src=r7 offset=0 imm=0
@@ -4864,7 +4865,7 @@ label_80:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1614 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1614 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1615 dst=r1 src=r7 offset=0 imm=0
@@ -4968,7 +4969,7 @@ label_83:
     if ((test_maps_helpers[9].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1651 dst=r0 src=r0 offset=-132 imm=0
+        // EBPF_OP_JA pc=1651 dst=r0 src=r0 offset=-132 imm=0
 #line 141 "sample/map.c"
     goto label_75;
 label_84:
@@ -4999,7 +5000,7 @@ label_84:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1660 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1660 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1661 dst=r1 src=r7 offset=0 imm=0
@@ -5016,7 +5017,7 @@ label_84:
     if (r1 == IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_85;
-    // EBPF_OP_JA pc=1665 dst=r0 src=r0 offset=-47 imm=0
+        // EBPF_OP_JA pc=1665 dst=r0 src=r0 offset=-47 imm=0
 #line 141 "sample/map.c"
     goto label_81;
 label_85:
@@ -5047,7 +5048,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1674 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1674 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1675 dst=r1 src=r7 offset=0 imm=0
@@ -5064,7 +5065,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1679 dst=r1 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=1679 dst=r1 src=r0 offset=0 imm=3
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=1680 dst=r10 src=r1 offset=-4 imm=0
@@ -5091,7 +5092,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1687 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1687 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1688 dst=r1 src=r7 offset=0 imm=0
@@ -5108,7 +5109,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1692 dst=r1 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=1692 dst=r1 src=r0 offset=0 imm=4
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=1693 dst=r10 src=r1 offset=-4 imm=0
@@ -5135,7 +5136,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1700 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1700 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1701 dst=r1 src=r7 offset=0 imm=0
@@ -5152,7 +5153,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1705 dst=r1 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1705 dst=r1 src=r0 offset=0 imm=5
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=1706 dst=r10 src=r1 offset=-4 imm=0
@@ -5179,7 +5180,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1713 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1713 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1714 dst=r1 src=r7 offset=0 imm=0
@@ -5196,7 +5197,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1718 dst=r1 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1718 dst=r1 src=r0 offset=0 imm=6
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=1719 dst=r10 src=r1 offset=-4 imm=0
@@ -5223,7 +5224,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1726 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1726 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1727 dst=r1 src=r7 offset=0 imm=0
@@ -5240,7 +5241,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1731 dst=r1 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1731 dst=r1 src=r0 offset=0 imm=7
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=1732 dst=r10 src=r1 offset=-4 imm=0
@@ -5267,7 +5268,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1739 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1739 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1740 dst=r1 src=r7 offset=0 imm=0
@@ -5284,7 +5285,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1744 dst=r1 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1744 dst=r1 src=r0 offset=0 imm=8
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=1745 dst=r10 src=r1 offset=-4 imm=0
@@ -5311,7 +5312,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1752 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1752 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1753 dst=r1 src=r7 offset=0 imm=0
@@ -5328,7 +5329,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1757 dst=r1 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1757 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=1758 dst=r10 src=r1 offset=-4 imm=0
@@ -5355,7 +5356,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1765 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1765 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1766 dst=r1 src=r7 offset=0 imm=0
@@ -5372,7 +5373,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1770 dst=r6 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1770 dst=r6 src=r0 offset=0 imm=10
 #line 141 "sample/map.c"
     r6 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=1771 dst=r10 src=r6 offset=-4 imm=0
@@ -5402,7 +5403,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 144 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1779 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1779 dst=r7 src=r0 offset=0 imm=0
 #line 144 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1780 dst=r5 src=r7 offset=0 imm=0
@@ -5425,7 +5426,7 @@ label_85:
     if (r1 == r2)
 #line 144 "sample/map.c"
         goto label_86;
-    // EBPF_OP_STXB pc=1787 dst=r10 src=r8 offset=-10 imm=0
+        // EBPF_OP_STXB pc=1787 dst=r10 src=r8 offset=-10 imm=0
 #line 144 "sample/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1788 dst=r1 src=r0 offset=0 imm=25637
@@ -5522,7 +5523,7 @@ label_86:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 145 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1824 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1824 dst=r7 src=r0 offset=0 imm=0
 #line 145 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1825 dst=r5 src=r7 offset=0 imm=0
@@ -5542,7 +5543,7 @@ label_86:
     if (r1 == IMMEDIATE(0))
 #line 145 "sample/map.c"
         goto label_87;
-    // EBPF_OP_MOV64_IMM pc=1830 dst=r1 src=r0 offset=0 imm=25637
+        // EBPF_OP_MOV64_IMM pc=1830 dst=r1 src=r0 offset=0 imm=25637
 #line 145 "sample/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1831 dst=r10 src=r1 offset=-12 imm=0
@@ -5627,7 +5628,7 @@ label_87:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1863 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1863 dst=r7 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1864 dst=r4 src=r7 offset=0 imm=0
@@ -5647,7 +5648,7 @@ label_87:
     if (r1 == IMMEDIATE(0))
 #line 147 "sample/map.c"
         goto label_89;
-    // EBPF_OP_MOV64_IMM pc=1869 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=1869 dst=r1 src=r0 offset=0 imm=100
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1870 dst=r10 src=r1 offset=-16 imm=0
@@ -5714,7 +5715,7 @@ label_88:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1895 dst=r0 src=r0 offset=-376 imm=0
+        // EBPF_OP_JA pc=1895 dst=r0 src=r0 offset=-376 imm=0
 #line 147 "sample/map.c"
     goto label_75;
 label_89:
@@ -5726,7 +5727,7 @@ label_89:
     if (r3 == IMMEDIATE(10))
 #line 147 "sample/map.c"
         goto label_90;
-    // EBPF_OP_MOV64_IMM pc=1898 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1898 dst=r1 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1899 dst=r10 src=r1 offset=-24 imm=0
@@ -5802,7 +5803,7 @@ label_90:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1927 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1927 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1928 dst=r1 src=r7 offset=0 imm=0
@@ -5960,7 +5961,7 @@ label_94:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1987 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1987 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1988 dst=r1 src=r7 offset=0 imm=0
@@ -5977,7 +5978,7 @@ label_94:
     if (r1 == IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_95;
-    // EBPF_OP_JA pc=1992 dst=r0 src=r0 offset=-61 imm=0
+        // EBPF_OP_JA pc=1992 dst=r0 src=r0 offset=-61 imm=0
 #line 150 "sample/map.c"
     goto label_91;
 label_95:
@@ -5992,7 +5993,7 @@ label_95:
     if (r3 != IMMEDIATE(9))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=1996 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1996 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1997 dst=r10 src=r1 offset=-4 imm=0
@@ -6016,7 +6017,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2003 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2003 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2004 dst=r1 src=r7 offset=0 imm=0
@@ -6033,7 +6034,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2008 dst=r4 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=2008 dst=r4 src=r0 offset=0 imm=8
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(8);
     // EBPF_OP_LDXW pc=2009 dst=r3 src=r10 offset=-4 imm=0
@@ -6044,7 +6045,7 @@ label_95:
     if (r3 != IMMEDIATE(8))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2011 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2011 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2012 dst=r10 src=r1 offset=-4 imm=0
@@ -6068,7 +6069,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2018 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2018 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2019 dst=r1 src=r7 offset=0 imm=0
@@ -6085,7 +6086,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2023 dst=r4 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=2023 dst=r4 src=r0 offset=0 imm=7
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(7);
     // EBPF_OP_LDXW pc=2024 dst=r3 src=r10 offset=-4 imm=0
@@ -6096,7 +6097,7 @@ label_95:
     if (r3 != IMMEDIATE(7))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2026 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2026 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2027 dst=r10 src=r1 offset=-4 imm=0
@@ -6120,7 +6121,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2033 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2033 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2034 dst=r1 src=r7 offset=0 imm=0
@@ -6137,7 +6138,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2038 dst=r4 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=2038 dst=r4 src=r0 offset=0 imm=6
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(6);
     // EBPF_OP_LDXW pc=2039 dst=r3 src=r10 offset=-4 imm=0
@@ -6148,7 +6149,7 @@ label_95:
     if (r3 != IMMEDIATE(6))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2041 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2041 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2042 dst=r10 src=r1 offset=-4 imm=0
@@ -6172,7 +6173,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2048 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2048 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2049 dst=r1 src=r7 offset=0 imm=0
@@ -6189,7 +6190,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2053 dst=r4 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=2053 dst=r4 src=r0 offset=0 imm=5
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(5);
     // EBPF_OP_LDXW pc=2054 dst=r3 src=r10 offset=-4 imm=0
@@ -6200,7 +6201,7 @@ label_95:
     if (r3 != IMMEDIATE(5))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2056 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2056 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2057 dst=r10 src=r1 offset=-4 imm=0
@@ -6224,7 +6225,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2063 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2063 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2064 dst=r1 src=r7 offset=0 imm=0
@@ -6241,7 +6242,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2068 dst=r4 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=2068 dst=r4 src=r0 offset=0 imm=4
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(4);
     // EBPF_OP_LDXW pc=2069 dst=r3 src=r10 offset=-4 imm=0
@@ -6252,7 +6253,7 @@ label_95:
     if (r3 != IMMEDIATE(4))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2071 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2071 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2072 dst=r10 src=r1 offset=-4 imm=0
@@ -6276,7 +6277,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2078 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2078 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2079 dst=r1 src=r7 offset=0 imm=0
@@ -6293,7 +6294,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2083 dst=r4 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=2083 dst=r4 src=r0 offset=0 imm=3
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(3);
     // EBPF_OP_LDXW pc=2084 dst=r3 src=r10 offset=-4 imm=0
@@ -6304,7 +6305,7 @@ label_95:
     if (r3 != IMMEDIATE(3))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2086 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2086 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2087 dst=r10 src=r1 offset=-4 imm=0
@@ -6328,7 +6329,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2093 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2093 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2094 dst=r1 src=r7 offset=0 imm=0
@@ -6345,7 +6346,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=2
+        // EBPF_OP_MOV64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=2
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(2);
     // EBPF_OP_LDXW pc=2099 dst=r3 src=r10 offset=-4 imm=0
@@ -6356,7 +6357,7 @@ label_95:
     if (r3 != IMMEDIATE(2))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2101 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2101 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2102 dst=r10 src=r1 offset=-4 imm=0
@@ -6380,7 +6381,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2108 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2108 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2109 dst=r1 src=r7 offset=0 imm=0
@@ -6397,7 +6398,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2113 dst=r4 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=2113 dst=r4 src=r0 offset=0 imm=1
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=2114 dst=r3 src=r10 offset=-4 imm=0
@@ -6408,7 +6409,7 @@ label_95:
     if (r3 != IMMEDIATE(1))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2116 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2116 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2117 dst=r10 src=r1 offset=-4 imm=0
@@ -6432,7 +6433,7 @@ label_95:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 153 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2123 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2123 dst=r7 src=r0 offset=0 imm=0
 #line 153 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2124 dst=r4 src=r7 offset=0 imm=0
@@ -6455,7 +6456,7 @@ label_95:
     if (r1 == r2)
 #line 153 "sample/map.c"
         goto label_96;
-    // EBPF_OP_JA pc=2131 dst=r0 src=r0 offset=-665 imm=0
+        // EBPF_OP_JA pc=2131 dst=r0 src=r0 offset=-665 imm=0
 #line 153 "sample/map.c"
     goto label_69;
 label_96:
@@ -6467,7 +6468,7 @@ label_96:
     if (r3 == IMMEDIATE(0))
 #line 153 "sample/map.c"
         goto label_97;
-    // EBPF_OP_JA pc=2134 dst=r0 src=r0 offset=-639 imm=0
+        // EBPF_OP_JA pc=2134 dst=r0 src=r0 offset=-639 imm=0
 #line 153 "sample/map.c"
     goto label_72;
 label_97:
@@ -6495,7 +6496,7 @@ label_97:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 154 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2142 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2142 dst=r7 src=r0 offset=0 imm=0
 #line 154 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2143 dst=r4 src=r7 offset=0 imm=0
@@ -6518,7 +6519,7 @@ label_97:
     if (r1 == r2)
 #line 154 "sample/map.c"
         goto label_98;
-    // EBPF_OP_JA pc=2150 dst=r0 src=r0 offset=-590 imm=0
+        // EBPF_OP_JA pc=2150 dst=r0 src=r0 offset=-590 imm=0
 #line 154 "sample/map.c"
     goto label_77;
 label_98:
@@ -6530,7 +6531,7 @@ label_98:
     if (r3 == IMMEDIATE(0))
 #line 154 "sample/map.c"
         goto label_99;
-    // EBPF_OP_JA pc=2153 dst=r0 src=r0 offset=-567 imm=0
+        // EBPF_OP_JA pc=2153 dst=r0 src=r0 offset=-567 imm=0
 #line 154 "sample/map.c"
     goto label_79;
 label_99:

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -119,6 +119,7 @@ static uint16_t lookup_update_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup_update(void* context)
+#line 47 "sample/map_reuse_2.c"
 {
 #line 47 "sample/map_reuse_2.c"
     // Prologue
@@ -172,12 +173,12 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 52 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 53 "sample/map_reuse_2.c"
     if (r0 == IMMEDIATE(0))
 #line 53 "sample/map_reuse_2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/map_reuse_2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -201,7 +202,7 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 55 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 55 "sample/map_reuse_2.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
@@ -209,7 +210,7 @@ lookup_update(void* context)
     if (r7 != IMMEDIATE(0))
 #line 56 "sample/map_reuse_2.c"
         goto label_1;
-    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 56 "sample/map_reuse_2.c"
     goto label_2;
 label_1:
@@ -249,7 +250,7 @@ label_1:
     if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
 #line 60 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 62 "sample/map_reuse_2.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -77,6 +77,7 @@ static uint16_t lookup_update_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup_update(void* context)
+#line 47 "sample/map_reuse_2.c"
 {
 #line 47 "sample/map_reuse_2.c"
     // Prologue
@@ -130,12 +131,12 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 52 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 53 "sample/map_reuse_2.c"
     if (r0 == IMMEDIATE(0))
 #line 53 "sample/map_reuse_2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/map_reuse_2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -159,7 +160,7 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 55 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 55 "sample/map_reuse_2.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
@@ -167,7 +168,7 @@ lookup_update(void* context)
     if (r7 != IMMEDIATE(0))
 #line 56 "sample/map_reuse_2.c"
         goto label_1;
-    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 56 "sample/map_reuse_2.c"
     goto label_2;
 label_1:
@@ -207,7 +208,7 @@ label_1:
     if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
 #line 60 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 62 "sample/map_reuse_2.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -244,6 +244,7 @@ static uint16_t lookup_update_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup_update(void* context)
+#line 47 "sample/map_reuse_2.c"
 {
 #line 47 "sample/map_reuse_2.c"
     // Prologue
@@ -297,12 +298,12 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 52 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 53 "sample/map_reuse_2.c"
     if (r0 == IMMEDIATE(0))
 #line 53 "sample/map_reuse_2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/map_reuse_2.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -326,7 +327,7 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 55 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 55 "sample/map_reuse_2.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
@@ -334,7 +335,7 @@ lookup_update(void* context)
     if (r7 != IMMEDIATE(0))
 #line 56 "sample/map_reuse_2.c"
         goto label_1;
-    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 56 "sample/map_reuse_2.c"
     goto label_2;
 label_1:
@@ -374,7 +375,7 @@ label_1:
     if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
 #line 60 "sample/map_reuse_2.c"
         return 0;
-    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 62 "sample/map_reuse_2.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -119,6 +119,7 @@ static uint16_t lookup_update_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup_update(void* context)
+#line 45 "sample/map_reuse.c"
 {
 #line 45 "sample/map_reuse.c"
     // Prologue
@@ -172,12 +173,12 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 50 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 51 "sample/map_reuse.c"
     if (r0 == IMMEDIATE(0))
 #line 51 "sample/map_reuse.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 51 "sample/map_reuse.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -201,7 +202,7 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 53 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 53 "sample/map_reuse.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
@@ -209,7 +210,7 @@ lookup_update(void* context)
     if (r7 != IMMEDIATE(0))
 #line 54 "sample/map_reuse.c"
         goto label_1;
-    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 54 "sample/map_reuse.c"
     goto label_2;
 label_1:
@@ -249,7 +250,7 @@ label_1:
     if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
 #line 58 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 60 "sample/map_reuse.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -77,6 +77,7 @@ static uint16_t lookup_update_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup_update(void* context)
+#line 45 "sample/map_reuse.c"
 {
 #line 45 "sample/map_reuse.c"
     // Prologue
@@ -130,12 +131,12 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 50 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 51 "sample/map_reuse.c"
     if (r0 == IMMEDIATE(0))
 #line 51 "sample/map_reuse.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 51 "sample/map_reuse.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -159,7 +160,7 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 53 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 53 "sample/map_reuse.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
@@ -167,7 +168,7 @@ lookup_update(void* context)
     if (r7 != IMMEDIATE(0))
 #line 54 "sample/map_reuse.c"
         goto label_1;
-    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 54 "sample/map_reuse.c"
     goto label_2;
 label_1:
@@ -207,7 +208,7 @@ label_1:
     if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
 #line 58 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 60 "sample/map_reuse.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -244,6 +244,7 @@ static uint16_t lookup_update_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 lookup_update(void* context)
+#line 45 "sample/map_reuse.c"
 {
 #line 45 "sample/map_reuse.c"
     // Prologue
@@ -297,12 +298,12 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 50 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=21 imm=0
 #line 51 "sample/map_reuse.c"
     if (r0 == IMMEDIATE(0))
 #line 51 "sample/map_reuse.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
 #line 51 "sample/map_reuse.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
@@ -326,7 +327,7 @@ lookup_update(void* context)
     if ((lookup_update_helpers[0].tail_call) && (r0 == 0))
 #line 53 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=14 dst=r7 src=r0 offset=0 imm=0
 #line 53 "sample/map_reuse.c"
     r7 = r0;
     // EBPF_OP_JNE_IMM pc=15 dst=r7 src=r0 offset=1 imm=0
@@ -334,7 +335,7 @@ lookup_update(void* context)
     if (r7 != IMMEDIATE(0))
 #line 54 "sample/map_reuse.c"
         goto label_1;
-    // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
+        // EBPF_OP_JA pc=16 dst=r0 src=r0 offset=12 imm=0
 #line 54 "sample/map_reuse.c"
     goto label_2;
 label_1:
@@ -374,7 +375,7 @@ label_1:
     if ((lookup_update_helpers[1].tail_call) && (r0 == 0))
 #line 58 "sample/map_reuse.c"
         return 0;
-    // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r6 src=r7 offset=0 imm=0
 #line 60 "sample/map_reuse.c"
     r6 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
 label_2:

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -317,6 +317,7 @@ static uint16_t test_maps_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 test_maps(void* context)
+#line 173 "sample/map.c"
 {
 #line 173 "sample/map.c"
     // Prologue
@@ -389,7 +390,7 @@ test_maps(void* context)
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r3 src=r6 offset=0 imm=0
@@ -406,7 +407,7 @@ test_maps(void* context)
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=17 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=19 dst=r10 src=r1 offset=-40 imm=0
@@ -443,12 +444,12 @@ label_1:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=31 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=33 dst=r10 src=r1 offset=-32 imm=0
@@ -496,7 +497,7 @@ label_1:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=50 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=52 dst=r0 src=r0 offset=26 imm=0
@@ -521,7 +522,7 @@ label_2:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=59 dst=r3 src=r6 offset=0 imm=0
@@ -538,7 +539,7 @@ label_2:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_7;
-    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-40 imm=0
@@ -693,7 +694,7 @@ label_7:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=116 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=116 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r6 offset=0 imm=0
@@ -710,7 +711,7 @@ label_7:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_8;
-    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-40 imm=0
@@ -747,12 +748,12 @@ label_8:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=135 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=135 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_9;
-    // EBPF_OP_MOV64_IMM pc=136 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=136 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=137 dst=r10 src=r1 offset=-32 imm=0
@@ -800,7 +801,7 @@ label_8:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=154 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=154 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=156 dst=r0 src=r0 offset=26 imm=0
@@ -825,7 +826,7 @@ label_9:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=162 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=162 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=163 dst=r3 src=r6 offset=0 imm=0
@@ -842,7 +843,7 @@ label_9:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_12;
-    // EBPF_OP_LDDW pc=167 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=167 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=169 dst=r10 src=r1 offset=-40 imm=0
@@ -989,7 +990,7 @@ label_12:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=222 dst=r3 src=r6 offset=0 imm=0
@@ -1006,7 +1007,7 @@ label_12:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_13;
-    // EBPF_OP_LDDW pc=226 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=226 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=228 dst=r10 src=r1 offset=-40 imm=0
@@ -1043,12 +1044,12 @@ label_13:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=240 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=240 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_14;
-    // EBPF_OP_MOV64_IMM pc=241 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=241 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=242 dst=r10 src=r1 offset=-32 imm=0
@@ -1096,7 +1097,7 @@ label_13:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=259 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=259 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=261 dst=r0 src=r0 offset=26 imm=0
@@ -1121,7 +1122,7 @@ label_14:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=267 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=267 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=268 dst=r3 src=r6 offset=0 imm=0
@@ -1138,7 +1139,7 @@ label_14:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_17;
-    // EBPF_OP_LDDW pc=272 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=272 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=274 dst=r10 src=r1 offset=-40 imm=0
@@ -1285,7 +1286,7 @@ label_17:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=325 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=325 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=326 dst=r3 src=r6 offset=0 imm=0
@@ -1302,7 +1303,7 @@ label_17:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_18;
-    // EBPF_OP_LDDW pc=330 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=330 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=332 dst=r10 src=r1 offset=-40 imm=0
@@ -1339,12 +1340,12 @@ label_18:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=344 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=344 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_19;
-    // EBPF_OP_MOV64_IMM pc=345 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=345 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=346 dst=r10 src=r1 offset=-32 imm=0
@@ -1392,7 +1393,7 @@ label_18:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=363 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=363 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=365 dst=r0 src=r0 offset=26 imm=0
@@ -1417,7 +1418,7 @@ label_19:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=371 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=371 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=372 dst=r3 src=r6 offset=0 imm=0
@@ -1434,7 +1435,7 @@ label_19:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_22;
-    // EBPF_OP_LDDW pc=376 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=376 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=378 dst=r10 src=r1 offset=-40 imm=0
@@ -1581,7 +1582,7 @@ label_22:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=430 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=430 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=431 dst=r3 src=r6 offset=0 imm=0
@@ -1598,7 +1599,7 @@ label_22:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_23;
-    // EBPF_OP_LDDW pc=435 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=435 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=437 dst=r10 src=r1 offset=-40 imm=0
@@ -1635,12 +1636,12 @@ label_23:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=449 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=449 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_24;
-    // EBPF_OP_MOV64_IMM pc=450 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=450 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=451 dst=r10 src=r1 offset=-32 imm=0
@@ -1688,7 +1689,7 @@ label_23:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=468 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=468 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=470 dst=r0 src=r0 offset=26 imm=0
@@ -1713,7 +1714,7 @@ label_24:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=476 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=476 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=477 dst=r3 src=r6 offset=0 imm=0
@@ -1730,7 +1731,7 @@ label_24:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_27;
-    // EBPF_OP_LDDW pc=481 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=481 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=483 dst=r10 src=r1 offset=-40 imm=0
@@ -1871,7 +1872,7 @@ label_27:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=533 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=533 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=534 dst=r3 src=r6 offset=0 imm=0
@@ -1888,7 +1889,7 @@ label_27:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 57 "sample/map.c"
         goto label_28;
-    // EBPF_OP_LDDW pc=538 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=538 dst=r1 src=r0 offset=0 imm=1684369010
 #line 57 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=540 dst=r10 src=r1 offset=-40 imm=0
@@ -1925,12 +1926,12 @@ label_28:
     if ((test_maps_helpers[1].tail_call) && (r0 == 0))
 #line 62 "sample/map.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=552 dst=r0 src=r0 offset=21 imm=0
+        // EBPF_OP_JNE_IMM pc=552 dst=r0 src=r0 offset=21 imm=0
 #line 63 "sample/map.c"
     if (r0 != IMMEDIATE(0))
 #line 63 "sample/map.c"
         goto label_29;
-    // EBPF_OP_MOV64_IMM pc=553 dst=r1 src=r0 offset=0 imm=76
+        // EBPF_OP_MOV64_IMM pc=553 dst=r1 src=r0 offset=0 imm=76
 #line 63 "sample/map.c"
     r1 = IMMEDIATE(76);
     // EBPF_OP_STXH pc=554 dst=r10 src=r1 offset=-32 imm=0
@@ -1978,7 +1979,7 @@ label_28:
     if ((test_maps_helpers[2].tail_call) && (r0 == 0))
 #line 64 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=571 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=571 dst=r6 src=r0 offset=0 imm=-1
 #line 64 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JA pc=573 dst=r0 src=r0 offset=26 imm=0
@@ -2003,7 +2004,7 @@ label_29:
     if ((test_maps_helpers[3].tail_call) && (r0 == 0))
 #line 68 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=579 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=579 dst=r6 src=r0 offset=0 imm=0
 #line 68 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=580 dst=r3 src=r6 offset=0 imm=0
@@ -2020,7 +2021,7 @@ label_29:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 69 "sample/map.c"
         goto label_32;
-    // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=1684369010
 #line 69 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=586 dst=r10 src=r1 offset=-40 imm=0
@@ -2171,7 +2172,7 @@ label_33:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 86 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=640 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=640 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=641 dst=r7 src=r6 offset=0 imm=0
@@ -2188,7 +2189,7 @@ label_33:
     if ((int64_t)r8 > (int64_t)r7)
 #line 87 "sample/map.c"
         goto label_37;
-    // EBPF_OP_LDXW pc=645 dst=r1 src=r10 offset=-4 imm=0
+        // EBPF_OP_LDXW pc=645 dst=r1 src=r10 offset=-4 imm=0
 #line 85 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ADD64_IMM pc=646 dst=r1 src=r0 offset=0 imm=1
@@ -2208,7 +2209,7 @@ label_33:
     if (r9 > r1)
 #line 85 "sample/map.c"
         goto label_33;
-    // EBPF_OP_MOV64_IMM pc=651 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=651 dst=r8 src=r0 offset=0 imm=0
 #line 85 "sample/map.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=652 dst=r10 src=r8 offset=-4 imm=0
@@ -2251,7 +2252,7 @@ label_34:
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
 #line 86 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=664 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=664 dst=r6 src=r0 offset=0 imm=0
 #line 86 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=665 dst=r7 src=r6 offset=0 imm=0
@@ -2268,7 +2269,7 @@ label_34:
     if ((int64_t)r8 > (int64_t)r7)
 #line 87 "sample/map.c"
         goto label_38;
-    // EBPF_OP_LDXW pc=669 dst=r1 src=r10 offset=-4 imm=0
+        // EBPF_OP_LDXW pc=669 dst=r1 src=r10 offset=-4 imm=0
 #line 85 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ADD64_IMM pc=670 dst=r1 src=r0 offset=0 imm=1
@@ -2288,7 +2289,7 @@ label_34:
     if (r9 > r1)
 #line 85 "sample/map.c"
         goto label_34;
-    // EBPF_OP_MOV64_IMM pc=675 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=675 dst=r1 src=r0 offset=0 imm=0
 #line 85 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=676 dst=r10 src=r1 offset=-4 imm=0
@@ -2312,7 +2313,7 @@ label_34:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=682 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=682 dst=r6 src=r0 offset=0 imm=0
 #line 137 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=683 dst=r4 src=r6 offset=0 imm=0
@@ -2403,7 +2404,7 @@ label_36:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=716 dst=r0 src=r0 offset=104 imm=0
+        // EBPF_OP_JA pc=716 dst=r0 src=r0 offset=104 imm=0
 #line 137 "sample/map.c"
     goto label_44;
 label_37:
@@ -2452,7 +2453,7 @@ label_37:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 88 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=734 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=734 dst=r1 src=r0 offset=0 imm=100
 #line 88 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=735 dst=r10 src=r1 offset=-28 imm=0
@@ -2546,7 +2547,7 @@ label_38:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 88 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=771 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=771 dst=r1 src=r0 offset=0 imm=0
 #line 88 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=772 dst=r10 src=r1 offset=-20 imm=0
@@ -2673,7 +2674,7 @@ label_43:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=819 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=819 dst=r6 src=r0 offset=0 imm=-1
 #line 137 "sample/map.c"
     r6 = (uint64_t)4294967295;
 label_44:
@@ -2691,7 +2692,7 @@ label_44:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 186 "sample/map.c"
         goto label_68;
-    // EBPF_OP_LDDW pc=825 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=825 dst=r1 src=r0 offset=0 imm=1684369010
 #line 186 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=827 dst=r10 src=r1 offset=-32 imm=0
@@ -2758,7 +2759,7 @@ label_45:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 138 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=851 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=851 dst=r6 src=r0 offset=0 imm=0
 #line 138 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=852 dst=r4 src=r6 offset=0 imm=0
@@ -2916,7 +2917,7 @@ label_49:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=912 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=912 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=913 dst=r1 src=r6 offset=0 imm=0
@@ -3020,7 +3021,7 @@ label_52:
     if ((test_maps_helpers[9].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=-129 imm=0
+        // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=-129 imm=0
 #line 141 "sample/map.c"
     goto label_44;
 label_53:
@@ -3051,7 +3052,7 @@ label_53:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=958 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=958 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=959 dst=r1 src=r6 offset=0 imm=0
@@ -3068,7 +3069,7 @@ label_53:
     if (r1 == IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_54;
-    // EBPF_OP_JA pc=963 dst=r0 src=r0 offset=-47 imm=0
+        // EBPF_OP_JA pc=963 dst=r0 src=r0 offset=-47 imm=0
 #line 141 "sample/map.c"
     goto label_50;
 label_54:
@@ -3099,7 +3100,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=972 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=972 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=973 dst=r1 src=r6 offset=0 imm=0
@@ -3116,7 +3117,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=977 dst=r1 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=977 dst=r1 src=r0 offset=0 imm=3
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=978 dst=r10 src=r1 offset=-4 imm=0
@@ -3143,7 +3144,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=985 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=985 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=986 dst=r1 src=r6 offset=0 imm=0
@@ -3160,7 +3161,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=990 dst=r1 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=990 dst=r1 src=r0 offset=0 imm=4
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=991 dst=r10 src=r1 offset=-4 imm=0
@@ -3187,7 +3188,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=998 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=998 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=999 dst=r1 src=r6 offset=0 imm=0
@@ -3204,7 +3205,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1003 dst=r1 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1003 dst=r1 src=r0 offset=0 imm=5
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=1004 dst=r10 src=r1 offset=-4 imm=0
@@ -3231,7 +3232,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1011 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1011 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1012 dst=r1 src=r6 offset=0 imm=0
@@ -3248,7 +3249,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1016 dst=r1 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1016 dst=r1 src=r0 offset=0 imm=6
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=1017 dst=r10 src=r1 offset=-4 imm=0
@@ -3275,7 +3276,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1024 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1024 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1025 dst=r1 src=r6 offset=0 imm=0
@@ -3292,7 +3293,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=7
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=1030 dst=r10 src=r1 offset=-4 imm=0
@@ -3319,7 +3320,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1037 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1037 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1038 dst=r1 src=r6 offset=0 imm=0
@@ -3336,7 +3337,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=8
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=1043 dst=r10 src=r1 offset=-4 imm=0
@@ -3363,7 +3364,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1050 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1050 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1051 dst=r1 src=r6 offset=0 imm=0
@@ -3380,7 +3381,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1055 dst=r1 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1055 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=1056 dst=r10 src=r1 offset=-4 imm=0
@@ -3407,7 +3408,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1063 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1063 dst=r6 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1064 dst=r1 src=r6 offset=0 imm=0
@@ -3424,7 +3425,7 @@ label_54:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_50;
-    // EBPF_OP_MOV64_IMM pc=1068 dst=r7 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1068 dst=r7 src=r0 offset=0 imm=10
 #line 141 "sample/map.c"
     r7 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=1069 dst=r10 src=r7 offset=-4 imm=0
@@ -3454,7 +3455,7 @@ label_54:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 144 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1077 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1077 dst=r6 src=r0 offset=0 imm=0
 #line 144 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1078 dst=r5 src=r6 offset=0 imm=0
@@ -3477,7 +3478,7 @@ label_54:
     if (r1 == r2)
 #line 144 "sample/map.c"
         goto label_55;
-    // EBPF_OP_STXB pc=1085 dst=r10 src=r8 offset=-10 imm=0
+        // EBPF_OP_STXB pc=1085 dst=r10 src=r8 offset=-10 imm=0
 #line 144 "sample/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1086 dst=r1 src=r0 offset=0 imm=25637
@@ -3574,7 +3575,7 @@ label_55:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 145 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1122 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1122 dst=r6 src=r0 offset=0 imm=0
 #line 145 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1123 dst=r5 src=r6 offset=0 imm=0
@@ -3594,7 +3595,7 @@ label_55:
     if (r1 == IMMEDIATE(0))
 #line 145 "sample/map.c"
         goto label_56;
-    // EBPF_OP_MOV64_IMM pc=1128 dst=r1 src=r0 offset=0 imm=25637
+        // EBPF_OP_MOV64_IMM pc=1128 dst=r1 src=r0 offset=0 imm=25637
 #line 145 "sample/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1129 dst=r10 src=r1 offset=-12 imm=0
@@ -3679,7 +3680,7 @@ label_56:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1161 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1161 dst=r6 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1162 dst=r4 src=r6 offset=0 imm=0
@@ -3699,7 +3700,7 @@ label_56:
     if (r1 == IMMEDIATE(0))
 #line 147 "sample/map.c"
         goto label_58;
-    // EBPF_OP_MOV64_IMM pc=1167 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=1167 dst=r1 src=r0 offset=0 imm=100
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1168 dst=r10 src=r1 offset=-16 imm=0
@@ -3766,7 +3767,7 @@ label_57:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1193 dst=r0 src=r0 offset=-373 imm=0
+        // EBPF_OP_JA pc=1193 dst=r0 src=r0 offset=-373 imm=0
 #line 147 "sample/map.c"
     goto label_44;
 label_58:
@@ -3778,7 +3779,7 @@ label_58:
     if (r3 == IMMEDIATE(1))
 #line 147 "sample/map.c"
         goto label_59;
-    // EBPF_OP_MOV64_IMM pc=1196 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1196 dst=r1 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1197 dst=r10 src=r1 offset=-24 imm=0
@@ -3854,7 +3855,7 @@ label_59:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1225 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1225 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1226 dst=r1 src=r6 offset=0 imm=0
@@ -4012,7 +4013,7 @@ label_63:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1285 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1285 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1286 dst=r1 src=r6 offset=0 imm=0
@@ -4029,7 +4030,7 @@ label_63:
     if (r1 == IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_64;
-    // EBPF_OP_JA pc=1290 dst=r0 src=r0 offset=-61 imm=0
+        // EBPF_OP_JA pc=1290 dst=r0 src=r0 offset=-61 imm=0
 #line 150 "sample/map.c"
     goto label_60;
 label_64:
@@ -4044,7 +4045,7 @@ label_64:
     if (r3 != IMMEDIATE(2))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1294 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1294 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1295 dst=r10 src=r1 offset=-4 imm=0
@@ -4068,7 +4069,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1301 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1301 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1302 dst=r1 src=r6 offset=0 imm=0
@@ -4085,7 +4086,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1306 dst=r4 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=1306 dst=r4 src=r0 offset=0 imm=3
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(3);
     // EBPF_OP_LDXW pc=1307 dst=r3 src=r10 offset=-4 imm=0
@@ -4096,7 +4097,7 @@ label_64:
     if (r3 != IMMEDIATE(3))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1309 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1309 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1310 dst=r10 src=r1 offset=-4 imm=0
@@ -4120,7 +4121,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1316 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1316 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1317 dst=r1 src=r6 offset=0 imm=0
@@ -4137,7 +4138,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1321 dst=r4 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=1321 dst=r4 src=r0 offset=0 imm=4
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(4);
     // EBPF_OP_LDXW pc=1322 dst=r3 src=r10 offset=-4 imm=0
@@ -4148,7 +4149,7 @@ label_64:
     if (r3 != IMMEDIATE(4))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1324 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1324 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1325 dst=r10 src=r1 offset=-4 imm=0
@@ -4172,7 +4173,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1331 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1331 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1332 dst=r1 src=r6 offset=0 imm=0
@@ -4189,7 +4190,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1336 dst=r4 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1336 dst=r4 src=r0 offset=0 imm=5
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(5);
     // EBPF_OP_LDXW pc=1337 dst=r3 src=r10 offset=-4 imm=0
@@ -4200,7 +4201,7 @@ label_64:
     if (r3 != IMMEDIATE(5))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1340 dst=r10 src=r1 offset=-4 imm=0
@@ -4224,7 +4225,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1346 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1346 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1347 dst=r1 src=r6 offset=0 imm=0
@@ -4241,7 +4242,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1351 dst=r4 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1351 dst=r4 src=r0 offset=0 imm=6
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(6);
     // EBPF_OP_LDXW pc=1352 dst=r3 src=r10 offset=-4 imm=0
@@ -4252,7 +4253,7 @@ label_64:
     if (r3 != IMMEDIATE(6))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1354 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1354 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1355 dst=r10 src=r1 offset=-4 imm=0
@@ -4276,7 +4277,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1361 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1361 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1362 dst=r1 src=r6 offset=0 imm=0
@@ -4293,7 +4294,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1366 dst=r4 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1366 dst=r4 src=r0 offset=0 imm=7
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(7);
     // EBPF_OP_LDXW pc=1367 dst=r3 src=r10 offset=-4 imm=0
@@ -4304,7 +4305,7 @@ label_64:
     if (r3 != IMMEDIATE(7))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1369 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1369 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1370 dst=r10 src=r1 offset=-4 imm=0
@@ -4328,7 +4329,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1376 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1376 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1377 dst=r1 src=r6 offset=0 imm=0
@@ -4345,7 +4346,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1381 dst=r4 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1381 dst=r4 src=r0 offset=0 imm=8
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(8);
     // EBPF_OP_LDXW pc=1382 dst=r3 src=r10 offset=-4 imm=0
@@ -4356,7 +4357,7 @@ label_64:
     if (r3 != IMMEDIATE(8))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1384 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1384 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1385 dst=r10 src=r1 offset=-4 imm=0
@@ -4380,7 +4381,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1391 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1391 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1392 dst=r1 src=r6 offset=0 imm=0
@@ -4397,7 +4398,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1396 dst=r4 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1396 dst=r4 src=r0 offset=0 imm=9
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(9);
     // EBPF_OP_LDXW pc=1397 dst=r3 src=r10 offset=-4 imm=0
@@ -4408,7 +4409,7 @@ label_64:
     if (r3 != IMMEDIATE(9))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1399 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1399 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1400 dst=r10 src=r1 offset=-4 imm=0
@@ -4432,7 +4433,7 @@ label_64:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1406 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1406 dst=r6 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1407 dst=r1 src=r6 offset=0 imm=0
@@ -4449,7 +4450,7 @@ label_64:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_60;
-    // EBPF_OP_MOV64_IMM pc=1411 dst=r4 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1411 dst=r4 src=r0 offset=0 imm=10
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(10);
     // EBPF_OP_LDXW pc=1412 dst=r3 src=r10 offset=-4 imm=0
@@ -4460,7 +4461,7 @@ label_64:
     if (r3 != IMMEDIATE(10))
 #line 150 "sample/map.c"
         goto label_62;
-    // EBPF_OP_MOV64_IMM pc=1414 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1414 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1415 dst=r10 src=r1 offset=-4 imm=0
@@ -4484,7 +4485,7 @@ label_64:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 153 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1421 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1421 dst=r6 src=r0 offset=0 imm=0
 #line 153 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1422 dst=r4 src=r6 offset=0 imm=0
@@ -4507,7 +4508,7 @@ label_64:
     if (r1 == r2)
 #line 153 "sample/map.c"
         goto label_65;
-    // EBPF_OP_JA pc=1429 dst=r0 src=r0 offset=-740 imm=0
+        // EBPF_OP_JA pc=1429 dst=r0 src=r0 offset=-740 imm=0
 #line 153 "sample/map.c"
     goto label_35;
 label_65:
@@ -4519,7 +4520,7 @@ label_65:
     if (r3 == IMMEDIATE(0))
 #line 153 "sample/map.c"
         goto label_66;
-    // EBPF_OP_JA pc=1432 dst=r0 src=r0 offset=-636 imm=0
+        // EBPF_OP_JA pc=1432 dst=r0 src=r0 offset=-636 imm=0
 #line 153 "sample/map.c"
     goto label_41;
 label_66:
@@ -4547,7 +4548,7 @@ label_66:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 154 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1440 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1440 dst=r6 src=r0 offset=0 imm=0
 #line 154 "sample/map.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=1441 dst=r4 src=r6 offset=0 imm=0
@@ -4570,7 +4571,7 @@ label_66:
     if (r1 == r2)
 #line 154 "sample/map.c"
         goto label_67;
-    // EBPF_OP_JA pc=1448 dst=r0 src=r0 offset=-590 imm=0
+        // EBPF_OP_JA pc=1448 dst=r0 src=r0 offset=-590 imm=0
 #line 154 "sample/map.c"
     goto label_46;
 label_67:
@@ -4582,7 +4583,7 @@ label_67:
     if (r3 == IMMEDIATE(0))
 #line 154 "sample/map.c"
         goto label_68;
-    // EBPF_OP_JA pc=1451 dst=r0 src=r0 offset=-567 imm=0
+        // EBPF_OP_JA pc=1451 dst=r0 src=r0 offset=-567 imm=0
 #line 154 "sample/map.c"
     goto label_48;
 label_68:
@@ -4610,7 +4611,7 @@ label_68:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
 #line 137 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1460 dst=r4 src=r7 offset=0 imm=0
@@ -4701,7 +4702,7 @@ label_70:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1493 dst=r0 src=r0 offset=26 imm=0
+        // EBPF_OP_JA pc=1493 dst=r0 src=r0 offset=26 imm=0
 #line 137 "sample/map.c"
     goto label_75;
 label_71:
@@ -4773,7 +4774,7 @@ label_74:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 137 "sample/map.c"
         return 0;
-    // EBPF_OP_LDDW pc=1518 dst=r7 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=1518 dst=r7 src=r0 offset=0 imm=-1
 #line 137 "sample/map.c"
     r7 = (uint64_t)4294967295;
 label_75:
@@ -4794,7 +4795,7 @@ label_75:
     if ((int64_t)r3 > (int64_t)IMMEDIATE(-1))
 #line 187 "sample/map.c"
         goto label_6;
-    // EBPF_OP_LDDW pc=1525 dst=r1 src=r0 offset=0 imm=1684369010
+        // EBPF_OP_LDDW pc=1525 dst=r1 src=r0 offset=0 imm=1684369010
 #line 187 "sample/map.c"
     r1 = (uint64_t)28188318724615794;
     // EBPF_OP_STXDW pc=1527 dst=r10 src=r1 offset=-32 imm=0
@@ -4842,7 +4843,7 @@ label_75:
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
 #line 187 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1544 dst=r6 src=r7 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1544 dst=r6 src=r7 offset=0 imm=0
 #line 187 "sample/map.c"
     r6 = r7;
     // EBPF_OP_JA pc=1545 dst=r0 src=r0 offset=-1444 imm=0
@@ -4873,7 +4874,7 @@ label_76:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 138 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1553 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1553 dst=r7 src=r0 offset=0 imm=0
 #line 138 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1554 dst=r4 src=r7 offset=0 imm=0
@@ -5031,7 +5032,7 @@ label_80:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1614 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1614 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1615 dst=r1 src=r7 offset=0 imm=0
@@ -5135,7 +5136,7 @@ label_83:
     if ((test_maps_helpers[9].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1651 dst=r0 src=r0 offset=-132 imm=0
+        // EBPF_OP_JA pc=1651 dst=r0 src=r0 offset=-132 imm=0
 #line 141 "sample/map.c"
     goto label_75;
 label_84:
@@ -5166,7 +5167,7 @@ label_84:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1660 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1660 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1661 dst=r1 src=r7 offset=0 imm=0
@@ -5183,7 +5184,7 @@ label_84:
     if (r1 == IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_85;
-    // EBPF_OP_JA pc=1665 dst=r0 src=r0 offset=-47 imm=0
+        // EBPF_OP_JA pc=1665 dst=r0 src=r0 offset=-47 imm=0
 #line 141 "sample/map.c"
     goto label_81;
 label_85:
@@ -5214,7 +5215,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1674 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1674 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1675 dst=r1 src=r7 offset=0 imm=0
@@ -5231,7 +5232,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1679 dst=r1 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=1679 dst=r1 src=r0 offset=0 imm=3
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(3);
     // EBPF_OP_STXW pc=1680 dst=r10 src=r1 offset=-4 imm=0
@@ -5258,7 +5259,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1687 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1687 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1688 dst=r1 src=r7 offset=0 imm=0
@@ -5275,7 +5276,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1692 dst=r1 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=1692 dst=r1 src=r0 offset=0 imm=4
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(4);
     // EBPF_OP_STXW pc=1693 dst=r10 src=r1 offset=-4 imm=0
@@ -5302,7 +5303,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1700 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1700 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1701 dst=r1 src=r7 offset=0 imm=0
@@ -5319,7 +5320,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1705 dst=r1 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=1705 dst=r1 src=r0 offset=0 imm=5
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(5);
     // EBPF_OP_STXW pc=1706 dst=r10 src=r1 offset=-4 imm=0
@@ -5346,7 +5347,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1713 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1713 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1714 dst=r1 src=r7 offset=0 imm=0
@@ -5363,7 +5364,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1718 dst=r1 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=1718 dst=r1 src=r0 offset=0 imm=6
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(6);
     // EBPF_OP_STXW pc=1719 dst=r10 src=r1 offset=-4 imm=0
@@ -5390,7 +5391,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1726 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1726 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1727 dst=r1 src=r7 offset=0 imm=0
@@ -5407,7 +5408,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1731 dst=r1 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=1731 dst=r1 src=r0 offset=0 imm=7
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=1732 dst=r10 src=r1 offset=-4 imm=0
@@ -5434,7 +5435,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1739 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1739 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1740 dst=r1 src=r7 offset=0 imm=0
@@ -5451,7 +5452,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1744 dst=r1 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=1744 dst=r1 src=r0 offset=0 imm=8
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(8);
     // EBPF_OP_STXW pc=1745 dst=r10 src=r1 offset=-4 imm=0
@@ -5478,7 +5479,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1752 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1752 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1753 dst=r1 src=r7 offset=0 imm=0
@@ -5495,7 +5496,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1757 dst=r1 src=r0 offset=0 imm=9
+        // EBPF_OP_MOV64_IMM pc=1757 dst=r1 src=r0 offset=0 imm=9
 #line 141 "sample/map.c"
     r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=1758 dst=r10 src=r1 offset=-4 imm=0
@@ -5522,7 +5523,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 141 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1765 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1765 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1766 dst=r1 src=r7 offset=0 imm=0
@@ -5539,7 +5540,7 @@ label_85:
     if (r1 != IMMEDIATE(0))
 #line 141 "sample/map.c"
         goto label_81;
-    // EBPF_OP_MOV64_IMM pc=1770 dst=r6 src=r0 offset=0 imm=10
+        // EBPF_OP_MOV64_IMM pc=1770 dst=r6 src=r0 offset=0 imm=10
 #line 141 "sample/map.c"
     r6 = IMMEDIATE(10);
     // EBPF_OP_STXW pc=1771 dst=r10 src=r6 offset=-4 imm=0
@@ -5569,7 +5570,7 @@ label_85:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 144 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1779 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1779 dst=r7 src=r0 offset=0 imm=0
 #line 144 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1780 dst=r5 src=r7 offset=0 imm=0
@@ -5592,7 +5593,7 @@ label_85:
     if (r1 == r2)
 #line 144 "sample/map.c"
         goto label_86;
-    // EBPF_OP_STXB pc=1787 dst=r10 src=r8 offset=-10 imm=0
+        // EBPF_OP_STXB pc=1787 dst=r10 src=r8 offset=-10 imm=0
 #line 144 "sample/map.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-10)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=1788 dst=r1 src=r0 offset=0 imm=25637
@@ -5689,7 +5690,7 @@ label_86:
     if ((test_maps_helpers[8].tail_call) && (r0 == 0))
 #line 145 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1824 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1824 dst=r7 src=r0 offset=0 imm=0
 #line 145 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1825 dst=r5 src=r7 offset=0 imm=0
@@ -5709,7 +5710,7 @@ label_86:
     if (r1 == IMMEDIATE(0))
 #line 145 "sample/map.c"
         goto label_87;
-    // EBPF_OP_MOV64_IMM pc=1830 dst=r1 src=r0 offset=0 imm=25637
+        // EBPF_OP_MOV64_IMM pc=1830 dst=r1 src=r0 offset=0 imm=25637
 #line 145 "sample/map.c"
     r1 = IMMEDIATE(25637);
     // EBPF_OP_STXH pc=1831 dst=r10 src=r1 offset=-12 imm=0
@@ -5794,7 +5795,7 @@ label_87:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1863 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1863 dst=r7 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1864 dst=r4 src=r7 offset=0 imm=0
@@ -5814,7 +5815,7 @@ label_87:
     if (r1 == IMMEDIATE(0))
 #line 147 "sample/map.c"
         goto label_89;
-    // EBPF_OP_MOV64_IMM pc=1869 dst=r1 src=r0 offset=0 imm=100
+        // EBPF_OP_MOV64_IMM pc=1869 dst=r1 src=r0 offset=0 imm=100
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(100);
     // EBPF_OP_STXH pc=1870 dst=r10 src=r1 offset=-16 imm=0
@@ -5881,7 +5882,7 @@ label_88:
     if ((test_maps_helpers[6].tail_call) && (r0 == 0))
 #line 147 "sample/map.c"
         return 0;
-    // EBPF_OP_JA pc=1895 dst=r0 src=r0 offset=-376 imm=0
+        // EBPF_OP_JA pc=1895 dst=r0 src=r0 offset=-376 imm=0
 #line 147 "sample/map.c"
     goto label_75;
 label_89:
@@ -5893,7 +5894,7 @@ label_89:
     if (r3 == IMMEDIATE(10))
 #line 147 "sample/map.c"
         goto label_90;
-    // EBPF_OP_MOV64_IMM pc=1898 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1898 dst=r1 src=r0 offset=0 imm=0
 #line 147 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=1899 dst=r10 src=r1 offset=-24 imm=0
@@ -5969,7 +5970,7 @@ label_90:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1927 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1927 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1928 dst=r1 src=r7 offset=0 imm=0
@@ -6127,7 +6128,7 @@ label_94:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=1987 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=1987 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1988 dst=r1 src=r7 offset=0 imm=0
@@ -6144,7 +6145,7 @@ label_94:
     if (r1 == IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_95;
-    // EBPF_OP_JA pc=1992 dst=r0 src=r0 offset=-61 imm=0
+        // EBPF_OP_JA pc=1992 dst=r0 src=r0 offset=-61 imm=0
 #line 150 "sample/map.c"
     goto label_91;
 label_95:
@@ -6159,7 +6160,7 @@ label_95:
     if (r3 != IMMEDIATE(9))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=1996 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=1996 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1997 dst=r10 src=r1 offset=-4 imm=0
@@ -6183,7 +6184,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2003 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2003 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2004 dst=r1 src=r7 offset=0 imm=0
@@ -6200,7 +6201,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2008 dst=r4 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=2008 dst=r4 src=r0 offset=0 imm=8
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(8);
     // EBPF_OP_LDXW pc=2009 dst=r3 src=r10 offset=-4 imm=0
@@ -6211,7 +6212,7 @@ label_95:
     if (r3 != IMMEDIATE(8))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2011 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2011 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2012 dst=r10 src=r1 offset=-4 imm=0
@@ -6235,7 +6236,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2018 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2018 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2019 dst=r1 src=r7 offset=0 imm=0
@@ -6252,7 +6253,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2023 dst=r4 src=r0 offset=0 imm=7
+        // EBPF_OP_MOV64_IMM pc=2023 dst=r4 src=r0 offset=0 imm=7
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(7);
     // EBPF_OP_LDXW pc=2024 dst=r3 src=r10 offset=-4 imm=0
@@ -6263,7 +6264,7 @@ label_95:
     if (r3 != IMMEDIATE(7))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2026 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2026 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2027 dst=r10 src=r1 offset=-4 imm=0
@@ -6287,7 +6288,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2033 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2033 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2034 dst=r1 src=r7 offset=0 imm=0
@@ -6304,7 +6305,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2038 dst=r4 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=2038 dst=r4 src=r0 offset=0 imm=6
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(6);
     // EBPF_OP_LDXW pc=2039 dst=r3 src=r10 offset=-4 imm=0
@@ -6315,7 +6316,7 @@ label_95:
     if (r3 != IMMEDIATE(6))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2041 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2041 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2042 dst=r10 src=r1 offset=-4 imm=0
@@ -6339,7 +6340,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2048 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2048 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2049 dst=r1 src=r7 offset=0 imm=0
@@ -6356,7 +6357,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2053 dst=r4 src=r0 offset=0 imm=5
+        // EBPF_OP_MOV64_IMM pc=2053 dst=r4 src=r0 offset=0 imm=5
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(5);
     // EBPF_OP_LDXW pc=2054 dst=r3 src=r10 offset=-4 imm=0
@@ -6367,7 +6368,7 @@ label_95:
     if (r3 != IMMEDIATE(5))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2056 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2056 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2057 dst=r10 src=r1 offset=-4 imm=0
@@ -6391,7 +6392,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2063 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2063 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2064 dst=r1 src=r7 offset=0 imm=0
@@ -6408,7 +6409,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2068 dst=r4 src=r0 offset=0 imm=4
+        // EBPF_OP_MOV64_IMM pc=2068 dst=r4 src=r0 offset=0 imm=4
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(4);
     // EBPF_OP_LDXW pc=2069 dst=r3 src=r10 offset=-4 imm=0
@@ -6419,7 +6420,7 @@ label_95:
     if (r3 != IMMEDIATE(4))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2071 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2071 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2072 dst=r10 src=r1 offset=-4 imm=0
@@ -6443,7 +6444,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2078 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2078 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2079 dst=r1 src=r7 offset=0 imm=0
@@ -6460,7 +6461,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2083 dst=r4 src=r0 offset=0 imm=3
+        // EBPF_OP_MOV64_IMM pc=2083 dst=r4 src=r0 offset=0 imm=3
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(3);
     // EBPF_OP_LDXW pc=2084 dst=r3 src=r10 offset=-4 imm=0
@@ -6471,7 +6472,7 @@ label_95:
     if (r3 != IMMEDIATE(3))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2086 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2086 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2087 dst=r10 src=r1 offset=-4 imm=0
@@ -6495,7 +6496,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2093 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2093 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2094 dst=r1 src=r7 offset=0 imm=0
@@ -6512,7 +6513,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=2
+        // EBPF_OP_MOV64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=2
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(2);
     // EBPF_OP_LDXW pc=2099 dst=r3 src=r10 offset=-4 imm=0
@@ -6523,7 +6524,7 @@ label_95:
     if (r3 != IMMEDIATE(2))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2101 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2101 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2102 dst=r10 src=r1 offset=-4 imm=0
@@ -6547,7 +6548,7 @@ label_95:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 150 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2108 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2108 dst=r7 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2109 dst=r1 src=r7 offset=0 imm=0
@@ -6564,7 +6565,7 @@ label_95:
     if (r1 != IMMEDIATE(0))
 #line 150 "sample/map.c"
         goto label_91;
-    // EBPF_OP_MOV64_IMM pc=2113 dst=r4 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=2113 dst=r4 src=r0 offset=0 imm=1
 #line 150 "sample/map.c"
     r4 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=2114 dst=r3 src=r10 offset=-4 imm=0
@@ -6575,7 +6576,7 @@ label_95:
     if (r3 != IMMEDIATE(1))
 #line 150 "sample/map.c"
         goto label_93;
-    // EBPF_OP_MOV64_IMM pc=2116 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=2116 dst=r1 src=r0 offset=0 imm=0
 #line 150 "sample/map.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2117 dst=r10 src=r1 offset=-4 imm=0
@@ -6599,7 +6600,7 @@ label_95:
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
 #line 153 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2123 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2123 dst=r7 src=r0 offset=0 imm=0
 #line 153 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2124 dst=r4 src=r7 offset=0 imm=0
@@ -6622,7 +6623,7 @@ label_95:
     if (r1 == r2)
 #line 153 "sample/map.c"
         goto label_96;
-    // EBPF_OP_JA pc=2131 dst=r0 src=r0 offset=-665 imm=0
+        // EBPF_OP_JA pc=2131 dst=r0 src=r0 offset=-665 imm=0
 #line 153 "sample/map.c"
     goto label_69;
 label_96:
@@ -6634,7 +6635,7 @@ label_96:
     if (r3 == IMMEDIATE(0))
 #line 153 "sample/map.c"
         goto label_97;
-    // EBPF_OP_JA pc=2134 dst=r0 src=r0 offset=-639 imm=0
+        // EBPF_OP_JA pc=2134 dst=r0 src=r0 offset=-639 imm=0
 #line 153 "sample/map.c"
     goto label_72;
 label_97:
@@ -6662,7 +6663,7 @@ label_97:
     if ((test_maps_helpers[7].tail_call) && (r0 == 0))
 #line 154 "sample/map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=2142 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=2142 dst=r7 src=r0 offset=0 imm=0
 #line 154 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=2143 dst=r4 src=r7 offset=0 imm=0
@@ -6685,7 +6686,7 @@ label_97:
     if (r1 == r2)
 #line 154 "sample/map.c"
         goto label_98;
-    // EBPF_OP_JA pc=2150 dst=r0 src=r0 offset=-590 imm=0
+        // EBPF_OP_JA pc=2150 dst=r0 src=r0 offset=-590 imm=0
 #line 154 "sample/map.c"
     goto label_77;
 label_98:
@@ -6697,7 +6698,7 @@ label_98:
     if (r3 == IMMEDIATE(0))
 #line 154 "sample/map.c"
         goto label_99;
-    // EBPF_OP_JA pc=2153 dst=r0 src=r0 offset=-567 imm=0
+        // EBPF_OP_JA pc=2153 dst=r0 src=r0 offset=-567 imm=0
 #line 154 "sample/map.c"
     goto label_79;
 label_99:

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -73,6 +73,7 @@ static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
+#line 18 "sample/printk.c"
 {
 #line 18 "sample/printk.c"
     // Prologue
@@ -145,7 +146,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 23 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -178,7 +179,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -211,7 +212,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -256,7 +257,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 28 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 30 "sample/printk.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -310,7 +311,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 30 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 30 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -349,7 +350,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 34 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 34 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -382,7 +383,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 35 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -415,7 +416,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 36 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 36 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -445,7 +446,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 37 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 37 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -478,7 +479,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 41 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 41 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -505,7 +506,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 42 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 45 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -541,7 +542,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 45 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 45 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -73,6 +73,7 @@ static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
+#line 26 "sample/printk_legacy.c"
 {
 #line 26 "sample/printk_legacy.c"
     // Prologue
@@ -145,7 +146,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 31 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 31 "sample/printk_legacy.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -178,7 +179,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 32 "sample/printk_legacy.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -211,7 +212,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 35 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 35 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -256,7 +257,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 36 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 38 "sample/printk_legacy.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -310,7 +311,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 38 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 38 "sample/printk_legacy.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -349,7 +350,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 42 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 42 "sample/printk_legacy.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -382,7 +383,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 43 "sample/printk_legacy.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -415,7 +416,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 44 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 44 "sample/printk_legacy.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -445,7 +446,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 45 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 45 "sample/printk_legacy.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -478,7 +479,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 49 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 49 "sample/printk_legacy.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -505,7 +506,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 50 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 53 "sample/printk_legacy.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -541,7 +542,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 53 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -31,6 +31,7 @@ static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
+#line 26 "sample/printk_legacy.c"
 {
 #line 26 "sample/printk_legacy.c"
     // Prologue
@@ -103,7 +104,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 31 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 31 "sample/printk_legacy.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -136,7 +137,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 32 "sample/printk_legacy.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -169,7 +170,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 35 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 35 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -214,7 +215,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 36 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 38 "sample/printk_legacy.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -268,7 +269,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 38 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 38 "sample/printk_legacy.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -307,7 +308,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 42 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 42 "sample/printk_legacy.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -340,7 +341,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 43 "sample/printk_legacy.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -373,7 +374,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 44 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 44 "sample/printk_legacy.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -403,7 +404,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 45 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 45 "sample/printk_legacy.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -436,7 +437,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 49 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 49 "sample/printk_legacy.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -463,7 +464,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 50 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 53 "sample/printk_legacy.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -499,7 +500,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 53 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -198,6 +198,7 @@ static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
+#line 26 "sample/printk_legacy.c"
 {
 #line 26 "sample/printk_legacy.c"
     // Prologue
@@ -270,7 +271,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 31 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 31 "sample/printk_legacy.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -303,7 +304,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 32 "sample/printk_legacy.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -336,7 +337,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 35 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 35 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -381,7 +382,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 36 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 38 "sample/printk_legacy.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -435,7 +436,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 38 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 38 "sample/printk_legacy.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -474,7 +475,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 42 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 42 "sample/printk_legacy.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -507,7 +508,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 43 "sample/printk_legacy.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -540,7 +541,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 44 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 44 "sample/printk_legacy.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -570,7 +571,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 45 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 45 "sample/printk_legacy.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -603,7 +604,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 49 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 49 "sample/printk_legacy.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -630,7 +631,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 50 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 53 "sample/printk_legacy.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -666,7 +667,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 53 "sample/printk_legacy.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 53 "sample/printk_legacy.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -31,6 +31,7 @@ static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
+#line 18 "sample/printk.c"
 {
 #line 18 "sample/printk.c"
     // Prologue
@@ -103,7 +104,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 23 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -136,7 +137,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -169,7 +170,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -214,7 +215,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 28 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 30 "sample/printk.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -268,7 +269,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 30 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 30 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -307,7 +308,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 34 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 34 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -340,7 +341,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 35 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -373,7 +374,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 36 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 36 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -403,7 +404,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 37 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 37 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -436,7 +437,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 41 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 41 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -463,7 +464,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 42 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 45 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -499,7 +500,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 45 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 45 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -198,6 +198,7 @@ static GUID func_attach_type_guid = {0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
+#line 18 "sample/printk.c"
 {
 #line 18 "sample/printk.c"
     // Prologue
@@ -270,7 +271,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 23 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r8 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -303,7 +304,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_LDDW pc=22 dst=r1 src=r0 offset=0 imm=977553744
@@ -336,7 +337,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=31 dst=r6 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_IMM pc=32 dst=r8 src=r0 offset=0 imm=117
@@ -381,7 +382,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 28 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
+        // EBPF_OP_STXH pc=46 dst=r10 src=r8 offset=-4 imm=0
 #line 30 "sample/printk.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
     // EBPF_OP_MOV64_IMM pc=47 dst=r1 src=r0 offset=0 imm=622869070
@@ -435,7 +436,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 30 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=64 dst=r1 src=r0 offset=0 imm=9504
 #line 30 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=65 dst=r10 src=r1 offset=-28 imm=0
@@ -474,7 +475,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 34 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=75 dst=r1 src=r0 offset=0 imm=843333954
 #line 34 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=77 dst=r10 src=r1 offset=-32 imm=0
@@ -507,7 +508,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=85 dst=r1 src=r0 offset=0 imm=860111170
 #line 35 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=87 dst=r10 src=r1 offset=-32 imm=0
@@ -540,7 +541,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 36 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=876888386
 #line 36 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=97 dst=r10 src=r1 offset=-32 imm=0
@@ -570,7 +571,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 37 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=104 dst=r1 src=r0 offset=0 imm=893665602
 #line 37 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=105 dst=r10 src=r1 offset=-32 imm=0
@@ -603,7 +604,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 41 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=113 dst=r1 src=r0 offset=0 imm=910442818
 #line 41 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-32 imm=0
@@ -630,7 +631,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 42 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=121 dst=r10 src=r8 offset=-22 imm=0
 #line 45 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=122 dst=r1 src=r0 offset=0 imm=25966
@@ -666,7 +667,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 45 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=132 dst=r6 src=r0 offset=0 imm=0
 #line 45 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=133 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -68,6 +68,7 @@ static GUID reflect_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/re~1")
 static uint64_t
 reflect_packet(void* context)
+#line 23 "sample/reflect_packet.c"
 {
 #line 23 "sample/reflect_packet.c"
     // Prologue
@@ -113,7 +114,7 @@ reflect_packet(void* context)
     if (r3 > r2)
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 33 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=56 imm=56710
@@ -121,12 +122,12 @@ reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 33 "sample/reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
 #line 33 "sample/reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 33 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -137,7 +138,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 39 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=195 imm=17
@@ -145,7 +146,7 @@ reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 39 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 39 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
@@ -168,7 +169,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 39 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
 #line 44 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=186 imm=7459
@@ -176,7 +177,7 @@ reflect_packet(void* context)
     if (r2 != IMMEDIATE(7459))
 #line 44 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r2 src=r0 offset=0 imm=8
@@ -311,7 +312,7 @@ label_1:
     if (r3 > r2)
 #line 52 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
 #line 52 "sample/reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
@@ -322,7 +323,7 @@ label_1:
     if (r3 > r2)
 #line 57 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
 #line 57 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
@@ -330,7 +331,7 @@ label_1:
     if (r2 != IMMEDIATE(17))
 #line 57 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=73 dst=r2 src=r0 offset=135 imm=7459
@@ -338,7 +339,7 @@ label_1:
     if (r2 != IMMEDIATE(7459))
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=75 dst=r2 src=r0 offset=0 imm=8

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.c
@@ -26,6 +26,7 @@ static GUID reflect_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/re~1")
 static uint64_t
 reflect_packet(void* context)
+#line 23 "sample/reflect_packet.c"
 {
 #line 23 "sample/reflect_packet.c"
     // Prologue
@@ -71,7 +72,7 @@ reflect_packet(void* context)
     if (r3 > r2)
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 33 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=56 imm=56710
@@ -79,12 +80,12 @@ reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 33 "sample/reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
 #line 33 "sample/reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 33 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -95,7 +96,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 39 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=195 imm=17
@@ -103,7 +104,7 @@ reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 39 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 39 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
@@ -126,7 +127,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 39 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
 #line 44 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=186 imm=7459
@@ -134,7 +135,7 @@ reflect_packet(void* context)
     if (r2 != IMMEDIATE(7459))
 #line 44 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r2 src=r0 offset=0 imm=8
@@ -269,7 +270,7 @@ label_1:
     if (r3 > r2)
 #line 52 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
 #line 52 "sample/reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
@@ -280,7 +281,7 @@ label_1:
     if (r3 > r2)
 #line 57 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
 #line 57 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
@@ -288,7 +289,7 @@ label_1:
     if (r2 != IMMEDIATE(17))
 #line 57 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=73 dst=r2 src=r0 offset=135 imm=7459
@@ -296,7 +297,7 @@ label_1:
     if (r2 != IMMEDIATE(7459))
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=75 dst=r2 src=r0 offset=0 imm=8

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.c
@@ -193,6 +193,7 @@ static GUID reflect_packet_attach_type_guid = {
 #pragma code_seg(push, "xdp/re~1")
 static uint64_t
 reflect_packet(void* context)
+#line 23 "sample/reflect_packet.c"
 {
 #line 23 "sample/reflect_packet.c"
     // Prologue
@@ -238,7 +239,7 @@ reflect_packet(void* context)
     if (r3 > r2)
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 33 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=56 imm=56710
@@ -246,12 +247,12 @@ reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 33 "sample/reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
 #line 33 "sample/reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 33 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -262,7 +263,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 39 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=195 imm=17
@@ -270,7 +271,7 @@ reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 39 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 39 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
@@ -293,7 +294,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 39 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
 #line 44 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=186 imm=7459
@@ -301,7 +302,7 @@ reflect_packet(void* context)
     if (r2 != IMMEDIATE(7459))
 #line 44 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r2 src=r0 offset=0 imm=8
@@ -436,7 +437,7 @@ label_1:
     if (r3 > r2)
 #line 52 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
 #line 52 "sample/reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
@@ -447,7 +448,7 @@ label_1:
     if (r3 > r2)
 #line 57 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
 #line 57 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
@@ -455,7 +456,7 @@ label_1:
     if (r2 != IMMEDIATE(17))
 #line 57 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 62 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=73 dst=r2 src=r0 offset=135 imm=7459
@@ -463,7 +464,7 @@ label_1:
     if (r2 != IMMEDIATE(7459))
 #line 62 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=75 dst=r2 src=r0 offset=0 imm=8

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -107,6 +107,7 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
+#line 65 "sample/sockops.c"
 {
 #line 65 "sample/sockops.c"
     // Prologue
@@ -154,12 +155,12 @@ connection_monitor(void* context)
     if (r2 == IMMEDIATE(0))
 #line 70 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+        // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
 #line 70 "sample/sockops.c"
     if (r2 == IMMEDIATE(2))
 #line 70 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
@@ -167,7 +168,7 @@ connection_monitor(void* context)
     if (r2 != IMMEDIATE(1))
 #line 70 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
 #line 70 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -189,7 +190,7 @@ label_2:
     if (r2 != IMMEDIATE(2))
 #line 87 "sample/sockops.c"
         goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
 #line 87 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=15 dst=r10 src=r6 offset=-4 imm=0
@@ -236,7 +237,7 @@ label_2:
     if (r4 != IMMEDIATE(0))
 #line 24 "sample/sockops.c"
         goto label_3;
-    // EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
+        // EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
 #line 24 "sample/sockops.c"
     r5 = IMMEDIATE(28);
 label_3:
@@ -263,7 +264,7 @@ label_3:
     if (r4 != IMMEDIATE(0))
 #line 25 "sample/sockops.c"
         goto label_4;
-    // EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
 #line 25 "sample/sockops.c"
     r3 = IMMEDIATE(44);
 label_4:
@@ -284,7 +285,7 @@ label_4:
     if (r4 != IMMEDIATE(0))
 #line 27 "sample/sockops.c"
         goto label_5;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
 #line 27 "sample/sockops.c"
     r0 = IMMEDIATE(24);
 label_5:
@@ -293,7 +294,7 @@ label_5:
     if (r4 != IMMEDIATE(0))
 #line 26 "sample/sockops.c"
         goto label_6;
-    // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
 #line 26 "sample/sockops.c"
     r2 = IMMEDIATE(8);
 label_6:
@@ -351,12 +352,12 @@ label_6:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/sockops.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
+        // EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
 #line 32 "sample/sockops.c"
     if (r0 == IMMEDIATE(0))
 #line 32 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
+        // EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
 #line 32 "sample/sockops.c"
     goto label_12;
 label_7:
@@ -401,7 +402,7 @@ label_7:
     if (r4 != IMMEDIATE(0))
 #line 46 "sample/sockops.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
     r0 = r3;
 label_8:
@@ -476,7 +477,7 @@ label_8:
     if (r4 != IMMEDIATE(0))
 #line 48 "sample/sockops.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+        // EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
 #line 48 "sample/sockops.c"
     r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104));
 label_9:
@@ -521,7 +522,7 @@ label_9:
     if (r4 != IMMEDIATE(0))
 #line 48 "sample/sockops.c"
         goto label_10;
-    // EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
     r1 = IMMEDIATE(44);
     // EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
@@ -551,7 +552,7 @@ label_10:
     if (r4 != IMMEDIATE(0))
 #line 51 "sample/sockops.c"
         goto label_11;
-    // EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
@@ -816,7 +817,7 @@ label_11:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
@@ -849,7 +850,7 @@ label_12:
     if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
 #line 56 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
     r6 = r0;
 label_13:

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -65,6 +65,7 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
+#line 65 "sample/sockops.c"
 {
 #line 65 "sample/sockops.c"
     // Prologue
@@ -112,12 +113,12 @@ connection_monitor(void* context)
     if (r2 == IMMEDIATE(0))
 #line 70 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+        // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
 #line 70 "sample/sockops.c"
     if (r2 == IMMEDIATE(2))
 #line 70 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
@@ -125,7 +126,7 @@ connection_monitor(void* context)
     if (r2 != IMMEDIATE(1))
 #line 70 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
 #line 70 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -147,7 +148,7 @@ label_2:
     if (r2 != IMMEDIATE(2))
 #line 87 "sample/sockops.c"
         goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
 #line 87 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=15 dst=r10 src=r6 offset=-4 imm=0
@@ -194,7 +195,7 @@ label_2:
     if (r4 != IMMEDIATE(0))
 #line 24 "sample/sockops.c"
         goto label_3;
-    // EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
+        // EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
 #line 24 "sample/sockops.c"
     r5 = IMMEDIATE(28);
 label_3:
@@ -221,7 +222,7 @@ label_3:
     if (r4 != IMMEDIATE(0))
 #line 25 "sample/sockops.c"
         goto label_4;
-    // EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
 #line 25 "sample/sockops.c"
     r3 = IMMEDIATE(44);
 label_4:
@@ -242,7 +243,7 @@ label_4:
     if (r4 != IMMEDIATE(0))
 #line 27 "sample/sockops.c"
         goto label_5;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
 #line 27 "sample/sockops.c"
     r0 = IMMEDIATE(24);
 label_5:
@@ -251,7 +252,7 @@ label_5:
     if (r4 != IMMEDIATE(0))
 #line 26 "sample/sockops.c"
         goto label_6;
-    // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
 #line 26 "sample/sockops.c"
     r2 = IMMEDIATE(8);
 label_6:
@@ -309,12 +310,12 @@ label_6:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/sockops.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
+        // EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
 #line 32 "sample/sockops.c"
     if (r0 == IMMEDIATE(0))
 #line 32 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
+        // EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
 #line 32 "sample/sockops.c"
     goto label_12;
 label_7:
@@ -359,7 +360,7 @@ label_7:
     if (r4 != IMMEDIATE(0))
 #line 46 "sample/sockops.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
     r0 = r3;
 label_8:
@@ -434,7 +435,7 @@ label_8:
     if (r4 != IMMEDIATE(0))
 #line 48 "sample/sockops.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+        // EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
 #line 48 "sample/sockops.c"
     r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104));
 label_9:
@@ -479,7 +480,7 @@ label_9:
     if (r4 != IMMEDIATE(0))
 #line 48 "sample/sockops.c"
         goto label_10;
-    // EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
     r1 = IMMEDIATE(44);
     // EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
@@ -509,7 +510,7 @@ label_10:
     if (r4 != IMMEDIATE(0))
 #line 51 "sample/sockops.c"
         goto label_11;
-    // EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
@@ -774,7 +775,7 @@ label_11:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
@@ -807,7 +808,7 @@ label_12:
     if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
 #line 56 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
     r6 = r0;
 label_13:

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -232,6 +232,7 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
+#line 65 "sample/sockops.c"
 {
 #line 65 "sample/sockops.c"
     // Prologue
@@ -279,12 +280,12 @@ connection_monitor(void* context)
     if (r2 == IMMEDIATE(0))
 #line 70 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+        // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
 #line 70 "sample/sockops.c"
     if (r2 == IMMEDIATE(2))
 #line 70 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 70 "sample/sockops.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=214 imm=1
@@ -292,7 +293,7 @@ connection_monitor(void* context)
     if (r2 != IMMEDIATE(1))
 #line 70 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
 #line 70 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -314,7 +315,7 @@ label_2:
     if (r2 != IMMEDIATE(2))
 #line 87 "sample/sockops.c"
         goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
 #line 87 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=15 dst=r10 src=r6 offset=-4 imm=0
@@ -361,7 +362,7 @@ label_2:
     if (r4 != IMMEDIATE(0))
 #line 24 "sample/sockops.c"
         goto label_3;
-    // EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
+        // EBPF_OP_MOV64_IMM pc=29 dst=r5 src=r0 offset=0 imm=28
 #line 24 "sample/sockops.c"
     r5 = IMMEDIATE(28);
 label_3:
@@ -388,7 +389,7 @@ label_3:
     if (r4 != IMMEDIATE(0))
 #line 25 "sample/sockops.c"
         goto label_4;
-    // EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=37 dst=r3 src=r0 offset=0 imm=44
 #line 25 "sample/sockops.c"
     r3 = IMMEDIATE(44);
 label_4:
@@ -409,7 +410,7 @@ label_4:
     if (r4 != IMMEDIATE(0))
 #line 27 "sample/sockops.c"
         goto label_5;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=43 dst=r0 src=r0 offset=0 imm=24
 #line 27 "sample/sockops.c"
     r0 = IMMEDIATE(24);
 label_5:
@@ -418,7 +419,7 @@ label_5:
     if (r4 != IMMEDIATE(0))
 #line 26 "sample/sockops.c"
         goto label_6;
-    // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=8
 #line 26 "sample/sockops.c"
     r2 = IMMEDIATE(8);
 label_6:
@@ -476,12 +477,12 @@ label_6:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/sockops.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
+        // EBPF_OP_JEQ_IMM pc=63 dst=r0 src=r0 offset=158 imm=0
 #line 32 "sample/sockops.c"
     if (r0 == IMMEDIATE(0))
 #line 32 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
+        // EBPF_OP_JA pc=64 dst=r0 src=r0 offset=149 imm=0
 #line 32 "sample/sockops.c"
     goto label_12;
 label_7:
@@ -526,7 +527,7 @@ label_7:
     if (r4 != IMMEDIATE(0))
 #line 46 "sample/sockops.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r0 src=r3 offset=0 imm=0
 #line 46 "sample/sockops.c"
     r0 = r3;
 label_8:
@@ -601,7 +602,7 @@ label_8:
     if (r4 != IMMEDIATE(0))
 #line 48 "sample/sockops.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
+        // EBPF_OP_LDXDW pc=102 dst=r3 src=r10 offset=-104 imm=0
 #line 48 "sample/sockops.c"
     r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104));
 label_9:
@@ -646,7 +647,7 @@ label_9:
     if (r4 != IMMEDIATE(0))
 #line 48 "sample/sockops.c"
         goto label_10;
-    // EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=116 dst=r1 src=r0 offset=0 imm=44
 #line 48 "sample/sockops.c"
     r1 = IMMEDIATE(44);
     // EBPF_OP_STXDW pc=117 dst=r10 src=r1 offset=-64 imm=0
@@ -676,7 +677,7 @@ label_10:
     if (r4 != IMMEDIATE(0))
 #line 51 "sample/sockops.c"
         goto label_11;
-    // EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=125 dst=r1 src=r0 offset=0 imm=24
 #line 51 "sample/sockops.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXDW pc=126 dst=r10 src=r1 offset=-72 imm=0
@@ -941,7 +942,7 @@ label_11:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 56 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=212 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=213 dst=r0 src=r0 offset=8 imm=0
@@ -974,7 +975,7 @@ label_12:
     if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
 #line 56 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=221 dst=r6 src=r0 offset=0 imm=0
 #line 56 "sample/sockops.c"
     r6 = r0;
 label_13:

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -105,6 +105,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 21 "sample/tail_call_bad.c"
 {
 #line 21 "sample/tail_call_bad.c"
     // Prologue
@@ -153,7 +154,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 27 "sample/tail_call_bad.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
 #line 27 "sample/tail_call_bad.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=7 dst=r2 src=r10 offset=0 imm=0
@@ -174,12 +175,12 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 29 "sample/tail_call_bad.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
+        // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
 #line 30 "sample/tail_call_bad.c"
     if (r0 == IMMEDIATE(0))
 #line 30 "sample/tail_call_bad.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
 #line 30 "sample/tail_call_bad.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=14 dst=r0 src=r1 offset=0 imm=0
@@ -202,6 +203,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 37 "sample/tail_call_bad.c"
 {
 #line 37 "sample/tail_call_bad.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -63,6 +63,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 21 "sample/tail_call_bad.c"
 {
 #line 21 "sample/tail_call_bad.c"
     // Prologue
@@ -111,7 +112,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 27 "sample/tail_call_bad.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
 #line 27 "sample/tail_call_bad.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=7 dst=r2 src=r10 offset=0 imm=0
@@ -132,12 +133,12 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 29 "sample/tail_call_bad.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
+        // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
 #line 30 "sample/tail_call_bad.c"
     if (r0 == IMMEDIATE(0))
 #line 30 "sample/tail_call_bad.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
 #line 30 "sample/tail_call_bad.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=14 dst=r0 src=r1 offset=0 imm=0
@@ -160,6 +161,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 37 "sample/tail_call_bad.c"
 {
 #line 37 "sample/tail_call_bad.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -230,6 +230,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 21 "sample/tail_call_bad.c"
 {
 #line 21 "sample/tail_call_bad.c"
     // Prologue
@@ -278,7 +279,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 27 "sample/tail_call_bad.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=6 dst=r6 src=r0 offset=0 imm=0
 #line 27 "sample/tail_call_bad.c"
     r6 = r0;
     // EBPF_OP_MOV64_REG pc=7 dst=r2 src=r10 offset=0 imm=0
@@ -299,12 +300,12 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 29 "sample/tail_call_bad.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
+        // EBPF_OP_JEQ_IMM pc=12 dst=r0 src=r0 offset=2 imm=0
 #line 30 "sample/tail_call_bad.c"
     if (r0 == IMMEDIATE(0))
 #line 30 "sample/tail_call_bad.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=1
 #line 30 "sample/tail_call_bad.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=14 dst=r0 src=r1 offset=0 imm=0
@@ -327,6 +328,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 37 "sample/tail_call_bad.c"
 {
 #line 37 "sample/tail_call_bad.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -105,6 +105,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 21 "sample/tail_call.c"
 {
 #line 21 "sample/tail_call.c"
     // Prologue
@@ -151,7 +152,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 26 "sample/tail_call.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/tail_call.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=7 dst=r2 src=r0 offset=0 imm=-4
@@ -169,12 +170,12 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 29 "sample/tail_call.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
+        // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
 #line 30 "sample/tail_call.c"
     if (r0 == IMMEDIATE(0))
 #line 30 "sample/tail_call.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
 #line 30 "sample/tail_call.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r0 src=r1 offset=0 imm=0
@@ -197,6 +198,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 37 "sample/tail_call.c"
 {
 #line 37 "sample/tail_call.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -104,6 +104,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 29 "sample/tail_call_map.c"
 {
 #line 29 "sample/tail_call_map.c"
     // Prologue
@@ -158,7 +159,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/tail_call_map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/tail_call_map.c"
     r1 = r6;
     // EBPF_OP_MOV64_REG pc=9 dst=r2 src=r0 offset=0 imm=0
@@ -176,7 +177,7 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 34 "sample/tail_call_map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
 #line 37 "sample/tail_call_map.c"
     r0 = IMMEDIATE(6);
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
@@ -192,6 +193,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 40 "sample/tail_call_map.c"
 {
 #line 40 "sample/tail_call_map.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -62,6 +62,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 29 "sample/tail_call_map.c"
 {
 #line 29 "sample/tail_call_map.c"
     // Prologue
@@ -116,7 +117,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/tail_call_map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/tail_call_map.c"
     r1 = r6;
     // EBPF_OP_MOV64_REG pc=9 dst=r2 src=r0 offset=0 imm=0
@@ -134,7 +135,7 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 34 "sample/tail_call_map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
 #line 37 "sample/tail_call_map.c"
     r0 = IMMEDIATE(6);
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
@@ -150,6 +151,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 40 "sample/tail_call_map.c"
 {
 #line 40 "sample/tail_call_map.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -229,6 +229,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 29 "sample/tail_call_map.c"
 {
 #line 29 "sample/tail_call_map.c"
     // Prologue
@@ -283,7 +284,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 32 "sample/tail_call_map.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/tail_call_map.c"
     r1 = r6;
     // EBPF_OP_MOV64_REG pc=9 dst=r2 src=r0 offset=0 imm=0
@@ -301,7 +302,7 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 34 "sample/tail_call_map.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_MOV64_IMM pc=12 dst=r0 src=r0 offset=0 imm=6
 #line 37 "sample/tail_call_map.c"
     r0 = IMMEDIATE(6);
     // EBPF_OP_EXIT pc=13 dst=r0 src=r0 offset=0 imm=0
@@ -317,6 +318,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 40 "sample/tail_call_map.c"
 {
 #line 40 "sample/tail_call_map.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -91,6 +91,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 24 "sample/tail_call_multiple.c"
 {
 #line 24 "sample/tail_call_multiple.c"
     // Prologue
@@ -131,7 +132,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/tail_call_multiple.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
 #line 27 "sample/tail_call_multiple.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -155,6 +156,7 @@ static uint16_t callee0_maps[] = {
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee0(void* context)
+#line 35 "sample/tail_call_multiple.c"
 {
 #line 35 "sample/tail_call_multiple.c"
     // Prologue
@@ -195,7 +197,7 @@ callee0(void* context)
     if ((callee0_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/tail_call_multiple.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
+        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
 #line 38 "sample/tail_call_multiple.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -211,6 +213,7 @@ static GUID callee1_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72,
 #pragma code_seg(push, "xdp_pr~2")
 static uint64_t
 callee1(void* context)
+#line 41 "sample/tail_call_multiple.c"
 {
 #line 41 "sample/tail_call_multiple.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -49,6 +49,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 24 "sample/tail_call_multiple.c"
 {
 #line 24 "sample/tail_call_multiple.c"
     // Prologue
@@ -89,7 +90,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/tail_call_multiple.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
 #line 27 "sample/tail_call_multiple.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -113,6 +114,7 @@ static uint16_t callee0_maps[] = {
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee0(void* context)
+#line 35 "sample/tail_call_multiple.c"
 {
 #line 35 "sample/tail_call_multiple.c"
     // Prologue
@@ -153,7 +155,7 @@ callee0(void* context)
     if ((callee0_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/tail_call_multiple.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
+        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
 #line 38 "sample/tail_call_multiple.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -169,6 +171,7 @@ static GUID callee1_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72,
 #pragma code_seg(push, "xdp_pr~2")
 static uint64_t
 callee1(void* context)
+#line 41 "sample/tail_call_multiple.c"
 {
 #line 41 "sample/tail_call_multiple.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -216,6 +216,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 24 "sample/tail_call_multiple.c"
 {
 #line 24 "sample/tail_call_multiple.c"
     // Prologue
@@ -256,7 +257,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/tail_call_multiple.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=1
 #line 27 "sample/tail_call_multiple.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -280,6 +281,7 @@ static uint16_t callee0_maps[] = {
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee0(void* context)
+#line 35 "sample/tail_call_multiple.c"
 {
 #line 35 "sample/tail_call_multiple.c"
     // Prologue
@@ -320,7 +322,7 @@ callee0(void* context)
     if ((callee0_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/tail_call_multiple.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
+        // EBPF_OP_MOV64_IMM pc=4 dst=r0 src=r0 offset=0 imm=2
 #line 38 "sample/tail_call_multiple.c"
     r0 = IMMEDIATE(2);
     // EBPF_OP_EXIT pc=5 dst=r0 src=r0 offset=0 imm=0
@@ -336,6 +338,7 @@ static GUID callee1_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72,
 #pragma code_seg(push, "xdp_pr~2")
 static uint64_t
 callee1(void* context)
+#line 41 "sample/tail_call_multiple.c"
 {
 #line 41 "sample/tail_call_multiple.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -63,6 +63,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 21 "sample/tail_call.c"
 {
 #line 21 "sample/tail_call.c"
     // Prologue
@@ -109,7 +110,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 26 "sample/tail_call.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/tail_call.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=7 dst=r2 src=r0 offset=0 imm=-4
@@ -127,12 +128,12 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 29 "sample/tail_call.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
+        // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
 #line 30 "sample/tail_call.c"
     if (r0 == IMMEDIATE(0))
 #line 30 "sample/tail_call.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
 #line 30 "sample/tail_call.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r0 src=r1 offset=0 imm=0
@@ -155,6 +156,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 37 "sample/tail_call.c"
 {
 #line 37 "sample/tail_call.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -230,6 +230,7 @@ static uint16_t caller_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 caller(void* context)
+#line 21 "sample/tail_call.c"
 {
 #line 21 "sample/tail_call.c"
     // Prologue
@@ -276,7 +277,7 @@ caller(void* context)
     if ((caller_helpers[0].tail_call) && (r0 == 0))
 #line 26 "sample/tail_call.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=6 dst=r2 src=r10 offset=0 imm=0
 #line 26 "sample/tail_call.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=7 dst=r2 src=r0 offset=0 imm=-4
@@ -294,12 +295,12 @@ caller(void* context)
     if ((caller_helpers[1].tail_call) && (r0 == 0))
 #line 29 "sample/tail_call.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
+        // EBPF_OP_JEQ_IMM pc=11 dst=r0 src=r0 offset=2 imm=0
 #line 30 "sample/tail_call.c"
     if (r0 == IMMEDIATE(0))
 #line 30 "sample/tail_call.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=1
 #line 30 "sample/tail_call.c"
     r1 = IMMEDIATE(1);
     // EBPF_OP_STXW pc=13 dst=r0 src=r1 offset=0 imm=0
@@ -322,6 +323,7 @@ static GUID callee_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 
 #pragma code_seg(push, "xdp_pr~1")
 static uint64_t
 callee(void* context)
+#line 37 "sample/tail_call.c"
 {
 #line 37 "sample/tail_call.c"
     // Prologue

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -108,6 +108,7 @@ static uint16_t test_program_entry_maps[] = {
 #pragma code_seg(push, "sample~1")
 static uint64_t
 test_program_entry(void* context)
+#line 29 "sample/test_sample_ebpf.c"
 {
 #line 29 "sample/test_sample_ebpf.c"
     // Prologue
@@ -166,7 +167,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
 #line 35 "sample/test_sample_ebpf.c"
     r8 = r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
@@ -187,7 +188,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
@@ -195,7 +196,7 @@ test_program_entry(void* context)
     if (r8 == IMMEDIATE(0))
 #line 38 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
 #line 38 "sample/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
@@ -206,7 +207,7 @@ test_program_entry(void* context)
     if (r1 >= r2)
 #line 38 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
     r2 -= r1;
     // EBPF_OP_MOV64_REG pc=21 dst=r3 src=r8 offset=0 imm=0
@@ -224,12 +225,12 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
 #line 44 "sample/test_sample_ebpf.c"
     if (r7 == IMMEDIATE(0))
 #line 44 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=26 dst=r2 src=r6 offset=8 imm=0
@@ -256,7 +257,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[2].tail_call) && (r0 == 0))
 #line 45 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
 #line 45 "sample/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r1 src=r0 offset=5 imm=0
@@ -277,7 +278,7 @@ label_1:
     if ((test_program_entry_helpers[3].tail_call) && (r0 == 0))
 #line 53 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
 #line 53 "sample/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=37 dst=r1 src=r0 offset=1 imm=0
@@ -285,7 +286,7 @@ label_1:
     if ((int64_t)r1 > (int64_t)r0)
 #line 54 "sample/test_sample_ebpf.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
 #line 54 "sample/test_sample_ebpf.c"
     r0 = IMMEDIATE(42);
 label_2:
@@ -315,6 +316,7 @@ static uint16_t test_utility_helpers_maps[] = {
 #pragma code_seg(push, "sample~2")
 static uint64_t
 test_utility_helpers(void* context)
+#line 73 "sample/test_sample_ebpf.c"
 {
 #line 73 "sample/test_sample_ebpf.c"
     // Prologue
@@ -376,7 +378,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
@@ -388,7 +390,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=7
@@ -400,7 +402,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
@@ -412,7 +414,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
+        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
@@ -445,7 +447,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
 #line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address
 #line 36 "sample/./sample_common_routines.h"
@@ -454,7 +456,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
 #line 36 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=7
@@ -466,7 +468,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=7
@@ -478,7 +480,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
@@ -505,7 +507,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
 #line 75 "sample/test_sample_ebpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=39 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -66,6 +66,7 @@ static uint16_t test_program_entry_maps[] = {
 #pragma code_seg(push, "sample~1")
 static uint64_t
 test_program_entry(void* context)
+#line 29 "sample/test_sample_ebpf.c"
 {
 #line 29 "sample/test_sample_ebpf.c"
     // Prologue
@@ -124,7 +125,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
 #line 35 "sample/test_sample_ebpf.c"
     r8 = r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
@@ -145,7 +146,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
@@ -153,7 +154,7 @@ test_program_entry(void* context)
     if (r8 == IMMEDIATE(0))
 #line 38 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
 #line 38 "sample/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
@@ -164,7 +165,7 @@ test_program_entry(void* context)
     if (r1 >= r2)
 #line 38 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
     r2 -= r1;
     // EBPF_OP_MOV64_REG pc=21 dst=r3 src=r8 offset=0 imm=0
@@ -182,12 +183,12 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
 #line 44 "sample/test_sample_ebpf.c"
     if (r7 == IMMEDIATE(0))
 #line 44 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=26 dst=r2 src=r6 offset=8 imm=0
@@ -214,7 +215,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[2].tail_call) && (r0 == 0))
 #line 45 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
 #line 45 "sample/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r1 src=r0 offset=5 imm=0
@@ -235,7 +236,7 @@ label_1:
     if ((test_program_entry_helpers[3].tail_call) && (r0 == 0))
 #line 53 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
 #line 53 "sample/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=37 dst=r1 src=r0 offset=1 imm=0
@@ -243,7 +244,7 @@ label_1:
     if ((int64_t)r1 > (int64_t)r0)
 #line 54 "sample/test_sample_ebpf.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
 #line 54 "sample/test_sample_ebpf.c"
     r0 = IMMEDIATE(42);
 label_2:
@@ -273,6 +274,7 @@ static uint16_t test_utility_helpers_maps[] = {
 #pragma code_seg(push, "sample~2")
 static uint64_t
 test_utility_helpers(void* context)
+#line 73 "sample/test_sample_ebpf.c"
 {
 #line 73 "sample/test_sample_ebpf.c"
     // Prologue
@@ -334,7 +336,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
@@ -346,7 +348,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=7
@@ -358,7 +360,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
@@ -370,7 +372,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
+        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
@@ -403,7 +405,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
 #line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address
 #line 36 "sample/./sample_common_routines.h"
@@ -412,7 +414,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
 #line 36 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=7
@@ -424,7 +426,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=7
@@ -436,7 +438,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
@@ -463,7 +465,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
 #line 75 "sample/test_sample_ebpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=39 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -233,6 +233,7 @@ static uint16_t test_program_entry_maps[] = {
 #pragma code_seg(push, "sample~1")
 static uint64_t
 test_program_entry(void* context)
+#line 29 "sample/test_sample_ebpf.c"
 {
 #line 29 "sample/test_sample_ebpf.c"
     // Prologue
@@ -291,7 +292,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
 #line 35 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r8 src=r0 offset=0 imm=0
 #line 35 "sample/test_sample_ebpf.c"
     r8 = r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
@@ -312,7 +313,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=15 dst=r7 src=r0 offset=0 imm=0
 #line 36 "sample/test_sample_ebpf.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=16 dst=r8 src=r0 offset=17 imm=0
@@ -320,7 +321,7 @@ test_program_entry(void* context)
     if (r8 == IMMEDIATE(0))
 #line 38 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=17 dst=r1 src=r6 offset=0 imm=0
 #line 38 "sample/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=18 dst=r2 src=r6 offset=8 imm=0
@@ -331,7 +332,7 @@ test_program_entry(void* context)
     if (r1 >= r2)
 #line 38 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_SUB64_REG pc=20 dst=r2 src=r1 offset=0 imm=0
 #line 43 "sample/test_sample_ebpf.c"
     r2 -= r1;
     // EBPF_OP_MOV64_REG pc=21 dst=r3 src=r8 offset=0 imm=0
@@ -349,12 +350,12 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
+        // EBPF_OP_JEQ_IMM pc=24 dst=r7 src=r0 offset=9 imm=0
 #line 44 "sample/test_sample_ebpf.c"
     if (r7 == IMMEDIATE(0))
 #line 44 "sample/test_sample_ebpf.c"
         goto label_1;
-    // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=25 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/test_sample_ebpf.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=26 dst=r2 src=r6 offset=8 imm=0
@@ -381,7 +382,7 @@ test_program_entry(void* context)
     if ((test_program_entry_helpers[2].tail_call) && (r0 == 0))
 #line 45 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=32 dst=r1 src=r0 offset=0 imm=0
 #line 45 "sample/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=33 dst=r1 src=r0 offset=5 imm=0
@@ -402,7 +403,7 @@ label_1:
     if ((test_program_entry_helpers[3].tail_call) && (r0 == 0))
 #line 53 "sample/test_sample_ebpf.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=0
 #line 53 "sample/test_sample_ebpf.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=37 dst=r1 src=r0 offset=1 imm=0
@@ -410,7 +411,7 @@ label_1:
     if ((int64_t)r1 > (int64_t)r0)
 #line 54 "sample/test_sample_ebpf.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=42
 #line 54 "sample/test_sample_ebpf.c"
     r0 = IMMEDIATE(42);
 label_2:
@@ -440,6 +441,7 @@ static uint16_t test_utility_helpers_maps[] = {
 #pragma code_seg(push, "sample~2")
 static uint64_t
 test_utility_helpers(void* context)
+#line 73 "sample/test_sample_ebpf.c"
 {
 #line 73 "sample/test_sample_ebpf.c"
     // Prologue
@@ -501,7 +503,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
@@ -513,7 +515,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=7
@@ -525,7 +527,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
@@ -537,7 +539,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
+        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
@@ -570,7 +572,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
 #line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address
 #line 36 "sample/./sample_common_routines.h"
@@ -579,7 +581,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
 #line 36 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=7
@@ -591,7 +593,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=7
@@ -603,7 +605,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
@@ -630,7 +632,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
 #line 75 "sample/test_sample_ebpf.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=39 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -96,6 +96,7 @@ static uint16_t test_utility_helpers_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 test_utility_helpers(void* context)
+#line 31 "sample/test_utility_helpers.c"
 {
 #line 31 "sample/test_utility_helpers.c"
     // Prologue
@@ -153,7 +154,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
@@ -165,7 +166,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=7
@@ -177,7 +178,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
@@ -189,7 +190,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
+        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
@@ -222,7 +223,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
 #line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address
 #line 36 "sample/./sample_common_routines.h"
@@ -231,7 +232,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
 #line 36 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=7
@@ -243,7 +244,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=7
@@ -255,7 +256,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
@@ -282,7 +283,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=39 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -54,6 +54,7 @@ static uint16_t test_utility_helpers_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 test_utility_helpers(void* context)
+#line 31 "sample/test_utility_helpers.c"
 {
 #line 31 "sample/test_utility_helpers.c"
     // Prologue
@@ -111,7 +112,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
@@ -123,7 +124,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=7
@@ -135,7 +136,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
@@ -147,7 +148,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
+        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
@@ -180,7 +181,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
 #line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address
 #line 36 "sample/./sample_common_routines.h"
@@ -189,7 +190,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
 #line 36 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=7
@@ -201,7 +202,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=7
@@ -213,7 +214,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
@@ -240,7 +241,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=39 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -221,6 +221,7 @@ static uint16_t test_utility_helpers_maps[] = {
 #pragma code_seg(push, "xdp")
 static uint64_t
 test_utility_helpers(void* context)
+#line 31 "sample/test_utility_helpers.c"
 {
 #line 31 "sample/test_utility_helpers.c"
     // Prologue
@@ -278,7 +279,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 16 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=9 dst=r10 src=r0 offset=-40 imm=0
 #line 16 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=10 dst=r0 src=r0 offset=0 imm=7
@@ -290,7 +291,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 24 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=11 dst=r10 src=r0 offset=-24 imm=0
 #line 24 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=12 dst=r0 src=r0 offset=0 imm=7
@@ -302,7 +303,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=13 dst=r10 src=r0 offset=-32 imm=0
 #line 27 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=8
@@ -314,7 +315,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
+        // EBPF_OP_STXW pc=15 dst=r10 src=r0 offset=-16 imm=0
 #line 30 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
@@ -347,7 +348,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 33 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
+        // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=6
 #line 36 "sample/./sample_common_routines.h"
     r0 = test_utility_helpers_helpers[0].address
 #line 36 "sample/./sample_common_routines.h"
@@ -356,7 +357,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[0].tail_call) && (r0 == 0))
 #line 36 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
+        // EBPF_OP_STXW pc=26 dst=r10 src=r0 offset=-40 imm=0
 #line 36 "sample/./sample_common_routines.h"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r0;
     // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=7
@@ -368,7 +369,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 39 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
+        // EBPF_OP_STXDW pc=28 dst=r10 src=r0 offset=-32 imm=0
 #line 39 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r0;
     // EBPF_OP_CALL pc=29 dst=r0 src=r0 offset=0 imm=7
@@ -380,7 +381,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[1].tail_call) && (r0 == 0))
 #line 42 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
+        // EBPF_OP_STXDW pc=30 dst=r10 src=r0 offset=-24 imm=0
 #line 42 "sample/./sample_common_routines.h"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
@@ -407,7 +408,7 @@ test_utility_helpers(void* context)
     if ((test_utility_helpers_helpers[3].tail_call) && (r0 == 0))
 #line 45 "sample/./sample_common_routines.h"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=38 dst=r0 src=r0 offset=0 imm=0
 #line 33 "sample/test_utility_helpers.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=39 dst=r0 src=r0 offset=0 imm=0

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -891,7 +891,7 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         // Emit entry point
         output_stream << "#pragma code_seg(push, \"" << section.pe_section_name << "\")" << std::endl;
         output_stream << format_string("static uint64_t\n%s(void* context)", sanitize_name(program_name)) << std::endl;
-        output_stream << "{" << std::endl;
+        output_stream << prolog_line_info << "{" << std::endl;
 
         // Emit prologue
         output_stream << prolog_line_info << INDENT "// Prologue" << std::endl;


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

The bpf2c tool wasn't emitting a #line directive for the first line of the BPF program, resulting in incorrect debugger behavior.

## Testing

Manual testing.

## Documentation

No.

Resolves: #1089
