### PR TITLE
Fix test automation.

### DIFF
--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -256,8 +256,16 @@ function Import-ResultsFromVM
         Write-Log ("Copy CodeCoverage from eBPF on $VMName to $pwd\..\..")
         Copy-Item -FromSession $VMSession "$VMSystemDrive\eBPF\ebpf_for_windows.xml" -Destination "$pwd\..\.." -Recurse -Force -ErrorAction Ignore 2>&1 | Write-Log
 
-        # Copy ETL from Test VM.
         $EtlFile = $LogFileName.Substring(0, $LogFileName.IndexOf('.')) + ".etl"
+
+        # Stop ETW Traces.
+        Invoke-Command -Session $VMSession -ScriptBlock {
+            param([Parameter(Mandatory=$True)] [string] $EtlFile)
+            Write-Log ("Stopping ETW tracing, creating file: " + $EtlFile)
+            Start-Process -FilePath "wpr.exe" -ArgumentList @("-stop", $EtlFile) -NoNewWindow -Wait
+        } -ArgumentList ($EtlFile) -ErrorAction Ignore
+
+        # Copy ETL from Test VM.
         Write-Log ("Copy $EtlFile from eBPF on $VMName to $pwd\TestLogs")
         Copy-Item -FromSession $VMSession -Path "$VMSystemDrive\eBPF\$EtlFile" -Destination ".\TestLogs\$VMName\Logs" -Recurse -Force -ErrorAction Ignore 2>&1 | Write-Log
     }

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -260,10 +260,13 @@ function Import-ResultsFromVM
 
         # Stop ETW Traces.
         Invoke-Command -Session $VMSession -ScriptBlock {
-            param([Parameter(Mandatory=$True)] [string] $EtlFile)
+            param([Parameter(Mandatory=$True)] [string] $LogFileName,
+                  [Parameter(Mandatory=$True)] [string] $EtlFile)
+            Import-Module $WorkingDirectory\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
+
             Write-Log ("Stopping ETW tracing, creating file: " + $EtlFile)
             Start-Process -FilePath "wpr.exe" -ArgumentList @("-stop", $EtlFile) -NoNewWindow -Wait
-        } -ArgumentList ($EtlFile) -ErrorAction Ignore
+        } -ArgumentList ($LogFileName, $EtlFile) -ErrorAction Ignore
 
         # Copy ETL from Test VM.
         Write-Log ("Copy $EtlFile from eBPF on $VMName to $pwd\TestLogs")

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -111,8 +111,4 @@ function Stop-eBPFComponents
     $EbpfDrivers.GetEnumerator() | ForEach-Object {
         Stop-Service $_.Name -ErrorAction Ignore 2>&1 | Write-Log
     }
-
-    $EtlFile = $LogFileName.Substring(0, $LogFileName.IndexOf('.')) + ".etl";
-    Write-Log ("Stopping ETW tracing, creating file: " + $EtlFile)
-    Start-Process -FilePath "wpr.exe" -ArgumentList @("-stop", $EtlFile) -NoNewWindow -Wait
 }


### PR DESCRIPTION
## Description

In the driver tests automation, the ETW traces are stopped as part of the execute_test script. If any tests fail the script is aborted and the ETW session is not stopped. As a result in the cleanup script no ETL logs get collected as part of the result. The fix is to move the wpr command to stop ETW traces to the cleanup script.

## Testing

CI.

## Documentation

NA.
