### PR TITLE
Free preemptible work_item during native module unload

### DIFF
--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -442,6 +442,14 @@ extern "C"
         _In_opt_ void* work_item_context);
 
     /**
+     * @brief Free a preemptible work item.
+     *
+     * @param[in] work_item Pointer to the work item to free.
+     */
+    void
+    ebpf_free_preemptible_work_item(_Frees_ptr_opt_ ebpf_preemptible_work_item_t* work_item);
+
+    /**
      * @brief Schedule a preemptible work item to run.
      *
      * @param[in] work_item Work item to schedule.

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -494,10 +494,6 @@ _ebpf_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ PVOID cont
     }
     ebpf_preemptible_work_item_t* work_item = (ebpf_preemptible_work_item_t*)context;
     work_item->work_item_routine(work_item->work_item_context);
-
-    IoFreeWorkItem(work_item->io_work_item);
-    ebpf_free(work_item->work_item_context);
-    ebpf_free(work_item);
 }
 
 ebpf_result_t
@@ -526,6 +522,15 @@ Done:
         *work_item = NULL;
     }
     return result;
+}
+
+void
+ebpf_free_preemptible_work_item(_Frees_ptr_opt_ ebpf_preemptible_work_item_t* work_item)
+{
+    if (work_item) {
+        IoFreeWorkItem(work_item->io_work_item);
+        ebpf_free(work_item);
+    }
 }
 
 void

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -715,9 +715,6 @@ _ebpf_preemptible_routine(_Inout_ PTP_CALLBACK_INSTANCE instance, _In_opt_ PVOID
 
     ebpf_preemptible_work_item_t* work_item = (ebpf_preemptible_work_item_t*)parameter;
     work_item->work_item_routine(work_item->work_item_context);
-
-    ebpf_free(work_item->work_item_context);
-    ebpf_free(work_item);
 }
 
 void
@@ -752,6 +749,15 @@ Done:
         *work_item = nullptr;
     }
     return result;
+}
+
+void
+ebpf_free_preemptible_work_item(_Frees_ptr_opt_ ebpf_preemptible_work_item_t* work_item)
+{
+    if (work_item) {
+        CloseThreadpoolWork(work_item->work);
+        ebpf_free(work_item);
+    }
 }
 
 typedef struct _ebpf_timer_work_item


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

ebpf_queue_preemptible_work_item has undocumented / odd behavior. The documented behavior is that it runs the provided work item. The actual behavior is to run the work item, free it, and free memory passes as context.

## Testing

CI/CD

## Documentation

No. Doxygen comments now match code.
