### PR TITLE
Fix API ebpf_object_set_execution_type()

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2217,12 +2217,18 @@ ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_ty
         if (execution_type == EBPF_EXECUTION_INTERPRET || execution_type == EBPF_EXECUTION_JIT) {
             return EBPF_INVALID_ARGUMENT;
         }
+
+        object->execution_type = EBPF_EXECUTION_NATIVE;
     } else {
         if (execution_type == EBPF_EXECUTION_NATIVE) {
             return EBPF_INVALID_ARGUMENT;
         }
+
+        // Set the default execution type to JIT if execution_type is EBPF_EXECUTION_ANY.
+        // This will eventually be decided by a system-wide policy.
+        // TODO(Issue #288): Configure system-wide execution type.
+        object->execution_type = (execution_type == EBPF_EXECUTION_ANY) ? EBPF_EXECUTION_JIT : execution_type;
     }
-    object->execution_type = execution_type;
     return EBPF_SUCCESS;
 }
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2601,7 +2601,9 @@ TEST_CASE("test_ebpf_object_set_execution_type", "[end_to_end]")
 
     // The following should succeed.
     REQUIRE(ebpf_object_set_execution_type(native_object, EBPF_EXECUTION_ANY) == EBPF_SUCCESS);
+    REQUIRE(ebpf_object_get_execution_type(native_object) == EBPF_EXECUTION_NATIVE);
     REQUIRE(ebpf_object_set_execution_type(native_object, EBPF_EXECUTION_NATIVE) == EBPF_SUCCESS);
+    REQUIRE(ebpf_object_get_execution_type(native_object) == EBPF_EXECUTION_NATIVE);
 
     bpf_object__close(native_object);
 
@@ -2614,8 +2616,11 @@ TEST_CASE("test_ebpf_object_set_execution_type", "[end_to_end]")
 
     // The following should succeed.
     REQUIRE(ebpf_object_set_execution_type(jit_object, EBPF_EXECUTION_ANY) == EBPF_SUCCESS);
+    REQUIRE(ebpf_object_get_execution_type(jit_object) == EBPF_EXECUTION_JIT);
     REQUIRE(ebpf_object_set_execution_type(jit_object, EBPF_EXECUTION_JIT) == EBPF_SUCCESS);
+    REQUIRE(ebpf_object_get_execution_type(jit_object) == EBPF_EXECUTION_JIT);
     REQUIRE(ebpf_object_set_execution_type(jit_object, EBPF_EXECUTION_INTERPRET) == EBPF_SUCCESS);
+    REQUIRE(ebpf_object_get_execution_type(jit_object) == EBPF_EXECUTION_INTERPRET);
 
     bpf_object__close(jit_object);
 }


### PR DESCRIPTION
## Description

Fix API `ebpf_object_set_execution_type()` to set the default execution type when `EBPF_EXECUTION_ANY` is passed.

Reference discussion:
https://github.com/microsoft/ebpf-for-windows/pull/1547#discussion_r1011695765

## Testing

Added tests.

## Documentation

NA
