### PR TITLE
ebpf_extension_load should check both module_id and interface_id

### DIFF
--- a/libs/platform/user/ebpf_extension_user.c
+++ b/libs/platform/user/ebpf_extension_user.c
@@ -106,6 +106,13 @@ ebpf_extension_load(
     }
     local_extension_provider = *hash_table_find_result;
 
+    if (memcmp(interface_id, &local_extension_provider->interface_id, sizeof(GUID)) != 0) {
+        EBPF_LOG_MESSAGE_GUID(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE, "Wrong interface_id", *interface_id);
+        return_value = EBPF_INVALID_ARGUMENT;
+        goto Done;
+    }
+
     return_value = ebpf_hash_table_update(
         local_extension_provider->client_table,
         (const uint8_t*)&local_extension_client->client_module_id,


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

The user-mode ebpf_extension_load doesn't correctly emulate NMR behavior, causing it to incorrectly match provider and client based solely on the module_id.

## Testing

CI/CD

## Documentation

No.
