### PR TITLE
Remove more obsolete APIs

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -95,11 +95,9 @@ EXPORTS
     ebpf_free_string
     ebpf_get_attach_type_name
     ebpf_get_next_pinned_program_path
-    ebpf_get_next_program
     ebpf_get_program_type_by_name
     ebpf_get_program_type_name
     ebpf_link_close
-    ebpf_map_pin
     ebpf_object_get
     ebpf_object_unpin
     ebpf_program_attach

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -75,17 +75,6 @@ extern "C"
         _Out_ fd_t* map_fd);
 
     /**
-     * @brief Get file descriptor to the next eBPF program.
-     * @param[in] previous_fd File descriptor of the previous eBPF program or ebpf_fd_invalid to
-     *  start enumeration.
-     * @param[out] next_fd File descriptor of the next eBPF program or ebpf_fd_invalid if
-     *  this is the last program.
-     * @retval EBPF_SUCCESS The operation was successful.
-     */
-    ebpf_result_t
-    ebpf_get_next_program(fd_t previous_fd, _Out_ fd_t* next_fd);
-
-    /**
      * @brief Query info about an eBPF program.
      * @param[in] fd File descriptor of an eBPF program.
      * @param[out] execution_type On success, contains the execution type.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -852,39 +852,6 @@ ebpf_object_get(_In_z_ const char* path)
 }
 
 ebpf_result_t
-ebpf_get_next_program(fd_t previous_fd, _Out_ fd_t* next_fd)
-{
-    ebpf_assert(next_fd);
-    fd_t local_fd = previous_fd;
-    *next_fd = ebpf_fd_invalid;
-
-    ebpf_handle_t previous_handle = _get_handle_from_file_descriptor(local_fd);
-    ebpf_operation_get_next_program_request_t request{
-        sizeof(request), ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM, previous_handle};
-
-    ebpf_operation_get_next_program_reply_t reply;
-
-    uint32_t retval = invoke_ioctl(request, reply);
-    if (retval == ERROR_SUCCESS) {
-        ebpf_assert(reply.header.id == ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM);
-        ebpf_handle_t next_handle = reply.next_handle;
-        if (next_handle != ebpf_handle_invalid) {
-            fd_t fd = _create_file_descriptor_for_handle(next_handle);
-            if (fd == ebpf_fd_invalid) {
-                // Some error getting fd for the handle.
-                Platform::CloseHandle(next_handle);
-                retval = ERROR_OUTOFMEMORY;
-            } else {
-                *next_fd = fd;
-            }
-        } else {
-            *next_fd = ebpf_fd_invalid;
-        }
-    }
-    return win32_error_code_to_ebpf_result(retval);
-}
-
-ebpf_result_t
 ebpf_program_query_info(
     fd_t fd,
     _Out_ ebpf_execution_type_t* execution_type,

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -649,26 +649,23 @@ handle_ebpf_show_programs(
         std::cout << "======  ====  =====  =========  =============  ====================\n";
     }
 
+    uint32_t program_id = 0;
     fd_t program_fd = ebpf_fd_invalid;
     for (;;) {
         const char* program_file_name;
         const char* program_section_name;
         const char* execution_type_name;
         ebpf_execution_type_t program_execution_type;
-        fd_t next_program_fd;
-        status = ebpf_get_next_program(program_fd, &next_program_fd);
-        if (status != ERROR_SUCCESS) {
+        uint32_t next_program_id;
+        if (bpf_prog_get_next_id(program_id, &next_program_id) < 0) {
             break;
         }
+        program_id = next_program_id;
 
         if (program_fd != ebpf_fd_invalid) {
             Platform::_close(program_fd);
         }
-        program_fd = next_program_fd;
-
-        if (program_fd == ebpf_fd_invalid) {
-            break;
-        }
+        program_fd = bpf_prog_get_fd_by_id(program_id);
 
         struct bpf_prog_info info;
         uint32_t info_size = (uint32_t)sizeof(info);

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -849,17 +849,6 @@ _ebpf_core_protocol_get_next_map(
 }
 
 static ebpf_result_t
-_ebpf_core_protocol_get_next_program(
-    _In_ const struct _ebpf_operation_get_next_program_request* request,
-    _Inout_ struct _ebpf_operation_get_next_program_reply* reply,
-    uint16_t reply_length)
-{
-    EBPF_LOG_ENTRY();
-    UNREFERENCED_PARAMETER(reply_length);
-    EBPF_RETURN_RESULT(_ebpf_core_get_next_handle(request->previous_handle, EBPF_OBJECT_PROGRAM, &reply->next_handle));
-}
-
-static ebpf_result_t
 _ebpf_core_protocol_query_program_info(
     _In_ const struct _ebpf_operation_query_program_info_request* request,
     _Inout_ struct _ebpf_operation_query_program_info_reply* reply,
@@ -1845,11 +1834,6 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_get_next_map,
      sizeof(struct _ebpf_operation_get_next_map_request),
      sizeof(struct _ebpf_operation_get_next_map_reply)},
-
-    // EBPF_OPERATION_GET_NEXT_PROGRAM
-    {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_get_next_program,
-     sizeof(struct _ebpf_operation_get_next_program_request),
-     sizeof(struct _ebpf_operation_get_next_program_reply)},
 
     // EBPF_OPERATION_QUERY_PROGRAM_INFO
     {(ebpf_result_t(__cdecl*)(const void*))_ebpf_core_protocol_query_program_info,

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -20,7 +20,6 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_MAP_DELETE_ELEMENT,
     EBPF_OPERATION_MAP_GET_NEXT_KEY,
     EBPF_OPERATION_GET_NEXT_MAP,
-    EBPF_OPERATION_GET_NEXT_PROGRAM,
     EBPF_OPERATION_QUERY_PROGRAM_INFO,
     EBPF_OPERATION_UPDATE_PINNING,
     EBPF_OPERATION_GET_PINNING,
@@ -176,18 +175,6 @@ typedef struct _ebpf_operation_get_next_map_reply
     struct _ebpf_operation_header header;
     ebpf_handle_t next_handle;
 } ebpf_operation_get_next_map_reply_t;
-
-typedef struct _ebpf_operation_get_next_program_request
-{
-    struct _ebpf_operation_header header;
-    ebpf_handle_t previous_handle;
-} ebpf_operation_get_next_program_request_t;
-
-typedef struct _ebpf_operation_get_next_program_reply
-{
-    struct _ebpf_operation_header header;
-    ebpf_handle_t next_handle;
-} ebpf_operation_get_next_program_reply_t;
 
 typedef struct _ebpf_operation_get_handle_by_id_request
 {


### PR DESCRIPTION
* Remove ebpf_get_next_program (bpf_prog_get_next_id should be used instead)
* Don't export the internal ebpf_map_pin api

Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

Clean up code to reduce footprint.

## Testing

Tests are updated.

## Documentation

Documentation is updated.
