### PR TITLE
Revert "Bump ossf/scorecard-action from 1.0.3 to 1.1.1"

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: "Run analysis"
-        uses: ossf/scorecard-action@3e15ea8318eee9b333819ec77a36aca8d39df13e # Don't update this until they fix PR support
+        uses: ossf/scorecard-action@b614d455ee90608b5e36e3299cd50d457eb37d5f # Don't update this until they fix PR support
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
Reverts microsoft/ebpf-for-windows#1161

Many failures happened due to https://github.com/ossf/scorecard-action/issues/329 so reverting until that issue is fixed.