### PR TITLE
Remove failures on ebpf_hash_table_delete path due to low memory

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -209,7 +209,6 @@ ebpf_native_release_reference(_In_opt_ ebpf_native_module_t* module)
             ebpf_free(module_id);
         }
     } else if (new_ref_count == 0) {
-        // TODO: https://github.com/microsoft/ebpf-for-windows/issues/1506
         ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_native_client_table_lock);
         // Delete entry from hash table.
         ebpf_hash_table_delete(_ebpf_native_client_table, (const uint8_t*)&module->client_id);

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -304,8 +304,8 @@ _ebpf_hash_table_bucket_insert(
     result = EBPF_SUCCESS;
 
 Done:
-    ebpf_free(local_new_bucket);
-    ebpf_free(backup_bucket);
+    hash_table->free(local_new_bucket);
+    hash_table->free(backup_bucket);
 
     return result;
 }
@@ -420,8 +420,7 @@ _ebpf_hash_table_bucket_update(
     result = EBPF_SUCCESS;
 
 Done:
-    ebpf_free(local_new_bucket);
-
+    hash_table->free(local_new_bucket);
     return result;
 }
 

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -14,7 +14,7 @@
 // from causing loss of updates.
 
 /**
- * @brief Each bucket entry contains a pointer to the value, the key and a pointer to pre-allocated memory that can be
+ * @brief Each bucket entry contains a pointer to the value, the key, and a pointer to pre-allocated memory that can be
  * used to replace the current bucket with a bucket one entry smaller.
  */
 typedef struct _ebpf_hash_bucket_entry
@@ -68,7 +68,7 @@ typedef enum _ebpf_hash_bucket_operation
     EBPF_HASH_BUCKET_OPERATION_INSERT_OR_UPDATE, // Insert or update a key-value pair.
     EBPF_HASH_BUCKET_OPERATION_INSERT,           // Insert a key-value pair. Fails if key already exists.
     EBPF_HASH_BUCKET_OPERATION_UPDATE,           // Update a key-value pair. Fails if key does not exist.
-    EBPF_HASH_BUCKET_OPERATION_DELETE,           // Delete a key-value pair. Fail if key does not exist.
+    EBPF_HASH_BUCKET_OPERATION_DELETE,           // Delete a key-value pair. Fails if key does not exist.
 } ebpf_hash_bucket_operation_t;
 
 /**

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -562,7 +562,7 @@ extern "C"
      * @param[in] hash_table Hash-table to update.
      * @param[in] key Key to find and remove.
      * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NOT_FOUND Key not found in hash table.
      */
     ebpf_result_t
     ebpf_hash_table_delete(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key);


### PR DESCRIPTION
Resolves: #1506 

## Description

The ebpf_hash_table_delete API can fail in out-of-memory scenarios. To resolve this, pre-allocate the replacement block required for removing an element when adding an element to the hash table.

Each hash table bucket entry located at index N contains a pointer to memory needed to create a replacement bucket containing N-1 entries. 

## Testing

CI/CD

## Documentation

No.
