### PR TITLE
Annotate all functions that return ebpf_result_t with _Must_inspect_result_

### DIFF
--- a/ebpfapi/rpc_client.cpp
+++ b/ebpfapi/rpc_client.cpp
@@ -20,7 +20,7 @@
 static const WCHAR* _protocol_sequence = L"ncalrpc";
 static bool _binding_initialized = false;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_rpc_load_program(
     _In_ ebpf_program_load_info* info,
     _Outptr_result_maybenull_z_ const char** logs,

--- a/ebpfsvc/rpc_api.cpp
+++ b/ebpfsvc/rpc_api.cpp
@@ -11,7 +11,7 @@
 
 bool use_ebpf_store = false;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_server_verify_and_load_program(
     /* [ref][in] */ ebpf_program_load_info* info,
     /* [ref][out] */ uint32_t* logs_size,

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -36,7 +36,7 @@ extern "C"
      * @param[out] section_name On success, contains the section name.
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_query_info(
         fd_t fd,
         _Out_ ebpf_execution_type_t* execution_type,
@@ -72,7 +72,7 @@ extern "C"
 -     * @param[out] error_message On failure points to a text description of
 -     *  the error.
       */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_enumerate_sections(
         _In_z_ const char* file,
         bool verbose,
@@ -179,7 +179,7 @@ extern "C"
      *
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_object_unpin(_In_z_ const char* path);
 
     /**
@@ -190,7 +190,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operations succeeded.
      * @retval EBPF_INVALID_ARGUMENT The link handle is invalid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_api_unlink_program(ebpf_handle_t link_handle);
 
     /**
@@ -200,7 +200,7 @@ extern "C"
      * @retval EBPF_SUCCESS Handle was closed.
      * @retval EBPF_INVALID_OBJECT Handle is not valid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_api_close_handle(ebpf_handle_t handle);
 
     /**
@@ -213,7 +213,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Out of memory.
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_api_get_pinned_map_info(
         _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info);
 
@@ -247,7 +247,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type);
 
     /**
@@ -266,7 +266,7 @@ extern "C"
      *
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_attach(
         _In_ const struct bpf_program* program,
         _In_opt_ const ebpf_attach_type_t* attach_type,
@@ -290,7 +290,7 @@ extern "C"
      *
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_attach_by_fd(
         fd_t program_fd,
         _In_opt_ const ebpf_attach_type_t* attach_type,
@@ -307,7 +307,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_OBJECT Invalid object was passed.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_detach(_In_ struct bpf_link* link);
 
     /**
@@ -323,7 +323,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_OBJECT Invalid object was passed.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_detach(
         fd_t program_fd,
         _In_ const ebpf_attach_type_t* attach_type,
@@ -342,7 +342,7 @@ extern "C"
      * @sa bpf_link__destroy
      * @sa bpf_link_detach
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link);
 
     /**
@@ -352,7 +352,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_FD Invalid fd was provided.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_close_fd(fd_t fd);
 
     /**
@@ -365,7 +365,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_KEY_NOT_FOUND No program type was found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_get_program_type_by_name(
         _In_z_ const char* name,
         _Out_ ebpf_program_type_t* program_type,
@@ -400,7 +400,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MORE_KEYS No more entries found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_get_next_pinned_program_path(
         _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path);
 
@@ -415,7 +415,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND No program information was found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info);
 
 #ifdef __cplusplus

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -158,7 +158,7 @@ _get_program_and_map_names(
     }
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* sectionname,

--- a/libs/api/Verifier.h
+++ b/libs/api/Verifier.h
@@ -11,7 +11,7 @@
 typedef int (*map_create_fp)(
     uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* sectionname,

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -137,7 +137,7 @@ ebpf_program_previous(_In_opt_ const struct bpf_program* next, _In_ const struct
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_unload(_In_ struct bpf_program* program) noexcept;
 
 /**
@@ -149,7 +149,7 @@ ebpf_program_unload(_In_ struct bpf_program* program) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_bind_map(fd_t program_fd, fd_t map_fd) noexcept;
 
 /**
@@ -188,7 +188,7 @@ ebpf_map_previous(_In_opt_ const struct bpf_map* next, _In_ const struct bpf_obj
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  * @retval EBPF_NO_MEMORY Out of memory.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_create(
     enum bpf_map_type map_type,
     _In_opt_z_ const char* map_name,
@@ -226,7 +226,7 @@ initialize_map(_Out_ ebpf_map_t* map, _In_ const map_cache_t& map_cache) noexcep
  *
  * @retval EBPF_SUCCESS The operation was successful.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_pin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept;
 
 /**
@@ -236,7 +236,7 @@ ebpf_map_pin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept;
  *
  * @retval EBPF_SUCCESS The operation was successful.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_unpin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept;
 
 /**
@@ -248,7 +248,7 @@ ebpf_map_unpin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept;
  * @retval EBPF_NO_MEMORY Out of memory.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_set_pin_path(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept;
 
 /**
@@ -260,7 +260,7 @@ ebpf_map_set_pin_path(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noe
  *
  * @retval EBPF_SUCCESS The operation was successful.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_update_element(fd_t map_fd, _In_opt_ const void* key, _In_ const void* value, uint64_t flags) noexcept;
 
 /**
@@ -271,7 +271,7 @@ ebpf_map_update_element(fd_t map_fd, _In_opt_ const void* key, _In_ const void* 
  *
  * @retval EBPF_SUCCESS The operation was successful.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_delete_element(fd_t map_fd, _In_ const void* key) noexcept;
 
 /**
@@ -285,7 +285,7 @@ ebpf_map_delete_element(fd_t map_fd, _In_ const void* key) noexcept;
  *
  * @retval EBPF_SUCCESS The operation was successful.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_lookup_element(fd_t map_fd, _In_opt_ const void* key, _Out_ void* value) noexcept;
 
 /**
@@ -300,7 +300,7 @@ ebpf_map_lookup_element(fd_t map_fd, _In_opt_ const void* key, _Out_ void* value
  *
  * @retval EBPF_SUCCESS The operation was successful.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_lookup_and_delete_element(fd_t map_fd, _In_opt_ const void* key, _Out_ void* value) noexcept;
 
 /**
@@ -315,7 +315,7 @@ ebpf_map_lookup_and_delete_element(fd_t map_fd, _In_opt_ const void* key, _Out_ 
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_NO_MORE_KEYS previous_key was the last key.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_ void* next_key) noexcept;
 
 /**
@@ -326,7 +326,7 @@ ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_ void
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_FD The file descriptor was not valid.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_detach_link_by_fd(fd_t fd) noexcept;
 
 /**
@@ -338,7 +338,7 @@ ebpf_detach_link_by_fd(fd_t fd) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_PARAMETER No such ID found.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_map_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
 
 /**
@@ -350,7 +350,7 @@ ebpf_get_map_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_PARAMETER No such ID found.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_program_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
 
 /**
@@ -362,7 +362,7 @@ ebpf_get_program_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_PARAMETER No such ID found.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
 
 /**
@@ -374,7 +374,7 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_NO_MORE_KEYS No more IDs found.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_link_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
 
 /**
@@ -386,7 +386,7 @@ ebpf_get_next_link_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_NO_MORE_KEYS No more IDs found.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_map_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
 
 /**
@@ -398,7 +398,7 @@ ebpf_get_next_map_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_NO_MORE_KEYS No more IDs found.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_program_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
 
 /**
@@ -420,7 +420,7 @@ ebpf_get_next_program_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_get_info_by_fd(
     fd_t bpf_fd, _Inout_updates_bytes_to_(*info_size, *info_size) void* info, _Inout_ uint32_t* info_size) noexcept;
 
@@ -431,7 +431,7 @@ ebpf_object_get_info_by_fd(
  *
  * @retval EBPF_SUCCESS The operation was successful.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_pin(fd_t fd, _In_z_ const char* path) noexcept;
 
 /**
@@ -462,7 +462,7 @@ ebpf_object_get(_In_z_ const char* path) noexcept;
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  * @retval EBPF_NO_MEMORY Out of memory.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_open(
     _In_z_ const char* path,
     _In_opt_z_ const char* object_name,
@@ -481,7 +481,7 @@ ebpf_object_open(
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  * @retval EBPF_NO_MEMORY Out of memory.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_load(_Inout_ struct bpf_object* object) noexcept;
 
 /**
@@ -492,7 +492,7 @@ ebpf_object_load(_Inout_ struct bpf_object* object) noexcept;
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_unload(_In_ struct bpf_object* object) noexcept;
 
 typedef int (*ring_buffer_sample_fn)(void* ctx, void* data, size_t size);
@@ -508,7 +508,7 @@ typedef int (*ring_buffer_sample_fn)(void* ctx, void* data, size_t size);
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_NO_MEMORY Out of memory.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_subscribe(
     fd_t ring_buffer_map_fd,
     _In_opt_ void* sample_callback_context,
@@ -562,7 +562,7 @@ ebpf_api_elf_enumerate_sections(
  * @retval EBPF_VERIFICATION_FAILED The program failed verification.
  * @retval EBPF_FAILED Some other error occured.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_load_bytes(
     _In_ const ebpf_program_type_t* program_type,
     _In_opt_z_ const char* program_name,

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -229,7 +229,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_create(
     enum bpf_map_type map_type,
     _In_opt_z_ const char* map_name,
@@ -425,7 +425,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_lookup_element(fd_t map_fd, _In_opt_ const void* key, _Out_ void* value) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -434,7 +434,7 @@ ebpf_map_lookup_element(fd_t map_fd, _In_opt_ const void* key, _Out_ void* value
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_lookup_and_delete_element(fd_t map_fd, _In_opt_ const void* key, _Out_ void* value) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -509,7 +509,7 @@ _update_map_element_with_handle(
     EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer)));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_update_element(fd_t map_fd, _In_opt_ const void* key, _In_ const void* value, uint64_t flags) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -574,7 +574,7 @@ ebpf_map_update_element(fd_t map_fd, _In_opt_ const void* key, _In_ const void* 
     }
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_delete_element(fd_t map_fd, _In_ const void* key) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -635,7 +635,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_get_next_key(fd_t map_fd, _In_opt_ const void* previous_key, _Out_ void* next_key) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -761,7 +761,7 @@ ebpf_free_string(_In_opt_ _Post_invalid_ const char* error_message)
     EBPF_LOG_EXIT();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_pin(fd_t fd, _In_z_ const char* path) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -791,7 +791,7 @@ ebpf_object_pin(fd_t fd, _In_z_ const char* path) noexcept
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_unpin(_In_z_ const char* path)
 {
     EBPF_LOG_ENTRY();
@@ -807,7 +807,7 @@ ebpf_object_unpin(_In_z_ const char* path)
     EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(invoke_ioctl(request_buffer)));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_pin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -843,7 +843,7 @@ ebpf_map_pin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_set_pin_path(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -861,7 +861,7 @@ ebpf_map_set_pin_path(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noe
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_unpin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -915,7 +915,7 @@ ebpf_object_get(_In_z_ const char* path) noexcept
     EBPF_RETURN_FD(fd);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_query_info(
     fd_t fd,
     _Out_ ebpf_execution_type_t* execution_type,
@@ -1070,7 +1070,7 @@ _detach_link_by_handle(ebpf_handle_t link_handle) noexcept
     EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(invoke_ioctl(request)));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_detach_link_by_fd(fd_t fd) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -1082,7 +1082,7 @@ ebpf_detach_link_by_fd(fd_t fd) noexcept
     EBPF_RETURN_RESULT(_detach_link_by_handle(link_handle));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_attach(
     _In_ const struct bpf_program* program,
     _In_opt_ const ebpf_attach_type_t* attach_type,
@@ -1119,7 +1119,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_attach_by_fd(
     fd_t program_fd,
     _In_opt_ const ebpf_attach_type_t* attach_type,
@@ -1151,7 +1151,7 @@ ebpf_program_attach_by_fd(
         _link_ebpf_program(program_handle, attach_type, link, (uint8_t*)attach_parameters, attach_parameters_size));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_api_unlink_program(ebpf_handle_t link_handle)
 {
     EBPF_LOG_ENTRY();
@@ -1163,7 +1163,7 @@ ebpf_api_unlink_program(ebpf_handle_t link_handle)
     EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(invoke_ioctl(request)));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_detach(_In_ struct bpf_link* link)
 {
     EBPF_LOG_ENTRY();
@@ -1171,7 +1171,7 @@ ebpf_link_detach(_In_ struct bpf_link* link)
     EBPF_RETURN_RESULT(_detach_link_by_handle(link->handle));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_detach(
     fd_t program_fd,
     _In_ const ebpf_attach_type_t* attach_type,
@@ -1213,7 +1213,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link)
 {
     EBPF_LOG_ENTRY();
@@ -1223,7 +1223,7 @@ ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link)
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_api_close_handle(ebpf_handle_t handle)
 {
     EBPF_LOG_ENTRY();
@@ -1233,7 +1233,7 @@ ebpf_api_close_handle(ebpf_handle_t handle)
     EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(invoke_ioctl(request)));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_api_get_pinned_map_info(
     _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info)
 {
@@ -2138,7 +2138,7 @@ _ebpf_enumerate_native_sections(
     EBPF_RETURN_RESULT(context.result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_enumerate_sections(
     _In_z_ const char* file,
     bool verbose,
@@ -2157,7 +2157,7 @@ ebpf_enumerate_sections(
     }
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_open(
     _In_z_ const char* path,
     _In_opt_z_ const char* object_name,
@@ -2210,7 +2210,7 @@ _ebpf_is_map_in_map(ebpf_map_t* map) noexcept
     EBPF_RETURN_BOOL(false);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type)
 {
     if (Platform::_is_native_program(object->file_name)) {
@@ -2384,7 +2384,7 @@ _ebpf_object_create_maps(_Inout_ ebpf_object_t* object) noexcept(false)
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_load_bytes(
     _In_ const ebpf_program_type_t* program_type,
     _In_opt_z_ const char* program_name,
@@ -2563,7 +2563,7 @@ _ebpf_object_load_programs(_Inout_ struct bpf_object* object) noexcept(false)
 }
 
 // This logic is intended to be similar to libbpf's bpf_object__load_xattr().
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_load(_Inout_ struct bpf_object* object) noexcept
 {
     ebpf_result_t result;
@@ -2613,7 +2613,7 @@ Done:
 }
 
 // This function is intended to work like libbpf's bpf_object__unload().
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_unload(_In_ struct bpf_object* object) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -2638,7 +2638,7 @@ ebpf_object_unload(_In_ struct bpf_object* object) noexcept
 }
 
 // This function is intended to work like libbpf's bpf_program__unload().
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_unload(_In_ struct bpf_program* program) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -3128,7 +3128,7 @@ _get_fd_by_id(ebpf_operation_id_t operation, ebpf_id_t id, _Out_ int* fd) noexce
     EBPF_RETURN_RESULT((*fd == ebpf_fd_invalid) ? EBPF_NO_MEMORY : EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_map_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -3136,7 +3136,7 @@ ebpf_get_map_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept
     EBPF_RETURN_RESULT(_get_fd_by_id(ebpf_operation_id_t::EBPF_OPERATION_GET_MAP_HANDLE_BY_ID, id, fd));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_program_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -3144,7 +3144,7 @@ ebpf_get_program_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept
     EBPF_RETURN_RESULT(_get_fd_by_id(ebpf_operation_id_t::EBPF_OPERATION_GET_PROGRAM_HANDLE_BY_ID, id, fd));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -3152,7 +3152,7 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept
     EBPF_RETURN_RESULT(_get_fd_by_id(ebpf_operation_id_t::EBPF_OPERATION_GET_LINK_HANDLE_BY_ID, id, fd));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_pinned_program_path(
     _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path)
 {
@@ -3211,7 +3211,7 @@ _get_next_id(ebpf_operation_id_t operation, ebpf_id_t start_id, _Out_ ebpf_id_t*
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_link_id(ebpf_id_t start_id, _Out_ ebpf_id_t* next_id) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -3219,7 +3219,7 @@ ebpf_get_next_link_id(ebpf_id_t start_id, _Out_ ebpf_id_t* next_id) noexcept
     EBPF_RETURN_RESULT(_get_next_id(ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_LINK_ID, start_id, next_id));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_map_id(ebpf_id_t start_id, _Out_ ebpf_id_t* next_id) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -3227,7 +3227,7 @@ ebpf_get_next_map_id(ebpf_id_t start_id, _Out_ ebpf_id_t* next_id) noexcept
     EBPF_RETURN_RESULT(_get_next_id(ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_MAP_ID, start_id, next_id));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_program_id(ebpf_id_t start_id, _Out_ ebpf_id_t* next_id) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -3235,7 +3235,7 @@ ebpf_get_next_program_id(ebpf_id_t start_id, _Out_ ebpf_id_t* next_id) noexcept
     EBPF_RETURN_RESULT(_get_next_id(ebpf_operation_id_t::EBPF_OPERATION_GET_NEXT_PROGRAM_ID, start_id, next_id));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_get_info_by_fd(
     fd_t bpf_fd, _Inout_updates_bytes_to_(*info_size, *info_size) void* info, _Inout_ uint32_t* info_size) noexcept
 {
@@ -3251,7 +3251,7 @@ ebpf_object_get_info_by_fd(
     EBPF_RETURN_RESULT(ebpf_object_get_info(handle, info, info_size));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_program_type_by_name(
     _In_z_ const char* name, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* expected_attach_type)
 {
@@ -3266,7 +3266,7 @@ ebpf_get_program_type_by_name(
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info)
 {
     ebpf_result_t result = EBPF_SUCCESS;
@@ -3309,7 +3309,7 @@ ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type)
     EBPF_RETURN_POINTER(const char*, get_attach_type_name(attach_type));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_bind_map(fd_t program_fd, fd_t map_fd) noexcept
 {
     EBPF_LOG_ENTRY();
@@ -3472,7 +3472,7 @@ _ebpf_ring_buffer_map_async_query_completion(_Inout_ void* completion_context) n
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_subscribe(
     fd_t ring_buffer_map_fd,
     _In_opt_ void* sample_callback_context,

--- a/libs/api/rpc_client.h
+++ b/libs/api/rpc_client.h
@@ -12,7 +12,7 @@ initialize_rpc_binding(void);
 RPC_STATUS
 clean_up_rpc_binding(void);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_rpc_load_program(
     _In_ ebpf_program_load_info* info,
     _Outptr_result_maybenull_z_ const char** logs,

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -59,7 +59,7 @@ get_file_size(const char* filename, size_t* byte_code_size) noexcept
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_get_info(
     ebpf_handle_t handle,
     _Inout_updates_bytes_to_(*info_size, *info_size) void* info,
@@ -93,7 +93,7 @@ ebpf_object_get_info(
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 query_map_definition(
     ebpf_handle_t handle,
     _Out_ uint32_t* type,

--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -140,13 +140,13 @@ ebpf_result_to_errno(ebpf_result_t result)
     return error;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_get_info(
     ebpf_handle_t handle,
     _Inout_updates_bytes_to_(*info_size, *info_size) void* info,
     _Inout_ uint32_t* info_size) noexcept;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 query_map_definition(
     ebpf_handle_t handle,
     _Out_ uint32_t* type,

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -27,7 +27,7 @@ typedef struct _async_ioctl_completion_context
 static ebpf_handle_t _device_handle = ebpf_handle_invalid;
 static std::mutex _mutex;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 initialize_device_handle()
 {
     std::scoped_lock lock(_mutex);
@@ -86,7 +86,7 @@ clean_up_async_ioctl_completion(_Inout_opt_ _Post_invalid_ async_ioctl_completio
     }
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 register_wait_async_ioctl_operation(_Inout_ async_ioctl_completion_t* async_ioctl_completion)
 {
     ebpf_result_t result = EBPF_SUCCESS;
@@ -141,7 +141,7 @@ get_async_ioctl_operation_overlapped(_In_ const async_ioctl_completion_t* async_
     return const_cast<OVERLAPPED*>(&async_ioctl_completion->overlapped);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 get_async_ioctl_result(_In_ const async_ioctl_completion_t* ioctl_completion)
 {
     DWORD dummy;
@@ -154,7 +154,7 @@ get_async_ioctl_result(_In_ const async_ioctl_completion_t* ioctl_completion)
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 initialize_async_ioctl_operation(
     _Inout_opt_ void* callback_context,
     _In_ const async_ioctl_completion_callback_t callback,

--- a/libs/api_common/device_helper.hpp
+++ b/libs/api_common/device_helper.hpp
@@ -24,7 +24,7 @@ typedef struct empty_reply
 
 static empty_reply_t _empty_reply;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 initialize_device_handle();
 
 void
@@ -37,13 +37,13 @@ typedef ebpf_result_t (*async_ioctl_completion_callback_t)(_Inout_opt_ void* com
 
 typedef struct _async_ioctl_completion_context async_ioctl_completion_t;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 initialize_async_ioctl_operation(
     _Inout_opt_ void* callback_context,
     _In_ const async_ioctl_completion_callback_t callback,
     _Outptr_ async_ioctl_completion_t** async_ioctl_completion);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 register_wait_async_ioctl_operation(_Inout_ async_ioctl_completion_t* async_ioctl_completion);
 
 void
@@ -55,7 +55,7 @@ get_async_ioctl_operation_overlapped(_In_ const async_ioctl_completion_t* ioctl_
 bool
 cancel_async_ioctl(_In_opt_ OVERLAPPED* overlapped);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 get_async_ioctl_result(_In_ const async_ioctl_completion_t* ioctl_completion);
 
 template <typename request_t, typename reply_t = empty_reply_t>

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -273,7 +273,7 @@ Exit:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_store_load_program_information(
     _Outptr_result_buffer_maybenull_(*program_info_count) ebpf_program_info_t*** program_info,
     _Out_ uint32_t* program_info_count)
@@ -468,7 +468,7 @@ Exit:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_store_load_section_information(
     _Outptr_result_buffer_maybenull_(*section_info_count) ebpf_section_definition_t*** section_info,
     _Out_ uint32_t* section_info_count)
@@ -556,7 +556,7 @@ Exit:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_store_load_global_helper_information(
     _Outptr_result_buffer_maybenull_(*global_helper_info_count) ebpf_helper_function_prototype_t** global_helper_info,
     _Out_ uint32_t* global_helper_info_count)

--- a/libs/api_common/store_helper_internal.h
+++ b/libs/api_common/store_helper_internal.h
@@ -5,17 +5,17 @@
 
 #include "windows_program_type.h"
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_store_load_program_information(
     _Outptr_result_buffer_maybenull_(*program_info_count) ebpf_program_info_t*** program_info,
     _Out_ uint32_t* program_info_count);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_store_load_section_information(
     _Outptr_result_buffer_maybenull_(*section_info_count) ebpf_section_definition_t*** section_info,
     _Out_ uint32_t* section_info_count);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_store_load_global_helper_information(
     _Outptr_result_buffer_maybenull_(*global_helper_info_count) ebpf_helper_function_prototype_t** global_helper_info,
     _Out_ uint32_t* global_helper_info_count);

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -318,7 +318,7 @@ get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) noexcept
     return BPF_ATTACH_TYPE_UNSPEC;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 get_bpf_program_and_attach_type(
     const std::string& section, _Out_ bpf_prog_type_t* program_type, _Out_ bpf_attach_type_t* attach_type)
 {
@@ -337,7 +337,7 @@ Exit:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 get_program_and_attach_type(
     const std::string& section, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* attach_type)
 {
@@ -663,7 +663,7 @@ Exit:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 load_ebpf_provider_data()
 {
     ebpf_result_t result = _load_all_program_data_information();

--- a/libs/api_common/windows_platform_common.hpp
+++ b/libs/api_common/windows_platform_common.hpp
@@ -23,11 +23,11 @@ get_program_type_windows(const std::string& section, const std::string& path);
 EbpfMapDescriptor&
 get_map_descriptor_windows(int map_fd);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 get_bpf_program_and_attach_type(
     const std::string& section, _Out_ bpf_prog_type_t* program_type, _Out_ bpf_attach_type_t* attach_type);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 get_program_and_attach_type(
     const std::string& section, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* attach_type);
 
@@ -40,7 +40,7 @@ get_attach_type_windows(const std::string& section);
 _Ret_maybenull_z_ const char*
 get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 load_ebpf_provider_data();
 
 void

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -55,7 +55,7 @@ _prog_type_supports_interface(bpf_prog_type prog_type)
     return (prog_type == BPF_PROG_TYPE_XDP);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 _process_interface_parameter(_In_ LPWSTR interface_parameter, bpf_prog_type prog_type, _Out_ uint32_t* if_index)
 {
     ebpf_result_t result = EBPF_SUCCESS;
@@ -373,7 +373,7 @@ handle_ebpf_delete_program(
     return NO_ERROR;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 _ebpf_program_attach_by_id(ebpf_id_t program_id, ebpf_attach_type_t attach_type, _In_opt_ LPWSTR interface_parameter)
 {
     ebpf_result_t result = EBPF_SUCCESS;

--- a/libs/ebpfnetsh/utilities.cpp
+++ b/libs/ebpfnetsh/utilities.cpp
@@ -19,7 +19,7 @@ down_cast_from_wstring(const std::wstring& wide_string)
     return converter.to_bytes(wide_string);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 parse_if_index(_In_z_ const wchar_t* arg, _Out_ uint32_t* if_index)
 {
     ebpf_result_t result = EBPF_SUCCESS;

--- a/libs/ebpfnetsh/utilities.h
+++ b/libs/ebpfnetsh/utilities.h
@@ -18,5 +18,5 @@ down_cast_from_wstring(const std::wstring& wide_string);
  * @retval EBPF_SUCCESS Operation succeeded.
  * @retval EBPF_INVALID_ARGUMENT Input string could not be converted to interface index.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 parse_if_index(_In_z_ const wchar_t* arg, _Out_ uint32_t* if_index);

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -31,7 +31,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_initiate();
 
     /**
@@ -55,7 +55,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_invoke_protocol_handler(
         ebpf_operation_id_t operation_id,
         _In_reads_bytes_(input_buffer_length) const void* input_buffer,
@@ -76,7 +76,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_SUPPORTED The operation id is not valid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_get_protocol_handler_properties(
         ebpf_operation_id_t operation_id,
         _Out_ size_t* minimum_request_size,
@@ -123,7 +123,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_FOUND No object was pinned to the provided path.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_get_pinned_object(_In_ const ebpf_utf8_string_t* path, _Out_ ebpf_handle_t* handle);
 
     /**
@@ -138,7 +138,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      * @retval EBPF_NOT_FOUND No object was pinned to the provided path.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_update_pinning(const ebpf_handle_t handle, _In_ const ebpf_utf8_string_t* path);
 
     /**
@@ -152,7 +152,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_create_map(
         _In_ const ebpf_utf8_string_t* map_name,
         _In_ const ebpf_map_definition_in_memory_t* ebpf_map_definition,
@@ -171,7 +171,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_load_code(
         ebpf_handle_t program_handle,
         ebpf_code_type_t code_type,
@@ -191,7 +191,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_get_handle_by_id(ebpf_object_type_t type, ebpf_id_t id, _Out_ ebpf_handle_t* handle);
 
     /**
@@ -209,7 +209,7 @@ extern "C"
      * @retval EBPF_INVALID_FD The program is incompatible with the map.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_resolve_maps(
         ebpf_handle_t program_handle,
         uint32_t count_of_maps,
@@ -230,7 +230,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT An invalid argument was supplied.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_resolve_helper(
         ebpf_handle_t program_handle,
         const size_t count_of_helpers,

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -43,7 +43,7 @@ _ebpf_link_free(ebpf_core_object_t* object)
     ebpf_epoch_free(link);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_create(ebpf_link_t** link)
 {
     EBPF_LOG_ENTRY();
@@ -63,7 +63,7 @@ ebpf_link_create(ebpf_link_t** link)
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_initialize(
     ebpf_link_t* link, ebpf_attach_type_t attach_type, const uint8_t* context_data, size_t context_data_length)
 {
@@ -127,7 +127,7 @@ Exit:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_attach_program(ebpf_link_t* link, ebpf_program_t* program)
 {
     EBPF_LOG_ENTRY();
@@ -210,7 +210,7 @@ Exit:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_get_info(
     _In_ const ebpf_link_t* link, _Out_writes_to_(*info_size, *info_size) uint8_t* buffer, _Inout_ uint16_t* info_size)
 {

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -23,7 +23,7 @@ extern "C"
      *  link object.
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_create(ebpf_link_t** link);
 
     /**
@@ -37,7 +37,7 @@ extern "C"
      *  provider.
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_initialize(
         ebpf_link_t* link, ebpf_attach_type_t attach_type, const uint8_t* context_data, size_t context_data_length);
 
@@ -50,7 +50,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT Hook instance has not been
      *  initialized.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_attach_program(ebpf_link_t* link, ebpf_program_t* program);
 
     /**
@@ -72,7 +72,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_link_info.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_get_info(
         _In_ const ebpf_link_t* link,
         _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -28,7 +28,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  map.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_create(
         _In_ const ebpf_utf8_string_t* map_name,
         _In_ const ebpf_map_definition_in_memory_t* ebpf_map_definition,
@@ -63,7 +63,7 @@ extern "C"
      * @param[in] flags Zero or more EBPF_MAP_FIND_ENTRY_FLAG_* flags.
      * @return Pointer to the value if found or NULL.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_find_entry(
         _In_ ebpf_map_t* map,
         size_t key_size,
@@ -84,7 +84,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  entry.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_update_entry(
         _In_ ebpf_map_t* map,
         size_t key_size,
@@ -105,7 +105,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  entry.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_update_entry_with_handle(
         _In_ ebpf_map_t* map,
         size_t key_size,
@@ -122,7 +122,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are
      *  invalid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags);
 
     /**
@@ -137,7 +137,7 @@ extern "C"
      * @retval EBPF_NO_MORE_KEYS There is no key following the specified
      * key in lexicographically order.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_next_key(
         _In_ ebpf_map_t* map,
         size_t key_size,
@@ -167,7 +167,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_FD The program is incompatible with this map.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_associate_program(_In_ ebpf_map_t* map, _In_ const struct _ebpf_program* program);
 
     /**
@@ -181,7 +181,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_map_info.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_get_info(
         _In_ const ebpf_map_t* map,
         _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,
@@ -195,7 +195,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully mapped the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to map the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_query_buffer(_In_ const ebpf_map_t* map, _Outptr_ uint8_t** buffer);
 
     /**
@@ -206,7 +206,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully returned records to the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to return records to the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_return_buffer(_In_ const ebpf_map_t* map, size_t length);
 
     /**
@@ -218,7 +218,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Insufficient memory to complete this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_async_query(
         _In_ ebpf_map_t* map,
         _Inout_ ebpf_ring_buffer_map_async_query_result_t* async_query_result,
@@ -233,7 +233,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully wrote record into ring buffer.
      * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_output(_In_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length);
 
     /**
@@ -248,7 +248,7 @@ extern "C"
      *  entry.
      * @retval EBPF_OUT_OF_SPACE Map is full and BPF_EXIST was not supplied.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_push_entry(
         _In_ ebpf_map_t* map, size_t value_size, _In_reads_(value_size) const uint8_t* value, int flags);
 
@@ -263,7 +263,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND The map is empty.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_pop_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
 
     /**
@@ -277,7 +277,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND The map is empty.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_peek_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
 
     /**

--- a/libs/execution_context/ebpf_native.h
+++ b/libs/execution_context/ebpf_native.h
@@ -20,7 +20,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_initiate();
 
     /**
@@ -46,7 +46,7 @@ extern "C"
      * @retval EBPF_OBJECT_ALREADY_EXISTS Native module for this module ID is already
      *  initialized.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_load(
         _In_reads_(service_name_length) const wchar_t* service_name,
         uint16_t service_name_length,
@@ -72,7 +72,7 @@ extern "C"
      * @retval EBPF_OBJECT_ALREADY_EXISTS Native module for this module ID is already
      *  loaded.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_load_programs(
         _In_ const GUID* module_id,
         size_t count_of_map_handles,
@@ -89,7 +89,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND Specified module was not found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_get_count_of_programs(_In_ const GUID* module_id, _Out_ size_t* count_of_programs);
 
     /**
@@ -101,7 +101,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND Specified module was not found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_get_count_of_maps(_In_ const GUID* module_id, _Out_ size_t* count_of_maps);
 
     /**
@@ -112,7 +112,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate memory for service name.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_unload(_In_ const GUID* module_id);
 
     /**

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -861,7 +861,8 @@ ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out
         }
     }
 
-    ebpf_state_store(_ebpf_program_state_index, 0);
+    // Ignore failure to cleanup state.
+    (void)ebpf_state_store(_ebpf_program_state_index, 0);
 }
 
 static ebpf_result_t

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -75,7 +75,7 @@ typedef struct _ebpf_program
 static ebpf_result_t
 _ebpf_program_register_helpers(_In_ const ebpf_program_t* program);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_initiate()
 {
     return ebpf_state_allocate_index(&_ebpf_program_state_index);
@@ -392,7 +392,7 @@ Done:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_create(_Outptr_ ebpf_program_t** program)
 {
     EBPF_LOG_ENTRY();
@@ -433,7 +433,7 @@ Done:
     EBPF_RETURN_RESULT(retval);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_initialize(_Inout_ ebpf_program_t* program, _In_ const ebpf_program_parameters_t* program_parameters)
 {
     EBPF_LOG_ENTRY();
@@ -516,7 +516,7 @@ ebpf_expected_attach_type(_In_ const ebpf_program_t* program)
     return &ebpf_program_get_parameters(program)->expected_attach_type;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_associate_additional_map(ebpf_program_t* program, ebpf_map_t* map)
 {
     EBPF_LOG_ENTRY();
@@ -547,7 +547,7 @@ Done:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t maps_count)
 {
     EBPF_LOG_ENTRY();
@@ -748,7 +748,7 @@ Done:
 }
 #endif
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_load_code(
     _Inout_ ebpf_program_t* program,
     ebpf_code_type_t code_type,
@@ -789,7 +789,7 @@ typedef struct _ebpf_program_tail_call_state
     uint32_t count;
 } ebpf_program_tail_call_state_t;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_set_tail_call(_In_ const ebpf_program_t* next_program)
 {
     // High volume call - Skip entry/exit logging.
@@ -900,7 +900,7 @@ _ebpf_program_get_helper_function_address(
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_get_helper_function_addresses(
     _In_ const ebpf_program_t* program, size_t addresses_count, _Out_writes_(addresses_count) uint64_t* addresses)
 {
@@ -923,7 +923,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_set_helper_function_ids(
     _Inout_ ebpf_program_t* program,
     const size_t helper_function_count,
@@ -960,7 +960,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_get_program_info(_In_ const ebpf_program_t* program, _Outptr_ ebpf_program_info_t** program_info)
 {
     EBPF_LOG_ENTRY();
@@ -1082,7 +1082,7 @@ ebpf_program_detach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* l
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_get_info(
     _In_ const ebpf_program_t* program,
     _In_reads_(*info_size) const uint8_t* input_buffer,
@@ -1139,7 +1139,7 @@ ebpf_program_get_info(
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_create_and_initialize(
     _In_ const ebpf_program_parameters_t* parameters, _Out_ ebpf_handle_t* program_handle)
 {

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -43,7 +43,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_initiate();
 
     /**
@@ -61,7 +61,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_create(_Outptr_ ebpf_program_t** program);
 
     /**
@@ -75,7 +75,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_initialize(_Inout_ ebpf_program_t* program, _In_ const ebpf_program_parameters_t* program_parameters);
 
     /**
@@ -106,7 +106,7 @@ extern "C"
      * @retval EBPF_ERROR_EXTENSION_FAILED_TO_LOAD The program info isn't
      *  available.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_get_program_info(_In_ const ebpf_program_t* program, _Outptr_ ebpf_program_info_t** program_info);
 
     /**
@@ -127,7 +127,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t maps_count);
 
     /**
@@ -139,7 +139,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_associate_additional_map(ebpf_program_t* program, ebpf_map_t* map);
 
     /**
@@ -155,7 +155,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_load_code(
         _Inout_ ebpf_program_t* program,
         ebpf_code_type_t code_type,
@@ -185,7 +185,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT The helper function IDs array is already populated.
      * @retval EBPF_NO_MEMORY Could not allocate array of helper function IDs.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_set_helper_function_ids(
         _Inout_ ebpf_program_t* program,
         const size_t helper_function_count,
@@ -202,7 +202,7 @@ extern "C"
      * @retval EBPF_INSUFFICIENT_BUFFER Output array is insufficient.
      * @retval EBPF_INVALID_ARGUMENT At least one helper function id is not valid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_get_helper_function_addresses(
         _In_ const ebpf_program_t* program,
         const size_t addresses_count,
@@ -234,7 +234,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT Internal error.
      * @retval EBPF_NO_MORE_TAIL_CALLS Program has executed to many tail calls.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_set_tail_call(_In_ const ebpf_program_t* next_program);
 
     /**
@@ -249,7 +249,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_prog_info.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_get_info(
         _In_ const ebpf_program_t* program,
         _In_reads_(*info_size) const uint8_t* input_buffer,
@@ -268,7 +268,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_create_and_initialize(
         _In_ const ebpf_program_parameters_t* parameters, _Out_ ebpf_handle_t* program_handle);
 

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -946,7 +946,7 @@ static empty_reply_t _empty_reply;
 typedef std::vector<uint8_t> ebpf_protocol_buffer_t;
 
 template <typename request_t, typename reply_t = empty_reply_t>
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 invoke_protocol(
     ebpf_operation_id_t operation_id,
     request_t& request,

--- a/libs/platform/ebpf_async.c
+++ b/libs/platform/ebpf_async.c
@@ -15,7 +15,7 @@ static ebpf_hash_table_t* _ebpf_async_tracker_table = NULL;
 
 static const size_t _ebpf_async_tracker_table_bucket_count = 64;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_async_initiate()
 {
     EBPF_LOG_ENTRY();
@@ -40,7 +40,7 @@ ebpf_async_terminate()
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_async_set_completion_callback(_In_ void* context, _In_ void (*on_complete)(_In_ void*, size_t, ebpf_result_t))
 {
     EBPF_LOG_ENTRY();
@@ -71,7 +71,7 @@ _remove_tracker(_In_ void* context)
     return ebpf_hash_table_delete(_ebpf_async_tracker_table, key) == EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_async_set_cancel_callback(
     _In_ void* context, _In_ void* cancellation_context, _In_ void (*on_cancel)(_In_ void* cancellation_context))
 {
@@ -121,7 +121,7 @@ ebpf_async_complete(_In_ void* context, size_t output_buffer_length, ebpf_result
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_async_reset_completion_callback(_In_ void* context)
 {
     return _remove_tracker(context);

--- a/libs/platform/ebpf_async.h
+++ b/libs/platform/ebpf_async.h
@@ -44,7 +44,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_async_initiate();
 
     /**
@@ -64,7 +64,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_async_set_completion_callback(_In_ void* context, _In_ void (*on_complete)(_In_ void*, size_t, ebpf_result_t));
 
     /**
@@ -72,7 +72,7 @@ extern "C"
      *
      * @param[in] context Context of action to stop tracking.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_async_reset_completion_callback(_In_ void* context);
 
     /**
@@ -84,7 +84,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT The action context hasn't been registered.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_async_set_cancel_callback(
         _In_ void* context, _In_ void* cancellation_context, _In_ void (*on_cancel)(_In_ void* cancellation_context));
 

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -190,7 +190,7 @@ static _Requires_lock_held_(_ebpf_epoch_cpu_table[cpu_id].lock) ebpf_epoch_threa
  */
 static _Requires_lock_held_(cpu_entry->lock) void _ebpf_epoch_arm_timer_if_needed(ebpf_epoch_cpu_entry_t* cpu_entry);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_epoch_initiate()
 {
     EBPF_LOG_ENTRY();
@@ -286,7 +286,7 @@ ebpf_epoch_terminate()
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_epoch_enter()
 {
     ebpf_result_t return_value;
@@ -624,7 +624,7 @@ _ebpf_epoch_get_release_epoch(_Out_ int64_t* release_epoch)
             // If the stale flag is set, then schedule the DPC to release the stale items.
             if (_ebpf_epoch_cpu_table[cpu_id].epoch_state.stale) {
                 if (!_ebpf_epoch_cpu_table[cpu_id].stale_worker) {
-                    ebpf_allocate_non_preemptible_work_item(
+                    (void)ebpf_allocate_non_preemptible_work_item(
                         &_ebpf_epoch_cpu_table[cpu_id].stale_worker, cpu_id, _ebpf_epoch_stale_worker, NULL);
                 }
                 if (_ebpf_epoch_cpu_table[cpu_id].stale_worker) {
@@ -709,10 +709,18 @@ static _Requires_lock_held_(_ebpf_epoch_cpu_table[cpu_id].lock) ebpf_epoch_threa
             (const uint8_t*)&thread_id,
             (const uint8_t*)&local_thread_epoch,
             EBPF_HASH_TABLE_OPERATION_INSERT);
-        ebpf_hash_table_find(
+        if (return_value != EBPF_SUCCESS) {
+            thread_entry = NULL;
+            goto Done;
+        }
+        return_value = ebpf_hash_table_find(
             _ebpf_epoch_cpu_table[cpu_id].thread_table, (uint8_t*)&thread_id, (uint8_t**)&thread_entry);
+        if (return_value != EBPF_SUCCESS) {
+            thread_entry = NULL;
+            goto Done;
+        }
     }
-
+Done:
     return thread_entry;
 }
 
@@ -737,6 +745,7 @@ _ebpf_epoch_stale_worker(_In_ void* work_item_context, _In_ void* parameter_1)
 {
     UNREFERENCED_PARAMETER(work_item_context);
     UNREFERENCED_PARAMETER(parameter_1);
-    ebpf_epoch_enter();
-    ebpf_epoch_exit();
+    if (ebpf_epoch_enter() == EBPF_SUCCESS) {
+        ebpf_epoch_exit();
+    }
 }

--- a/libs/platform/ebpf_epoch.h
+++ b/libs/platform/ebpf_epoch.h
@@ -19,7 +19,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_epoch_initiate();
 
     /**
@@ -35,7 +35,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate per-thread
      *   tracking state.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_epoch_enter();
 
     /**

--- a/libs/platform/ebpf_etw.c
+++ b/libs/platform/ebpf_etw.c
@@ -14,7 +14,7 @@ TRACELOGGING_DEFINE_PROVIDER(
 
 static bool _ebpf_trace_initiated = false;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_trace_initiate()
 {
     if (_ebpf_trace_initiated) {

--- a/libs/platform/ebpf_handle.h
+++ b/libs/platform/ebpf_handle.h
@@ -16,7 +16,7 @@ extern "C"
      *
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_handle_table_initiate();
 
     /**
@@ -35,7 +35,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_handle_create(ebpf_handle_t* handle, struct _ebpf_core_object* object);
 
     /**
@@ -46,7 +46,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_ERROR_INVALID_HANDLE The provided handle is not valid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_handle_close(ebpf_handle_t handle);
 
     /**

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -405,7 +405,7 @@ Done:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_hash_table_create(
     _Out_ ebpf_hash_table_t** hash_table,
     _In_ void* (*allocate)(size_t size),
@@ -475,7 +475,7 @@ ebpf_hash_table_destroy(_In_opt_ _Post_ptr_invalid_ ebpf_hash_table_t* hash_tabl
     hash_table->free(hash_table);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_hash_table_find(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _Outptr_ uint8_t** value)
 {
     ebpf_result_t retval;
@@ -515,7 +515,7 @@ Done:
     return retval;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_hash_table_update(
     _In_ ebpf_hash_table_t* hash_table,
     _In_ const uint8_t* key,
@@ -550,7 +550,7 @@ Done:
     return retval;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_hash_table_delete(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key)
 {
     ebpf_result_t retval;
@@ -566,7 +566,7 @@ Done:
     return retval;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_hash_table_next_key_pointer_and_value(
     _In_ ebpf_hash_table_t* hash_table,
     _In_opt_ const uint8_t* previous_key,
@@ -640,7 +640,7 @@ Done:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_hash_table_next_key_and_value(
     _In_ ebpf_hash_table_t* hash_table,
     _In_opt_ const uint8_t* previous_key,
@@ -656,7 +656,7 @@ ebpf_hash_table_next_key_and_value(
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_hash_table_next_key(
     _In_ ebpf_hash_table_t* hash_table, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
 {

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -308,7 +308,7 @@ ebpf_object_reference_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outpt
     return return_value;
 }
 
-void
+ebpf_result_t
 ebpf_object_dereference_by_id(ebpf_id_t id, ebpf_object_type_t object_type)
 {
     ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -133,7 +133,7 @@ ebpf_object_tracking_terminate()
     }
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_initialize(
     ebpf_core_object_t* object,
     ebpf_object_type_t object_type,
@@ -213,7 +213,7 @@ ebpf_object_get_type(ebpf_core_object_t* object)
     return object->type;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_duplicate_utf8_string(_Out_ ebpf_utf8_string_t* destination, _In_ const ebpf_utf8_string_t* source)
 {
     if (!source->value || !source->length) {
@@ -248,7 +248,7 @@ _Requires_lock_held_(&_ebpf_object_tracking_list_lock) static ebpf_core_object_t
     return NULL;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_get_next_id(ebpf_id_t start_id, ebpf_object_type_t object_type, _Out_ ebpf_id_t* next_id)
 {
     ebpf_result_t return_value = EBPF_NO_MORE_KEYS;
@@ -284,7 +284,7 @@ ebpf_object_reference_next_object(
     ebpf_lock_unlock(&_ebpf_object_tracking_list_lock, state);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_object_reference_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_ ebpf_core_object_t** object)
 {
     ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);
@@ -308,7 +308,7 @@ ebpf_object_reference_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outpt
     return return_value;
 }
 
-ebpf_result_t
+void
 ebpf_object_dereference_by_id(ebpf_id_t id, ebpf_object_type_t object_type)
 {
     ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -65,7 +65,7 @@ extern "C"
      * @retval EBPF_SUCCESS Initialization succeeded.
      * @retval EBPF_NO_MEMORY Could not insert into the tracking table.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_object_initialize(
         ebpf_core_object_t* object,
         ebpf_object_type_t object_type,
@@ -122,7 +122,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_KEY_NOT_FOUND The provided ID is not valid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_object_reference_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_ ebpf_core_object_t** object);
 
     /**
@@ -135,7 +135,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_KEY_NOT_FOUND The provided ID is not valid.
      */
-    ebpf_result_t
+    void
     ebpf_object_dereference_by_id(ebpf_id_t id, ebpf_object_type_t object_type);
 
     /**
@@ -146,7 +146,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MORE_KEYS No such IDs found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_object_get_next_id(ebpf_id_t start_id, ebpf_object_type_t object_type, _Out_ ebpf_id_t* next_id);
 
 #ifdef __cplusplus

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -135,7 +135,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_KEY_NOT_FOUND The provided ID is not valid.
      */
-    void
+    _Must_inspect_result_ ebpf_result_t
     ebpf_object_dereference_by_id(ebpf_id_t id, ebpf_object_type_t object_type);
 
     /**

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -45,7 +45,7 @@ _ebpf_pinning_entry_free(ebpf_pinning_entry_t* pinning_entry)
     ebpf_free(pinning_entry);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_pinning_table_allocate(ebpf_pinning_table_t** pinning_table)
 {
     EBPF_LOG_ENTRY();
@@ -97,7 +97,7 @@ ebpf_pinning_table_free(ebpf_pinning_table_t* pinning_table)
             if (return_value != EBPF_SUCCESS) {
                 break;
             }
-            ebpf_pinning_table_delete(pinning_table, key);
+            (void)ebpf_pinning_table_delete(pinning_table, key);
         }
         ebpf_hash_table_destroy(pinning_table->hash_table);
     }
@@ -107,7 +107,7 @@ ebpf_pinning_table_free(ebpf_pinning_table_t* pinning_table)
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_pinning_table_insert(
     ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_core_object_t* object)
 {
@@ -167,7 +167,7 @@ Done:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_pinning_table_find(
     ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_core_object_t** object)
 {
@@ -191,7 +191,7 @@ ebpf_pinning_table_find(
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_pinning_table_delete(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path)
 {
     EBPF_LOG_ENTRY();
@@ -226,7 +226,7 @@ ebpf_pinning_table_delete(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_s
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_pinning_table_enumerate_entries(
     _In_ ebpf_pinning_table_t* pinning_table,
     ebpf_object_type_t object_type,
@@ -323,7 +323,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_pinning_table_get_next_path(
     _In_ ebpf_pinning_table_t* pinning_table,
     ebpf_object_type_t object_type,

--- a/libs/platform/ebpf_pinning_table.h
+++ b/libs/platform/ebpf_pinning_table.h
@@ -29,7 +29,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  pinning table.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_allocate(ebpf_pinning_table_t** pinning_table);
 
     /**
@@ -51,7 +51,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  entry.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_insert(
         ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_core_object_t* object);
 
@@ -66,7 +66,7 @@ extern "C"
      * @retval EBPF_OBJECT_NOT_FOUND The path is not present in the pinning
      *  table.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_find(
         ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path, ebpf_core_object_t** object);
 
@@ -80,7 +80,7 @@ extern "C"
      * @retval EBPF_OBJECT_NOT_FOUND The path is not present in the pinning
      *  table.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_delete(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_string_t* path);
 
     /**
@@ -94,7 +94,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Output array of entries could not be allocated.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_enumerate_entries(
         _In_ ebpf_pinning_table_t* pinning_table,
         ebpf_object_type_t object_type,
@@ -111,7 +111,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MORE_KEYS No more entries found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_get_next_path(
         _In_ ebpf_pinning_table_t* pinning_table,
         ebpf_object_type_t object_type,

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -115,7 +115,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_platform_initiate();
 
     /**
@@ -204,7 +204,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT An invalid argument was supplied.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_protect_memory(_In_ const ebpf_memory_descriptor_t* memory_descriptor, ebpf_page_protection_t protection);
 
     /**
@@ -268,7 +268,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  UTF-8 string.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_duplicate_utf8_string(_Out_ ebpf_utf8_string_t* destination, _In_ const ebpf_utf8_string_t* source);
 
     /**
@@ -277,7 +277,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_SUPPORTED Unable to obtain state from platform.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_get_code_integrity_state(_Out_ ebpf_code_integrity_state_t* state);
 
     /**
@@ -400,7 +400,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  work item.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_allocate_non_preemptible_work_item(
         _Out_ ebpf_non_preemptible_work_item_t** work_item,
         uint32_t cpu_id,
@@ -437,7 +437,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  work item.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_allocate_preemptible_work_item(
         _Outptr_ ebpf_preemptible_work_item_t** work_item,
         _In_ void (*work_item_routine)(_In_opt_ const void* work_item_context),
@@ -461,7 +461,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  timer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_allocate_timer_work_item(
         _Out_ ebpf_timer_work_item_t** timer,
         _In_ void (*work_item_routine)(void* work_item_context),
@@ -505,7 +505,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  hash table.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_hash_table_create(
         _Out_ ebpf_hash_table_t** hash_table,
         _In_ void* (*allocate)(size_t size),
@@ -535,7 +535,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_FOUND Key not found in hash table.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_hash_table_find(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _Outptr_ uint8_t** value);
 
     /**
@@ -549,7 +549,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate memory for this
      *  entry in the hash table.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_hash_table_update(
         _In_ ebpf_hash_table_t* hash_table,
         _In_ const uint8_t* key,
@@ -564,7 +564,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_hash_table_delete(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key);
 
     /**
@@ -577,7 +577,7 @@ extern "C"
      * @retval EBPF_NO_MORE_KEYS No keys exist in the hash table that
      * are lexicographically after the specified key.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_hash_table_next_key(
         _In_ ebpf_hash_table_t* hash_table, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
 
@@ -592,7 +592,7 @@ extern "C"
      * @retval EBPF_NO_MORE_KEYS No keys exist in the hash table that
      * are lexicographically after the specified key.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_hash_table_next_key_and_value(
         _In_ ebpf_hash_table_t* hash_table,
         _In_opt_ const uint8_t* previous_key,
@@ -610,7 +610,7 @@ extern "C"
      * @retval EBPF_NO_MORE_KEYS No keys exist in the hash table that
      * are lexicographically after the specified key.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_hash_table_next_key_pointer_and_value(
         _In_ ebpf_hash_table_t* hash_table,
         _In_opt_ const uint8_t* previous_key,
@@ -792,7 +792,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_extension_load(
         _Outptr_ ebpf_extension_client_t** client_context,
         _In_ const GUID* interface_id,
@@ -857,7 +857,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_provider_load(
         _Outptr_ ebpf_extension_provider_t** provider_context,
         _In_ const GUID* interface_id,
@@ -880,7 +880,7 @@ extern "C"
     void
     ebpf_provider_detach_client_complete(_In_ const GUID* interface_id, ebpf_handle_t client_binding_handle);
 
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_guid_create(_Out_ GUID* new_guid);
 
     int32_t
@@ -896,7 +896,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_allocate_trampoline_table(size_t entry_count, _Outptr_ ebpf_trampoline_table_t** trampoline_table);
 
     /**
@@ -919,7 +919,7 @@ extern "C"
      *  operation.
      * @retval EBPF_INVALID_ARGUMENT An invalid argument was supplied.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_update_trampoline_table(
         _Inout_ ebpf_trampoline_table_t* trampoline_table,
         uint32_t helper_function_count,
@@ -937,7 +937,7 @@ extern "C"
      *  operation.
      * @retval EBPF_INVALID_ARGUMENT An invalid argument was supplied.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_get_trampoline_function(
         _In_ const ebpf_trampoline_table_t* trampoline_table, size_t index, _Out_ void** function);
 
@@ -952,7 +952,7 @@ extern "C"
      *  operation.
      * @retval EBPF_INVALID_ARGUMENT An invalid argument was supplied.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_get_trampoline_helper_address(
         _In_ const ebpf_trampoline_table_t* trampoline_table, size_t index, _Out_ void** helper_address);
 
@@ -970,7 +970,7 @@ extern "C"
      * @retval EBPF_SUCCESS Requested access is granted.
      * @retval EBPF_ACCESS_DENIED Requested access is denied.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_access_check(
         _In_ ebpf_security_descriptor_t* security_descriptor,
         ebpf_security_access_mask_t request_access,
@@ -984,7 +984,7 @@ extern "C"
      * @retval EBPF_SUCCESS Security descriptor is well formed.
      * @retval EBPF_INVALID_ARGUMENT Security descriptor is malformed.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_validate_security_descriptor(
         _In_ ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length);
 
@@ -1005,7 +1005,7 @@ extern "C"
     uint64_t
     ebpf_query_time_since_boot(bool include_suspended_time);
 
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask);
 
     void
@@ -1060,7 +1060,7 @@ extern "C"
 
     TRACELOGGING_DECLARE_PROVIDER(ebpf_tracelog_provider);
 
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_trace_initiate();
 
     void
@@ -1074,7 +1074,7 @@ extern "C"
      *
      * @returns Status of the operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_update_global_helpers(
         _In_reads_(helper_info_count) ebpf_helper_function_prototype_t* helper_info, uint32_t helper_info_count);
 

--- a/libs/platform/ebpf_ring_buffer.c
+++ b/libs/platform/ebpf_ring_buffer.c
@@ -73,7 +73,7 @@ _ring_buffer_acquire_record(_Inout_ ebpf_ring_buffer_t* ring, size_t requested_l
     return record;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_create(_Outptr_ ebpf_ring_buffer_t** ring, size_t capacity)
 {
     EBPF_LOG_ENTRY();
@@ -121,7 +121,7 @@ ebpf_ring_buffer_destroy(_Frees_ptr_opt_ ebpf_ring_buffer_t* ring)
     }
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_output(_Inout_ ebpf_ring_buffer_t* ring, _In_reads_bytes_(length) uint8_t* data, size_t length)
 {
     ebpf_result_t result;
@@ -149,7 +149,7 @@ ebpf_ring_buffer_query(_In_ const ebpf_ring_buffer_t* ring, _Out_ size_t* consum
     *producer = ring->producer_offset;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_return(_Inout_ ebpf_ring_buffer_t* ring, size_t length)
 {
     ebpf_result_t result;
@@ -187,7 +187,7 @@ Done:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_buffer(_In_ const ebpf_ring_buffer_t* ring, _Outptr_ uint8_t** buffer)
 {
     *buffer = ebpf_ring_map_readonly_user(ring->ring_descriptor);
@@ -198,7 +198,7 @@ ebpf_ring_buffer_map_buffer(_In_ const ebpf_ring_buffer_t* ring, _Outptr_ uint8_
     }
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_reserve(
     _Inout_ ebpf_ring_buffer_t* ring, _Outptr_result_bytebuffer_(length) uint8_t** data, size_t length)
 {
@@ -220,7 +220,7 @@ Done:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_submit(_Frees_ptr_opt_ uint8_t* data)
 {
     if (!data) {
@@ -238,7 +238,7 @@ ebpf_ring_buffer_submit(_Frees_ptr_opt_ uint8_t* data)
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_discard(_Frees_ptr_opt_ uint8_t* data)
 {
     if (!data) {

--- a/libs/platform/ebpf_ring_buffer.h
+++ b/libs/platform/ebpf_ring_buffer.h
@@ -31,7 +31,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully allocated ring buffer.
      * @retval EBPF_NO_MEMORY Unable to allocate ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_create(_Outptr_ ebpf_ring_buffer_t** ring_buffer, size_t capacity);
 
     /**
@@ -51,7 +51,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully wrote record ring buffer.
      * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_output(
         _Inout_ ebpf_ring_buffer_t* ring_buffer, _In_reads_bytes_(length) uint8_t* data, size_t length);
 
@@ -73,7 +73,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully returned records to the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to return records to the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_return(_Inout_ ebpf_ring_buffer_t* ring_buffer, size_t length);
 
     /**
@@ -84,7 +84,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully mapped the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to map the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_buffer(_In_ const ebpf_ring_buffer_t* ring_buffer, _Outptr_ uint8_t** buffer);
 
     /**
@@ -97,7 +97,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully reserved space in the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to reserve space in the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_reserve(
         _Inout_ ebpf_ring_buffer_t* ring_buffer, _Outptr_result_bytebuffer_(length) uint8_t** data, size_t length);
 
@@ -108,7 +108,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully submitted space in the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to submit space in the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_submit(_Frees_ptr_opt_ uint8_t* data);
 
     /**
@@ -118,7 +118,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully discarded space in the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to discard space in the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_discard(_Frees_ptr_opt_ uint8_t* data);
 
     /**

--- a/libs/platform/ebpf_serialize.c
+++ b/libs/platform/ebpf_serialize.c
@@ -58,7 +58,7 @@ ebpf_map_info_array_free(uint16_t map_count, _In_opt_count_(map_count) _Post_ptr
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_serialize_internal_map_info_array(
     uint16_t map_count,
     _In_count_(map_count) const ebpf_map_info_internal_t* map_info,
@@ -134,7 +134,7 @@ Exit:
 
 #pragma warning(push)
 #pragma warning(disable : 6101) // ebpf_map_info_array_free at exit label
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_deserialize_map_info_array(
     size_t input_buffer_length,
     _In_reads_bytes_(input_buffer_length) const uint8_t* input_buffer,
@@ -261,7 +261,7 @@ ebpf_program_info_free(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_serialize_program_info(
     _In_ const ebpf_program_info_t* program_info,
     _Out_writes_bytes_to_(output_buffer_length, *serialized_data_length) uint8_t* output_buffer,
@@ -447,7 +447,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_deserialize_program_info(
     size_t input_buffer_length,
     _In_reads_bytes_(input_buffer_length) const uint8_t* input_buffer,

--- a/libs/platform/ebpf_serialize.h
+++ b/libs/platform/ebpf_serialize.h
@@ -46,7 +46,7 @@ extern "C"
      * @retval EBPF_SUCCESS The serialization was successful.
      * @retval EBPF_ERROR_INSUFFICIENT_BUFFER The output buffer is insufficient to store serialized data.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_serialize_internal_map_info_array(
         uint16_t map_count,
         _In_count_(map_count) const ebpf_map_info_internal_t* map_info,
@@ -67,7 +67,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more input parameters are incorrect.
      * @retval EBPF_NO_MEMORY Output array could not be allocated.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_deserialize_map_info_array(
         size_t input_buffer_length,
         _In_reads_bytes_(input_buffer_length) const uint8_t* input_buffer,
@@ -98,7 +98,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more input parameters are incorrect.
      * @retval EBPF_ERROR_INSUFFICIENT_BUFFER The output buffer is insufficient to store serialized data.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_serialize_program_info(
         _In_ const ebpf_program_info_t* program_info,
         _Out_writes_bytes_to_(output_buffer_length, *serialized_data_length) uint8_t* output_buffer,
@@ -117,7 +117,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more input parameters are incorrect.
      * @retval EBPF_NO_MEMORY Output array could not be allocated.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_deserialize_program_info(
         size_t input_buffer_length,
         _In_reads_bytes_(input_buffer_length) const uint8_t* input_buffer,

--- a/libs/platform/ebpf_state.c
+++ b/libs/platform/ebpf_state.c
@@ -20,7 +20,7 @@ typedef struct _ebpf_state_entry
 static _Writable_elements_(_ebpf_state_cpu_table_size) ebpf_state_entry_t* _ebpf_state_cpu_table = NULL;
 static uint32_t _ebpf_state_cpu_table_size = 0;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_state_initiate()
 {
     EBPF_LOG_ENTRY();
@@ -72,7 +72,7 @@ ebpf_state_terminate()
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_state_allocate_index(_Out_ size_t* new_index)
 {
     EBPF_LOG_ENTRY();
@@ -84,7 +84,7 @@ ebpf_state_allocate_index(_Out_ size_t* new_index)
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 _ebpf_state_get_entry(_Out_ ebpf_state_entry_t** entry)
 {
     // High frequency call, don't log entry/exit.
@@ -112,6 +112,9 @@ _ebpf_state_get_entry(_Out_ ebpf_state_entry_t** entry)
 
             return_value = ebpf_hash_table_find(
                 _ebpf_state_thread_table, (const uint8_t*)&current_thread_id, (uint8_t**)&local_entry);
+            if (return_value != EBPF_SUCCESS) {
+                return return_value;
+            }
         }
     } else {
         uint32_t current_cpu = ebpf_get_current_cpu();
@@ -124,7 +127,7 @@ _ebpf_state_get_entry(_Out_ ebpf_state_entry_t** entry)
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_state_store(size_t index, uintptr_t value)
 {
     // High frequency call, don't log entry/exit.
@@ -138,7 +141,7 @@ ebpf_state_store(size_t index, uintptr_t value)
     return return_value;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_state_load(size_t index, _Out_ uintptr_t* value)
 {
     // High frequency call, don't log entry/exit.

--- a/libs/platform/ebpf_state.h
+++ b/libs/platform/ebpf_state.h
@@ -17,7 +17,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_state_initiate();
 
     /**
@@ -35,7 +35,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_state_allocate_index(_Out_ size_t* new_index);
 
     /**
@@ -47,7 +47,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_state_store(size_t index, uintptr_t value);
 
     /**
@@ -59,7 +59,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_state_load(size_t index, _Out_ uintptr_t* value);
 
 #ifdef __cplusplus

--- a/libs/platform/ebpf_trampoline.c
+++ b/libs/platform/ebpf_trampoline.c
@@ -22,7 +22,7 @@ typedef struct _ebpf_trampoline_table
     size_t entry_count;
 } ebpf_trampoline_table_t;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_allocate_trampoline_table(size_t entry_count, _Outptr_ ebpf_trampoline_table_t** trampoline_table)
 {
     EBPF_LOG_ENTRY();
@@ -63,7 +63,7 @@ ebpf_free_trampoline_table(_Frees_ptr_opt_ ebpf_trampoline_table_t* trampoline_t
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_update_trampoline_table(
     _Inout_ ebpf_trampoline_table_t* trampoline_table,
     uint32_t helper_function_count,
@@ -120,7 +120,7 @@ Exit:
 #endif
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_trampoline_function(_In_ const ebpf_trampoline_table_t* trampoline_table, size_t index, _Out_ void** function)
 {
     EBPF_LOG_ENTRY();
@@ -146,7 +146,7 @@ Exit:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_trampoline_helper_address(
     _In_ const ebpf_trampoline_table_t* trampoline_table, size_t index, _Out_ void** helper_address)
 {

--- a/libs/platform/kernel/ebpf_extension_kernel.c
+++ b/libs/platform/kernel/ebpf_extension_kernel.c
@@ -169,7 +169,7 @@ _ebpf_extension_client_cleanup_binding_context(void* client_binding_context)
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_extension_load(
     _Outptr_ ebpf_extension_client_t** client_context,
     _In_ const GUID* interface_id,
@@ -439,7 +439,7 @@ _ebpf_extension_provider_cleanup_binding_context(void* provider_binding_context)
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_provider_load(
     _Outptr_ ebpf_extension_provider_t** provider_context,
     _In_ const GUID* interface_id,

--- a/libs/platform/kernel/ebpf_handle_kernel.c
+++ b/libs/platform/kernel/ebpf_handle_kernel.c
@@ -7,7 +7,7 @@
 extern DEVICE_OBJECT*
 ebpf_driver_get_device_object();
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_handle_table_initiate()
 {
     return EBPF_SUCCESS;
@@ -17,7 +17,7 @@ void
 ebpf_handle_table_terminate()
 {}
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_handle_create(ebpf_handle_t* handle, ebpf_core_object_t* object)
 {
     EBPF_LOG_ENTRY();
@@ -75,7 +75,7 @@ Done:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_handle_close(ebpf_handle_t handle)
 {
     EBPF_LOG_ENTRY();
@@ -128,7 +128,7 @@ Done:
     return return_value;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_handle_by_type(ebpf_handle_t previous_handle, ebpf_object_type_t object_type, ebpf_handle_t* next_handle)
 {
     UNREFERENCED_PARAMETER(previous_handle);

--- a/libs/platform/kernel/ebpf_native_kernel.c
+++ b/libs/platform/kernel/ebpf_native_kernel.c
@@ -5,7 +5,7 @@
 #include "ebpf_handle.h"
 #include "framework.h"
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_native_load_driver(_In_z_ const wchar_t* service_name)
 {
     UNICODE_STRING driver_service_name;

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -40,7 +40,7 @@ typedef enum _ebpf_pool_tag
 static KDEFERRED_ROUTINE _ebpf_deferred_routine;
 static KDEFERRED_ROUTINE _ebpf_timer_routine;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_platform_initiate()
 {
     _ebpf_platform_maximum_processor_count = KeQueryMaximumProcessorCountEx(ALL_PROCESSOR_GROUPS);
@@ -142,7 +142,7 @@ ebpf_unmap_memory(_Frees_ptr_opt_ ebpf_memory_descriptor_t* memory_descriptor)
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_protect_memory(_In_ const ebpf_memory_descriptor_t* memory_descriptor, ebpf_page_protection_t protection)
 {
     EBPF_LOG_ENTRY();
@@ -317,7 +317,7 @@ NtQuerySystemInformation(
     uint32_t* return_length);
 // End code pulled from winternl.h.
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_code_integrity_state(_Out_ ebpf_code_integrity_state_t* state)
 {
     NTSTATUS status;
@@ -385,7 +385,7 @@ _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVE
     KeReleaseSpinLock(lock, state);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask)
 {
     if (KeGetCurrentIrql() > PASSIVE_LEVEL) {
@@ -446,7 +446,7 @@ _ebpf_deferred_routine(
     deferred_routine_context->work_item_routine(deferred_context, system_argument_1);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_allocate_non_preemptible_work_item(
     _Out_ ebpf_non_preemptible_work_item_t** work_item,
     uint32_t cpu_id,
@@ -503,7 +503,7 @@ _ebpf_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ PVOID cont
     ebpf_free(work_item);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_allocate_preemptible_work_item(
     _Outptr_ ebpf_preemptible_work_item_t** work_item,
     _In_ void (*work_item_routine)(_In_opt_ const void* work_item_context),
@@ -555,7 +555,7 @@ _ebpf_timer_routine(
     timer_work_item->work_item_routine(deferred_context);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_allocate_timer_work_item(
     _Out_ ebpf_timer_work_item_t** timer_work_item,
     _In_ void (*work_item_routine)(void* work_item_context),
@@ -617,7 +617,7 @@ ebpf_log_function(_In_ void* context, _In_z_ const char* format_string, ...)
     return 0;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_access_check(
     _In_ ebpf_security_descriptor_t* security_descriptor,
     ebpf_security_access_mask_t request_access,
@@ -650,7 +650,7 @@ ebpf_access_check(
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_validate_security_descriptor(
     _In_ ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length)
 {
@@ -699,7 +699,7 @@ ebpf_query_time_since_boot(bool include_suspended_time)
     }
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_guid_create(_Out_ GUID* new_guid)
 {
     if (NT_SUCCESS(ExUuidCreate(new_guid)))
@@ -731,7 +731,7 @@ ebpf_platform_printk(_In_z_ const char* format, va_list arg_list)
     return bytes_written;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_update_global_helpers(
     _In_reads_(helper_info_count) ebpf_helper_function_prototype_t* helper_info, uint32_t helper_info_count)
 {

--- a/libs/platform/user/ebpf_handle_user.c
+++ b/libs/platform/user/ebpf_handle_user.c
@@ -13,7 +13,7 @@ static _Requires_lock_held_(&_ebpf_handle_table_lock) ebpf_handle_entry_t _ebpf_
 
 static bool _ebpf_handle_table_initiated = false;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_handle_table_initiate()
 {
     EBPF_LOG_ENTRY();
@@ -32,13 +32,14 @@ ebpf_handle_table_terminate()
         EBPF_RETURN_VOID();
 
     for (handle = 0; handle < EBPF_COUNT_OF(_ebpf_handle_table); handle++) {
-        ebpf_handle_close(handle);
+        // Terminating, ignore invalid handles.
+        (void)ebpf_handle_close(handle);
     }
     _ebpf_handle_table_initiated = false;
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_handle_create(ebpf_handle_t* handle, ebpf_core_object_t* object)
 {
     EBPF_LOG_ENTRY();
@@ -67,7 +68,7 @@ Done:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_handle_close(ebpf_handle_t handle)
 {
     // High volume call - Skip entry/exit logging.
@@ -109,7 +110,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) ebpf_result_t ebpf_reference_object_by_handle
     return return_value;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_next_handle_by_type(ebpf_handle_t previous_handle, ebpf_object_type_t object_type, ebpf_handle_t* next_handle)
 {
     ebpf_lock_state_t state;

--- a/libs/platform/user/ebpf_native_user.c
+++ b/libs/platform/user/ebpf_native_user.c
@@ -4,7 +4,7 @@
 #include "ebpf_result.h"
 #include "framework.h"
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_native_load_driver(_In_z_ const wchar_t* service_name)
 {
     UNREFERENCED_PARAMETER(service_name);

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -130,7 +130,8 @@ class _ebpf_emulated_dpc
             ebpf_non_preemptible = true;
             std::unique_lock<std::mutex> l(mutex);
             uintptr_t old_thread_affinity;
-            ebpf_set_current_thread_affinity(1ull << i, &old_thread_affinity);
+            // Ignore set thread affinity failure.
+            (void)ebpf_set_current_thread_affinity(1ull << i, &old_thread_affinity);
             SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_TIME_CRITICAL);
             for (;;) {
                 if (terminate) {
@@ -213,7 +214,7 @@ class _ebpf_emulated_dpc
     bool terminate;
 };
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_platform_initiate()
 {
 
@@ -245,7 +246,7 @@ ebpf_platform_terminate()
     _ebpf_emulated_dpcs.resize(0);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_get_code_integrity_state(_Out_ ebpf_code_integrity_state_t* state)
 {
     EBPF_LOG_ENTRY();
@@ -522,7 +523,7 @@ ebpf_ring_map_readonly_user(_In_ ebpf_ring_descriptor_t* ring)
     EBPF_RETURN_POINTER(void*, ebpf_ring_descriptor_get_base_address(ring));
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_protect_memory(_In_ const ebpf_memory_descriptor_t* memory_descriptor, ebpf_page_protection_t protection)
 {
     EBPF_LOG_ENTRY();
@@ -632,7 +633,7 @@ ebpf_query_time_since_boot(bool include_suspended_time)
     return interrupt_time;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintptr_t* old_thread_affinity_mask)
 {
     uintptr_t old_mask = SetThreadAffinityMask(GetCurrentThread(), new_thread_affinity_mask);
@@ -679,7 +680,7 @@ ebpf_get_current_thread_id()
     return GetCurrentThreadId();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_allocate_non_preemptible_work_item(
     _Out_ ebpf_non_preemptible_work_item_t** work_item,
     uint32_t cpu_id,
@@ -742,7 +743,7 @@ ebpf_queue_preemptible_work_item(_In_ ebpf_preemptible_work_item_t* work_item)
     SubmitThreadpoolWork(work_item->work);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_allocate_preemptible_work_item(
     _Outptr_ ebpf_preemptible_work_item_t** work_item,
     _In_ void (*work_item_routine)(_In_opt_ const void* work_item_context),
@@ -787,7 +788,7 @@ _ebpf_timer_callback(_Inout_ TP_CALLBACK_INSTANCE* instance, _Inout_opt_ void* c
         timer_work_item->work_item_routine(timer_work_item->work_item_context);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_allocate_timer_work_item(
     _Out_ ebpf_timer_work_item_t** work_item,
     _In_ void (*work_item_routine)(void* work_item_context),
@@ -847,7 +848,7 @@ ebpf_free_timer_work_item(_Frees_ptr_opt_ ebpf_timer_work_item_t* work_item)
     ebpf_free(work_item);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_guid_create(_Out_ GUID* new_guid)
 {
     if (UuidCreate(new_guid) == RPC_S_OK)
@@ -870,7 +871,7 @@ ebpf_log_function(_In_ void* context, _In_z_ const char* format_string, ...)
     return 0;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_access_check(
     _In_ ebpf_security_descriptor_t* security_descriptor,
     ebpf_security_access_mask_t request_access,
@@ -919,7 +920,7 @@ Done:
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_validate_security_descriptor(
     _In_ ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length)
 {
@@ -980,7 +981,7 @@ ebpf_platform_printk(_In_z_ const char* format, va_list arg_list)
     return bytes_written;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_update_global_helpers(
     _In_reads_(helper_info_count) ebpf_helper_function_prototype_t* helper_info, uint32_t helper_info_count)
 {

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -229,7 +229,7 @@ _query_and_cache_map_descriptors(
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_verify_and_load_program(
     _In_ const GUID* program_type,
     ebpf_handle_t program_handle,

--- a/libs/service/api_service.h
+++ b/libs/service/api_service.h
@@ -10,7 +10,7 @@
 #include "ebpf_result.h"
 #include "rpc_interface_h.h"
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_verify_and_load_program(
     _In_ const GUID* program_type,
     ebpf_handle_t program_handle,

--- a/libs/service/verifier_service.cpp
+++ b/libs/service/verifier_service.cpp
@@ -41,7 +41,7 @@ _analyze(raw_program& raw_prog, const char** error_message, uint32_t* error_mess
     return EBPF_SUCCESS; // Success.
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 verify_byte_code(
     const GUID* program_type,
     _In_reads_(instruction_count) const ebpf_inst* instruction_array,

--- a/libs/service/verifier_service.h
+++ b/libs/service/verifier_service.h
@@ -6,7 +6,7 @@
 #include "config.hpp"
 #include "platform.hpp"
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 verify_byte_code(
     _In_ const GUID* program_type,
     _In_reads_(instruction_count) const ebpf_inst* instructions,

--- a/libs/thunk/mock/mock.cpp
+++ b/libs/thunk/mock/mock.cpp
@@ -190,7 +190,7 @@ initialize_rpc_binding() { return RPC_S_OK; }
 RPC_STATUS
 clean_up_rpc_binding() { return RPC_S_OK; }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_rpc_load_program(ebpf_program_load_info* info, const char** logs, uint32_t* logs_size)
 {
     // Set the handle of program being verified in thread-local storage.

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -189,7 +189,7 @@ static HANDLE _fwp_engine_handle;
 // WFP component management related utility functions.
 //
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_wfp_filter_context_create(
     size_t filter_context_size,
     _In_ const net_ebpf_extension_hook_client_t* client_context,
@@ -304,7 +304,7 @@ net_ebpf_extension_delete_wfp_filters(uint32_t filter_count, _Frees_ptr_ _In_cou
     NET_EBPF_EXT_LOG_EXIT();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_add_wfp_filters(
     uint32_t filter_count,
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -91,7 +91,7 @@ typedef struct _net_ebpf_extension_wfp_filter_context
  * @retval EBPF_SUCCESS The filter context was created successfully.
  * @retval EBPF_NO_MEMORY Out of memory.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_wfp_filter_context_create(
     size_t filter_context_size,
     _In_ const struct _net_ebpf_extension_hook_client* client_context,
@@ -166,7 +166,7 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
  * @retval EBPF_SUCCESS The operation completed successfully.
  * @retval EBPF_INVALID_ARGUMENT One or more arguments are invalid.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_add_wfp_filters(
     uint32_t filter_count,
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -198,7 +198,7 @@ net_ebpf_extension_hook_provider_get_custom_data(_In_ const net_ebpf_extension_h
     return provider_context->custom_data;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_hook_invoke_program(
     _In_ const net_ebpf_extension_hook_client_t* client, _In_ void* context, _Out_ uint32_t* result)
 {
@@ -211,7 +211,7 @@ net_ebpf_extension_hook_invoke_program(
     return invoke_result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_hook_check_attach_parameter(
     size_t attach_parameter_size,
     _In_reads_(attach_parameter_size) const void* attach_parameter,

--- a/netebpfext/net_ebpf_ext_hook_provider.h
+++ b/netebpfext/net_ebpf_ext_hook_provider.h
@@ -148,7 +148,7 @@ net_ebpf_extension_hook_provider_register(
  * @retval EBPF_NO_MEMORY Unable to allocate resources for this
  * operation.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_hook_invoke_program(
     _In_ const net_ebpf_extension_hook_client_t* client, _In_ void* context, _Out_ uint32_t* result);
 
@@ -185,7 +185,7 @@ net_ebpf_extension_hook_get_next_attached_client(
  * @retval EBPF_ACCESS_DENIED Request to attach client is denied by the provider.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_hook_check_attach_parameter(
     size_t attach_parameter_size,
     _In_reads_(attach_parameter_size) const void* attach_parameter,

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -70,7 +70,7 @@ typedef class _hook_helper
   public:
     _hook_helper(ebpf_attach_type_t attach_type) : _attach_type(attach_type) {}
 
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     attach_link(
         fd_t program_fd,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
@@ -139,7 +139,7 @@ typedef class _single_instance_hook : public _hook_helper
         }
     }
 
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     detach(
         fd_t program_fd,
         _In_reads_bytes_(attach_parameter_size) void* attach_parameter,
@@ -160,7 +160,7 @@ typedef class _single_instance_hook : public _hook_helper
         ebpf_link_close(link);
     }
 
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     fire(void* context, int* result)
     {
         ebpf_result_t (*invoke_program)(void* link, void* context, int* result) =

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -604,7 +604,7 @@ set_native_module_failures(bool expected)
     _expect_native_module_load_failures = expected;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 get_service_details_for_file(
     _In_ const std::wstring& file_path, _Out_ const wchar_t** service_name, _Out_ GUID* provider_guid)
 {

--- a/tests/end_to_end/test_helper.hpp
+++ b/tests/end_to_end/test_helper.hpp
@@ -35,6 +35,6 @@ class _test_helper_libbpf
 void
 set_native_module_failures(bool expected);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 get_service_details_for_file(
     _In_ const std::wstring& file_path, _Out_ const wchar_t** service_name, _Out_ GUID* provider_guid);

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -47,7 +47,7 @@ typedef struct _test_client_context
 
 // This callback occurs when netebpfext gets a packet and submits it to our dummy
 // eBPF program to handle.
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 netebpfext_unit_invoke_program(
     _In_ const void* client_binding_context, _In_ const void* context, _Out_ uint32_t* result)
 {

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -502,7 +502,7 @@ Exit:
     return status;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* context, _Out_ uint32_t* result)
 {
     ebpf_result_t return_value = EBPF_SUCCESS;
@@ -525,7 +525,7 @@ Exit:
     return return_value;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 sample_ebpf_extension_profile_program(
     _In_ sample_ebpf_ext_profile_request_t* request,
     size_t request_length,

--- a/tests/sample/ext/drv/sample_ext.h
+++ b/tests/sample/ext/drv/sample_ext.h
@@ -54,7 +54,7 @@ sample_ebpf_extension_hook_provider_unregister();
  * @retval EBPF_SUCCESS Operation succeeded.
  * @retval EBPF_OPERATION_NOT_SUPPORTED Operation not supported.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* context, _Out_ uint32_t* result);
 
 /**
@@ -67,7 +67,7 @@ sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* contex
  * @retval EBPF_SUCCESS Operation succeeded.
  * @retval EBPF_OPERATION_NOT_SUPPORTED Operation not supported.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 sample_ebpf_extension_profile_program(
     _In_ sample_ebpf_ext_profile_request_t* request,
     size_t request_length,


### PR DESCRIPTION
## Description

Annotate all functions that return ebpf_result_t with _Must_inspect_result_. This catches bugs where callers ignore the return value.

## Testing

CI/CD

## Documentation

No.
