### PR TITLE
Make ebpf_epoch_enter / ebpf_epoch_exit recursive.

### DIFF
--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -203,7 +203,8 @@ static void
 _ebpf_driver_file_close(WDFFILEOBJECT wdf_file_object)
 {
     FILE_OBJECT* file_object = WdfFileObjectWdmGetFileObject(wdf_file_object);
-    ebpf_object_release_reference(file_object->FsContext2);
+    ebpf_result_t result = ebpf_core_release_object_reference_in_epoch(file_object->FsContext2);
+    ebpf_assert(result == EBPF_SUCCESS);
 }
 
 static void

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -299,7 +299,7 @@ Done:
 }
 
 ebpf_result_t
-ebpf_core_release_object_reference_in_epoch(void* ebpf_object)
+ebpf_core_release_object_reference_in_epoch(_In_ void* ebpf_object)
 {
     uintptr_t old_affinity_mask = 0;
     bool affinity_set = false;

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -237,6 +237,16 @@ extern "C"
         _In_reads_(count_of_helpers) const uint32_t* helper_function_ids,
         _Out_writes_(count_of_helpers) uint64_t* helper_function_addresses);
 
+    /**
+     * @brief Call ebpf_epoch_enter, release ref-count, and call ebpf_epoch exit.
+     *
+     * @param[in] ebpf_object Object with ref-count to decrement.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
+     */
+    ebpf_result_t
+    ebpf_core_release_object_reference_in_epoch(_In_ void* ebpf_object);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Call ebpf_epoch_enter / ebpf_epoch_exit from handle rundown.

Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Fix issue 1109 where netsh ebpf program delete leaves the native module loaded.
To solve this, this change makes ebpf epoch code re-entrant and invokes it during handle rundown.

## Testing

CI/CD

## Documentation

Updated docs in ebpf_epoch.c
