### PR TITLE
Set interjob dependencies

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -52,12 +52,12 @@ jobs:
   # Run the unit tests in GitHub.
   unit_tests:
     # Always run this job.
+    needs: regular
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
       test_command: unit_tests.exe -d yes
-      build_job: cmake / build
       build_artifact: Build-x64
       environment: windows-2019
       code_coverage: true
@@ -67,13 +67,13 @@ jobs:
   # Run the bpf2c tests in GitHub.
   bpf2c:
     # Always run this job.
+    needs: regular
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
       pre_test: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       test_command: bpf2c_tests.exe -d yes
       name: bpf2c
-      build_job: cmake / build
       build_artifact: Build-x64
       environment: windows-2019
       code_coverage: true
@@ -84,6 +84,7 @@ jobs:
   driver:
     # Always run this job.
     # Only run this on repos that have self-host runners.
+    needs: regular
     if: github.repository == 'microsoft/ebpf-for-windows'
     uses: ./.github/workflows/reusable-test.yml
     with:
@@ -91,7 +92,6 @@ jobs:
       test_command: powershell ".\execute_ebpf_cicd_tests.ps1"
       post_test: powershell ".\cleanup_ebpf_cicd_tests.ps1"
       name: driver
-      build_job: cmake / build
       build_artifact: Build-x64
       environment: ebpf_cicd_tests
       # driver test copies dumps to testlog folder.
@@ -101,10 +101,10 @@ jobs:
 
   ossar:
     # Always run this job.
+    needs: regular
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/ossar-scan.yml
     with:
-      build_job: cmake / build
       build_artifact: Build-x64
 
   # Additional jobs to run on pull and schedule only (skip push).
@@ -129,13 +129,13 @@ jobs:
 
   # Run the fuzzing tests in GitHub.
   fuzzing:
+    needs: sanitize
     # Always run this job.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: fuzzing
       test_command: fuzz.exe -d yes
-      build_job: sanitize / build
       build_artifact: Build-x64-Sanitize
       environment: windows-2019
       code_coverage: false
@@ -143,13 +143,13 @@ jobs:
 
   # Run Cilium regression tests in GitHub.
   cilium_tests:
+    needs: regular
     # Only run on schedule and pull request.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: cilium_tests
       test_command: cilium_tests.exe -d yes
-      build_job: cmake / build
       build_artifact: Build-x64
       environment: windows-2019
       code_coverage: false
@@ -157,6 +157,7 @@ jobs:
 
   # Run the quick stress tests in GitHub.
   stress:
+    needs: regular
     # Only run on schedule and pull request.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-test.yml
@@ -164,7 +165,6 @@ jobs:
       name: stress
       # Until there is a dedicated stress test, re-use the perf test.
       test_command: ebpf_performance.exe
-      build_job: cmake / build
       build_artifact: Build-x64
       environment: windows-2019
       # No code coverage on stress.
@@ -173,13 +173,13 @@ jobs:
 
   # Run the unit tests in GitHub with address sanitizer.
   sanitize_unit_tests:
+    needs: sanitize
     # Only run on schedule and pull request.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
       test_command: unit_tests.exe -d yes
-      build_job: sanitize / build
       build_artifact: Build-x64-Sanitize
       environment: windows-2019
       code_coverage: false

--- a/.github/workflows/ossar-scan.yml
+++ b/.github/workflows/ossar-scan.yml
@@ -8,10 +8,6 @@ name: ossar-scan
 on:
   workflow_call:
     inputs:
-      # The name of the build job to wait for.
-      build_job:
-        required: true
-        type: string
       # The name of the build artifact to download.
       build_artifact:
         required: true
@@ -44,16 +40,6 @@ jobs:
       with:
         # Only check out main repo, not submodules.
         ref: ${{ github.event.workflow_run.head_branch }}
-
-    - name: Wait for build to succeed
-      uses: fountainhead/action-wait-for-check@507b029e31edbe1a72d4de429476e1f4efe98869
-      id: wait_for_build
-      with:
-        timeoutSeconds: 1500
-        intervalSeconds: 30
-        token: ${{secrets.GITHUB_TOKEN}}
-        checkName: ${{inputs.build_job}} (${{env.BUILD_CONFIGURATION}})
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Download build artifact
       if: success()

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -15,10 +15,6 @@ on:
       test_command:
         required: true
         type: string
-      # The name of the build job to wait for.
-      build_job:
-        required: true
-        type: string
       # The name of the build artifact to download.
       build_artifact:
         required: true
@@ -97,16 +93,6 @@ jobs:
         New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -ErrorAction SilentlyContinue
         New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpType" -Value 2 -PropertyType DWord -ErrorAction SilentlyContinue
         New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "c:\dumps\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}" -PropertyType ExpandString -ErrorAction SilentlyContinue
-
-    - name: Wait for build to succeed
-      uses: fountainhead/action-wait-for-check@507b029e31edbe1a72d4de429476e1f4efe98869
-      id: wait_for_build
-      with:
-        timeoutSeconds: 1500
-        intervalSeconds: 30
-        token: ${{secrets.GITHUB_TOKEN}}
-        checkName: ${{inputs.build_job}} (${{env.BUILD_CONFIGURATION}})
-        ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
     - name: Remove existing artifacts
       if: inputs.environment == 'ebpf_cicd_tests'


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Use the "need" keyword to declare dependencies between jobs.

## Testing

CI/CD

## Documentation

No.

Resolves: #1066 