### PR TITLE
Support bpf_object__load() with native programs

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -92,7 +92,7 @@ EXPORTS
     ebpf_api_close_handle
     ebpf_api_get_pinned_map_info
     ebpf_api_map_info_free
-    ebpf_enumerate_program_sections
+    ebpf_enumerate_sections
     ebpf_free_sections
     ebpf_free_string
     ebpf_get_attach_type_name

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -51,6 +51,7 @@ EXPORTS
     bpf_object__next
     bpf_object__next_map
     bpf_object__next_program
+    bpf_object__open
     bpf_object__open_file
     bpf_object__pin
     bpf_object__pin_maps
@@ -90,7 +91,7 @@ EXPORTS
     ebpf_api_close_handle
     ebpf_api_get_pinned_map_info
     ebpf_api_map_info_free
-    ebpf_enumerate_sections
+    ebpf_enumerate_program_sections
     ebpf_free_sections
     ebpf_free_string
     ebpf_get_attach_type_name

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -71,6 +71,7 @@ EXPORTS
     bpf_program__fd
     bpf_program__get_expected_attach_type
     bpf_program__get_type=bpf_program__type
+    bpf_program__log_buf
     bpf_program__name
     bpf_program__next
     bpf_program__pin
@@ -100,10 +101,11 @@ EXPORTS
     ebpf_get_program_type_name
     ebpf_link_close
     ebpf_object_get
+    ebpf_object_get_execution_type
+    ebpf_object_set_execution_type
     ebpf_object_unpin
     ebpf_program_attach
     ebpf_program_attach_by_fd
-    ebpf_program_load
     ebpf_program_query_info
     libbpf_get_error
     libbpf_num_possible_cpus

--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -341,6 +341,16 @@ bpf_object__next(struct bpf_object* prev);
  * @brief Open a file without loading the programs.
  *
  * @param[in] path File name to open.
+ *
+ * @returns Pointer to an eBPF object, or NULL on failure.
+ */
+struct bpf_object*
+bpf_object__open(const char* path);
+
+/**
+ * @brief Open a file without loading the programs.
+ *
+ * @param[in] path File name to open.
  * @param[opts] opts Options to use when opening the object.
  *
  * @returns Pointer to an eBPF object, or NULL on failure.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -118,7 +118,7 @@ extern "C"
 -     *  the error.
       */
     ebpf_result_t
-    ebpf_enumerate_program_sections(
+    ebpf_enumerate_sections(
         _In_z_ const char* file,
         bool verbose,
         _Outptr_result_maybenull_ ebpf_section_info_t** infos,

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -101,6 +101,7 @@ extern "C"
         struct _ebpf_section_info* next;
         _Field_z_ const char* section_name;
         _Field_z_ const char* program_type_name;
+        _Field_z_ const char* program_name;
         size_t map_count;
         size_t raw_data_size;
         _Field_size_(raw_data_size) char* raw_data;

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -112,18 +112,19 @@ extern "C"
 -     * @param[in] file Name of file containing eBPF programs.
 -     * @param[in] verbose Obtain additional info about the programs.
 -     * @param[out] infos On success points to a list of eBPF programs.
+      * The caller is responsible for freeing the list via ebpf_free_sections().
 -     * @param[out] error_message On failure points to a text description of
 -     *  the error.
       */
     ebpf_result_t
-    ebpf_enumerate_sections(
+    ebpf_enumerate_program_sections(
         _In_z_ const char* file,
         bool verbose,
         _Outptr_result_maybenull_ ebpf_section_info_t** infos,
         _Outptr_result_maybenull_z_ const char** error_message);
 
     /**
-     * @brief Free memory returned from \ref ebpf_enumerate_sections.
+     * @brief Free memory returned from \ref ebpf_enumerate_program_sections.
      * @param[in] data Memory to free.
      */
     void

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -125,7 +125,7 @@ extern "C"
         _Outptr_result_maybenull_z_ const char** error_message);
 
     /**
-     * @brief Free memory returned from \ref ebpf_enumerate_program_sections.
+     * @brief Free memory returned from \ref ebpf_enumerate_sections.
      * @param[in] data Memory to free.
      */
     void
@@ -286,8 +286,11 @@ extern "C"
      *
      * @param[in] object The eBPF object file.
      * @param[in] execution_type Execution type to set.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
      */
-    void
+    ebpf_result_t
     ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type);
 
     /**

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -271,51 +271,23 @@ extern "C"
         uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info);
 
     /**
-     * @brief Load eBPF programs from an ELF file based on default load
-     * attributes. This API does the following:
-     * 1. Read the ELF file.
-     * 2. Create maps.
-     * 3. Load all programs.
-     * 4. Return fd to the first program.
+     * @brief Get the execution type for an eBPF object file.
      *
-     * If the caller supplies a program type and/or attach type, that
-     * supplied value takes precedence over the derived program/attach type.
+     * @param[in] object The eBPF object file.
      *
-     * @param[in] file_name When loading from an ELF file, ELF file name with full path.
-     *  When loading from a native driver, driver file name with full path.
-     * @param[in] program_type Optionally, the program type to use when loading
-     *  the eBPF program. If program type is not supplied, it is derived from
-     *  the section prefix in the ELF file.
-     * @param[in] attach_type Optionally, the attach type to use for the loaded
-     *  eBPF program. If attach type is not supplied, it is derived from the
-     *  section prefix in the ELF file.
-     * @param[in] execution_type The execution type to use for this program. If
-     *  EBPF_EXECUTION_ANY is specified, execution type will be decided by a
-     *  system-wide policy.
-     * @param[out] object Returns pointer to ebpf_object object. The caller
-     *  is expected to call bpf_object__close() at the end.
-     * @param[out] program_fd Returns a file descriptor for the first program.
-     *  The caller should not call _close() on the fd, but should instead use
-     *  bpf_object__close() to close this (and other) file descriptors.
-     * @param[out] log_buffer Returns a pointer to a null-terminated log buffer.
-     *  The caller is responsible for freeing the returned log_buffer pointer
-     *  by calling ebpf_free_string().
-     *
-     * @retval EBPF_SUCCESS The programs are loaded and maps are created successfully.
-     * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
-     * @retval EBPF_NO_MEMORY Out of memory.
-     * @retval EBPF_ELF_PARSING_FAILED Failure in parsing ELF file.
-     * @retval EBPF_FAILED Some other error occured.
+     * @returns Execution type.
      */
-    ebpf_result_t
-    ebpf_program_load(
-        _In_z_ const char* file_name,
-        _In_opt_ const ebpf_program_type_t* program_type,
-        _In_opt_ const ebpf_attach_type_t* attach_type,
-        ebpf_execution_type_t execution_type,
-        _Outptr_ struct bpf_object** object,
-        _Out_ fd_t* program_fd,
-        _Outptr_result_maybenull_z_ const char** log_buffer);
+    ebpf_execution_type_t
+    ebpf_object_get_execution_type(_In_ struct bpf_object* object);
+
+    /**
+     * @brief Set the execution type for an eBPF object file.
+     *
+     * @param[in] object The eBPF object file.
+     * @param[in] execution_type Execution type to set.
+     */
+    void
+    ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type);
 
     /**
      * @brief Load an eBPF programs from raw instructions.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -478,14 +478,13 @@ ebpf_object_open(
  * @brief Load all the programs in a given object.
  *
  * @param[in] object Object from which to load programs.
- * @param[in] execution_type Execution type.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  * @retval EBPF_NO_MEMORY Out of memory.
  */
 ebpf_result_t
-ebpf_object_load(_Inout_ struct bpf_object* object, ebpf_execution_type_t execution_type);
+ebpf_object_load(_Inout_ struct bpf_object* object);
 
 /**
  * @brief Unload all the programs in a given object.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -24,6 +24,8 @@ typedef struct bpf_program
     ebpf_handle_t handle;
     fd_t fd;
     bool pinned;
+    const char* log_buffer;
+    uint32_t log_buffer_size;
 } ebpf_program_t;
 
 typedef struct bpf_map
@@ -67,9 +69,11 @@ typedef struct bpf_link
 typedef struct bpf_object
 {
     char* object_name = nullptr;
+    char* file_name = nullptr;
     std::vector<ebpf_program_t*> programs;
     std::vector<ebpf_map_t*> maps;
     bool loaded = false;
+    ebpf_execution_type_t execution_type = EBPF_EXECUTION_ANY;
 } ebpf_object_t;
 
 /**
@@ -475,18 +479,13 @@ ebpf_object_open(
  *
  * @param[in] object Object from which to load programs.
  * @param[in] execution_type Execution type.
- * @param[out] error_message Error message string, which
- * the caller must free using ebpf_free_string().
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  * @retval EBPF_NO_MEMORY Out of memory.
  */
 ebpf_result_t
-ebpf_object_load(
-    _Inout_ struct bpf_object* object,
-    ebpf_execution_type_t execution_type,
-    _Outptr_result_maybenull_z_ const char** error_message);
+ebpf_object_load(_Inout_ struct bpf_object* object, ebpf_execution_type_t execution_type);
 
 /**
  * @brief Unload all the programs in a given object.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1991,7 +1991,7 @@ _ebpf_enumerate_native_sections(
 }
 
 ebpf_result_t
-ebpf_enumerate_program_sections(
+ebpf_enumerate_sections(
     _In_z_ const char* file,
     bool verbose,
     _Outptr_result_maybenull_ ebpf_section_info_t** infos,

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1873,11 +1873,13 @@ _ebpf_pe_get_section_names(
     if (section_name == "programs") {
         // bpf2c generates a section that has ELF section names as strings at the
         // start of the section.  Skip over them looking for the program_entry_t
-        // which starts with a 16-byte-aligned NULL pointer.
+        // which starts with a 16-byte-aligned NULL pointer where the previous
+        // byte (if any) is also 00.
         uint32_t program_offset = 0;
         uint64_t zero = 0;
         while (program_offset < section_header.Misc.VirtualSize &&
-               memcmp(buffer->buf + program_offset, &zero, sizeof(zero)) != 0) {
+               (memcmp(buffer->buf + program_offset, &zero, sizeof(zero)) != 0 ||
+                (program_offset > 0 && buffer->buf[program_offset - 1] != 0))) {
             program_offset += 16;
         }
         int program_count = (section_header.Misc.VirtualSize - program_offset) / sizeof(program_entry_t);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1530,7 +1530,7 @@ _initialize_ebpf_object_native(
     ebpf_assert(object.file_name != nullptr);
     ebpf_assert(object.object_name != nullptr);
 
-    // TODO(issue #951): populate maps at open time
+    // TODO(issue #1140): populate maps at open time
     for (auto& map : object.maps) {
         map->object = &object;
     }
@@ -1608,7 +1608,7 @@ _initialize_ebpf_object_from_native_file(
         program = nullptr;
     }
 
-    // TODO(issue #951): populate object.maps
+    // TODO(issue #1140): populate object.maps
     UNREFERENCED_PARAMETER(pin_root_path);
 
 Exit:

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1955,8 +1955,12 @@ _ebpf_pe_add_section(
     }
     memcpy(info->raw_data, buffer->buf, section_header.Misc.VirtualSize);
 
-    info->next = pe_context->infos;
-    pe_context->infos = info;
+    // Append to existing list.
+    ebpf_section_info_t** pnext = &pe_context->infos;
+    while (*pnext) {
+        pnext = &(*pnext)->next;
+    }
+    *pnext = info;
 
     EBPF_LOG_EXIT();
     return 0;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1491,14 +1491,6 @@ _initialize_ebpf_programs_native(
         }
         program->handle = program_handles[i];
         program_handles[i] = ebpf_handle_invalid;
-        if (program->program_name == nullptr && info.name[0]) {
-            // TODO(issue #851): make _ebpf_enumerate_native_sections populate program_name.
-            program->program_name = _strdup(info.name);
-            if (program->program_name == nullptr) {
-                result = EBPF_NO_MEMORY;
-                goto Exit;
-            }
-        }
         program->program_type = info.type_uuid;
         program->attach_type = info.attach_type_uuid;
     }
@@ -1540,7 +1532,7 @@ _initialize_ebpf_object_native(
     ebpf_assert(object.file_name != nullptr);
     ebpf_assert(object.object_name != nullptr);
 
-    // TODO(issue #851): can we populate maps at open time?
+    // TODO(issue #851): populate maps at open time
     for (auto& map : object.maps) {
         map->object = &object;
     }
@@ -1618,7 +1610,7 @@ _initialize_ebpf_object_from_native_file(
         program = nullptr;
     }
 
-    // TODO: populate object.maps
+    // TODO(issue #851): populate object.maps
     UNREFERENCED_PARAMETER(pin_root_path);
 
 Exit:
@@ -2015,7 +2007,6 @@ ebpf_enumerate_program_sections(
     }
 }
 
-// TODO (issue #951): update to look more like bpf_object__open_xattr
 ebpf_result_t
 ebpf_object_open(
     _In_z_ const char* path,

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2062,10 +2062,20 @@ _ebpf_is_map_in_map(ebpf_map_t* map)
     EBPF_RETURN_BOOL(false);
 }
 
-void
+ebpf_result_t
 ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type)
 {
+    if (Platform::_is_native_program(object->file_name)) {
+        if (object->execution_type == EBPF_EXECUTION_INTERPRET || object->execution_type == EBPF_EXECUTION_JIT) {
+            return EBPF_INVALID_ARGUMENT;
+        }
+    } else {
+        if (object->execution_type == EBPF_EXECUTION_NATIVE) {
+            return EBPF_INVALID_ARGUMENT;
+        }
+    }
     object->execution_type = execution_type;
+    return EBPF_SUCCESS;
 }
 
 ebpf_execution_type_t

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -109,7 +109,7 @@ bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
 int
 bpf_object__load_xattr(struct bpf_object_load_attr* attr)
 {
-    ebpf_result result = ebpf_object_load(attr->obj, EBPF_EXECUTION_ANY);
+    ebpf_result result = ebpf_object_load(attr->obj);
     return libbpf_result_err(result);
 }
 

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -109,9 +109,7 @@ bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
 int
 bpf_object__load_xattr(struct bpf_object_load_attr* attr)
 {
-    const char* error_message;
-    ebpf_result result = ebpf_object_load(attr->obj, EBPF_EXECUTION_ANY, &error_message);
-    ebpf_free_string(error_message);
+    ebpf_result result = ebpf_object_load(attr->obj, EBPF_EXECUTION_ANY);
     return libbpf_result_err(result);
 }
 

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -84,6 +84,13 @@ bpf_obj_get(const char* pathname)
 }
 
 struct bpf_object*
+bpf_object__open(const char* path)
+{
+    struct bpf_object_open_opts opts = {.sz = sizeof(opts)};
+    return bpf_object__open_file(path, &opts);
+}
+
+struct bpf_object*
 bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
 {
     if (!path) {

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -159,7 +159,7 @@ bpf_prog_load_deprecated(const char* file_name, enum bpf_prog_type type, struct 
         return libbpf_result_err(result);
     }
 
-    result = ebpf_object_load(new_object, EBPF_EXECUTION_ANY);
+    result = ebpf_object_load(new_object);
     if (result != EBPF_SUCCESS) {
         ebpf_object_close(new_object);
         return libbpf_result_err(result);

--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -128,7 +128,7 @@ handle_ebpf_show_sections(
     ebpf_section_info_t* section_data = nullptr;
 
     const char* error_message = nullptr;
-    if (ebpf_enumerate_sections(filename.c_str(), level == VL_VERBOSE, &section_data, &error_message) != 0) {
+    if (ebpf_enumerate_program_sections(filename.c_str(), level == VL_VERBOSE, &section_data, &error_message) != 0) {
         std::cerr << error_message << std::endl;
         ebpf_free_string(error_message);
         ebpf_free_sections(section_data);

--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -128,7 +128,7 @@ handle_ebpf_show_sections(
     ebpf_section_info_t* section_data = nullptr;
 
     const char* error_message = nullptr;
-    if (ebpf_enumerate_program_sections(filename.c_str(), level == VL_VERBOSE, &section_data, &error_message) != 0) {
+    if (ebpf_enumerate_sections(filename.c_str(), level == VL_VERBOSE, &section_data, &error_message) != 0) {
         std::cerr << error_message << std::endl;
         ebpf_free_string(error_message);
         ebpf_free_sections(section_data);

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -109,8 +109,8 @@ handle_ebpf_add_program(
 
     std::string filename;
     std::string pinpath;
-    ebpf_program_type_t program_type = EBPF_PROGRAM_TYPE_UNSPECIFIED;
-    ebpf_attach_type_t attach_type = EBPF_ATTACH_TYPE_UNSPECIFIED;
+    bpf_prog_type prog_type = BPF_PROG_TYPE_UNSPEC;
+    bpf_attach_type attach_type = BPF_ATTACH_TYPE_UNSPEC;
     pinned_type_t pinned_type = PT_FIRST; // Like bpftool, we default to pin first.
     ebpf_execution_type_t execution = EBPF_EXECUTION_JIT;
     LPWSTR interface_parameter = nullptr;
@@ -123,8 +123,7 @@ handle_ebpf_add_program(
         }
         case TYPE_INDEX: {
             std::string type_name = down_cast_from_wstring(std::wstring(argv[current_index + i]));
-            ebpf_result_t result = ebpf_get_program_type_by_name(type_name.c_str(), &program_type, &attach_type);
-            if (result != EBPF_SUCCESS) {
+            if (libbpf_prog_type_by_name(type_name.c_str(), &prog_type, &attach_type) < 0) {
                 status = ERROR_INVALID_PARAMETER;
             }
             break;
@@ -164,28 +163,34 @@ handle_ebpf_add_program(
     struct bpf_object* object;
     int program_fd;
     PCSTR error_message;
-    ebpf_result_t result = ebpf_program_load(
-        filename.c_str(),
-        (tags[TYPE_INDEX].bPresent ? &program_type : nullptr),
-        (tags[TYPE_INDEX].bPresent ? &attach_type : nullptr),
-        EBPF_EXECUTION_ANY,
-        &object,
-        &program_fd,
-        &error_message);
-    if (result != EBPF_SUCCESS) {
-        std::cerr << "error " << result << ": could not load program" << std::endl;
-        if (error_message != nullptr) {
-            std::cerr << error_message << std::endl;
-            ebpf_free_string(error_message);
-        }
+    object = bpf_object__open(filename.c_str());
+    if (object == nullptr) {
+        std::cerr << "error " << errno << ": could not open file" << std::endl;
         return ERROR_SUPPRESS_OUTPUT;
     }
+
+    struct bpf_program* program = bpf_object__next_program(object, nullptr);
+    if (prog_type != BPF_PROG_TYPE_UNSPEC) {
+        bpf_program__set_type(program, prog_type);
+    }
+
+    if (bpf_object__load(object) < 0) {
+        std::cerr << "error " << errno << ": could not load program" << std::endl;
+        size_t error_message_size;
+        error_message = bpf_program__log_buf(program, &error_message_size);
+        if (error_message != nullptr) {
+            std::cerr << error_message << std::endl;
+        }
+        bpf_object__close(object);
+        return ERROR_SUPPRESS_OUTPUT;
+    }
+    program_fd = bpf_program__fd(program);
+
     // Program loaded. Populate the unloader with object pointer and program fd, such that
     // the program gets unloaded automatically, if it fails to get attached.
     struct _program_unloader unloader = {object, program_fd};
 
-    struct bpf_program* program = bpf_program__next(nullptr, object);
-
+    ebpf_result_t result;
     uint32_t if_index;
     void* attach_parameters = nullptr;
     size_t attach_parameters_size = 0;
@@ -200,12 +205,7 @@ handle_ebpf_add_program(
     }
 
     struct bpf_link* link;
-    result = ebpf_program_attach(
-        program,
-        (tags[TYPE_INDEX].bPresent ? &attach_type : nullptr),
-        attach_parameters,
-        attach_parameters_size,
-        &link);
+    result = ebpf_program_attach(program, nullptr, attach_parameters, attach_parameters_size, &link);
     if (result != EBPF_SUCCESS) {
         std::cerr << "error " << result << ": could not attach program" << std::endl;
         return ERROR_SUPPRESS_OUTPUT;

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -80,7 +80,7 @@ _program_load_helper(
 static void
 _test_program_load(
     const char* file_name,
-    bpf_prog_type prog_type,
+    bpf_prog_type program_type,
     ebpf_execution_type_t execution_type,
     ebpf_result_t expected_load_result)
 {
@@ -88,7 +88,7 @@ _test_program_load(
     struct bpf_object* object = nullptr;
     fd_t program_fd;
 
-    result = _program_load_helper(file_name, prog_type, execution_type, &object, &program_fd);
+    result = _program_load_helper(file_name, program_type, execution_type, &object, &program_fd);
     REQUIRE(result == expected_load_result);
 
     if (expected_load_result == EBPF_SUCCESS) {
@@ -151,11 +151,11 @@ _test_multiple_programs_load(
 
     for (int i = 0; i < program_count; i++) {
         const char* file_name = parameters[i].file_name;
-        bpf_prog_type prog_type = parameters[i].prog_type;
+        bpf_prog_type program_type = parameters[i].prog_type;
         struct bpf_object* object;
         fd_t program_fd;
 
-        result = _program_load_helper(file_name, prog_type, execution_type, &object, &program_fd);
+        result = _program_load_helper(file_name, program_type, execution_type, &object, &program_fd);
         REQUIRE(expected_load_result == result);
         if (expected_load_result == EBPF_SUCCESS) {
             REQUIRE(program_fd > 0);

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -50,23 +50,37 @@ static service_install_helper
 static ebpf_result_t
 _program_load_helper(
     const char* file_name,
-    const ebpf_program_type_t* program_type,
+    bpf_prog_type prog_type,
     ebpf_execution_type_t execution_type,
     struct bpf_object** object,
     fd_t* program_fd)
 {
-    ebpf_result_t result;
-    const char* log_buffer = nullptr;
-    result = ebpf_program_load(file_name, program_type, nullptr, execution_type, object, program_fd, &log_buffer);
+    struct bpf_object* new_object = bpf_object__open(file_name);
+    if (new_object == nullptr) {
+        return EBPF_FAILED;
+    }
 
-    ebpf_free_string(log_buffer);
-    return result;
+    ebpf_object_set_execution_type(new_object, execution_type);
+
+    struct bpf_program* program = bpf_object__next_program(new_object, nullptr);
+
+    bpf_program__set_type(program, prog_type);
+
+    int error = bpf_object__load(new_object);
+    if (error < 0) {
+        bpf_object__close(new_object);
+        return EBPF_FAILED;
+    }
+
+    *program_fd = bpf_program__fd(program);
+    *object = new_object;
+    return EBPF_SUCCESS;
 }
 
 static void
 _test_program_load(
     const char* file_name,
-    ebpf_program_type_t* program_type,
+    bpf_prog_type prog_type,
     ebpf_execution_type_t execution_type,
     ebpf_result_t expected_load_result)
 {
@@ -74,7 +88,7 @@ _test_program_load(
     struct bpf_object* object = nullptr;
     fd_t program_fd;
 
-    result = _program_load_helper(file_name, program_type, execution_type, &object, &program_fd);
+    result = _program_load_helper(file_name, prog_type, execution_type, &object, &program_fd);
     REQUIRE(result == expected_load_result);
 
     if (expected_load_result == EBPF_SUCCESS) {
@@ -121,7 +135,7 @@ _test_program_load(
 struct _ebpf_program_load_test_parameters
 {
     _Field_z_ const char* file_name;
-    ebpf_program_type_t* program_type;
+    bpf_prog_type prog_type;
 };
 
 static void
@@ -137,11 +151,11 @@ _test_multiple_programs_load(
 
     for (int i = 0; i < program_count; i++) {
         const char* file_name = parameters[i].file_name;
-        const ebpf_program_type_t* program_type = parameters[i].program_type;
+        bpf_prog_type prog_type = parameters[i].prog_type;
         struct bpf_object* object;
         fd_t program_fd;
 
-        result = _program_load_helper(file_name, program_type, execution_type, &object, &program_fd);
+        result = _program_load_helper(file_name, prog_type, execution_type, &object, &program_fd);
         REQUIRE(expected_load_result == result);
         if (expected_load_result == EBPF_SUCCESS) {
             REQUIRE(program_fd > 0);
@@ -172,7 +186,7 @@ _test_map_next_previous(const char* file_name, int expected_map_count)
     int map_count = 0;
     struct bpf_map* previous = nullptr;
     struct bpf_map* next = nullptr;
-    result = _program_load_helper(file_name, nullptr, EBPF_EXECUTION_ANY, &object, &program_fd);
+    result = _program_load_helper(file_name, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, &object, &program_fd);
     REQUIRE(result == EBPF_SUCCESS);
 
     next = bpf_map__next(previous, object);
@@ -206,7 +220,7 @@ _test_program_next_previous(const char* file_name, int expected_program_count)
     int program_count = 0;
     struct bpf_program* previous = nullptr;
     struct bpf_program* next = nullptr;
-    result = _program_load_helper(file_name, nullptr, EBPF_EXECUTION_ANY, &object, &program_fd);
+    result = _program_load_helper(file_name, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, &object, &program_fd);
     REQUIRE(result == EBPF_SUCCESS);
 
     next = bpf_program__next(previous, object);
@@ -255,50 +269,50 @@ TEST_CASE("pinned_map_enum", "[pinned_map_enum]") { ebpf_test_pinned_map_enum();
 #endif
 
 // Load droppacket (JIT) without providing expected program type.
-DECLARE_LOAD_TEST_CASE("droppacket.o", nullptr, EBPF_EXECUTION_JIT, EBPF_SUCCESS);
+DECLARE_LOAD_TEST_CASE("droppacket.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_JIT, EBPF_SUCCESS);
 
-DECLARE_LOAD_TEST_CASE("droppacket_km.sys", nullptr, EBPF_EXECUTION_NATIVE, EBPF_SUCCESS);
+DECLARE_LOAD_TEST_CASE("droppacket_km.sys", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, EBPF_SUCCESS);
 
 // Declare a duplicate test case. This will ensure that the earlier driver is actually unloaded,
 // else this test case will fail.
-DECLARE_DUPLICATE_LOAD_TEST_CASE("droppacket_km.sys", nullptr, EBPF_EXECUTION_NATIVE, 2, EBPF_SUCCESS);
+DECLARE_DUPLICATE_LOAD_TEST_CASE("droppacket_km.sys", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, 2, EBPF_SUCCESS);
 
 // Load droppacket (ANY) without providing expected program type.
-DECLARE_LOAD_TEST_CASE("droppacket.o", nullptr, EBPF_EXECUTION_ANY, EBPF_SUCCESS);
+DECLARE_LOAD_TEST_CASE("droppacket.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, EBPF_SUCCESS);
 
 // Load droppacket (INTERPRET) without providing expected program type.
-DECLARE_LOAD_TEST_CASE("droppacket.o", nullptr, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
+DECLARE_LOAD_TEST_CASE("droppacket.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
 
 // Load droppacket with providing expected program type.
-DECLARE_LOAD_TEST_CASE("droppacket.o", &EBPF_PROGRAM_TYPE_XDP, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
+DECLARE_LOAD_TEST_CASE("droppacket.o", BPF_PROG_TYPE_XDP, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
 
 // Load bindmonitor (JIT) without providing expected program type.
-DECLARE_LOAD_TEST_CASE("bindmonitor.o", nullptr, EBPF_EXECUTION_JIT, EBPF_SUCCESS);
+DECLARE_LOAD_TEST_CASE("bindmonitor.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_JIT, EBPF_SUCCESS);
 
 // Load bindmonitor (INTERPRET) without providing expected program type.
-DECLARE_LOAD_TEST_CASE("bindmonitor.o", nullptr, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
+DECLARE_LOAD_TEST_CASE("bindmonitor.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
 
 // Load bindmonitor with providing expected program type.
-DECLARE_LOAD_TEST_CASE("bindmonitor.o", &EBPF_PROGRAM_TYPE_BIND, EBPF_EXECUTION_JIT, EBPF_SUCCESS);
+DECLARE_LOAD_TEST_CASE("bindmonitor.o", BPF_PROG_TYPE_BIND, EBPF_EXECUTION_JIT, EBPF_SUCCESS);
 
 // Try to load bindmonitor with providing wrong program type.
-DECLARE_LOAD_TEST_CASE("bindmonitor.o", &EBPF_PROGRAM_TYPE_XDP, EBPF_EXECUTION_ANY, EBPF_VERIFICATION_FAILED);
+DECLARE_LOAD_TEST_CASE("bindmonitor.o", BPF_PROG_TYPE_XDP, EBPF_EXECUTION_ANY, EBPF_VERIFICATION_FAILED);
 
 // Try to load an unsafe program.
-DECLARE_LOAD_TEST_CASE("droppacket_unsafe.o", nullptr, EBPF_EXECUTION_ANY, EBPF_VERIFICATION_FAILED);
+DECLARE_LOAD_TEST_CASE("droppacket_unsafe.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, EBPF_VERIFICATION_FAILED);
 
 // Try to load multiple programs of different program types
 TEST_CASE("test_ebpf_multiple_programs_load_jit")
 {
     struct _ebpf_program_load_test_parameters test_parameters[] = {
-        {"droppacket.o", &EBPF_PROGRAM_TYPE_XDP}, {"bindmonitor.o", &EBPF_PROGRAM_TYPE_BIND}};
+        {"droppacket.o", BPF_PROG_TYPE_XDP}, {"bindmonitor.o", BPF_PROG_TYPE_BIND}};
     _test_multiple_programs_load(_countof(test_parameters), test_parameters, EBPF_EXECUTION_JIT, EBPF_SUCCESS);
 }
 
 TEST_CASE("test_ebpf_multiple_programs_load_interpret")
 {
     struct _ebpf_program_load_test_parameters test_parameters[] = {
-        {"droppacket.o", &EBPF_PROGRAM_TYPE_XDP}, {"bindmonitor.o", &EBPF_PROGRAM_TYPE_BIND}};
+        {"droppacket.o", BPF_PROG_TYPE_XDP}, {"bindmonitor.o", BPF_PROG_TYPE_BIND}};
     _test_multiple_programs_load(
         _countof(test_parameters), test_parameters, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
 }
@@ -353,7 +367,7 @@ ring_buffer_api_test(ebpf_execution_type_t execution_type)
     struct bpf_object* object = nullptr;
     hook_helper_t hook(EBPF_ATTACH_TYPE_BIND);
     program_load_attach_helper_t _helper(
-        "bindmonitor_ringbuf.o", EBPF_PROGRAM_TYPE_BIND, "bind_monitor", execution_type, nullptr, 0, hook);
+        "bindmonitor_ringbuf.o", BPF_PROG_TYPE_BIND, "bind_monitor", execution_type, nullptr, 0, hook);
     object = _helper.get_object();
 
     fd_t process_map_fd = bpf_object__find_map_fd_by_name(object, "process_map");
@@ -379,7 +393,7 @@ divide_by_zero_test_km(ebpf_execution_type_t execution_type)
     struct bpf_object* object = nullptr;
     hook_helper_t hook(EBPF_ATTACH_TYPE_BIND);
     program_load_attach_helper_t _helper(
-        "divide_by_zero.o", EBPF_PROGRAM_TYPE_BIND, "divide_by_zero", execution_type, nullptr, 0, hook);
+        "divide_by_zero.o", BPF_PROG_TYPE_BIND, "divide_by_zero", execution_type, nullptr, 0, hook);
     object = _helper.get_object();
 
     perform_socket_bind(0, true);
@@ -442,8 +456,7 @@ TEST_CASE("tailcall_load_test", "[tailcall_load_test]")
     struct bpf_object* object = nullptr;
     fd_t program_fd;
 
-    result =
-        _program_load_helper("tail_call_multiple.o", &EBPF_PROGRAM_TYPE_XDP, EBPF_EXECUTION_ANY, &object, &program_fd);
+    result = _program_load_helper("tail_call_multiple.o", BPF_PROG_TYPE_XDP, EBPF_EXECUTION_ANY, &object, &program_fd);
     REQUIRE(result == EBPF_SUCCESS);
 
     REQUIRE(program_fd > 0);
@@ -527,7 +540,7 @@ TEST_CASE("bindmonitor_native_test", "[native_tests]")
     struct bpf_object* object = nullptr;
     hook_helper_t hook(EBPF_ATTACH_TYPE_BIND);
     program_load_attach_helper_t _helper(
-        "bindmonitor_km.sys", EBPF_PROGRAM_TYPE_BIND, "BindMonitor", EBPF_EXECUTION_NATIVE, nullptr, 0, hook);
+        "bindmonitor_km.sys", BPF_PROG_TYPE_BIND, "BindMonitor", EBPF_EXECUTION_NATIVE, nullptr, 0, hook);
     object = _helper.get_object();
 
     bindmonitor_test(object);
@@ -538,7 +551,7 @@ TEST_CASE("bindmonitor_tailcall_native_test", "[native_tests]")
     struct bpf_object* object = nullptr;
     hook_helper_t hook(EBPF_ATTACH_TYPE_BIND);
     program_load_attach_helper_t _helper(
-        "bindmonitor_tailcall_km.sys", EBPF_PROGRAM_TYPE_BIND, "BindMonitor", EBPF_EXECUTION_JIT, nullptr, 0, hook);
+        "bindmonitor_tailcall_km.sys", BPF_PROG_TYPE_BIND, "BindMonitor", EBPF_EXECUTION_JIT, nullptr, 0, hook);
     object = _helper.get_object();
 
     // Setup tail calls.
@@ -604,7 +617,7 @@ TEST_CASE("bpf_get_current_pid_tgid", "[helpers]")
     uint32_t ifindex = 0;
     const char* program_name = "func";
     program_load_attach_helper_t _helper(
-        "pidtgid.sys", EBPF_PROGRAM_TYPE_BIND, program_name, EBPF_EXECUTION_NATIVE, &ifindex, sizeof(ifindex), hook);
+        "pidtgid.sys", BPF_PROG_TYPE_BIND, program_name, EBPF_EXECUTION_NATIVE, &ifindex, sizeof(ifindex), hook);
     struct bpf_object* object = _helper.get_object();
 
     // Bind a socket.

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -40,11 +40,7 @@ division_by_zero(uint32_t address)
     if (std::string(NAME) == #X)      \
         return &X;
 
-metadata_table_t*
-get_metadata_table()
-{
-    return &metadata_table;
-}
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"
 
@@ -92,121 +88,121 @@ static uint16_t func_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
 {
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     // Prologue
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r0 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r1 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r2 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r3 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r4 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r5 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r6 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r10 = 0;
 
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r1 = (uintptr_t)context;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r6 = r1;
     // EBPF_OP_LDXB pc=1 dst=r1 src=r6 offset=40 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r1 = *(uint8_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=2 dst=r2 src=r0 offset=0 imm=16
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r2 = IMMEDIATE(16);
     // EBPF_OP_JGT_REG pc=3 dst=r2 src=r1 offset=18 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     if (r2 > r1)
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
         goto label_1;
         // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     if (r1 != IMMEDIATE(15295))
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
         goto label_1;
         // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r0 = func_helpers[0].address
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
          (r1, r2, r3, r4, r5);
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     if ((func_helpers[0].tail_call) && (r0 == 0))
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
         return 0;
         // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
-#line 48 "sample/pidtgid.c"
+#line 45 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r0;
     // EBPF_OP_RSH64_IMM pc=9 dst=r0 src=r0 offset=0 imm=32
-#line 48 "sample/pidtgid.c"
+#line 45 "sample/pidtgid.c"
     r0 >>= IMMEDIATE(32);
     // EBPF_OP_STXW pc=10 dst=r10 src=r0 offset=-12 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r0;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-16 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-20 imm=0
-#line 49 "sample/pidtgid.c"
+#line 46 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=14 dst=r2 src=r10 offset=0 imm=0
-#line 49 "sample/pidtgid.c"
+#line 46 "sample/pidtgid.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=15 dst=r2 src=r0 offset=0 imm=-20
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=16 dst=r3 src=r10 offset=0 imm=0
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=17 dst=r3 src=r0 offset=0 imm=-16
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=18 dst=r1 src=r0 offset=0 imm=0
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=20 dst=r4 src=r0 offset=0 imm=0
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=21 dst=r0 src=r0 offset=0 imm=2
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r0 = func_helpers[1].address
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     if ((func_helpers[1].tail_call) && (r0 == 0))
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
     return r0;
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -50,121 +50,121 @@ static uint16_t func_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
 {
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     // Prologue
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r0 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r1 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r2 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r3 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r4 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r5 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r6 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r10 = 0;
 
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r1 = (uintptr_t)context;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r6 = r1;
     // EBPF_OP_LDXB pc=1 dst=r1 src=r6 offset=40 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r1 = *(uint8_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=2 dst=r2 src=r0 offset=0 imm=16
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r2 = IMMEDIATE(16);
     // EBPF_OP_JGT_REG pc=3 dst=r2 src=r1 offset=18 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     if (r2 > r1)
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
         goto label_1;
         // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     if (r1 != IMMEDIATE(15295))
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
         goto label_1;
         // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r0 = func_helpers[0].address
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
          (r1, r2, r3, r4, r5);
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     if ((func_helpers[0].tail_call) && (r0 == 0))
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
         return 0;
         // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
-#line 48 "sample/pidtgid.c"
+#line 45 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r0;
     // EBPF_OP_RSH64_IMM pc=9 dst=r0 src=r0 offset=0 imm=32
-#line 48 "sample/pidtgid.c"
+#line 45 "sample/pidtgid.c"
     r0 >>= IMMEDIATE(32);
     // EBPF_OP_STXW pc=10 dst=r10 src=r0 offset=-12 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r0;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-16 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-20 imm=0
-#line 49 "sample/pidtgid.c"
+#line 46 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=14 dst=r2 src=r10 offset=0 imm=0
-#line 49 "sample/pidtgid.c"
+#line 46 "sample/pidtgid.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=15 dst=r2 src=r0 offset=0 imm=-20
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=16 dst=r3 src=r10 offset=0 imm=0
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=17 dst=r3 src=r0 offset=0 imm=-16
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=18 dst=r1 src=r0 offset=0 imm=0
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=20 dst=r4 src=r0 offset=0 imm=0
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=21 dst=r0 src=r0 offset=0 imm=2
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r0 = func_helpers[1].address
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     if ((func_helpers[1].tail_call) && (r0 == 0))
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
     return r0;
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -217,121 +217,121 @@ static uint16_t func_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 func(void* context)
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
 {
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     // Prologue
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r0 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r1 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r2 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r3 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r4 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r5 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r6 = 0;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     register uint64_t r10 = 0;
 
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r1 = (uintptr_t)context;
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 33 "sample/pidtgid.c"
+#line 30 "sample/pidtgid.c"
     r6 = r1;
     // EBPF_OP_LDXB pc=1 dst=r1 src=r6 offset=40 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r1 = *(uint8_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_MOV64_IMM pc=2 dst=r2 src=r0 offset=0 imm=16
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r2 = IMMEDIATE(16);
     // EBPF_OP_JGT_REG pc=3 dst=r2 src=r1 offset=18 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     if (r2 > r1)
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
         goto label_1;
         // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
     if (r1 != IMMEDIATE(15295))
-#line 45 "sample/pidtgid.c"
+#line 42 "sample/pidtgid.c"
         goto label_1;
         // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r0 = func_helpers[0].address
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
          (r1, r2, r3, r4, r5);
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     if ((func_helpers[0].tail_call) && (r0 == 0))
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
         return 0;
         // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
-#line 48 "sample/pidtgid.c"
+#line 45 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r0;
     // EBPF_OP_RSH64_IMM pc=9 dst=r0 src=r0 offset=0 imm=32
-#line 48 "sample/pidtgid.c"
+#line 45 "sample/pidtgid.c"
     r0 >>= IMMEDIATE(32);
     // EBPF_OP_STXW pc=10 dst=r10 src=r0 offset=-12 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r0;
     // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-16 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_MOV64_IMM pc=12 dst=r1 src=r0 offset=0 imm=0
-#line 47 "sample/pidtgid.c"
+#line 44 "sample/pidtgid.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=13 dst=r10 src=r1 offset=-20 imm=0
-#line 49 "sample/pidtgid.c"
+#line 46 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=14 dst=r2 src=r10 offset=0 imm=0
-#line 49 "sample/pidtgid.c"
+#line 46 "sample/pidtgid.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=15 dst=r2 src=r0 offset=0 imm=-20
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r2 += IMMEDIATE(-20);
     // EBPF_OP_MOV64_REG pc=16 dst=r3 src=r10 offset=0 imm=0
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r3 = r10;
     // EBPF_OP_ADD64_IMM pc=17 dst=r3 src=r0 offset=0 imm=-16
-#line 46 "sample/pidtgid.c"
+#line 43 "sample/pidtgid.c"
     r3 += IMMEDIATE(-16);
     // EBPF_OP_LDDW pc=18 dst=r1 src=r0 offset=0 imm=0
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=20 dst=r4 src=r0 offset=0 imm=0
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=21 dst=r0 src=r0 offset=0 imm=2
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     r0 = func_helpers[1].address
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
     if ((func_helpers[1].tail_call) && (r0 == 0))
-#line 50 "sample/pidtgid.c"
+#line 47 "sample/pidtgid.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=22 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=23 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
     return r0;
-#line 53 "sample/pidtgid.c"
+#line 50 "sample/pidtgid.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -210,12 +210,6 @@ callee(void* context)
 #line 37 "sample/tail_call_bad.c"
     register uint64_t r1 = 0;
 #line 37 "sample/tail_call_bad.c"
-    register uint64_t r2 = 0;
-#line 37 "sample/tail_call_bad.c"
-    register uint64_t r3 = 0;
-#line 37 "sample/tail_call_bad.c"
-    register uint64_t r6 = 0;
-#line 37 "sample/tail_call_bad.c"
     register uint64_t r10 = 0;
 
 #line 37 "sample/tail_call_bad.c"

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -172,12 +172,6 @@ callee(void* context)
 #line 37 "sample/tail_call_bad.c"
     register uint64_t r1 = 0;
 #line 37 "sample/tail_call_bad.c"
-    register uint64_t r2 = 0;
-#line 37 "sample/tail_call_bad.c"
-    register uint64_t r3 = 0;
-#line 37 "sample/tail_call_bad.c"
-    register uint64_t r6 = 0;
-#line 37 "sample/tail_call_bad.c"
     register uint64_t r10 = 0;
 
 #line 37 "sample/tail_call_bad.c"

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -339,12 +339,6 @@ callee(void* context)
 #line 37 "sample/tail_call_bad.c"
     register uint64_t r1 = 0;
 #line 37 "sample/tail_call_bad.c"
-    register uint64_t r2 = 0;
-#line 37 "sample/tail_call_bad.c"
-    register uint64_t r3 = 0;
-#line 37 "sample/tail_call_bad.c"
-    register uint64_t r6 = 0;
-#line 37 "sample/tail_call_bad.c"
     register uint64_t r10 = 0;
 
 #line 37 "sample/tail_call_bad.c"

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -205,10 +205,6 @@ callee(void* context)
 #line 37 "sample/tail_call.c"
     register uint64_t r1 = 0;
 #line 37 "sample/tail_call.c"
-    register uint64_t r2 = 0;
-#line 37 "sample/tail_call.c"
-    register uint64_t r3 = 0;
-#line 37 "sample/tail_call.c"
     register uint64_t r10 = 0;
 
 #line 37 "sample/tail_call.c"

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -200,12 +200,6 @@ callee(void* context)
 #line 40 "sample/tail_call_map.c"
     register uint64_t r1 = 0;
 #line 40 "sample/tail_call_map.c"
-    register uint64_t r2 = 0;
-#line 40 "sample/tail_call_map.c"
-    register uint64_t r3 = 0;
-#line 40 "sample/tail_call_map.c"
-    register uint64_t r6 = 0;
-#line 40 "sample/tail_call_map.c"
     register uint64_t r10 = 0;
 
 #line 40 "sample/tail_call_map.c"

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -162,12 +162,6 @@ callee(void* context)
 #line 40 "sample/tail_call_map.c"
     register uint64_t r1 = 0;
 #line 40 "sample/tail_call_map.c"
-    register uint64_t r2 = 0;
-#line 40 "sample/tail_call_map.c"
-    register uint64_t r3 = 0;
-#line 40 "sample/tail_call_map.c"
-    register uint64_t r6 = 0;
-#line 40 "sample/tail_call_map.c"
     register uint64_t r10 = 0;
 
 #line 40 "sample/tail_call_map.c"

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -329,12 +329,6 @@ callee(void* context)
 #line 40 "sample/tail_call_map.c"
     register uint64_t r1 = 0;
 #line 40 "sample/tail_call_map.c"
-    register uint64_t r2 = 0;
-#line 40 "sample/tail_call_map.c"
-    register uint64_t r3 = 0;
-#line 40 "sample/tail_call_map.c"
-    register uint64_t r6 = 0;
-#line 40 "sample/tail_call_map.c"
     register uint64_t r10 = 0;
 
 #line 40 "sample/tail_call_map.c"

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -220,10 +220,6 @@ callee1(void* context)
 #line 41 "sample/tail_call_multiple.c"
     register uint64_t r1 = 0;
 #line 41 "sample/tail_call_multiple.c"
-    register uint64_t r2 = 0;
-#line 41 "sample/tail_call_multiple.c"
-    register uint64_t r3 = 0;
-#line 41 "sample/tail_call_multiple.c"
     register uint64_t r10 = 0;
 
 #line 41 "sample/tail_call_multiple.c"

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -182,10 +182,6 @@ callee1(void* context)
 #line 41 "sample/tail_call_multiple.c"
     register uint64_t r1 = 0;
 #line 41 "sample/tail_call_multiple.c"
-    register uint64_t r2 = 0;
-#line 41 "sample/tail_call_multiple.c"
-    register uint64_t r3 = 0;
-#line 41 "sample/tail_call_multiple.c"
     register uint64_t r10 = 0;
 
 #line 41 "sample/tail_call_multiple.c"

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -349,10 +349,6 @@ callee1(void* context)
 #line 41 "sample/tail_call_multiple.c"
     register uint64_t r1 = 0;
 #line 41 "sample/tail_call_multiple.c"
-    register uint64_t r2 = 0;
-#line 41 "sample/tail_call_multiple.c"
-    register uint64_t r3 = 0;
-#line 41 "sample/tail_call_multiple.c"
     register uint64_t r10 = 0;
 
 #line 41 "sample/tail_call_multiple.c"

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -167,10 +167,6 @@ callee(void* context)
 #line 37 "sample/tail_call.c"
     register uint64_t r1 = 0;
 #line 37 "sample/tail_call.c"
-    register uint64_t r2 = 0;
-#line 37 "sample/tail_call.c"
-    register uint64_t r3 = 0;
-#line 37 "sample/tail_call.c"
     register uint64_t r10 = 0;
 
 #line 37 "sample/tail_call.c"

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -334,10 +334,6 @@ callee(void* context)
 #line 37 "sample/tail_call.c"
     register uint64_t r1 = 0;
 #line 37 "sample/tail_call.c"
-    register uint64_t r2 = 0;
-#line 37 "sample/tail_call.c"
-    register uint64_t r3 = 0;
-#line 37 "sample/tail_call.c"
     register uint64_t r10 = 0;
 
 #line 37 "sample/tail_call.c"

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -333,10 +333,6 @@ test_utility_helpers(void* context)
 #line 73 "sample/test_sample_ebpf.c"
     register uint64_t r6 = 0;
 #line 73 "sample/test_sample_ebpf.c"
-    register uint64_t r7 = 0;
-#line 73 "sample/test_sample_ebpf.c"
-    register uint64_t r8 = 0;
-#line 73 "sample/test_sample_ebpf.c"
     register uint64_t r10 = 0;
 
 #line 73 "sample/test_sample_ebpf.c"

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -295,10 +295,6 @@ test_utility_helpers(void* context)
 #line 73 "sample/test_sample_ebpf.c"
     register uint64_t r6 = 0;
 #line 73 "sample/test_sample_ebpf.c"
-    register uint64_t r7 = 0;
-#line 73 "sample/test_sample_ebpf.c"
-    register uint64_t r8 = 0;
-#line 73 "sample/test_sample_ebpf.c"
     register uint64_t r10 = 0;
 
 #line 73 "sample/test_sample_ebpf.c"

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -462,10 +462,6 @@ test_utility_helpers(void* context)
 #line 73 "sample/test_sample_ebpf.c"
     register uint64_t r6 = 0;
 #line 73 "sample/test_sample_ebpf.c"
-    register uint64_t r7 = 0;
-#line 73 "sample/test_sample_ebpf.c"
-    register uint64_t r8 = 0;
-#line 73 "sample/test_sample_ebpf.c"
     register uint64_t r10 = 0;
 
 #line 73 "sample/test_sample_ebpf.c"

--- a/tests/cilium/cilium_tests.cpp
+++ b/tests/cilium/cilium_tests.cpp
@@ -34,12 +34,12 @@ verify_program(_In_z_ const char* file, uint32_t expected_section_count)
 #ifndef SKIP_VERIFICATION
         uint32_t result;
         ebpf_api_verifier_stats_t stats;
-        const char* error_message = nullptr;
+        const char* log_buffer = nullptr;
         const char* report = nullptr;
         REQUIRE(
-            (result = ebpf_api_elf_verify_section_from_file(file, section_name, false, &report, &error_message, &stats),
-             ebpf_free_string(error_message),
-             error_message = nullptr,
+            (result = ebpf_api_elf_verify_section_from_file(file, section_name, false, &report, &log_buffer, &stats),
+             ebpf_free_string(log_buffer),
+             log_buffer = nullptr,
              result == 0));
         REQUIRE(report != nullptr);
         ebpf_free_string(report);

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -319,7 +319,7 @@ ebpf_program_load(
     _In_z_ const char* file_name,
     bpf_prog_type prog_type,
     ebpf_execution_type_t execution_type,
-    _Outptr_ struct bpf_object** object,
+    _Outptr_result_maybenull_ struct bpf_object** object,
     _Out_ fd_t* program_fd,
     _Outptr_opt_result_maybenull_z_ const char** log_buffer)
 {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -335,7 +335,9 @@ ebpf_program_load(
     }
     ebpf_object_set_execution_type(new_object, execution_type);
     bpf_program* program = bpf_object__next_program(new_object, nullptr);
-    bpf_program__set_type(program, prog_type);
+    if (prog_type != BPF_PROG_TYPE_UNSPEC) {
+        bpf_program__set_type(program, prog_type);
+    }
     int error = bpf_object__load(new_object);
     if (error < 0) {
         if (log_buffer) {

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -845,7 +845,7 @@ TEST_CASE("enum section", "[end_to_end]")
     uint32_t result;
 
     REQUIRE(
-        (result = ebpf_enumerate_sections(SAMPLE_PATH "droppacket.o", true, &section_data, &error_message),
+        (result = ebpf_enumerate_program_sections(SAMPLE_PATH "droppacket.o", true, &section_data, &error_message),
          ebpf_free_string(error_message),
          error_message = nullptr,
          result == 0));
@@ -2190,4 +2190,3 @@ TEST_CASE("load_native_program_invalid4", "[end-to-end]")
     _load_invalid_program("empty_um.dll", EBPF_EXECUTION_NATIVE, EBPF_INVALID_OBJECT);
 }
 #endif
-

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -333,7 +333,7 @@ ebpf_program_load(
     if (new_object == nullptr) {
         return -errno;
     }
-    ebpf_object_set_execution_type(new_object, execution_type);
+    REQUIRE(ebpf_object_set_execution_type(new_object, execution_type) == EBPF_SUCCESS);
     bpf_program* program = bpf_object__next_program(new_object, nullptr);
     if (prog_type != BPF_PROG_TYPE_UNSPEC) {
         bpf_program__set_type(program, prog_type);

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -872,7 +872,7 @@ TEST_CASE("enum section", "[end_to_end]")
     uint32_t result;
 
     REQUIRE(
-        (result = ebpf_enumerate_program_sections(SAMPLE_PATH "droppacket.o", true, &section_data, &error_message),
+        (result = ebpf_enumerate_sections(SAMPLE_PATH "droppacket.o", true, &section_data, &error_message),
          ebpf_free_string(error_message),
          error_message = nullptr,
          result == 0));

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -169,9 +169,9 @@ TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
         output == "\n"
                   "             Section       Type  # Maps    Size\n"
                   "====================  =========  ======  ======\n"
-                  "          xdp_prog/1        xdp       0     214\n"
+                  "            xdp_prog        xdp       0     413\n"
                   "          xdp_prog/0        xdp       0     413\n"
-                  "            xdp_prog        xdp       0     413\n");
+                  "          xdp_prog/1        xdp       0     214\n");
 }
 
 // Test a .sys file with multiple programs, including ones with long names.
@@ -185,10 +185,10 @@ TEST_CASE("show sections cgroup_sock_addr.sys", "[netsh][sections]")
         output == "\n"
                   "             Section       Type  # Maps    Size\n"
                   "====================  =========  ======  ======\n"
-                  " cgroup/recv_accept6  sock_addr       2     728\n"
-                  " cgroup/recv_accept4  sock_addr       2     594\n"
+                  "     cgroup/connect4  sock_addr       2     594\n"
                   "     cgroup/connect6  sock_addr       2     728\n"
-                  "     cgroup/connect4  sock_addr       2     594\n");
+                  " cgroup/recv_accept4  sock_addr       2     594\n"
+                  " cgroup/recv_accept6  sock_addr       2     728\n");
 }
 
 TEST_CASE("show verification nosuchfile.o", "[netsh][verification]")

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -158,6 +158,22 @@ TEST_CASE("show sections map_reuse_um.dll", "[netsh][sections]")
                   "            xdp_prog        xdp       3    1087\n");
 }
 
+// Test a .dll file with multiple programs.
+TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
+{
+    int result;
+    std::string output =
+        _run_netsh_command(handle_ebpf_show_sections, L"tail_call_multiple_um.dll", nullptr, nullptr, &result);
+    REQUIRE(result == NO_ERROR);
+    REQUIRE(
+        output == "\n"
+                  "             Section       Type  # Maps    Size\n"
+                  "====================  =========  ======  ======\n"
+                  "          xdp_prog/1        xdp       0     214\n"
+                  "          xdp_prog/0        xdp       0     413\n"
+                  "            xdp_prog        xdp       0     413\n");
+}
+
 // Test a .sys file with multiple programs, including ones with long names.
 TEST_CASE("show sections cgroup_sock_addr.sys", "[netsh][sections]")
 {

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -171,7 +171,7 @@ TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
                   "====================  =========  ======  ======\n"
                   "            xdp_prog        xdp       0     413\n"
                   "          xdp_prog/0        xdp       0     413\n"
-                  "          xdp_prog/1        xdp       0     214\n");
+                  "          xdp_prog/1        xdp       0     190\n");
 }
 
 // Test a .sys file with multiple programs, including ones with long names.

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -6,31 +6,39 @@
 
 _program_load_attach_helper::_program_load_attach_helper(
     _In_z_ const char* file_name,
-    ebpf_program_type_t program_type,
+    bpf_prog_type prog_type,
     _In_z_ const char* program_name,
     ebpf_execution_type_t execution_type,
     _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
     _In_ size_t attach_parameters_size,
     hook_helper_t& hook)
-    : _file_name(file_name), _program_type(program_type), _program_name(program_name), _execution_type(execution_type),
+    : _file_name(file_name), _prog_type(prog_type), _program_name(program_name), _execution_type(execution_type),
       _link(nullptr), _object(nullptr)
 {
-    ebpf_result_t result;
     fd_t program_fd;
+    size_t log_buffer_size;
     const char* log_buffer = nullptr;
 
-    // Load BPF object from ELF file.
-    result = ebpf_program_load(
-        _file_name.c_str(), &_program_type, nullptr, _execution_type, &_object, &program_fd, &log_buffer);
-    if (log_buffer != nullptr) {
-        printf("ebpf_program_load: error: %s", log_buffer);
+    // Load BPF object from file.
+    _object = bpf_object__open(_file_name.c_str());
+    if (_object == nullptr) {
+        printf("bpf_object__open: error: %d\n", errno);
     }
-    REQUIRE(result == EBPF_SUCCESS);
-    REQUIRE(program_fd > 0);
+    REQUIRE(_object != nullptr);
+    ebpf_object_set_execution_type(_object, _execution_type);
 
     // Load program by name.
     struct bpf_program* program = bpf_object__find_program_by_name(_object, _program_name.c_str());
     REQUIRE(program != nullptr);
+    bpf_program__set_type(program, _prog_type);
+
+    int error = bpf_object__load(_object);
+    log_buffer = bpf_program__log_buf(program, &log_buffer_size);
+    if (log_buffer != nullptr) {
+        printf("bpf_object__load: error: %s", log_buffer);
+    }
+    REQUIRE(error == 0);
+
     program_fd = bpf_program__fd(program);
     REQUIRE(program_fd > 0);
 

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -30,7 +30,9 @@ _program_load_attach_helper::_program_load_attach_helper(
     // Load program by name.
     struct bpf_program* program = bpf_object__find_program_by_name(_object, _program_name.c_str());
     REQUIRE(program != nullptr);
-    bpf_program__set_type(program, _program_type);
+    if (_program_type != BPF_PROG_TYPE_UNSPEC) {
+        bpf_program__set_type(program, _program_type);
+    }
 
     int error = bpf_object__load(_object);
     log_buffer = bpf_program__log_buf(program, &log_buffer_size);

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -6,13 +6,13 @@
 
 _program_load_attach_helper::_program_load_attach_helper(
     _In_z_ const char* file_name,
-    bpf_prog_type prog_type,
+    bpf_prog_type program_type,
     _In_z_ const char* program_name,
     ebpf_execution_type_t execution_type,
     _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
     _In_ size_t attach_parameters_size,
     hook_helper_t& hook)
-    : _file_name(file_name), _prog_type(prog_type), _program_name(program_name), _execution_type(execution_type),
+    : _file_name(file_name), _program_type(program_type), _program_name(program_name), _execution_type(execution_type),
       _link(nullptr), _object(nullptr)
 {
     fd_t program_fd;
@@ -30,7 +30,7 @@ _program_load_attach_helper::_program_load_attach_helper(
     // Load program by name.
     struct bpf_program* program = bpf_object__find_program_by_name(_object, _program_name.c_str());
     REQUIRE(program != nullptr);
-    bpf_program__set_type(program, _prog_type);
+    bpf_program__set_type(program, _program_type);
 
     int error = bpf_object__load(_object);
     log_buffer = bpf_program__log_buf(program, &log_buffer_size);

--- a/tests/libs/util/program_helper.h
+++ b/tests/libs/util/program_helper.h
@@ -14,7 +14,7 @@ typedef class _program_load_attach_helper
   public:
     _program_load_attach_helper(
         _In_z_ const char* file_name,
-        ebpf_program_type_t program_type,
+        bpf_prog_type program_type,
         _In_z_ const char* program_name,
         ebpf_execution_type_t execution_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
@@ -28,7 +28,7 @@ typedef class _program_load_attach_helper
 
   private:
     std::string _file_name;
-    ebpf_program_type_t _program_type;
+    bpf_prog_type _prog_type;
     std::string _program_name;
     ebpf_execution_type_t _execution_type;
     bpf_link* _link;

--- a/tests/libs/util/program_helper.h
+++ b/tests/libs/util/program_helper.h
@@ -28,7 +28,7 @@ typedef class _program_load_attach_helper
 
   private:
     std::string _file_name;
-    bpf_prog_type _prog_type;
+    bpf_prog_type _program_type;
     std::string _program_name;
     ebpf_execution_type_t _execution_type;
     bpf_link* _link;

--- a/tests/sample/ext/app/sample_ext_app.cpp
+++ b/tests/sample/ext/app/sample_ext_app.cpp
@@ -114,7 +114,7 @@ TEST_CASE("jit_test", "[sample_ext_test]")
     struct bpf_object* object = nullptr;
     hook_helper_t hook(EBPF_ATTACH_TYPE_SAMPLE);
     program_load_attach_helper_t _helper(
-        "test_sample_ebpf.o", EBPF_PROGRAM_TYPE_SAMPLE, "test_program_entry", EBPF_EXECUTION_JIT, nullptr, 0, hook);
+        "test_sample_ebpf.o", BPF_PROG_TYPE_SAMPLE, "test_program_entry", EBPF_EXECUTION_JIT, nullptr, 0, hook);
 
     object = _helper.get_object();
 
@@ -127,13 +127,7 @@ TEST_CASE("interpret_test", "[sample_ext_test]")
     struct bpf_object* object = nullptr;
     hook_helper_t hook(EBPF_ATTACH_TYPE_SAMPLE);
     program_load_attach_helper_t _helper(
-        "test_sample_ebpf.o",
-        EBPF_PROGRAM_TYPE_SAMPLE,
-        "test_program_entry",
-        EBPF_EXECUTION_INTERPRET,
-        nullptr,
-        0,
-        hook);
+        "test_sample_ebpf.o", BPF_PROG_TYPE_SAMPLE, "test_program_entry", EBPF_EXECUTION_INTERPRET, nullptr, 0, hook);
 
     object = _helper.get_object();
 
@@ -147,7 +141,7 @@ utility_helpers_test(ebpf_execution_type_t execution_type)
     struct bpf_object* object = nullptr;
     hook_helper_t hook(EBPF_ATTACH_TYPE_SAMPLE);
     program_load_attach_helper_t _helper(
-        "test_sample_ebpf.o", EBPF_PROGRAM_TYPE_SAMPLE, "test_utility_helpers", execution_type, nullptr, 0, hook);
+        "test_sample_ebpf.o", BPF_PROG_TYPE_SAMPLE, "test_utility_helpers", execution_type, nullptr, 0, hook);
     object = _helper.get_object();
 
     std::vector<char> dummy(1);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1824,6 +1824,41 @@ TEST_CASE("libbpf_get_error", "[libbpf]")
     REQUIRE(libbpf_get_error(nullptr) == -123);
 }
 
+TEST_CASE("bpf_object__open with .dll", "[libbpf]")
+{
+    struct bpf_object* object = bpf_object__open("droppacket_um.dll");
+    REQUIRE(object != nullptr);
+
+    struct bpf_program* program = bpf_object__next_program(object, nullptr);
+    REQUIRE(program != nullptr);
+    REQUIRE(bpf_program__type(program) == BPF_PROG_TYPE_XDP);
+    REQUIRE(bpf_program__get_expected_attach_type(program) == BPF_XDP);
+
+    REQUIRE(bpf_object__next_program(object, program) == nullptr);
+
+    bpf_object__close(object);
+}
+
+TEST_CASE("bpf_object__open_file with .dll", "[libbpf]")
+{
+    const char* my_object_name = "my_object_name";
+    struct bpf_object_open_opts opts = {0};
+    opts.object_name = my_object_name;
+    struct bpf_object* object = bpf_object__open_file("droppacket_um.dll", &opts);
+    REQUIRE(object != nullptr);
+
+    REQUIRE(strcmp(bpf_object__name(object), my_object_name) == 0);
+
+    struct bpf_program* program = bpf_object__next_program(object, nullptr);
+    REQUIRE(program != nullptr);
+    REQUIRE(bpf_program__type(program) == BPF_PROG_TYPE_XDP);
+    REQUIRE(bpf_program__get_expected_attach_type(program) == BPF_XDP);
+
+    REQUIRE(bpf_object__next_program(object, program) == nullptr);
+
+    bpf_object__close(object);
+}
+
 TEST_CASE("bpf_object__load", "[libbpf]")
 {
     _test_helper_libbpf test_helper;

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -929,8 +929,8 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
             }
 #if defined(_DEBUG) || defined(BPF2C_VERBOSE)
             output_stream << INDENT "// " << _opcode_name_strings[output.instruction.opcode]
-                          << " pc=" << output.instruction_offset << " dst=" << get_register_name(output.instruction.dst)
-                          << " src=" << get_register_name(output.instruction.src)
+                          << " pc=" << output.instruction_offset << " dst=" << std::to_string(output.instruction.dst)
+                          << " src=" << std::to_string(output.instruction.src)
                           << " offset=" << std::to_string(output.instruction.offset)
                           << " imm=" << std::to_string(output.instruction.imm) << std::endl;
 #endif

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -929,8 +929,8 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
             }
 #if defined(_DEBUG) || defined(BPF2C_VERBOSE)
             output_stream << INDENT "// " << _opcode_name_strings[output.instruction.opcode]
-                          << " pc=" << output.instruction_offset << " dst=" << std::to_string(output.instruction.dst)
-                          << " src=" << std::to_string(output.instruction.src)
+                          << " pc=" << output.instruction_offset << " dst=r" << std::to_string(output.instruction.dst)
+                          << " src=r" << std::to_string(output.instruction.src)
                           << " offset=" << std::to_string(output.instruction.offset)
                           << " imm=" << std::to_string(output.instruction.imm) << std::endl;
 #endif


### PR DESCRIPTION
## Description

* Add bpf_object__open() libbpf API
* Add bpf_program__log_buf() libbpf API to keep verifier errors with the specific program, instead of the object
* Add windows-specific APIs  ebpf_object_get_execution_type() and ebpf_object_set_execution_type()
* Fix order of PE sections returned by ebpf_enumerate_sections()
* Fix bug in ebpf_enumerate_sections() hit when reading tail_call_multiple_um.dll which has a string of length 8 (plus null)
* Remove ebpf_program_load()
* Alan's bug fix in bpf2c which is needed to get the tail_call_multiple_um.dll test to pass

Fixes #851
Fixes #951 

Not included in this PR: populate maps in the bpf_object as part of bpf_object__open().  That will be done in a separate PR.  There are two TODO's in the code for that, which is now issue #1140

## Testing

Includes test updates.

## Documentation

Includes api doc updates.
