### PR TITLE
Create or update issue on workflow failure

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -26,7 +26,8 @@ concurrency:
 permissions:
   contents: read
   checks: read  # Required by reusable-test.yml to check build status.
-  security-events: write # Required by codeql task
+  security-events: write # Required by codeql task.
+  issues: write # Required to create issues.
 
 jobs:
   # Jobs to run on pull, push, and schedule.

--- a/.github/workflows/create-or-update-issue.yml
+++ b/.github/workflows/create-or-update-issue.yml
@@ -1,0 +1,78 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# This workflow executes a single test, optionally gathering code coverage and logs.
+
+name: Create or update an issue.
+
+on:
+  workflow_call:
+    inputs:
+      # The title of the issue to create or update.
+      title:
+        required: true
+        type: string
+      # The body of the issue to create or update.
+      body:
+        required: true
+        type: string
+      # Labels to add to the issue.
+      labels:
+        required: false
+        type: string
+
+permissions:
+  issues: write # Required to create issues.
+
+jobs:
+  create_or_update_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@c713e510dbd7d213d92d41b7a7805a986f4c5c66
+        env:
+          TITLE: ${{inputs.title}}
+          BODY: ${{inputs.body}}
+          LABELS: ${{inputs.labels}}
+
+        with:
+          script: |
+            # Extract the variables from the workflow.
+            const owner = process.env.GITHUB_REPOSITORY.split('/')[0]
+            const repo = process.env.GITHUB_REPOSITORY.split('/')[1]
+            const body = process.env.BODY;
+            const title = process.env.TITLE;
+            const labels = process.env.LABELS;
+            const label_array = labels ? labels.split(',') : [];
+            console.log(label_array);
+
+            # Get all issues that have these labels.
+            const opts = github.rest.issues.listForRepo.endpoint.merge({
+              ...context.issue,
+              state: 'open',
+              labels: label_array,
+            });
+            const issues = await github.paginate(opts);
+
+            # Look for an existing issue with the same title.
+            for (const issue of issues) {
+              if (issue.title === title) {
+                console.log(`Updating issue ${title}`);
+                await github.rest.issues.createComment({
+                  issue_number: issue.number,
+                  owner,
+                  repo,
+                  body,
+                });
+                return;
+              }
+            }
+
+            # Existing issue not found, create a new one.
+            console.log(`Creating issue ${title}`);
+            await github.rest.issues.create({
+              owner: owner,
+              repo: repo,
+              title: title,
+              body: body,
+              labels: label_array,
+            });

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -49,6 +49,7 @@ on:
 permissions:
   checks: read  # Required by fountainhead/action-wait-for-check to wait for another GitHub check to complete.
   contents: read  # Required by actions/checkout to fetch code.
+  issues: write # Required to create issues.
 
 jobs:
   run_test:
@@ -70,8 +71,6 @@ jobs:
     # Checking out the branch is needed to gather correct code coverage data.
     steps:
     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-      # Only check out source code if code coverage is being gathered.
-      if: inputs.code_coverage == true
       with:
         submodules: 'recursive'
         ref: ${{ github.event.workflow_run.head_branch }}
@@ -294,3 +293,16 @@ jobs:
     - name: Mark run as failed if crash dumps are found
       if: steps.check_dumps.outputs.files_exists == 'true'
       run: exit 1
+
+    - name: Create or update an issue if the workflow fails
+      if: failure() && ${{github.branch}} == 'main'
+      uses: ./.github/workflows/create-or-update-issue.yml
+      with:
+        title: Workflow failed - ${{env.NAME}}
+        body: |
+          [Failed Run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          [Codebase](https://github.com/${{ github.repository }}/tree/${{ github.sha }})
+          Test name -     `${{ github.workflow }}`
+          Job -           `${{ github.job }}`
+          status -        `${{ job.status }}`
+        labels: bug,ci/cd


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

When a test workflow fails on main, then either file a new issue or update any existing issue.

## Testing

CI/CD

## Documentation

No.

Resolves: #1273 
