### PR TITLE
Include hash of program information in metadata

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -101,6 +101,7 @@ EXPORTS
     ebpf_free_string
     ebpf_get_attach_type_name
     ebpf_get_next_pinned_program_path
+    ebpf_get_program_info_from_verifier
     ebpf_get_program_type_by_name
     ebpf_get_program_type_name
     ebpf_link_close

--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -78,6 +78,8 @@ extern "C"
         size_t bpf_instruction_count;
         ebpf_program_type_t* program_type;
         ebpf_attach_type_t* expected_attach_type;
+        const uint8_t* program_info_hash;
+        size_t program_info_hash_length;
     } program_entry_t;
 
     typedef struct _metadata_table

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -413,6 +413,20 @@ extern "C"
     ebpf_get_next_pinned_program_path(
         _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path);
 
+    typedef struct _ebpf_program_info ebpf_program_info_t;
+
+    /**
+     * @brief Get the set of program information used by the verifier during
+     * the last verification.
+     *
+     * @param[out] program_info Pointer to the program information used to
+     * verify the program.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_OBJECT_NOT_FOUND No program information was found.
+     */
+    ebpf_result_t
+    ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3256,6 +3256,17 @@ ebpf_get_program_type_by_name(
     EBPF_RETURN_RESULT(result);
 }
 
+ebpf_result_t
+ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    EBPF_LOG_ENTRY();
+
+    result = get_program_type_info(program_info);
+
+    EBPF_RETURN_RESULT(result);
+}
+
 _Ret_maybenull_ const ebpf_program_type_t*
 ebpf_get_ebpf_program_type(bpf_prog_type_t bpf_program_type) noexcept
 {

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -218,9 +218,14 @@ class bpf_code_generator
      * @param[in] section_name Section in the ELF file to parse.
      * @param[in] program_type Program type GUID for the section.
      * @param[in] attach_type Expected attach type GUID for the section.
+     * @param[in] program_info_hash Optional bytes containing hash of the program info.
      */
     void
-    parse(const unsafe_string& section_name, const GUID& program_type, const GUID& attach_type);
+    parse(
+        const unsafe_string& section_name,
+        const GUID& program_type,
+        const GUID& attach_type,
+        const std::optional<std::vector<uint8_t>>& program_info_hash);
 
     /**
      * @brief Parse global data (currently map information) in the eBPF file.
@@ -276,6 +281,7 @@ class bpf_code_generator
         unsafe_string program_name;
         GUID program_type = {0};
         GUID expected_attach_type = {0};
+        std::optional<std::vector<uint8_t>> program_info_hash;
         // Indices of the maps used in this section.
         std::set<size_t> referenced_map_indices;
         std::map<unsafe_string, helper_function_t> helper_functions;
@@ -302,9 +308,13 @@ class bpf_code_generator
      *
      * @param[in] program_type Program type GUID.
      * @param[in] attach_type Attach type GUID.
+     * @param[in] program_info_hash Hash of the program information used to verify this program.
      */
     void
-    set_program_and_attach_type(const GUID& program_type, const GUID& attach_type);
+    set_program_and_attach_type_and_hash(
+        const GUID& program_type,
+        const GUID& attach_type,
+        const std::optional<std::vector<uint8_t>>& program_info_hash);
 
     /**
      * @brief Extract the helper function and map relocation data from the eBPF file.


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Add a SHA256 hash of the program information used to verify that a program is safe to the program metadata. A subsequent change in EC will verify that the hash matches prior to permitting the attach to complete.

## Testing

CI/Cd

## Documentation

No.
