### PR TITLE
Switch to using the type safe std::format

### DIFF
--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -341,24 +341,6 @@ class bpf_code_generator
     void
     encode_instructions(const unsafe_string& section_name);
 
-    /**
-     * @brief Format a string and insert up to 4 strings in it.
-     *
-     * @param[in] format Format string.
-     * @param[in] insert_1 First string to insert.
-     * @param[in] insert_2 Second string to insert or empty.
-     * @param[in] insert_3 Third string to insert or empty.
-     * @param[in] insert_4 Fourth string to insert or empty.
-     * @return The formatted string.
-     */
-    std::string
-    format_string(
-        const std::string& format,
-        const std::string insert_1,
-        const std::string insert_2 = "",
-        const std::string insert_3 = "",
-        const std::string insert_4 = "");
-
 #if defined(_MSC_VER)
     /**
      * @brief Format a GUID as a string.


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Switch from using the type-unsafe C style formatting to the type-safe std::format formatting.

## Testing

CI/CD

## Documentation

No.

See the following for how std::format interprets format strings:
https://en.cppreference.com/w/cpp/utility/format/formatter#Standard_format_specification