### PR TITLE
Increase build timeout to 90 minutes

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   build:
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     strategy:
       matrix:


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Increase the timeout of the build to permit the CodeQL build to complete.

## Testing

CI/CD

## Documentation

No.

Resolves: #1228 
