### PR TITLE
More low memory fixes

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -196,6 +196,7 @@ ebpf_core_terminate()
     ebpf_async_terminate();
 
     ebpf_pinning_table_free(_ebpf_core_map_pinning_table);
+    _ebpf_core_map_pinning_table = NULL;
 
     ebpf_state_terminate();
 

--- a/libs/platform/ebpf_state.c
+++ b/libs/platform/ebpf_state.c
@@ -67,6 +67,7 @@ ebpf_state_terminate()
 {
     EBPF_LOG_ENTRY();
     ebpf_hash_table_destroy(_ebpf_state_thread_table);
+    _ebpf_state_thread_table = NULL;
     ebpf_free_cache_aligned(_ebpf_state_cpu_table);
     _ebpf_state_cpu_table = NULL;
     EBPF_RETURN_VOID();

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -333,21 +333,23 @@ TEST_CASE("epoch_test_stale_items", "[platform]")
         auto t1 = [&]() {
             uintptr_t old_thread_affinity;
             ebpf_set_current_thread_affinity(1, &old_thread_affinity);
-            ebpf_epoch_enter();
-            void* memory = ebpf_epoch_allocate(10);
+            bool _in_epoch = (ebpf_epoch_enter() == EBPF_SUCCESS);
+            void* memory = _in_epoch ? ebpf_epoch_allocate(10) : nullptr;
             signal_2.signal();
             signal_1.wait();
             ebpf_epoch_free(memory);
-            ebpf_epoch_exit();
+            if (_in_epoch)
+                ebpf_epoch_exit();
         };
         auto t2 = [&]() {
             uintptr_t old_thread_affinity;
             ebpf_set_current_thread_affinity(2, &old_thread_affinity);
             signal_2.wait();
-            ebpf_epoch_enter();
-            void* memory = ebpf_epoch_allocate(10);
-            ebpf_epoch_free(memory);
-            ebpf_epoch_exit();
+            if (ebpf_epoch_enter() == EBPF_SUCCESS) {
+                void* memory = ebpf_epoch_allocate(10);
+                ebpf_epoch_free(memory);
+                ebpf_epoch_exit();
+            }
             signal_1.signal();
         };
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

Resolves: #1523 

## Description

Reset global variables to NULL after freeing memory.
Only call ebpf_epoch_exit if ebpf_epoch_enter succeeded.

## Testing

CI/CD

## Documentation

No.
