### PR TITLE
Enable docker tracking by dependabot - (#1463)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,9 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+
+  - package-ecosystem: "docker"
+    directory: "/images"
+    schedule:
+      interval: "weekly"
+      day: "saturday"


### PR DESCRIPTION
## Description

This PR enables ```dependabot``` tracking of our ```docker``` components.

## Testing

This is a ```dependabot``` enhancement and it's testing cannot be automated (hence no existing tests).  

Manually ensured that:
- the 'docker' entry shows up in github->Insights->Dependency Graph->Dependabot tab.
- the 'Check for updates' link (accessible from the 'Last checked xxx...' link for the 'docker' entry) does not show any errors.
- local testing with rolled back nanoserver sha256 tag values (in Dockerfile.install) correctly generates the requisite 'version bump' PR with the latest version.

## Documentation

1. Dependabot alerts need to be enabled (github -> security -> Dependabot) in the forked repository for this to work.

2. The docker image configuration file (named ```Dockerfile``` by default) can be called anything so long as the name contains the string 'dockerfile' (case insensitive).

3. the ```directory``` key for the 'docker' section in the ```dependabot``` configuration file ```dependabot.xml``` must specify the _exact_ location directory of the dockerfile (```/images``` in our case).   Not doing so causes dependabot's checks to fail.  Failure is visually indicated in the 'docker' entry in github->Insights->Dependency Graph->Dependabot tab, with failure log contents available through the 'Last checked xxx...' link at the same location.

