### PR TITLE
Update hash in GettingStarted.md

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -21,7 +21,7 @@ Alternative install steps:
 ```
 Set-ExecutionPolicy Bypass -Scope Process -Force
 Invoke-WebRequest 'https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/scripts/Setup-DevEnv.ps1' -OutFile $env:TEMP\Setup-DeveEnv.ps1
-if ((get-filehash $env:TEMP\Setup-DeveEnv.ps1).Hash -eq 'C0632C7015BE9BF78AD36A8F9039B16CBF78068BAC8D23EA3C02422DBA90D0B9') { &"$env:TEMP\Setup-DeveEnv.ps1" }
+if ((get-filehash $env:TEMP\Setup-DeveEnv.ps1).Hash -eq '4000D4B2478A5CE9A779140DEDAEF99E422D9A8706B4ECE596CF0F69DB667055') { &"$env:TEMP\Setup-DeveEnv.ps1" }
 ```
 3. Launch Visual Studio Installer and select "MSVC v142 - VS 2019 C++ x64/x86 Spectre-mitigated libs (latest)"
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

GettingStarted.md had old hash, resulting in failure to download and execute ps1 script.

## Testing

Manual.

## Documentation

Doc change.

Resolves: #1059 
