### PR TITLE
Fix reusable test workflow to upload driver test logs in case of failure.

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -254,6 +254,7 @@ jobs:
 
     - name: Check for TestLogs
       uses: andstor/file-existence-action@f02338908d150e00a4b8bebc2dad18bd9e5229b0
+      if: always()
       id: check_logs
       with:
         files: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/TestLogs/*

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -260,7 +260,7 @@ jobs:
         files: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/TestLogs/*
 
     - name: Upload log files
-      if: steps.check_logs.outputs.files_exists == 'true'
+      if: always() && steps.check_logs.outputs.files_exists == 'true'
       id: upload_logs
       uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8
       with:


### PR DESCRIPTION
## Description

The driver test logs were not getting uploaded in case of failure. Fixed it by putting an always() clause for this step of the workflow.

## Testing

CI.

## Documentation

N/A.
