### PR TITLE
Fix API ebpf_object_set_execution_type()

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2214,11 +2214,11 @@ ebpf_result_t
 ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type)
 {
     if (Platform::_is_native_program(object->file_name)) {
-        if (object->execution_type == EBPF_EXECUTION_INTERPRET || object->execution_type == EBPF_EXECUTION_JIT) {
+        if (execution_type == EBPF_EXECUTION_INTERPRET || execution_type == EBPF_EXECUTION_JIT) {
             return EBPF_INVALID_ARGUMENT;
         }
     } else {
-        if (object->execution_type == EBPF_EXECUTION_NATIVE) {
+        if (execution_type == EBPF_EXECUTION_NATIVE) {
             return EBPF_INVALID_ARGUMENT;
         }
     }

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -61,7 +61,7 @@ _program_load_helper(
         return EBPF_FAILED;
     }
 
-    ebpf_object_set_execution_type(new_object, execution_type);
+    REQUIRE(ebpf_object_set_execution_type(new_object, execution_type) == EBPF_SUCCESS);
 
     struct bpf_program* program = bpf_object__next_program(new_object, nullptr);
 
@@ -553,7 +553,7 @@ TEST_CASE("bindmonitor_tailcall_native_test", "[native_tests]")
     struct bpf_object* object = nullptr;
     hook_helper_t hook(EBPF_ATTACH_TYPE_BIND);
     program_load_attach_helper_t _helper(
-        "bindmonitor_tailcall.sys", BPF_PROG_TYPE_BIND, "BindMonitor", EBPF_EXECUTION_JIT, nullptr, 0, hook);
+        "bindmonitor_tailcall.sys", BPF_PROG_TYPE_BIND, "BindMonitor", EBPF_EXECUTION_NATIVE, nullptr, 0, hook);
     object = _helper.get_object();
 
     // Setup tail calls.

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -25,7 +25,7 @@ _program_load_attach_helper::_program_load_attach_helper(
         printf("bpf_object__open: error: %d\n", errno);
     }
     REQUIRE(_object != nullptr);
-    ebpf_object_set_execution_type(_object, _execution_type);
+    REQUIRE(ebpf_object_set_execution_type(_object, _execution_type) == EBPF_SUCCESS);
 
     // Load program by name.
     struct bpf_program* program = bpf_object__find_program_by_name(_object, _program_name.c_str());


### PR DESCRIPTION
## Description

API `ebpf_object_set_execution_type()` was allowing to set incorrect execution types.
This PR fixes that and adds test case for the API.

## Testing

Added test.

## Documentation

NA
