### PR TITLE
Free preemptible work_item during native module unload

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -54,6 +54,7 @@ typedef struct _ebpf_native_module
     size_t program_count;
     ebpf_handle_t client_binding_handle;
     ebpf_list_entry_t list_entry;
+    ebpf_preemptible_work_item_t* unloading_work_item;
 } ebpf_native_module_t;
 
 static GUID _ebpf_native_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
@@ -148,6 +149,8 @@ _ebpf_native_clean_up_module(_In_ ebpf_native_module_t* module)
     module->map_count = 0;
     module->programs = NULL;
     module->program_count = 0;
+
+    ebpf_free_preemptible_work_item(module->unloading_work_item);
 
     ebpf_free(module->service_name);
     ebpf_lock_destroy(&module->lock);
@@ -1316,7 +1319,6 @@ ebpf_native_unload(_In_ const GUID* module_id)
     wchar_t* service_name = NULL;
     size_t service_name_length;
     bool queue_work_item = false;
-    ebpf_preemptible_work_item_t* work_item = NULL;
 
     // Find the native entry in hash table.
     state = ebpf_lock_lock(&_ebpf_native_client_table_lock);
@@ -1359,7 +1361,8 @@ ebpf_native_unload(_In_ const GUID* module_id)
 
     // Create a work item if we are running at DISPATCH.
     if (!ebpf_is_preemptible()) {
-        result = ebpf_allocate_preemptible_work_item(&work_item, _ebpf_native_unload_work_item, service_name);
+        result = ebpf_allocate_preemptible_work_item(
+            &module->unloading_work_item, _ebpf_native_unload_work_item, service_name);
         if (result != EBPF_SUCCESS) {
             goto Done;
         }
@@ -1373,7 +1376,7 @@ ebpf_native_unload(_In_ const GUID* module_id)
     lock_acquired = false;
 
     if (queue_work_item) {
-        ebpf_queue_preemptible_work_item(work_item);
+        ebpf_queue_preemptible_work_item(module->unloading_work_item);
     } else {
         ebpf_native_unload_driver(service_name);
     }

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -442,6 +442,14 @@ extern "C"
         _In_opt_ void* work_item_context);
 
     /**
+     * @brief Free a preemptible work item.
+     *
+     * @param[in] work_item Pointer to the work item to free.
+     */
+    void
+    ebpf_free_preemptible_work_item(_Frees_ptr_opt_ ebpf_preemptible_work_item_t* work_item);
+
+    /**
      * @brief Schedule a preemptible work item to run.
      *
      * @param[in] work_item Work item to schedule.

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -529,6 +529,15 @@ Done:
 }
 
 void
+ebpf_free_preemptible_work_item(_Frees_ptr_opt_ ebpf_preemptible_work_item_t* work_item)
+{
+    if (work_item) {
+        IoFreeWorkItem(work_item->io_work_item);
+        ebpf_free(work_item);
+    }
+}
+
+void
 ebpf_queue_preemptible_work_item(_In_ ebpf_preemptible_work_item_t* work_item)
 {
     IoQueueWorkItem(work_item->io_work_item, _ebpf_preemptible_routine, DelayedWorkQueue, work_item);

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -754,6 +754,15 @@ Done:
     return result;
 }
 
+void
+ebpf_free_preemptible_work_item(_Frees_ptr_opt_ ebpf_preemptible_work_item_t* work_item)
+{
+    if (work_item) {
+        CloseThreadpoolWork(work_item->work);
+        ebpf_free(work_item);
+    }
+}
+
 typedef struct _ebpf_timer_work_item
 {
     TP_TIMER* threadpool_timer;


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Free the IO_WORKITEM and memory allocated by eBPF when unloading a native module.

## Testing

Covered by existing CI/CD.

## Documentation

No.

Resolves: #1364 
