### PR TITLE
bpf_object__open_file() should allow null opts

### DIFF
--- a/include/bpf/libbpf.h
+++ b/include/bpf/libbpf.h
@@ -347,7 +347,7 @@ bpf_object__open(const char* path);
  * @brief Open a file without loading the programs.
  *
  * @param[in] path File name to open.
- * @param[opts] opts Options to use when opening the object.
+ * @param[opts] opts Options to use when opening the object, or NULL pointer for default.
  *
  * @returns Pointer to an eBPF object, or NULL on failure.
  */

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -86,8 +86,7 @@ bpf_obj_get(const char* pathname)
 struct bpf_object*
 bpf_object__open(const char* path)
 {
-    struct bpf_object_open_opts opts = {.sz = sizeof(opts)};
-    return bpf_object__open_file(path, &opts);
+    return bpf_object__open_file(path, nullptr);
 }
 
 struct bpf_object*
@@ -99,8 +98,14 @@ bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
 
     struct bpf_object* object = nullptr;
     const char* error_message;
-    ebpf_result_t result =
-        ebpf_object_open(path, opts->object_name, opts->pin_root_path, nullptr, nullptr, &object, &error_message);
+    ebpf_result_t result = ebpf_object_open(
+        path,
+        ((opts) ? opts->object_name : nullptr),
+        ((opts) ? opts->pin_root_path : nullptr),
+        nullptr,
+        nullptr,
+        &object,
+        &error_message);
     ebpf_free_string(error_message);
     libbpf_result_err(result); // Set errno.
     return object;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1783,8 +1783,8 @@ TEST_CASE("bpf_prog_attach", "[libbpf]")
 {
     _test_helper_libbpf test_helper;
 
-    struct bpf_object_open_opts opts = {0};
-    struct bpf_object* object = bpf_object__open_file("cgroup_sock_addr.o", &opts);
+    // Test calling bpf_object__open_file with null opts.
+    struct bpf_object* object = bpf_object__open_file("cgroup_sock_addr.o", nullptr);
     REQUIRE(object != nullptr);
 
     struct bpf_program* program = bpf_object__find_program_by_name(object, "authorize_connect4");
@@ -1819,8 +1819,7 @@ TEST_CASE("bpf_link__pin", "[libbpf]")
 {
     _test_helper_libbpf test_helper;
 
-    struct bpf_object_open_opts opts = {0};
-    struct bpf_object* object = bpf_object__open_file("droppacket.o", &opts);
+    struct bpf_object* object = bpf_object__open("droppacket.o");
     REQUIRE(object != nullptr);
 
     struct bpf_program* program = bpf_object__find_program_by_name(object, "DropPacket");


### PR DESCRIPTION
Fixes #1354

Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

bpf_object__open_file() should allow null opts, for consistency with libbpf.

## Testing

Updated tests

## Documentation

Updated docs
