### PR TITLE
Mark ebpf_result_t with _Must_inspect_result_

### DIFF
--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -13,7 +13,7 @@ extern "C"
 #endif
 
 #pragma warning(disable : 26812) // Prefer enum class
-    typedef _Return_type_success_(return == EBPF_SUCCESS) enum ebpf_result {
+    typedef _Must_inspect_result_ _Return_type_success_(return == EBPF_SUCCESS) enum ebpf_result {
         /// The operation was successful.
         EBPF_SUCCESS, // = 0
 

--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -13,7 +13,7 @@ extern "C"
 #endif
 
 #pragma warning(disable : 26812) // Prefer enum class
-    typedef _Must_inspect_result_ _Return_type_success_(return == EBPF_SUCCESS) enum ebpf_result {
+    typedef _Check_return_ _Return_type_success_(return == EBPF_SUCCESS) enum ebpf_result {
         /// The operation was successful.
         EBPF_SUCCESS, // = 0
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

## Description

Mark ebpf_result_t with _Must_inspect_result_ to catch cases where the return value is ignored.

## Testing

CI/CD

## Documentation

No.
