### PR TITLE
Create bpf_map structures from bpf_object__open() on a native file

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -102,7 +102,6 @@ extern "C"
         _Field_z_ const char* section_name;
         _Field_z_ const char* program_type_name;
         _Field_z_ const char* program_name;
-        size_t map_count;
         size_t raw_data_size;
         _Field_size_(raw_data_size) char* raw_data;
         ebpf_stat_t* stats;

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -404,7 +404,6 @@ ebpf_api_elf_enumerate_sections(
 
             info->section_name = _strdup(raw_program.section.c_str());
             info->program_type_name = _strdup(raw_program.info.type.name.c_str());
-            info->map_count = raw_program.info.map_descriptors.size();
 
             std::vector<uint8_t> raw_data = convert_ebpf_program_to_bytes(raw_program.prog);
             info->raw_data_size = raw_data.size();

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1822,7 +1822,8 @@ _ebpf_pe_get_map_definitions(
             map_offset += 8;
         }
         if (pe_context->object != nullptr) {
-            for (; map_offset < section_header.Misc.VirtualSize; map_offset += sizeof(map_entry_t)) {
+            for (int map_index = 0; map_offset + sizeof(map_entry_t) <= section_header.Misc.VirtualSize;
+                 map_offset += sizeof(map_entry_t), map_index++) {
                 map_entry_t* entry = (map_entry_t*)(buffer->buf + map_offset);
 
                 ebpf_map_t* map = (ebpf_map_t*)calloc(1, sizeof(ebpf_map_t));
@@ -1831,7 +1832,7 @@ _ebpf_pe_get_map_definitions(
                 }
 
                 map->map_handle = ebpf_handle_invalid;
-                map->original_fd = entry->definition.id;
+                map->original_fd = (fd_t)map_index;
                 map->map_definition.type = entry->definition.type;
                 map->map_definition.key_size = entry->definition.key_size;
                 map->map_definition.value_size = entry->definition.value_size;
@@ -1926,7 +1927,7 @@ _ebpf_pe_get_section_names(
         // byte (if any) is also 00.
         uint32_t program_offset = 0;
         uint64_t zero = 0;
-        while (program_offset < section_header.Misc.VirtualSize &&
+        while (program_offset + sizeof(zero) <= section_header.Misc.VirtualSize &&
                (memcmp(buffer->buf + program_offset, &zero, sizeof(zero)) != 0 ||
                 (program_offset > 0 && buffer->buf[program_offset - 1] != 0))) {
             program_offset += 16;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1429,16 +1429,12 @@ _initialize_ebpf_maps_native(
             goto Exit;
         }
 
-        map = (ebpf_map_t*)calloc(1, sizeof(ebpf_map_t));
-        if (map == nullptr) {
-            result = EBPF_NO_MEMORY;
-            goto Exit;
-        }
-
-        map->map_definition.type = info.type;
-        map->map_definition.key_size = info.key_size;
-        map->map_definition.value_size = info.value_size;
-        map->map_definition.max_entries = info.max_entries;
+        map = maps[i];
+        ebpf_assert(strcmp(map->name, info.name) == 0);
+        ebpf_assert(map->map_definition.type == info.type);
+        ebpf_assert(map->map_definition.key_size == info.key_size);
+        ebpf_assert(map->map_definition.value_size == info.value_size);
+        ebpf_assert(map->map_definition.max_entries == info.max_entries);
         map->map_definition.inner_map_id = info.inner_map_id;
         map->map_fd = _create_file_descriptor_for_handle(map_handles[i]);
         if (map->map_fd == ebpf_fd_invalid) {
@@ -1447,14 +1443,6 @@ _initialize_ebpf_maps_native(
         }
         map->map_handle = map_handles[i];
         map_handles[i] = ebpf_handle_invalid;
-        map->name = _strdup(info.name);
-        if (map->name == nullptr) {
-            result = EBPF_NO_MEMORY;
-            goto Exit;
-        }
-
-        maps.emplace_back(map);
-        map = nullptr;
     }
 
 Exit:

--- a/libs/thunk/mock/mock.cpp
+++ b/libs/thunk/mock/mock.cpp
@@ -115,7 +115,7 @@ _is_native_program(_In_z_ const char* file_name)
 {
     std::string file_name_string(file_name);
     std::string file_extension = file_name_string.substr(file_name_string.find_last_of(".") + 1);
-    if (file_extension == "dll") {
+    if (file_extension == "dll" || file_extension == "sys") {
         return true;
     }
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -869,24 +869,6 @@ DECLARE_ALL_TEST_CASES("bindmonitor-ringbuf", "[end_to_end]", bindmonitor_ring_b
 DECLARE_ALL_TEST_CASES("utility-helpers", "[end_to_end]", _utility_helper_functions_test);
 DECLARE_ALL_TEST_CASES("map", "[end_to_end]", map_test);
 
-TEST_CASE("wrong platform", "[end_to_end]")
-{
-    _test_helper_end_to_end test_helper;
-
-    int result;
-    const char* error_message = nullptr;
-    bpf_object* object = nullptr;
-    fd_t program_fd;
-
-    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
-    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
-
-    // Try loading a .sys file into user-mode.
-    result =
-        ebpf_program_load("map.sys", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, &object, &program_fd, &error_message);
-    REQUIRE(result == -ENOENT);
-}
-
 TEST_CASE("enum section", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;
@@ -2287,6 +2269,25 @@ TEST_CASE("load_native_program_negative4", "[end-to-end]")
 
     // Delete the created service.
     Platform::_delete_service(service_handle);
+}
+
+// Try to load a .sys in user mode.
+TEST_CASE("load_native_program_negative5", "[end_to_end]")
+{
+    _test_helper_end_to_end test_helper;
+
+    int result;
+    const char* error_message = nullptr;
+    bpf_object* object = nullptr;
+    fd_t program_fd;
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
+
+    set_native_module_failures(true);
+    result =
+        ebpf_program_load("map.sys", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, &object, &program_fd, &error_message);
+    REQUIRE(result == -ENOENT);
 }
 
 // The below tests try to load native drivers for invalid programs (that will fail verification).

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -869,6 +869,24 @@ DECLARE_ALL_TEST_CASES("bindmonitor-ringbuf", "[end_to_end]", bindmonitor_ring_b
 DECLARE_ALL_TEST_CASES("utility-helpers", "[end_to_end]", _utility_helper_functions_test);
 DECLARE_ALL_TEST_CASES("map", "[end_to_end]", map_test);
 
+TEST_CASE("wrong platform", "[end_to_end]")
+{
+    _test_helper_end_to_end test_helper;
+
+    int result;
+    const char* error_message = nullptr;
+    bpf_object* object = nullptr;
+    fd_t program_fd;
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
+
+    // Try loading a .sys file into user-mode.
+    result =
+        ebpf_program_load("map.sys", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, &object, &program_fd, &error_message);
+    REQUIRE(result == -ENOENT);
+}
+
 TEST_CASE("enum section", "[end_to_end]")
 {
     _test_helper_end_to_end test_helper;

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -94,9 +94,14 @@ TEST_CASE("show sections bpf.o", "[netsh][sections]")
     REQUIRE(result == NO_ERROR);
     REQUIRE(
         output == "\n"
-                  "             Section       Type  # Maps    Size\n"
-                  "====================  =========  ======  ======\n"
-                  "               .text        xdp       0      16\n");
+                  "                                    Size\n"
+                  "             Section       Type  (bytes)\n"
+                  "====================  =========  =======\n"
+                  "               .text        xdp       16\n"
+                  "\n"
+                  "                     Key  Value      Max\n"
+                  "          Map Type  Size   Size  Entries  Name\n"
+                  "==================  ====  =====  =======  ========\n");
 }
 
 // Test specifying a section name.
@@ -109,7 +114,6 @@ TEST_CASE("show sections bpf.o .text", "[netsh][sections]")
         output == "\n"
                   "Section      : .text\n"
                   "Program Type : xdp\n"
-                  "# Maps       : 0\n"
                   "Size         : 16 bytes\n"
                   "Instructions : 2\n"
                   "adjust_head  : 0\n"
@@ -128,7 +132,11 @@ TEST_CASE("show sections bpf.o .text", "[netsh][sections]")
                   "map_in_map   : 0\n"
                   "other        : 2\n"
                   "packet_access: 0\n"
-                  "store        : 0\n");
+                  "store        : 0\n"
+                  "\n"
+                  "                     Key  Value      Max\n"
+                  "          Map Type  Size   Size  Entries  Name\n"
+                  "==================  ====  =====  =======  ========\n");
 }
 
 // Test a .sys file.
@@ -140,9 +148,14 @@ TEST_CASE("show sections bpf.sys", "[netsh][sections]")
 
     REQUIRE(
         output == "\n"
-                  "             Section       Type  # Maps    Size\n"
-                  "====================  =========  ======  ======\n"
-                  "               .text        xdp       0    1752\n");
+                  "                                    Size\n"
+                  "             Section       Type  (bytes)\n"
+                  "====================  =========  =======\n"
+                  "               .text        xdp     1752\n"
+                  "\n"
+                  "                     Key  Value      Max\n"
+                  "          Map Type  Size   Size  Entries  Name\n"
+                  "==================  ====  =====  =======  ========\n");
 }
 
 // Test a DLL with multiple maps in the map section.
@@ -153,9 +166,17 @@ TEST_CASE("show sections map_reuse_um.dll", "[netsh][sections]")
     REQUIRE(result == NO_ERROR);
     REQUIRE(
         output == "\n"
-                  "             Section       Type  # Maps    Size\n"
-                  "====================  =========  ======  ======\n"
-                  "            xdp_prog        xdp       3    1087\n");
+                  "                                    Size\n"
+                  "             Section       Type  (bytes)\n"
+                  "====================  =========  =======\n"
+                  "            xdp_prog        xdp     1087\n"
+                  "\n"
+                  "                     Key  Value      Max\n"
+                  "          Map Type  Size   Size  Entries  Name\n"
+                  "==================  ====  =====  =======  ========\n"
+                  "      Hash of maps     4      4        1  outer_map\n"
+                  "             Array     4      4        1  inner_map\n"
+                  "             Array     4      4        1  port_map\n");
 }
 
 // Test a .dll file with multiple programs.
@@ -167,11 +188,17 @@ TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
     REQUIRE(result == NO_ERROR);
     REQUIRE(
         output == "\n"
-                  "             Section       Type  # Maps    Size\n"
-                  "====================  =========  ======  ======\n"
-                  "            xdp_prog        xdp       0     413\n"
-                  "          xdp_prog/0        xdp       0     413\n"
-                  "          xdp_prog/1        xdp       0     190\n");
+                  "                                    Size\n"
+                  "             Section       Type  (bytes)\n"
+                  "====================  =========  =======\n"
+                  "            xdp_prog        xdp      413\n"
+                  "          xdp_prog/0        xdp      413\n"
+                  "          xdp_prog/1        xdp      190\n"
+                  "\n"
+                  "                     Key  Value      Max\n"
+                  "          Map Type  Size   Size  Entries  Name\n"
+                  "==================  ====  =====  =======  ========\n"
+                  "     Program array     4      4       10  map\n");
 }
 
 // Test a .sys file with multiple programs, including ones with long names.
@@ -183,12 +210,19 @@ TEST_CASE("show sections cgroup_sock_addr.sys", "[netsh][sections]")
     REQUIRE(result == NO_ERROR);
     REQUIRE(
         output == "\n"
-                  "             Section       Type  # Maps    Size\n"
-                  "====================  =========  ======  ======\n"
-                  "     cgroup/connect4  sock_addr       2     594\n"
-                  "     cgroup/connect6  sock_addr       2     728\n"
-                  " cgroup/recv_accept4  sock_addr       2     594\n"
-                  " cgroup/recv_accept6  sock_addr       2     728\n");
+                  "                                    Size\n"
+                  "             Section       Type  (bytes)\n"
+                  "====================  =========  =======\n"
+                  "     cgroup/connect4  sock_addr      594\n"
+                  "     cgroup/connect6  sock_addr      728\n"
+                  " cgroup/recv_accept4  sock_addr      594\n"
+                  " cgroup/recv_accept6  sock_addr      728\n"
+                  "\n"
+                  "                     Key  Value      Max\n"
+                  "          Map Type  Size   Size  Entries  Name\n"
+                  "==================  ====  =====  =======  ========\n"
+                  "              Hash    44      4        1  ingress_connection_policy_map\n"
+                  "              Hash    44      4        1  egress_connection_policy_map\n");
 }
 
 TEST_CASE("show verification nosuchfile.o", "[netsh][verification]")

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -257,7 +257,10 @@ _preprocess_load_native_module(_Inout_ service_context_t* context)
 
     auto get_function =
         reinterpret_cast<decltype(&get_metadata_table)>(GetProcAddress(context->dll, "get_metadata_table"));
-    REQUIRE(get_function != nullptr);
+    if (get_function == nullptr) {
+        REQUIRE(_expect_native_module_load_failures);
+        return;
+    }
 
     metadata_table_t* table = get_function();
     REQUIRE(table != nullptr);

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -479,8 +479,8 @@ Glue_delete_service(SC_HANDLE handle)
             // Delete the service if it has not been loaded yet. Otherwise
             // mark it pending for delete.
             if (!context->loaded) {
-                _service_path_to_context_map.erase(path);
                 ebpf_free(context);
+                _service_path_to_context_map.erase(path);
             } else {
                 context->delete_pending = true;
             }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1999,6 +1999,7 @@ TEST_CASE("bpf_object__open_file with .dll", "[libbpf]")
     // Load the program.
     REQUIRE(bpf_object__load(object) == 0);
 
+    // The maps should now have FDs.
     map = bpf_object__next_map(object, nullptr);
     REQUIRE(map != nullptr);
     REQUIRE(strcmp(bpf_map__name(map), "dropped_packet_map") == 0);
@@ -2042,6 +2043,16 @@ TEST_CASE("bpf_object__load with .o", "[libbpf]")
 
     REQUIRE(bpf_program__set_type(program, BPF_PROG_TYPE_XDP) == 0);
 
+    struct bpf_map* map = bpf_object__next_map(object, nullptr);
+    REQUIRE(map != nullptr);
+    REQUIRE(strcmp(bpf_map__name(map), "dropped_packet_map") == 0);
+    REQUIRE(bpf_map__fd(map) == ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(strcmp(bpf_map__name(map), "interface_index_map") == 0);
+    REQUIRE(bpf_map__fd(map) == ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(map == nullptr);
+
     // Trying to attach the program should fail since it's not loaded yet.
     bpf_link* link = bpf_program__attach(program);
     REQUIRE(link == nullptr);
@@ -2053,6 +2064,17 @@ TEST_CASE("bpf_object__load with .o", "[libbpf]")
     // Attach should now succeed.
     link = bpf_program__attach(program);
     REQUIRE(link != nullptr);
+
+    // The maps should now have FDs.
+    map = bpf_object__next_map(object, nullptr);
+    REQUIRE(map != nullptr);
+    REQUIRE(strcmp(bpf_map__name(map), "dropped_packet_map") == 0);
+    REQUIRE(bpf_map__fd(map) != ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(strcmp(bpf_map__name(map), "interface_index_map") == 0);
+    REQUIRE(bpf_map__fd(map) != ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(map == nullptr);
 
     REQUIRE(bpf_link__destroy(link) == 0);
     bpf_object__close(object);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1984,8 +1984,10 @@ TEST_CASE("bpf_object__open_file with .dll", "[libbpf]")
     struct bpf_map* map = bpf_object__next_map(object, nullptr);
     REQUIRE(map != nullptr);
     REQUIRE(strcmp(bpf_map__name(map), "dropped_packet_map") == 0);
+    REQUIRE(bpf_map__fd(map) == ebpf_fd_invalid);
     map = bpf_object__next_map(object, map);
     REQUIRE(strcmp(bpf_map__name(map), "interface_index_map") == 0);
+    REQUIRE(bpf_map__fd(map) == ebpf_fd_invalid);
     map = bpf_object__next_map(object, map);
     REQUIRE(map == nullptr);
 
@@ -1996,6 +1998,16 @@ TEST_CASE("bpf_object__open_file with .dll", "[libbpf]")
 
     // Load the program.
     REQUIRE(bpf_object__load(object) == 0);
+
+    map = bpf_object__next_map(object, nullptr);
+    REQUIRE(map != nullptr);
+    REQUIRE(strcmp(bpf_map__name(map), "dropped_packet_map") == 0);
+    REQUIRE(bpf_map__fd(map) != ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(strcmp(bpf_map__name(map), "interface_index_map") == 0);
+    REQUIRE(bpf_map__fd(map) != ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(map == nullptr);
 
     // Attach should now succeed.
     link = bpf_program__attach(program);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1981,6 +1981,14 @@ TEST_CASE("bpf_object__open_file with .dll", "[libbpf]")
 
     REQUIRE(bpf_object__next_program(object, program) == nullptr);
 
+    struct bpf_map* map = bpf_object__next_map(object, nullptr);
+    REQUIRE(map != nullptr);
+    REQUIRE(strcmp(bpf_map__name(map), "dropped_packet_map") == 0);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(strcmp(bpf_map__name(map), "interface_index_map") == 0);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(map == nullptr);
+
     // Trying to attach the program should fail since it's not loaded yet.
     bpf_link* link = bpf_program__attach(program);
     REQUIRE(link == nullptr);


### PR DESCRIPTION
Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

* Populate object->maps when opening a native PE file.
* Fix ebpf_api.cpp bug in reading maps from PE file when a map name length had a multiple of 8 characters (not including the null terminator).  The same bug was previously fixed when reading programs from the PE file.
* Add test to end_to_end.cpp for trying to reuse a pinned map of the wrong type
* Add bpf_object__next_map() API to tests
* Add negative test trying to load a .sys file in user mode

Fixes #1140

## Testing

Added/updated tests in this PR.

## Documentation

Already documented.
