### PR TITLE
Remove unused typedefs

### DIFF
--- a/rpc_interface/rpc_interface.idl
+++ b/rpc_interface/rpc_interface.idl
@@ -16,19 +16,6 @@ import "wtypes.idl";
     // clang-format on
 
     interface ebpf_service_interface {
-        // TODO: (Issue #208): This is a duplicate of EbpfMapDescriptor
-        // structure defined in spec_type_descriptor.hpp. See if that
-        // file can be included so that we do not have to redefine this.
-        typedef struct _ebpf_map_descriptor
-        {
-            int original_fd;
-            uint32_t type; // Platform-specific type value in ELF file.
-            unsigned int key_size;
-            unsigned int value_size;
-            unsigned int max_entries;
-            unsigned int inner_map_fd;
-        } ebpf_map_descriptor;
-
         typedef[system_handle(sh_file)] HANDLE file_handle_t;
 
         typedef struct _original_fd_handle_map
@@ -60,16 +47,6 @@ import "wtypes.idl";
             uint32_t byte_code_size;
             [ size_is(byte_code_size), ref ] uint8_t* byte_code;
         } ebpf_program_load_info;
-
-        typedef struct _ebpf_program_verify_info
-        {
-            GUID program_type;
-            ebpf_execution_context_t execution_context;
-            uint32_t map_descriptors_count;
-            [size_is(map_descriptors_count)] ebpf_map_descriptor* map_descriptors;
-            uint32_t byte_code_size;
-            [ size_is(byte_code_size), ref ] uint8_t* byte_code;
-        } ebpf_program_verify_info;
 
         ebpf_result_t verify_and_load_program(
             [ in, ref ] ebpf_program_load_info * info,


### PR DESCRIPTION
## Description

Remove unused typedefs left over from when other APIs were removed.

## Testing

No changes needed.

## Documentation

No changes needed.
