### PR TITLE
Fix issued that caused epoch to not cleanup

### DIFF
--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -624,7 +624,7 @@ _ebpf_epoch_get_release_epoch(_Out_ int64_t* release_epoch)
                 break;
             }
 
-            // Include ths epoch state if it's active.
+            // Include this epoch state if it's active.
             if (thread_entry->epoch_state.active) {
                 int64_t age = now - thread_entry->last_used_time;
                 if (age > EBPF_EPOCH_STALE_THREAD_TIME_IN_NANO_SECONDS) {

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -38,7 +38,7 @@
 // Called if a CPU has items to be freed, but hasn't run anything in EBPF_EPOCH_FLUSH_DELAY_IN_MICROSECONDS.
 //
 // Stale flag:
-// The stale flag is set if the timer runs and the ebpf_epoch_cpu_entry_t has entries in it's free list.
+// The stale flag is set if the timer runs and the ebpf_epoch_cpu_entry_t has entries in its free list.
 // If the stale flag is already set, then the per-CPU stale_worker is scheduled.
 
 // Delay after the _ebpf_flush_timer is set before it runs.

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -183,9 +183,9 @@ static _Requires_lock_held_(_ebpf_epoch_cpu_table[cpu_id].lock) ebpf_epoch_threa
     uint32_t cpu_id, uintptr_t thread_id, ebpf_epoch_get_thread_entry_option_t option);
 
 /**
- * @brief Arm the flush timer if timer is:
- *  Not already armed.
- *  Not disabled.
+ * @brief Arm the flush timer if:
+ *  Timer is not already armed.
+ *  Timer is not disabled.
  *  Free list is not empty.
  */
 static _Requires_lock_held_(cpu_entry->lock) void _ebpf_epoch_arm_timer_if_needed(ebpf_epoch_cpu_entry_t* cpu_entry);

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -605,7 +605,7 @@ _ebpf_epoch_get_release_epoch(_Out_ int64_t* release_epoch)
             }
         }
 
-        // Include ths epoch state if it's active.
+        // Include this epoch state if it's active.
         if (_ebpf_epoch_cpu_table[cpu_id].epoch_state.active) {
             lowest_epoch = min(lowest_epoch, _ebpf_epoch_cpu_table[cpu_id].epoch_state.epoch);
         }

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -327,7 +327,7 @@ TEST_CASE("epoch_test_stale_items", "[platform]")
     if (ebpf_get_cpu_count() < 2) {
         return;
     }
-    for (size_t i = 0; i < 100; i++) {
+    for (size_t test_iteration = 0; test_iteration < 100; test_iteration++) {
 
         auto t1 = [&]() {
             uintptr_t old_thread_affinity;

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -327,36 +327,43 @@ TEST_CASE("epoch_test_stale_items", "[platform]")
     if (ebpf_get_cpu_count() < 2) {
         return;
     }
+    for (size_t i = 0; i < 100; i++) {
 
-    auto t1 = [&]() {
-        uintptr_t old_thread_affinity;
-        ebpf_set_current_thread_affinity(1, &old_thread_affinity);
-        ebpf_epoch_enter();
-        void* memory = ebpf_epoch_allocate(10);
-        signal_2.signal();
-        signal_1.wait();
-        ebpf_epoch_free(memory);
-        ebpf_epoch_exit();
-    };
-    auto t2 = [&]() {
-        uintptr_t old_thread_affinity;
-        ebpf_set_current_thread_affinity(2, &old_thread_affinity);
-        signal_2.wait();
-        ebpf_epoch_enter();
-        void* memory = ebpf_epoch_allocate(10);
-        ebpf_epoch_free(memory);
-        ebpf_epoch_exit();
-        signal_1.signal();
-    };
+        auto t1 = [&]() {
+            uintptr_t old_thread_affinity;
+            ebpf_set_current_thread_affinity(1, &old_thread_affinity);
+            ebpf_epoch_enter();
+            void* memory = ebpf_epoch_allocate(10);
+            signal_2.signal();
+            signal_1.wait();
+            ebpf_epoch_free(memory);
+            ebpf_epoch_exit();
+        };
+        auto t2 = [&]() {
+            uintptr_t old_thread_affinity;
+            ebpf_set_current_thread_affinity(2, &old_thread_affinity);
+            signal_2.wait();
+            ebpf_epoch_enter();
+            void* memory = ebpf_epoch_allocate(10);
+            ebpf_epoch_free(memory);
+            ebpf_epoch_exit();
+            signal_1.signal();
+        };
 
-    std::thread thread_1(t1);
-    std::thread thread_2(t2);
+        std::thread thread_1(t1);
+        std::thread thread_2(t2);
 
-    thread_1.join();
-    thread_2.join();
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-    REQUIRE(ebpf_epoch_is_free_list_empty(0));
-    REQUIRE(ebpf_epoch_is_free_list_empty(1));
+        thread_1.join();
+        thread_2.join();
+        for (size_t retry = 0; retry < 100; retry++) {
+            if (ebpf_epoch_is_free_list_empty(0) && ebpf_epoch_is_free_list_empty(1)) {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(1));
+        }
+        REQUIRE(ebpf_epoch_is_free_list_empty(0));
+        REQUIRE(ebpf_epoch_is_free_list_empty(1));
+    }
 }
 
 TEST_CASE("extension_test", "[platform]")

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -327,7 +327,8 @@ TEST_CASE("epoch_test_stale_items", "[platform]")
     if (ebpf_get_cpu_count() < 2) {
         return;
     }
-    for (size_t test_iteration = 0; test_iteration < 100; test_iteration++) {
+    size_t const test_iterations = 100;
+    for (size_t test_iteration = 0; test_iteration < test_iterations; test_iteration++) {
 
         auto t1 = [&]() {
             uintptr_t old_thread_affinity;

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -136,6 +136,7 @@ class _ebpf_emulated_dpc
                         condition_variable.notify_all();
                     } else {
                         l.unlock();
+                        ebpf_list_initialize(entry);
                         auto work_item = reinterpret_cast<ebpf_non_preemptible_work_item_t*>(entry);
                         work_item->work_item_routine(work_item->context, work_item->parameter_1);
                         l.lock();


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description
Cleanup the handling of flags in epoch code (put them all under the lock).
Set thread affinity on epoch_enter/exit (some paths where missing this).
Unify CPU and thread ebpf_epoch_state_t.
Fix issue with re-arming timer that caused use after free.

## Testing

Existing CI/CD tests.

## Documentation

Not needed.
