### PR TITLE
Add (non-deprecated) bpf_prog_load API support

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -64,6 +64,7 @@ EXPORTS
     bpf_prog_attach
     bpf_prog_bind_map
     bpf_prog_get_fd_by_id
+    bpf_prog_load
     bpf_prog_load_deprecated
     bpf_prog_get_next_id
     bpf_program__attach

--- a/include/bpf/bpf.h
+++ b/include/bpf/bpf.h
@@ -344,6 +344,67 @@ bpf_prog_get_fd_by_id(__u32 id);
 int
 bpf_prog_get_next_id(__u32 start_id, __u32* next_id);
 
+/**
+ * @brief Load (but do not attach) an eBPF programs.
+ *
+ * @param[in] prog_type Program type to use for loading eBPF programs.
+ * @param[in] prog_name Program name.
+ * @param[in] license License string (unused).
+ * @param[in] insns Array of eBPF instructions.
+ * @param[in] insn_cnt Count of instructions in the array.
+ * @param[in] opts Additional options.
+ *
+ * @returns A new file descriptor that refers to the program.
+ * The caller should call _close() on the fd to close this when done.
+ * A negative value indicates an error occurred and errno was set.
+ *
+ * @exception EACCES The program failed verification.
+ * @exception EINVAL One or more parameters are incorrect.
+ * @exception ENOMEM Out of memory.
+ *
+ * @sa bpf_load_program
+ * @sa bpf_load_program_xattr
+ * @sa bpf_object__close
+ * @sa bpf_program__attach
+ */
+int
+bpf_prog_load(
+    enum bpf_prog_type prog_type,
+    const char* prog_name,
+    const char* license,
+    const struct bpf_insn* insns,
+    size_t insn_cnt,
+    const struct bpf_prog_load_opts* opts);
+
+/**
+ * @brief Load (but do not attach) eBPF maps and programs from an ELF file.
+ *
+ * @param[in] file Path name to an ELF file.
+ * @param[in] type Program type to use for loading eBPF programs.  If BPF_PROG_TYPE_UNKNOWN,
+ * the program type is derived from the section prefix in the ELF file.
+ * @param[out] pobj Pointer to where to store the eBPF object loaded. The caller
+ * is expected to call bpf_object__close() to free the object.
+ * @param[out] prog_fd Returns a file descriptor for the first program.
+ * The caller should not call _close() on the fd, but should instead use
+ * bpf_object__close() on the object returned.
+ *
+ * @retval 0 The operation was successful.
+ * @retval <0 An error occured, and errno was set.
+ *
+ * @deprecated Use bpf_prog_load() instead.
+ *
+ * @exception EACCES The program failed verification.
+ * @exception EINVAL One or more parameters are incorrect.
+ * @exception ENOMEM Out of memory.
+ *
+ * @sa bpf_load_program
+ * @sa bpf_load_program_xattr
+ * @sa bpf_object__close
+ * @sa bpf_program__attach
+ */
+int
+bpf_prog_load_deprecated(const char* file, enum bpf_prog_type type, struct bpf_object** pobj, int* prog_fd);
+
 /** @} */
 
 #else

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -307,6 +307,8 @@ bpf_object__load(struct bpf_object* obj);
  * @retval 0 The operation was successful.
  * @retval <0 An error occured, and errno was set.
  *
+ * @deprecated Use bpf_object__load() instead.
+ *
  * @exception EINVAL An invalid argument was provided.
  * @exception ENOMEM Out of memory.
  *
@@ -492,6 +494,8 @@ bpf_object__unpin_programs(struct bpf_object* obj, const char* path);
  * @returns File descriptor that refers to the program, or <0 on error.
  * The caller should call _close() on the fd to close this when done.
  *
+ * @deprecated Use bpf_prog_load() instead.
+ *
  * @exception EACCES The program failed verification.
  * @exception EINVAL One or more parameters are incorrect.
  * @exception ENOMEM Out of memory.
@@ -524,38 +528,13 @@ bpf_load_program(
  * @exception EINVAL One or more parameters are incorrect.
  * @exception ENOMEM Out of memory.
  *
+ * @deprecated Use bpf_prog_load() instead.
+ *
  * @sa bpf_prog_load
  * @sa bpf_load_program
  */
 int
 bpf_load_program_xattr(const struct bpf_load_program_attr* load_attr, char* log_buf, size_t log_buf_sz);
-
-/**
- * @brief Load (but do not attach) eBPF maps and programs from an ELF file.
- *
- * @param[in] file Path name to an ELF file.
- * @param[in] type Program type to use for loading eBPF programs.  If BPF_PROG_TYPE_UNKNOWN,
- * the program type is derived from the section prefix in the ELF file.
- * @param[out] pobj Pointer to where to store the eBPF object loaded. The caller
- * is expected to call bpf_object__close() to free the object.
- * @param[out] prog_fd Returns a file descriptor for the first program.
- * The caller should not call _close() on the fd, but should instead use
- * bpf_object__close() on the object returned.
- *
- * @retval 0 The operation was successful.
- * @retval <0 An error occured, and errno was set.
- *
- * @exception EACCES The program failed verification.
- * @exception EINVAL One or more parameters are incorrect.
- * @exception ENOMEM Out of memory.
- *
- * @sa bpf_load_program
- * @sa bpf_load_program_xattr
- * @sa bpf_object__close
- * @sa bpf_program__attach
- */
-int
-bpf_prog_load(const char* file, enum bpf_prog_type type, struct bpf_object** pobj, int* prog_fd);
 
 /**
  * @brief Attach an eBPF program to a hook associated with the program's expected attach type.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -294,9 +294,10 @@ extern "C"
     ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type);
 
     /**
-     * @brief Load an eBPF programs from raw instructions.
+     * @brief Load an eBPF program from raw instructions.
      *
      * @param[in] program_type The eBPF program type.
+     * @param[in] program_name The eBPF program name.
      * @param[in] execution_type The execution type to use for this program. If
      *  EBPF_EXECUTION_ANY is specified, execution type will be decided by a
      *  system-wide policy.
@@ -317,6 +318,7 @@ extern "C"
     ebpf_result_t
     ebpf_program_load_bytes(
         _In_ const ebpf_program_type_t* program_type,
+        _In_opt_z_ const char* program_name,
         ebpf_execution_type_t execution_type,
         _In_reads_(byte_code_size) const uint8_t* byte_code,
         uint32_t byte_code_size,

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2239,6 +2239,7 @@ _ebpf_object_create_maps(_Inout_ ebpf_object_t* object)
 ebpf_result_t
 ebpf_program_load_bytes(
     _In_ const ebpf_program_type_t* program_type,
+    _In_opt_z_ const char* program_name,
     ebpf_execution_type_t execution_type,
     _In_reads_(byte_code_size) const uint8_t* byte_code,
     uint32_t byte_code_size,
@@ -2256,22 +2257,25 @@ ebpf_program_load_bytes(
         EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
     }
 
-    // Create a unique object/section/program name.
-    srand(static_cast<unsigned int>(time(nullptr)));
     char unique_name[80];
-    sprintf_s(unique_name, sizeof(unique_name), "raw#%u", rand());
+    if (program_name == nullptr) {
+        // Create a unique object/section/program name.
+        srand(static_cast<unsigned int>(time(nullptr)));
+        sprintf_s(unique_name, sizeof(unique_name), "raw#%u", rand());
+        program_name = unique_name;
+    }
 
     ebpf_handle_t program_handle;
-    ebpf_result_t result = _create_program(*program_type, unique_name, unique_name, unique_name, &program_handle);
+    ebpf_result_t result = _create_program(*program_type, program_name, program_name, program_name, &program_handle);
     if (result != EBPF_SUCCESS) {
         EBPF_RETURN_RESULT(result);
     }
 
     // Populate load_info.
     ebpf_program_load_info load_info = {0};
-    load_info.object_name = const_cast<char*>(unique_name);
-    load_info.section_name = const_cast<char*>(unique_name);
-    load_info.program_name = const_cast<char*>(unique_name);
+    load_info.object_name = const_cast<char*>(program_name);
+    load_info.section_name = const_cast<char*>(program_name);
+    load_info.program_name = const_cast<char*>(program_name);
     load_info.program_type = *program_type;
     load_info.program_handle = reinterpret_cast<file_handle_t>(program_handle);
     load_info.execution_type = execution_type;

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -32,7 +32,7 @@ connection_test(
 {
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("cgroup_sock_addr.o", BPF_PROG_TYPE_CGROUP_SOCK_ADDR, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("cgroup_sock_addr.o", BPF_PROG_TYPE_CGROUP_SOCK_ADDR, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 
@@ -158,7 +158,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
 {
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("cgroup_sock_addr.o", BPF_PROG_TYPE_CGROUP_SOCK_ADDR, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("cgroup_sock_addr.o", BPF_PROG_TYPE_CGROUP_SOCK_ADDR, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 
@@ -203,7 +203,7 @@ connection_monitor_test(
 {
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("sockops.o", BPF_PROG_TYPE_SOCK_OPS, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("sockops.o", BPF_PROG_TYPE_SOCK_OPS, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 
@@ -376,7 +376,7 @@ TEST_CASE("attach_sockops_programs", "[sock_ops_tests]")
 {
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("sockops.o", BPF_PROG_TYPE_SOCK_OPS, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("sockops.o", BPF_PROG_TYPE_SOCK_OPS, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -46,6 +46,26 @@ TEST_CASE("empty bpf_load_program", "[libbpf]")
     REQUIRE(errno == EINVAL);
 }
 
+TEST_CASE("empty bpf_prog_load", "[libbpf]")
+{
+    _test_helper_libbpf test_helper;
+
+    // An empty set of instructions is invalid.
+    int program_fd = bpf_prog_load(BPF_PROG_TYPE_XDP, "name", "license", nullptr, 0, nullptr);
+    REQUIRE(program_fd < 0);
+    REQUIRE(errno == EINVAL);
+}
+
+TEST_CASE("too big bpf_prog_load", "[libbpf]")
+{
+    _test_helper_libbpf test_helper;
+
+    // An empty set of instructions is invalid.
+    int program_fd = bpf_prog_load(BPF_PROG_TYPE_XDP, "name", "license", nullptr, UINT32_MAX, nullptr);
+    REQUIRE(program_fd < 0);
+    REQUIRE(errno == EINVAL);
+}
+
 TEST_CASE("invalid bpf_load_program", "[libbpf]")
 {
     _test_helper_libbpf test_helper;
@@ -64,6 +84,24 @@ TEST_CASE("invalid bpf_load_program", "[libbpf]")
     REQUIRE(strcmp(log_buffer, "\n0:  (r0.type == number)\n\n") == 0);
 }
 
+TEST_CASE("invalid bpf_prog_load", "[libbpf]")
+{
+    _test_helper_libbpf test_helper;
+
+    // Try with an invalid set of instructions.
+    struct bpf_insn instructions[] = {
+        {INST_OP_EXIT}, // return r0
+    };
+
+    // Try to load and verify the eBPF program.
+    char log_buffer[1024] = "";
+    struct bpf_prog_load_opts opts = {.sz = sizeof(opts), .log_size = sizeof(log_buffer), .log_buf = log_buffer};
+    int program_fd = bpf_prog_load(BPF_PROG_TYPE_XDP, "name", "license", instructions, _countof(instructions), &opts);
+    REQUIRE(program_fd < 0);
+    REQUIRE(errno == EACCES);
+    REQUIRE(strcmp(log_buffer, "\n0:  (r0.type == number)\n\n") == 0);
+}
+
 TEST_CASE("invalid bpf_load_program - wrong type", "[libbpf]")
 {
     _test_helper_libbpf test_helper;
@@ -76,6 +114,22 @@ TEST_CASE("invalid bpf_load_program - wrong type", "[libbpf]")
 
     // Load and verify the eBPF program.
     int program_fd = bpf_load_program((bpf_prog_type)-1, instructions, _countof(instructions), nullptr, 0, nullptr, 0);
+    REQUIRE(program_fd < 0);
+    REQUIRE(errno == EINVAL);
+}
+
+TEST_CASE("invalid bpf_prog_load - wrong type", "[libbpf]")
+{
+    _test_helper_libbpf test_helper;
+
+    // Try with a valid set of instructions.
+    struct bpf_insn instructions[] = {
+        {0xb7, R0_RETURN_VALUE, 0}, // r0 = 0
+        {INST_OP_EXIT},             // return r0
+    };
+
+    // Load and verify the eBPF program.
+    int program_fd = bpf_prog_load((bpf_prog_type)-1, "name", "license", instructions, _countof(instructions), nullptr);
     REQUIRE(program_fd < 0);
     REQUIRE(errno == EINVAL);
 }
@@ -100,6 +154,62 @@ TEST_CASE("valid bpf_load_program", "[libbpf]")
     REQUIRE(bpf_obj_get_info_by_fd(program_fd, &program_info, &program_info_size) == 0);
     REQUIRE(program_info_size == sizeof(program_info));
     REQUIRE(program_info.nr_map_ids == 0);
+
+    REQUIRE(program_info.type == BPF_PROG_TYPE_XDP);
+
+    Platform::_close(program_fd);
+}
+
+TEST_CASE("valid bpf_prog_load", "[libbpf]")
+{
+    _test_helper_libbpf test_helper;
+
+    // Try with a valid set of instructions.
+    struct bpf_insn instructions[] = {
+        {0xb7, R0_RETURN_VALUE, 0}, // r0 = 0
+        {INST_OP_EXIT},             // return r0
+    };
+
+    // Load and verify the eBPF program.
+    int program_fd = bpf_prog_load(BPF_PROG_TYPE_XDP, "name", nullptr, instructions, _countof(instructions), nullptr);
+    REQUIRE(program_fd >= 0);
+
+    // Now query the program info and verify it matches what we set.
+    bpf_prog_info program_info;
+    uint32_t program_info_size = sizeof(program_info);
+    REQUIRE(bpf_obj_get_info_by_fd(program_fd, &program_info, &program_info_size) == 0);
+    REQUIRE(program_info_size == sizeof(program_info));
+    REQUIRE(program_info.nr_map_ids == 0);
+    REQUIRE(strcmp(program_info.name, "name") == 0);
+
+    REQUIRE(program_info.type == BPF_PROG_TYPE_XDP);
+
+    Platform::_close(program_fd);
+}
+
+TEST_CASE("valid bpf_load_program_xattr", "[libbpf]")
+{
+    _test_helper_libbpf test_helper;
+
+    // Try with a valid set of instructions.
+    struct bpf_insn instructions[] = {
+        {0xb7, R0_RETURN_VALUE, 0}, // r0 = 0
+        {INST_OP_EXIT},             // return r0
+    };
+
+    // Load and verify the eBPF program.
+    struct bpf_load_program_attr attr = {
+        .prog_type = BPF_PROG_TYPE_XDP, .name = "name", .insns = instructions, .insns_cnt = _countof(instructions)};
+    int program_fd = bpf_load_program_xattr(&attr, nullptr, 0);
+    REQUIRE(program_fd >= 0);
+
+    // Now query the program info and verify it matches what we set.
+    bpf_prog_info program_info;
+    uint32_t program_info_size = sizeof(program_info);
+    REQUIRE(bpf_obj_get_info_by_fd(program_fd, &program_info, &program_info_size) == 0);
+    REQUIRE(program_info_size == sizeof(program_info));
+    REQUIRE(program_info.nr_map_ids == 0);
+    REQUIRE(strcmp(program_info.name, "name") == 0);
 
     REQUIRE(program_info.type == BPF_PROG_TYPE_XDP);
 
@@ -187,7 +297,7 @@ TEST_CASE("libbpf program", "[libbpf]")
 
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
     REQUIRE(program_fd != ebpf_fd_invalid);
@@ -228,7 +338,7 @@ TEST_CASE("libbpf program pinning", "[libbpf]")
 
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 
@@ -288,7 +398,7 @@ TEST_CASE("libbpf program attach", "[libbpf]")
 
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 
@@ -368,7 +478,7 @@ TEST_CASE("bpf_set_link_xdp_fd", "[libbpf]")
     bpf_prog_info program_info[2];
 
     for (int i = 0; i < 2; i++) {
-        REQUIRE(bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object[i], &program_fd[i]) == 0);
+        REQUIRE(bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &object[i], &program_fd[i]) == 0);
         REQUIRE(object[i] != nullptr);
 
         program[i] = bpf_object__find_program_by_name(object[i], "DropPacket");
@@ -391,7 +501,7 @@ TEST_CASE("libbpf map", "[libbpf]")
 
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 
@@ -677,7 +787,7 @@ TEST_CASE("libbpf map binding", "[libbpf]")
 
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
     struct bpf_program* program = bpf_program__next(nullptr, object);
@@ -732,7 +842,7 @@ TEST_CASE("libbpf map pinning", "[libbpf]")
 
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 
@@ -831,7 +941,7 @@ TEST_CASE("libbpf obj pinning", "[libbpf]")
 
     struct bpf_object* object;
     int program_fd;
-    int result = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int result = bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(result == 0);
     REQUIRE(object != nullptr);
 
@@ -871,7 +981,7 @@ _ebpf_test_tail_call(_In_z_ const char* filename, int expected_result)
 
     struct bpf_object* object;
     int program_fd;
-    int error = bpf_prog_load(filename, BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int error = bpf_prog_load_deprecated(filename, BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(error == 0);
     REQUIRE(object != nullptr);
 
@@ -978,7 +1088,7 @@ _multiple_tail_calls_test(ebpf_execution_type_t execution_type)
     const char* file_name =
         (execution_type == EBPF_EXECUTION_NATIVE ? "tail_call_multiple_um.dll" : "tail_call_multiple.o");
 
-    int error = bpf_prog_load(file_name, BPF_PROG_TYPE_XDP, &object, &program_fd);
+    int error = bpf_prog_load_deprecated(file_name, BPF_PROG_TYPE_XDP, &object, &program_fd);
     REQUIRE(error == 0);
     REQUIRE(object != nullptr);
 
@@ -1069,7 +1179,7 @@ _test_bind_fd_to_prog_array(ebpf_execution_type_t execution_type)
     struct bpf_object* xdp_object;
     int xdp_object_fd;
     const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE ? "tail_call_um.dll" : "tail_call.o");
-    int error = bpf_prog_load(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
+    int error = bpf_prog_load_deprecated(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
     REQUIRE(error == 0);
     REQUIRE(xdp_object != nullptr);
 
@@ -1083,7 +1193,7 @@ _test_bind_fd_to_prog_array(ebpf_execution_type_t execution_type)
     // the individual dll, instead of the combined DLL. This helps in testing the DLL stub which is generated
     // bpf2c.exe tool.
     const char* another_file_name = (execution_type == EBPF_EXECUTION_NATIVE ? "bindmonitor_um.dll" : "bindmonitor.o");
-    error = bpf_prog_load(another_file_name, BPF_PROG_TYPE_BIND, &bind_object, &bind_object_fd);
+    error = bpf_prog_load_deprecated(another_file_name, BPF_PROG_TYPE_BIND, &bind_object, &bind_object_fd);
     REQUIRE(error == 0);
     REQUIRE(bind_object != nullptr);
 
@@ -1117,13 +1227,13 @@ TEST_CASE("disallow prog_array mixed program type values", "[libbpf]")
 
     struct bpf_object* xdp_object;
     int xdp_object_fd;
-    int error = bpf_prog_load("droppacket.o", BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
+    int error = bpf_prog_load_deprecated("droppacket.o", BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
     REQUIRE(error == 0);
     REQUIRE(xdp_object != nullptr);
 
     struct bpf_object* bind_object;
     int bind_object_fd;
-    error = bpf_prog_load("bindmonitor.o", BPF_PROG_TYPE_BIND, &bind_object, &bind_object_fd);
+    error = bpf_prog_load_deprecated("bindmonitor.o", BPF_PROG_TYPE_BIND, &bind_object, &bind_object_fd);
     REQUIRE(error == 0);
     REQUIRE(bind_object != nullptr);
 
@@ -1165,7 +1275,7 @@ _enumerate_program_ids_test(ebpf_execution_type_t execution_type)
     struct bpf_object* xdp_object;
     int xdp_object_fd;
     const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE ? "tail_call_um.dll" : "tail_call.o");
-    int error = bpf_prog_load(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
+    int error = bpf_prog_load_deprecated(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
     REQUIRE(error == 0);
     REQUIRE(xdp_object != nullptr);
 
@@ -1270,7 +1380,7 @@ _array_of_maps_test(ebpf_execution_type_t execution_type)
     struct bpf_object* xdp_object;
     int xdp_object_fd;
     const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE ? "map_in_map_um.dll" : "map_in_map.o");
-    int error = bpf_prog_load(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
+    int error = bpf_prog_load_deprecated(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
     REQUIRE(error == 0);
     REQUIRE(xdp_object != nullptr);
 
@@ -1327,7 +1437,7 @@ _array_of_maps2_test(ebpf_execution_type_t execution_type)
     struct bpf_object* xdp_object;
     int xdp_object_fd;
     const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE ? "map_in_map_v2_um.dll" : "map_in_map_v2.o");
-    int error = bpf_prog_load(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
+    int error = bpf_prog_load_deprecated(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
     REQUIRE(error == 0);
     REQUIRE(xdp_object != nullptr);
 
@@ -1382,7 +1492,7 @@ _wrong_inner_map_types_test(ebpf_execution_type_t execution_type)
     struct bpf_object* xdp_object;
     int xdp_object_fd;
     const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE ? "map_in_map_um.dll" : "map_in_map.o");
-    int error = bpf_prog_load(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
+    int error = bpf_prog_load_deprecated(file_name, BPF_PROG_TYPE_XDP, &xdp_object, &xdp_object_fd);
     REQUIRE(error == 0);
     REQUIRE(xdp_object != nullptr);
 


### PR DESCRIPTION
Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

* Add bpf_prog_load()
* Move prototype for bpf_prog_load_deprecated() from libbpf.h to bpf.h to match libbpf
* Mark as deprecated bpf_object__load_xattr(), bpf_load_program(), and bpf_load_program_xattr() to match libbpf
* Make bpf_load_program_xattr() support the program name field, where previously it was ignored and a random name was used.

Fixes #1073

## Testing

Test additions included.

## Documentation

Doc changes included.
