### PR TITLE
Clean up hard coded program type in EC

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -68,6 +68,7 @@ The various fields of this structure should be set as follows:
 * `name`: Friendly name of the program type.
 * `context_descriptor`: Pointer of type `ebpf_context_descriptor_t`.
 * `program_type`: GUID for the program type. This should be the same as the `NpiId` in `NPI_REGISTRATION_INSTANCE` as noted above.
+* `bpf_prog_type`: Set to the equivalent bpf program type integer. If there is no equivalent bpf program type, this field should be set to `0 (BPF_PROG_TYPE_UNSPEC)`.
 * `is_privileged`: Set to `FALSE`.
 
 #### `ebpf_context_descriptor_t` Struct
@@ -159,7 +160,7 @@ This structure is used to specify the attach type supported by the extension for
 
 The `supported_program_type` field of the struct should be filled with the `ebpf_program_type_t` (GUID) of the supported program type. While attaching an eBPF program to a hook instance, the Execution Context enforces that the requested attach type is supported by the Hook NPI provider. If not, the eBPF program fails to attach to the hook.
 
-The `bpf_attach_type` field should contain the equivalent bpf attach type integer. If there is no equivalent bpf attach type, this field can be filled with `0 (BPF_ATTACH_TYPE_UNSPEC)`.
+The `bpf_attach_type` field should contain the equivalent bpf attach type integer. If there is no equivalent bpf attach type, this field should be set to `0 (BPF_ATTACH_TYPE_UNSPEC)`.
 
 ### 2.4 Hook NPI Client Attach and Detach Callbacks
 The eBPF Execution Context registers a Hook NPI client module with the NMR for each program that is attached to a hook. The attach type GUID is used as the NPI of the client module. And as a result, when an eBPF program gets attached to a hook, the associated Hook NPI client module will attach to the corresponding Hook NPI provider module in the extension. The [client attach callback](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nc-netioddk-npi_provider_attach_client_fn) function is invoked when the NPI client is being attached. The provider must store the following in a per-client data structure from the passed in parameters:

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -153,7 +153,13 @@ When registering itself to the NMR, the Hook NPI provider should have the [`NPI_
   * The `data` field of this structure should point to a structure of type `ebpf_attach_provider_data_t`.
 
 #### `ebpf_attach_provider_data_t` Struct
-This structure is used to specify the attach type supported by the extension for the given Hook NPI provider. The `supported_program_type` field of the struct should be filled with the `ebpf_program_type_t` (GUID) of the supported program type. While attaching an eBPF program to a hook instance, the Execution Context enforces that the requested attach type is supported by the Hook NPI provider. If not, the eBPF program fails to attach to the hook.
+This structure is used to specify the attach type supported by the extension for the given Hook NPI provider. It contains the following fields:
+* `supported_program_type`
+* `bpf_attach_type`
+
+The `supported_program_type` field of the struct should be filled with the `ebpf_program_type_t` (GUID) of the supported program type. While attaching an eBPF program to a hook instance, the Execution Context enforces that the requested attach type is supported by the Hook NPI provider. If not, the eBPF program fails to attach to the hook.
+
+The `bpf_attach_type` field should contain the equivalent bpf attach type integer. If there is no equivalent bpf attach type, this field can be filled with `0 (BPF_ATTACH_TYPE_UNSPEC)`.
 
 ### 2.4 Hook NPI Client Attach and Detach Callbacks
 The eBPF Execution Context registers a Hook NPI client module with the NMR for each program that is attached to a hook. The attach type GUID is used as the NPI of the client module. And as a result, when an eBPF program gets attached to a hook, the associated Hook NPI client module will attach to the corresponding Hook NPI provider module in the extension. The [client attach callback](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nc-netioddk-npi_provider_attach_client_fn) function is invoked when the NPI client is being attached. The provider must store the following in a per-client data structure from the passed in parameters:

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -15,6 +15,7 @@ typedef struct _ebpf_link
     ebpf_program_t* program;
 
     ebpf_attach_type_t attach_type;
+    bpf_attach_type_t bpf_attach_type;
     ebpf_program_type_t program_type;
     ebpf_extension_data_t client_data;
     ebpf_extension_client_t* extension_client_context;
@@ -118,6 +119,7 @@ ebpf_link_initialize(
     attach_provider_data = (ebpf_attach_provider_data_t*)provider_data->data;
     link->program_type = attach_provider_data->supported_program_type;
     link->attach_type = attach_type;
+    link->bpf_attach_type = attach_provider_data->bpf_attach_type;
 
 Exit:
     EBPF_RETURN_RESULT(return_value);
@@ -222,7 +224,7 @@ ebpf_link_get_info(
     info->type = BPF_LINK_TYPE_PLAIN;
     info->program_type_uuid = link->program_type;
     info->attach_type_uuid = link->attach_type;
-    info->attach_type = BPF_ATTACH_TYPE_UNSPEC; // TODO(#223): get actual integer, and also return attach_type_uuid
+    info->attach_type = link->bpf_attach_type;
 
     // Copy any additional parameters.  Currently only XDP has such.
     size_t size = sizeof(struct bpf_link_info) - FIELD_OFFSET(struct bpf_link_info, xdp);

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -242,17 +242,10 @@ _ebpf_program_get_program_type(_In_ const ebpf_core_object_t* object)
 static const bpf_prog_type_t
 _ebpf_program_get_bpf_prog_type(_In_ const ebpf_program_t* program)
 {
-    // TODO(issue #223)
     bpf_prog_type_t prog_type = BPF_PROG_TYPE_UNSPEC;
     if (program->program_info_binding_context != NULL) {
-        const ebpf_program_type_t* prog_type_uuid = ebpf_program_type_uuid(program);
-        if (memcmp(prog_type_uuid, &EBPF_PROGRAM_TYPE_XDP, sizeof(*prog_type_uuid)) == 0) {
-            prog_type = BPF_PROG_TYPE_XDP;
-        } else if (memcmp(prog_type_uuid, &EBPF_PROGRAM_TYPE_BIND, sizeof(*prog_type_uuid)) == 0) {
-            prog_type = BPF_PROG_TYPE_BIND;
-        } else if (memcmp(prog_type_uuid, &EBPF_PROGRAM_TYPE_SAMPLE, sizeof(*prog_type_uuid)) == 0) {
-            prog_type = BPF_PROG_TYPE_SAMPLE;
-        }
+        ebpf_program_data_t* program_data = (ebpf_program_data_t*)program->program_info_provider_data->data;
+        prog_type = program_data->program_info->program_type_descriptor.bpf_prog_type;
     }
 
     return prog_type;

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -3,6 +3,7 @@
 
 #pragma once
 #include "ebpf_result.h"
+#include "ebpf_structs.h"
 #include "ebpf_windows.h"
 #include "framework.h"
 
@@ -78,7 +79,7 @@ extern "C"
     typedef struct _ebpf_attach_provider_data
     {
         ebpf_program_type_t supported_program_type;
-        uint32_t bpf_attach_type;
+        bpf_attach_type_t bpf_attach_type;
     } ebpf_attach_provider_data_t;
 
 #define EBPF_ATTACH_CLIENT_DATA_VERSION 0

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -78,6 +78,7 @@ extern "C"
     typedef struct _ebpf_attach_provider_data
     {
         ebpf_program_type_t supported_program_type;
+        uint32_t bpf_attach_type;
     } ebpf_attach_provider_data_t;
 
 #define EBPF_ATTACH_CLIENT_DATA_VERSION 0

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -167,6 +167,7 @@ net_ebpf_ext_bind_register_providers()
     _net_ebpf_bind_hook_provider_data.supported_program_type = EBPF_PROGRAM_TYPE_BIND;
     // Set the attach type as the provider module id.
     _ebpf_bind_hook_provider_moduleid.Guid = EBPF_ATTACH_TYPE_BIND;
+    _net_ebpf_bind_hook_provider_data.bpf_attach_type = BPF_ATTACH_TYPE_BIND;
     status = net_ebpf_extension_hook_provider_register(
         &hook_provider_parameters,
         _net_ebpf_extension_bind_on_client_attach,

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -229,7 +229,7 @@ net_ebpf_ext_sock_addr_register_providers()
         _net_ebpf_sock_addr_hook_provider_data[i].bpf_attach_type = _net_ebpf_extension_sock_addr_bpf_attach_types[i];
         _net_ebpf_extension_sock_addr_hook_provider_data[i].version = EBPF_ATTACH_PROVIDER_DATA_VERSION;
         _net_ebpf_extension_sock_addr_hook_provider_data[i].data = &_net_ebpf_sock_addr_hook_provider_data[i];
-        _net_ebpf_extension_sock_addr_hook_provider_data[i].size = sizeof(_net_ebpf_sock_addr_hook_provider_data);
+        _net_ebpf_extension_sock_addr_hook_provider_data[i].size = sizeof(ebpf_attach_provider_data_t);
 
         // Set the attach type as the provider module id.
         _ebpf_sock_addr_hook_provider_moduleid[i].Length = sizeof(NPI_MODULEID);

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -22,6 +22,9 @@ const ebpf_attach_type_t* _net_ebpf_extension_sock_addr_attach_types[] = {
     &EBPF_ATTACH_TYPE_CGROUP_INET6_CONNECT,
     &EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT};
 
+const uint32_t _net_ebpf_extension_sock_addr_bpf_attach_types[] = {
+    BPF_CGROUP_INET4_CONNECT, BPF_CGROUP_INET4_RECV_ACCEPT, BPF_CGROUP_INET6_CONNECT, BPF_CGROUP_INET6_RECV_ACCEPT};
+
 #define NET_EBPF_SOCK_ADDR_HOOK_PROVIDER_COUNT EBPF_COUNT_OF(_net_ebpf_extension_sock_addr_attach_types)
 
 const net_ebpf_extension_wfp_filter_parameters_t _net_ebpf_extension_sock_addr_wfp_filter_parameters[] = {
@@ -65,13 +68,8 @@ static net_ebpf_extension_program_info_provider_t* _ebpf_sock_addr_program_info_
 // SOCK_ADDR Hook NPI Provider.
 //
 
-ebpf_attach_provider_data_t _net_ebpf_sock_addr_hook_provider_data;
-
-ebpf_extension_data_t _net_ebpf_extension_sock_addr_hook_provider_data = {
-    EBPF_ATTACH_PROVIDER_DATA_VERSION,
-    sizeof(_net_ebpf_sock_addr_hook_provider_data),
-    &_net_ebpf_sock_addr_hook_provider_data};
-
+ebpf_attach_provider_data_t _net_ebpf_sock_addr_hook_provider_data[NET_EBPF_SOCK_ADDR_HOOK_PROVIDER_COUNT] = {0};
+ebpf_extension_data_t _net_ebpf_extension_sock_addr_hook_provider_data[NET_EBPF_SOCK_ADDR_HOOK_PROVIDER_COUNT] = {0};
 NPI_MODULEID DECLSPEC_SELECTANY _ebpf_sock_addr_hook_provider_moduleid[NET_EBPF_SOCK_ADDR_HOOK_PROVIDER_COUNT] = {0};
 
 static net_ebpf_extension_hook_provider_t*
@@ -223,10 +221,15 @@ net_ebpf_ext_sock_addr_register_providers()
     if (status != STATUS_SUCCESS)
         goto Exit;
 
-    _net_ebpf_sock_addr_hook_provider_data.supported_program_type = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR;
     for (int i = 0; i < NET_EBPF_SOCK_ADDR_HOOK_PROVIDER_COUNT; i++) {
         const net_ebpf_extension_hook_provider_parameters_t hook_provider_parameters = {
-            &_ebpf_sock_addr_hook_provider_moduleid[i], &_net_ebpf_extension_sock_addr_hook_provider_data};
+            &_ebpf_sock_addr_hook_provider_moduleid[i], &_net_ebpf_extension_sock_addr_hook_provider_data[i]};
+
+        _net_ebpf_sock_addr_hook_provider_data[i].supported_program_type = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR;
+        _net_ebpf_sock_addr_hook_provider_data[i].bpf_attach_type = _net_ebpf_extension_sock_addr_bpf_attach_types[i];
+        _net_ebpf_extension_sock_addr_hook_provider_data[i].version = EBPF_ATTACH_PROVIDER_DATA_VERSION;
+        _net_ebpf_extension_sock_addr_hook_provider_data[i].data = &_net_ebpf_sock_addr_hook_provider_data[i];
+        _net_ebpf_extension_sock_addr_hook_provider_data[i].size = sizeof(_net_ebpf_sock_addr_hook_provider_data);
 
         // Set the attach type as the provider module id.
         _ebpf_sock_addr_hook_provider_moduleid[i].Length = sizeof(NPI_MODULEID);

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -283,6 +283,7 @@ net_ebpf_ext_sock_ops_register_providers()
         goto Exit;
 
     _net_ebpf_sock_ops_hook_provider_data.supported_program_type = EBPF_PROGRAM_TYPE_SOCK_OPS;
+    _net_ebpf_sock_ops_hook_provider_data.bpf_attach_type = BPF_CGROUP_SOCK_OPS;
     const net_ebpf_extension_hook_provider_parameters_t hook_provider_parameters = {
         &_ebpf_sock_ops_hook_provider_moduleid, &_net_ebpf_extension_sock_ops_hook_provider_data};
 

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -241,6 +241,7 @@ net_ebpf_ext_xdp_register_providers()
     _net_ebpf_xdp_hook_provider_data.supported_program_type = EBPF_PROGRAM_TYPE_XDP;
     // Set the attach type as the provider module id.
     _ebpf_xdp_hook_provider_moduleid.Guid = EBPF_ATTACH_TYPE_XDP;
+    _net_ebpf_xdp_hook_provider_data.bpf_attach_type = BPF_XDP;
     status = net_ebpf_extension_hook_provider_register(
         &hook_provider_parameters,
         net_ebpf_extension_xdp_on_client_attach,

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -10,6 +10,9 @@
 #include "net_ebpf_ext_program_info.h"
 #include "sample_ext_program_info.h"
 
+bpf_attach_type_t
+get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type);
+
 typedef struct _ebpf_free_memory
 {
     void
@@ -90,6 +93,7 @@ typedef class _single_instance_hook : public _hook_helper
     {
         ebpf_guid_create(&client_id);
         attach_provider_data.supported_program_type = program_type;
+        attach_provider_data.bpf_attach_type = get_bpf_attach_type(&attach_type);
         this->attach_type = attach_type;
 
         REQUIRE(

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -483,6 +483,7 @@ sample_ebpf_extension_hook_provider_register()
     NTSTATUS status = STATUS_SUCCESS;
 
     _sample_ebpf_extension_attach_provider_data.supported_program_type = EBPF_PROGRAM_TYPE_SAMPLE;
+    _sample_ebpf_extension_attach_provider_data.bpf_attach_type = BPF_ATTACH_TYPE_SAMPLE;
     _sample_ebpf_extension_hook_provider_moduleid.Guid = EBPF_ATTACH_TYPE_SAMPLE;
 
     local_provider_context = &_sample_ebpf_extension_hook_provider_context;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1913,6 +1913,60 @@ TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
     Platform::_close(link_fd);
 }
 
+TEST_CASE("bpf_obj_get_info_by_fd_2", "[libbpf]")
+{
+    _test_helper_end_to_end test_helper;
+    program_info_provider_t sock_addr_program_info(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR);
+    single_instance_hook_t v4_connect_hook(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR, EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT);
+
+    program_load_attach_helper_t sock_addr_helper(
+        "cgroup_sock_addr.o",
+        BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
+        "authorize_connect4",
+        EBPF_EXECUTION_JIT,
+        nullptr,
+        0,
+        v4_connect_hook);
+
+    struct bpf_object* object = sock_addr_helper.get_object();
+    REQUIRE(object != nullptr);
+
+    struct bpf_program* program = bpf_object__find_program_by_name(object, "authorize_connect4");
+    REQUIRE(program != nullptr);
+
+    int program_fd = bpf_program__fd(program);
+    REQUIRE(program_fd > 0);
+
+    // Fetch info about the program and verify it matches what we'd expect.
+    bpf_prog_info program_info;
+    uint32_t program_info_size = sizeof(program_info);
+    REQUIRE(bpf_obj_get_info_by_fd(program_fd, &program_info, &program_info_size) == 0);
+    REQUIRE(program_info_size == sizeof(program_info));
+    REQUIRE(strcmp(program_info.name, "authorize_connect4") == 0);
+    REQUIRE(program_info.nr_map_ids == 1);
+    REQUIRE(program_info.type == BPF_PROG_TYPE_CGROUP_SOCK_ADDR);
+
+    // Fetch info about the attachment and verify it matches what we'd expect.
+    uint32_t link_id;
+    REQUIRE(bpf_link_get_next_id(0, &link_id) == 0);
+    fd_t link_fd = bpf_link_get_fd_by_id(link_id);
+    REQUIRE(link_fd >= 0);
+
+    bpf_link_info link_info;
+    uint32_t link_info_size = sizeof(link_info);
+    REQUIRE(bpf_obj_get_info_by_fd(link_fd, &link_info, &link_info_size) == 0);
+    REQUIRE(link_info_size == sizeof(link_info));
+
+    REQUIRE(link_info.prog_id == program_info.id);
+    REQUIRE(link_info.attach_type == BPF_CGROUP_INET4_CONNECT);
+
+    // Verify we can detach using this link fd.
+    // This is the flow used by bpftool to detach a link.
+    REQUIRE(bpf_link_detach(link_fd) == 0);
+
+    Platform::_close(link_fd);
+}
+
 TEST_CASE("libbpf_prog_type_by_name_test", "[libbpf]")
 {
     _test_helper_end_to_end test_helper;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1203,6 +1203,13 @@ _test_bind_fd_to_prog_array(ebpf_execution_type_t execution_type)
     int map_fd = bpf_map__fd(map);
     REQUIRE(map_fd >= 0);
 
+    bpf_prog_info program_info;
+    uint32_t program_info_size = sizeof(program_info);
+    REQUIRE(bpf_obj_get_info_by_fd(callee_fd, &program_info, &program_info_size) == 0);
+    REQUIRE(program_info_size == sizeof(program_info));
+    REQUIRE(strcmp(program_info.name, "BindMonitor") == 0);
+    REQUIRE(program_info.type == BPF_PROG_TYPE_BIND);
+
     // Verify that we cannot add a BIND program fd to a prog_array map already
     // associated with an XDP program.
     int index = 0;
@@ -1883,6 +1890,7 @@ TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
     REQUIRE(program_info_size == sizeof(program_info));
     REQUIRE(strcmp(program_info.name, program_name) == 0);
     REQUIRE(program_info.nr_map_ids == 2);
+    REQUIRE(program_info.type == BPF_PROG_TYPE_XDP);
 
     // Fetch info about the attachment and verify it matches what we'd expect.
     uint32_t link_id;
@@ -1896,6 +1904,7 @@ TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
     REQUIRE(link_info_size == sizeof(link_info));
 
     REQUIRE(link_info.prog_id == program_info.id);
+    REQUIRE(link_info.attach_type == BPF_XDP);
 
     // Verify we can detach using this link fd.
     // This is the flow used by bpftool to detach a link.


### PR DESCRIPTION
## Description

This PR fixes some of the TODO items for Issue #223 which were left over in the code.

1. `_ebpf_core_protocol_get_object_info` now returns the bpf program and attach types as provided by the extensions.
2. Updated the documentation about the new fields added.

## Testing

Added new tests, and existing tests also cover the code changes.

## Documentation

Updated docs.
