### PR TITLE
Test helper's _net_ebpf_xdp_adjust_head shouldn't permit unbounded memory allocations

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -400,7 +400,7 @@ Done:
 }
 
 ebpf_result_t
-ebpf_program_create(ebpf_program_t** program)
+ebpf_program_create(_Outptr_ ebpf_program_t** program)
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t retval;
@@ -441,7 +441,7 @@ Done:
 }
 
 ebpf_result_t
-ebpf_program_initialize(ebpf_program_t* program, const ebpf_program_parameters_t* program_parameters)
+ebpf_program_initialize(_Inout_ ebpf_program_t* program, _In_ const ebpf_program_parameters_t* program_parameters)
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t return_value;

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -62,13 +62,13 @@ extern "C"
      *  program instance.
      */
     ebpf_result_t
-    ebpf_program_create(ebpf_program_t** program);
+    ebpf_program_create(_Outptr_ ebpf_program_t** program);
 
     /**
      * @brief Initialize a program instance from the provided program
      *  parameters.
      *
-     * @param[in] program Program instance to initialize.
+     * @param[in,out] program Program instance to initialize.
      * @param[in] program_parameters Program parameters to be used to initialize
      *  the program instance.
      * @retval EBPF_SUCCESS The operation was successful.
@@ -76,7 +76,7 @@ extern "C"
      *  program instance.
      */
     ebpf_result_t
-    ebpf_program_initialize(ebpf_program_t* program, const ebpf_program_parameters_t* program_parameters);
+    ebpf_program_initialize(_Inout_ ebpf_program_t* program, _In_ const ebpf_program_parameters_t* program_parameters);
 
     /**
      * @brief Get parameters describing the program instance.

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -238,6 +238,11 @@ typedef class xdp_md_helper : public xdp_md_t
                 _begin -= abs_delta;
             else {
                 size_t additional_space_needed = abs_delta - _begin;
+                const size_t MAX_ADDITIONAL_BYTES = 65536;
+                if (additional_space_needed > MAX_ADDITIONAL_BYTES) {
+                    return_value = -1;
+                    goto Done;
+                }
                 // Prepend _packet with additional_space_needed count of 0.
                 _packet->insert(_packet->begin(), additional_space_needed, 0);
                 _begin = 0;
@@ -263,8 +268,7 @@ typedef class _test_xdp_helper
     static int
     adjust_head(_In_ xdp_md_t* ctx, int delta)
     {
-        ((xdp_md_helper_t*)ctx)->adjust_head(delta);
-        return 0;
+        return ((xdp_md_helper_t*)ctx)->adjust_head(delta);
     }
 } test_xdp_helper_t;
 


### PR DESCRIPTION
## Description

Test helper's _net_ebpf_xdp_adjust_head shouldn't permit unbounded memory allocations

This bug only affected the tests, not the actual runtime.

Also fix some annotations found while debugging this

Fixes #1218

## Testing

Covered by existing tests

## Documentation

No impact
