### PR TITLE
Add bpf2c test logs to test artifacts

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -246,7 +246,7 @@ jobs:
       run: wpr.exe -stop ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\TestLogs\ebpfforwindows.etl
 
     - name: Copy bpf2c test logs (if any) to Test Logs
-      if: inputs.capture_etw == true
+      if: (inputs.name == 'bpf2c') && (inputs.capture_etw == true)
       shell: cmd
       run: |
           set EBPF_ENABLE_WER_REPORT=yes

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -245,7 +245,7 @@ jobs:
       shell: cmd
       run: wpr.exe -stop ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\TestLogs\ebpfforwindows.etl
 
-    - name: Copy bpf2c test logs (if any) to Test Logs
+    - name: Copy any bpf2c test logs to TestLogs
       if: (inputs.name == 'bpf2c') && (inputs.capture_etw == true)
       shell: cmd
       run: |

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -245,6 +245,13 @@ jobs:
       shell: cmd
       run: wpr.exe -stop ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\TestLogs\ebpfforwindows.etl
 
+    - name: Copy bpf2c test logs (if any) to Test Logs
+      if: inputs.capture_etw == true
+      shell: cmd
+      run: |
+          set EBPF_ENABLE_WER_REPORT=yes
+          copy ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\*.log ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\TestLogs
+
     - name: Check for crash dumps
       uses: andstor/file-existence-action@f02338908d150e00a4b8bebc2dad18bd9e5229b0
       id: check_dumps

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -249,7 +249,6 @@ jobs:
       if: (inputs.name == 'bpf2c') && (inputs.capture_etw == true)
       shell: cmd
       run: |
-          set EBPF_ENABLE_WER_REPORT=yes
           copy ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\*.log ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\TestLogs
 
     - name: Check for crash dumps


### PR DESCRIPTION
## Description

Add a step in CICD to copy the .log files generated by bpf2c tests to the `TestLogs` folder, so that they can be uploaded as artifacts.

## Testing

NA

## Documentation

NA
