### PR TITLE
Fix script to use provide VM name

### DIFF
--- a/scripts/deploy-ebpf.ps1.in
+++ b/scripts/deploy-ebpf.ps1.in
@@ -261,7 +261,7 @@ if (! $principal.IsInRole([Security.Principal.WindowsBuiltinRole]::Administrator
    exit 1
 }
 
-Enable-VMIntegrationService -VMName "Windows 10 dev environment" -Name "Guest Service Interface"
+Enable-VMIntegrationService -VMName $vm -Name "Guest Service Interface"
 if (! $?) {
     exit 1
 }


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Deploy-ebpf.ps1 doesn't correctly handle passing the name of the target vm.

## Testing

Manual testing.

## Documentation

No.
