### PR TITLE
Resolve deprecation warning on 'Set output' action

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -198,7 +198,7 @@ jobs:
       id: packages
       shell: bash
       run: |
-        echo ::set-output name=REL_MSI_PACKAGE_PATH::$(ls build/setup/*.msi)
+        echo "REL_MSI_PACKAGE_PATH=$(ls build/setup/*.msi)" >> $GITHUB_STATE
 
     - name: Upload the MSI package
       if: matrix.configurations == 'Release' && inputs.generate_release_package == true


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

GitHub is deprecating the use of "::set-output" command in CI/CD and replacing it. See: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

## Testing

CI/CD

## Documentation

_Is there any documentation impact for this change?
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
