### PR TITLE
Replace KdPrintEx calls (in NetEbpfExt) with Trace logging calls (#1466)

### DIFF
--- a/netebpfext/net_ebpf_ext_tracelog.h
+++ b/netebpfext/net_ebpf_ext_tracelog.h
@@ -66,6 +66,70 @@ net_ebpf_ext_trace_terminate();
         TraceLoggingOpcode(WINEVENT_OPCODE_STOP),                               \
         TraceLoggingString(__FUNCTION__, "==>"));
 
+#define NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(keyword, api, status) \
+    TraceLoggingWrite(                                              \
+        net_ebpf_ext_tracelog_provider,                             \
+        NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                      \
+        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),               \
+        TraceLoggingKeyword((keyword)),                             \
+        TraceLoggingString(#api, "api"),                            \
+        TraceLoggingNTStatus(status));
+
+#define NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(keyword, api, status, message, value) \
+    TraceLoggingWrite(                                                                             \
+        net_ebpf_ext_tracelog_provider,                                                            \
+        NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                                                     \
+        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                              \
+        TraceLoggingKeyword((keyword)),                                                            \
+        TraceLoggingString(#api, "api"),                                                           \
+        TraceLoggingNTStatus(status),                                                              \
+        TraceLoggingString(message, "Message"),                                                    \
+        TraceLoggingString((value), (#value)));
+
+#define NET_EBPF_EXT_LOG_MESSAGE(trace_level, keyword, message) \
+    TraceLoggingWrite(                                          \
+        net_ebpf_ext_tracelog_provider,                         \
+        NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,            \
+        TraceLoggingLevel(trace_level),                         \
+        TraceLoggingKeyword((keyword)),                         \
+        TraceLoggingString(message, "Message"));
+
+#define NET_EBPF_EXT_LOG_MESSAGE_STRING(trace_level, keyword, message, value) \
+    TraceLoggingWrite(                                                        \
+        net_ebpf_ext_tracelog_provider,                                       \
+        NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                          \
+        TraceLoggingLevel(trace_level),                                       \
+        TraceLoggingKeyword((keyword)),                                       \
+        TraceLoggingString(message, "Message"),                               \
+        TraceLoggingString((value), (#value)));
+
+#define NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, keyword, message, status) \
+    TraceLoggingWrite(                                                           \
+        net_ebpf_ext_tracelog_provider,                                          \
+        NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                             \
+        TraceLoggingLevel(trace_level),                                          \
+        TraceLoggingKeyword((keyword)),                                          \
+        TraceLoggingString(message, "Message"),                                  \
+        TraceLoggingNTStatus(status));
+
+#define NET_EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, keyword, message, value) \
+    TraceLoggingWrite(                                                        \
+        net_ebpf_ext_tracelog_provider,                                       \
+        NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                          \
+        TraceLoggingLevel(trace_level),                                       \
+        TraceLoggingKeyword((keyword)),                                       \
+        TraceLoggingString(message, "Message"),                               \
+        TraceLoggingUInt32((value), (#value)));
+
+#define NET_EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, keyword, message, value) \
+    TraceLoggingWrite(                                                        \
+        net_ebpf_ext_tracelog_provider,                                       \
+        NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                          \
+        TraceLoggingLevel(trace_level),                                       \
+        TraceLoggingKeyword((keyword)),                                       \
+        TraceLoggingString(message, "Message"),                               \
+        TraceLoggingUInt64((value), (#value)));
+
 #define NET_EBPF_EXT_RETURN_RESULT(status)                 \
     do {                                                   \
         ebpf_result_t local_result = (status);             \
@@ -87,38 +151,3 @@ net_ebpf_ext_trace_terminate();
         }                                                  \
         return local_result;                               \
     } while (false);
-
-#define NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(keyword, api, status) \
-    TraceLoggingWrite(                                              \
-        net_ebpf_ext_tracelog_provider,                             \
-        NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                      \
-        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),               \
-        TraceLoggingKeyword((keyword)),                             \
-        TraceLoggingString(#api, "api"),                            \
-        TraceLoggingNTStatus(status));
-
-#define NET_EBPF_EXT_LOG_MESSAGE(trace_level, keyword, message) \
-    TraceLoggingWrite(                                          \
-        net_ebpf_ext_tracelog_provider,                         \
-        NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,            \
-        TraceLoggingLevel(trace_level),                         \
-        TraceLoggingKeyword((keyword)),                         \
-        TraceLoggingString(message, "Message"));
-
-#define NET_EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, keyword, message, value) \
-    TraceLoggingWrite(                                                        \
-        net_ebpf_ext_tracelog_provider,                                       \
-        NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                          \
-        TraceLoggingLevel(trace_level),                                       \
-        TraceLoggingKeyword((keyword)),                                       \
-        TraceLoggingString(message, "Message"),                               \
-        TraceLoggingUInt32((value), (#value)));
-
-#define NET_EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, keyword, message, value) \
-    TraceLoggingWrite(                                                        \
-        net_ebpf_ext_tracelog_provider,                                       \
-        NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE,                          \
-        TraceLoggingLevel(trace_level),                                       \
-        TraceLoggingKeyword((keyword)),                                       \
-        TraceLoggingString(message, "Message"),                               \
-        TraceLoggingUInt64((value), (#value)));

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -602,7 +602,7 @@ net_ebpf_ext_layer_2_classify(
     }
 
     if (nbl == NULL) {
-        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "Null NBL \n"));
+        NET_EBPF_EXT_LOG_MESSAGE(NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "Null NBL");
         goto Done;
     }
 
@@ -620,7 +620,9 @@ net_ebpf_ext_layer_2_classify(
 
     net_buffer = NET_BUFFER_LIST_FIRST_NB(nbl);
     if (net_buffer == NULL) {
-        KdPrintEx((DPFLTR_IHVDRIVER_ID, DPFLTR_ERROR_LEVEL, "net_buffer not present\n"));
+        NET_EBPF_EXT_LOG_MESSAGE(
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "net_buffer not present");
+
         // nothing to do
         goto Done;
     }


### PR DESCRIPTION
## Description

This PR replaces all KdPrintEx calls in the ```ebpf-for-windows\NetEbpfExt``` project with suitable ```NET_EBPF_EXT_LOG_XXX``` equivalents.

## Testing

These messages are generally printed on encountering errors from WFP API calls, so added some sample log messages to ensure the new tracelogging macros behave as expected. Specifically:

1. Ensure installation updated and locally modified ```NetEbpfExt.sys``` driver on the test VM device (via WinDbgX).
2. Enable tracing for Windows ebpf drivers.
3. Run ```api_test.exe``` application to generate traces.
4. Extract traces after termination of the ```api_test.exe``` and ensure that the sample trace messages are present in the trace output.

## Documentation

No doc updates needed for this change.

Resolves: #1466