### PR TITLE
Fix unregistering hook providers

### DIFF
--- a/netebpfext/net_ebpf_ext_drv.c
+++ b/netebpfext/net_ebpf_ext_drv.c
@@ -46,9 +46,9 @@ _net_ebpf_ext_driver_uninitialize_objects()
 {
     _net_ebpf_ext_driver_unloading_flag = TRUE;
 
-    net_ebpf_extension_uninitialize_wfp_components();
-
     net_ebpf_ext_unregister_providers();
+
+    net_ebpf_extension_uninitialize_wfp_components();
 
     net_ebpf_ext_uninitialize_ndis_handles();
 


### PR DESCRIPTION
## Description

This PR fixes #1272  by swapping the order of operations to unregister eBPF hook providers and unregistering WFP callouts. Unregistering eBPF hooks for sock_ops will ensure flow contexts are dis-associated from callouts which can then be unregistered successfully.

## Testing

Private testing + CI.

## Documentation

No documentation changes are needed.
