### PR TITLE
Fix double close of fd in api_test.exe

### DIFF
--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -172,7 +172,6 @@ _test_multiple_programs_load(
     }
 
     for (int i = 0; i < program_count; i++) {
-        _close(fds[i]);
         bpf_object__close(objects[i]);
     }
 }

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -147,7 +147,6 @@ _test_multiple_programs_load(
 {
     int result;
     std::vector<struct bpf_object*> objects;
-    std::vector<fd_t> fds;
 
     for (int i = 0; i < program_count; i++) {
         const char* file_name = parameters[i].file_name;
@@ -164,7 +163,6 @@ _test_multiple_programs_load(
         }
 
         objects.push_back(object);
-        fds.push_back(program_fd);
     }
 
     if (expected_load_result != 0) {


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

Resolves: #1553 

## Description

Test case was double closing an FD from the OS.

## Testing

CI/CD.

## Documentation

No.
