### PR TITLE
Fix invalid map value size for prog_array and map_array

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -420,6 +420,11 @@ _create_object_array_map(
 
     *map = NULL;
 
+    if (map_definition->value_size != sizeof(ebpf_id_t)) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
     result = _create_array_map_with_map_struct_size(sizeof(ebpf_core_object_map_t), map_definition, &local_map);
     if (result != EBPF_SUCCESS)
         goto Exit;
@@ -781,6 +786,11 @@ _create_object_hash_map(
     ebpf_result_t result = EBPF_SUCCESS;
 
     EBPF_LOG_ENTRY();
+
+    if (map_definition->value_size != sizeof(ebpf_id_t)) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
 
     *map = NULL;
 

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -1164,6 +1164,24 @@ TEST_CASE("EBPF_OPERATION_CREATE_MAP", "[execution_context][negative]")
     create_map_request->ebpf_map_definition = _map_definitions["BPF_MAP_TYPE_HASH_OF_MAPS"];
     create_map_request->inner_map_handle = program_handles[0];
     REQUIRE(invoke_protocol(EBPF_OPERATION_CREATE_MAP, request, reply) == EBPF_INVALID_OBJECT);
+
+    // Array of maps with incorrect value size.
+    create_map_request->ebpf_map_definition = _map_definitions["BPF_MAP_TYPE_ARRAY_OF_MAPS"];
+    create_map_request->ebpf_map_definition.value_size = 1;
+    create_map_request->inner_map_handle = map_handles["BPF_MAP_TYPE_HASH"];
+    REQUIRE(invoke_protocol(EBPF_OPERATION_CREATE_MAP, request, reply) == EBPF_INVALID_ARGUMENT);
+
+    // Hash of maps with incorrect key size.
+    create_map_request->ebpf_map_definition = _map_definitions["BPF_MAP_TYPE_HASH_OF_MAPS"];
+    create_map_request->ebpf_map_definition.value_size = 1;
+    create_map_request->inner_map_handle = map_handles["BPF_MAP_TYPE_HASH"];
+    REQUIRE(invoke_protocol(EBPF_OPERATION_CREATE_MAP, request, reply) == EBPF_INVALID_ARGUMENT);
+
+    // Array of programs with incorrect key size.
+    create_map_request->ebpf_map_definition = _map_definitions["BPF_MAP_TYPE_PROG_ARRAY"];
+    create_map_request->ebpf_map_definition.value_size = 1;
+    create_map_request->inner_map_handle = program_handles[0];
+    REQUIRE(invoke_protocol(EBPF_OPERATION_CREATE_MAP, request, reply) == EBPF_INVALID_ARGUMENT);
 }
 
 TEST_CASE("EBPF_OPERATION_LOAD_CODE", "[execution_context][negative]")

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -801,7 +801,7 @@ std::map<std::string, ebpf_map_definition_in_memory_t> _map_definitions = {
         {
             BPF_MAP_TYPE_ARRAY_OF_MAPS,
             4,
-            20,
+            4,
             10,
             1,
         },
@@ -820,7 +820,7 @@ std::map<std::string, ebpf_map_definition_in_memory_t> _map_definitions = {
         {
             BPF_MAP_TYPE_HASH_OF_MAPS,
             4,
-            20,
+            4,
             10,
             1,
         },
@@ -848,7 +848,7 @@ std::map<std::string, ebpf_map_definition_in_memory_t> _map_definitions = {
         {
             BPF_MAP_TYPE_PROG_ARRAY,
             4,
-            20,
+            4,
             10,
         },
     },


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Block creating BPF_MAP_TYPE_PROG_ARRAY and BPF_MAP_TYPE_ARRAY_OF_MAPS if value size != sizeof(ebpf_id_t).

## Testing

Needs new negative tests.

## Documentation

No.

Resolves:  #1353