### PR TITLE
fix test failure incorrectly treated as success

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -99,9 +99,9 @@ jobs:
     if: github.repository == 'microsoft/ebpf-for-windows'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: ".\setup_ebpf_cicd_tests.ps1"
-      test_command: ".\execute_ebpf_cicd_tests.ps1"
-      post_test: ".\cleanup_ebpf_cicd_tests.ps1"
+      pre_test: .\setup_ebpf_cicd_tests.ps1
+      test_command: .\execute_ebpf_cicd_tests.ps1
+      post_test: .\cleanup_ebpf_cicd_tests.ps1
       name: driver
       build_artifact: Build-x64
       environment: ebpf_cicd_tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -82,11 +82,11 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
       test_command: bpf2c_tests.exe -d yes
       name: bpf2c
       build_artifact: Build-x64
       environment: windows-2019
+      vs_dev: true
       code_coverage: true
       gather_dumps: true
       capture_etw: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -68,7 +68,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
-      test_command: unit_tests.exe -d yes
+      test_command: .\unit_tests.exe -d yes
       build_artifact: Build-x64
       environment: windows-2019
       code_coverage: true
@@ -82,7 +82,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      test_command: bpf2c_tests.exe -d yes
+      test_command: .\bpf2c_tests.exe -d yes
       name: bpf2c
       build_artifact: Build-x64
       environment: windows-2019
@@ -99,9 +99,9 @@ jobs:
     if: github.repository == 'microsoft/ebpf-for-windows'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: powershell ".\setup_ebpf_cicd_tests.ps1"
-      test_command: powershell ".\execute_ebpf_cicd_tests.ps1"
-      post_test: powershell ".\cleanup_ebpf_cicd_tests.ps1"
+      pre_test: ".\setup_ebpf_cicd_tests.ps1"
+      test_command: ".\execute_ebpf_cicd_tests.ps1"
+      post_test: ".\cleanup_ebpf_cicd_tests.ps1"
       name: driver
       build_artifact: Build-x64
       environment: ebpf_cicd_tests
@@ -146,7 +146,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: fuzzing
-      test_command: fuzz.exe -d yes
+      test_command: .\fuzz.exe -d yes
       build_artifact: Build-x64-Sanitize
       environment: windows-2019
       code_coverage: false
@@ -159,7 +159,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: bpf2c_fuzzer
-      test_command: bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
       build_artifact: Build-x64-fuzzer
       environment: windows-2019
       code_coverage: false
@@ -173,7 +173,7 @@ jobs:
     with:
       name: execution_context_fuzzer
       pre_test: powershell Expand-Archive -Path .\corpus.zip -DestinationPath execution_context_fuzzer_corpus -Force
-      test_command: execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
+      test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
       build_artifact: Build-x64-fuzzer
       environment: windows-2019
       code_coverage: false
@@ -187,7 +187,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: verifier_fuzzer
-      test_command: verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=1800 -artifact_prefix=Artifacts\
+      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=1800 -artifact_prefix=Artifacts\
       build_artifact: Build-x64-fuzzer
       environment: windows-2019
       code_coverage: false
@@ -200,7 +200,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: core_helper_fuzzer
-      test_command: core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
+      test_command: .\core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
       build_artifact: Build-x64-fuzzer
       environment: windows-2019
       code_coverage: false
@@ -214,7 +214,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: cilium_tests
-      test_command: cilium_tests.exe -d yes
+      test_command: .\cilium_tests.exe -d yes
       build_artifact: Build-x64
       environment: windows-2019
       code_coverage: false
@@ -229,7 +229,7 @@ jobs:
     with:
       name: stress
       # Until there is a dedicated stress test, re-use the perf test.
-      test_command: ebpf_performance.exe
+      test_command: .\ebpf_performance.exe
       build_artifact: Build-x64
       environment: windows-2019
       # No code coverage on stress.
@@ -244,7 +244,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
-      test_command: unit_tests.exe -d yes
+      test_command: .\unit_tests.exe -d yes
       build_artifact: Build-x64-Sanitize
       environment: windows-2019
       code_coverage: false

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -138,7 +138,7 @@ jobs:
           set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
         } else {
-          set $env.EBPF_ENABLE_WER_REPORT=yes
+          set $env:EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
         }
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -129,18 +129,22 @@ jobs:
       run: |
         ${{env.PRE_COMMAND}}
 
-    - name: Run test with Code Coverage
-      if: inputs.code_coverage == true
+    - name: Run test with Code Coverage in VS Dev environment
+      if: (inputs.code_coverage == true) && (inputs.vs_dev == true)
       id: run_test_with_code_coverage
+      shell: cmd
       run: |
-        if ($${{inputs.vs_dev == true}}) {
-          cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
           set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
-        } else {
-          set $env:EBPF_ENABLE_WER_REPORT=yes
+
+    - name: Run test with Code Coverage
+      if: (inputs.code_coverage == true) && (inputs.vs_dev != true)
+      id: run_test_with_code_coverage
+      shell: cmd
+      run: |
+          set EBPF_ENABLE_WER_REPORT=yes
           OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
-        }
 
     - name: Run test without Code Coverage
       if: inputs.code_coverage == false

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -126,7 +126,6 @@ jobs:
     - name: Run pre test command
       id: run_pre_test_command
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-      shell: cmd
       run: |
         ${{env.PRE_COMMAND}}
 
@@ -134,7 +133,7 @@ jobs:
       if: inputs.code_coverage == true
       id: run_test_with_code_coverage
       run: |
-        if ($${{inputs.vs_dev == true}}) {call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
+        if ($${{inputs.vs_dev == true}}) {cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
         set env.EBPF_ENABLE_WER_REPORT=yes
         OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
 
@@ -143,13 +142,12 @@ jobs:
       id: run_test_without_code_coverage
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        if ($${{inputs.vs_dev == true}}) {call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
+        if ($${{inputs.vs_dev == true}}) {cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
         ${{env.TEST_COMMAND}}
 
     - name: Run post test command
       id: run_post_test_command
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-      shell: cmd
       run: |
         ${{env.POST_COMMAND}}
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -135,6 +135,7 @@ jobs:
       run: |
         if ($${{inputs.vs_dev == true}}) {cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
         set env.EBPF_ENABLE_WER_REPORT=yes
+        cl.exe
         OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
 
     - name: Run test without Code Coverage

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -119,15 +119,20 @@ jobs:
         mkdir ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\TestLogs
         wpr.exe -start ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\ebpfforwindows.wprp -filemode
 
+    - name: Run pre test command
+      id: run_pre_test_command
+      working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+      shell: cmd
+      run: |
+        ${{env.PRE_COMMAND}}
+
     - name: Run test with Code Coverage
       if: inputs.code_coverage == true
       id: run_test_with_code_coverage
       shell: cmd
       run: |
-        ${{env.PRE_COMMAND}}
         set EBPF_ENABLE_WER_REPORT=yes
         OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
-        ${{env.POST_COMMAND}}
 
     - name: Run test without Code Coverage
       if: inputs.code_coverage == false
@@ -135,8 +140,13 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       shell: cmd
       run: |
-        ${{env.PRE_COMMAND}}
         ${{env.TEST_COMMAND}}
+
+    - name: Run post test command
+      id: run_post_test_command
+      working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+      shell: cmd
+      run: |
         ${{env.POST_COMMAND}}
 
     - name: Check for CodeCoverage

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -154,6 +154,7 @@ jobs:
         ${{env.TEST_COMMAND}}
 
     - name: Run post test command
+      if: always()
       id: run_post_test_command
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -131,6 +131,7 @@ jobs:
       id: run_test_with_code_coverage
       shell: cmd
       run: |
+        if ($${{inputs.vs_dev == true}}) {call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
         set EBPF_ENABLE_WER_REPORT=yes
         OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
 
@@ -140,6 +141,7 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       shell: cmd
       run: |
+        if ($${{inputs.vs_dev == true}}) {call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
         ${{env.TEST_COMMAND}}
 
     - name: Run post test command

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -41,6 +41,10 @@ on:
       capture_etw:
         required: false
         type: boolean
+      # Set to true to use Visual Studio Developer command shell.
+      vs_dev:
+        required: false
+        type: boolean
 
 permissions:
   checks: read  # Required by fountainhead/action-wait-for-check to wait for another GitHub check to complete.
@@ -129,17 +133,15 @@ jobs:
     - name: Run test with Code Coverage
       if: inputs.code_coverage == true
       id: run_test_with_code_coverage
-      shell: cmd
       run: |
         if ($${{inputs.vs_dev == true}}) {call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
-        set EBPF_ENABLE_WER_REPORT=yes
+        set env.EBPF_ENABLE_WER_REPORT=yes
         OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
 
     - name: Run test without Code Coverage
       if: inputs.code_coverage == false
       id: run_test_without_code_coverage
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-      shell: cmd
       run: |
         if ($${{inputs.vs_dev == true}}) {call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
         ${{env.TEST_COMMAND}}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -133,17 +133,20 @@ jobs:
       if: inputs.code_coverage == true
       id: run_test_with_code_coverage
       run: |
-        if ($${{inputs.vs_dev == true}}) {cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
-        set env.EBPF_ENABLE_WER_REPORT=yes
-        cl.exe
-        OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
+        if ($${{inputs.vs_dev == true}}) {
+          cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"
+          set EBPF_ENABLE_WER_REPORT=yes
+          OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
+        } else {
+          set $env.EBPF_ENABLE_WER_REPORT=yes
+          OpenCppCoverage.exe --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
+        }
 
     - name: Run test without Code Coverage
       if: inputs.code_coverage == false
       id: run_test_without_code_coverage
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        if ($${{inputs.vs_dev == true}}) {cmd.exe /k "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"}
         ${{env.TEST_COMMAND}}
 
     - name: Run post test command

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -131,7 +131,7 @@ jobs:
 
     - name: Run test with Code Coverage in VS Dev environment
       if: (inputs.code_coverage == true) && (inputs.vs_dev == true)
-      id: run_test_with_code_coverage
+      id: run_test_with_code_coverage_in_vs_dev
       shell: cmd
       run: |
           call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat"


### PR DESCRIPTION
## Description

For the driver tests, `PRE_COMMAND`, `TEST_COMMAND` and `POST_COMMAND` are different ps1 scripts. But in the reusable-test.yml the 3 commands are part of the same job. So if the TEST_COMMAND fails but the POST_COMMAND succeeds, the task is treated as a success.

Fix is to split it into 3 jobs.

## Testing

CI.

## Documentation

N/A.
