### PR TITLE
Increase test timeout

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -52,7 +52,7 @@ permissions:
 
 jobs:
   run_test:
-    timeout-minutes: 30
+    timeout-minutes: 60
 
     strategy:
       matrix:


### PR DESCRIPTION
Tests are failing because they cannot complete in 30 minutes.
Temporarily increase the test timeout value.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

Other CI/CD runs are failing due to this issue.
Example: https://github.com/microsoft/ebpf-for-windows/runs/6476052133?check_suite_focus=true

## Testing

This PR fixes test runs.

## Documentation

None needed.
