### PR TITLE
Update nuget package to include export_program_info.exe

### DIFF
--- a/tools/nuget/ebpf-for-windows.nuspec
+++ b/tools/nuget/ebpf-for-windows.nuspec
@@ -20,6 +20,7 @@
   <files>
     <file src="..\..\x64\Release\Convert-BpfToNative.ps1"     target="build\native\bin"                    />
     <file src="..\..\x64\Release\bpf2c.exe"                   target="build\native\bin"                    />
+    <file src="..\..\x64\Release\export_program_info.exe"     target="build\native\bin"                    />
     <file src="..\..\x64\Release\ebpfapi.dll"                 target="build\native\bin"                    />
     <file src="..\..\x64\Release\ebpfapi.lib"                 target="build\native\lib"                    />
     <file src="..\..\include\**\*.*"                          target="build\native\include"                />


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

The development package needs to include export_program_info to permit building native images.

## Testing

No.

## Documentation

No.

Resolves: #1330 