### PR TITLE
Annotate execution context API's with _Must_inspect_result_

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -251,7 +251,7 @@ ebpf_core_terminate()
     ebpf_platform_terminate();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_load_code(
     ebpf_handle_t program_handle,
     ebpf_code_type_t code_type,
@@ -317,7 +317,7 @@ Done:
     EBPF_RETURN_RESULT(retval);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_resolve_helper(
     ebpf_handle_t program_handle,
     const size_t count_of_helpers,
@@ -390,7 +390,7 @@ Done:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_resolve_maps(
     ebpf_handle_t program_handle,
     uint32_t count_of_maps,
@@ -464,7 +464,7 @@ Done:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_create_map(
     _In_ const ebpf_utf8_string_t* map_name,
     _In_ const ebpf_map_definition_in_memory_t* ebpf_map_definition,
@@ -684,7 +684,14 @@ Done:
     // If this call failed, stop the native driver. ebpfapi will create a
     // new service for the driver in the next attempt.
     if (result != EBPF_SUCCESS) {
-        ebpf_native_unload(&request->module_id);
+        ebpf_result_t native_unload_result = ebpf_native_unload(&request->module_id);
+        if (native_unload_result != EBPF_SUCCESS) {
+            EBPF_LOG_MESSAGE_GUID(
+                EBPF_TRACELOG_LEVEL_ERROR,
+                EBPF_TRACELOG_KEYWORD_NATIVE,
+                "Failed to unload native driver",
+                request->module_id);
+        }
     }
 
     EBPF_RETURN_RESULT(result);
@@ -921,7 +928,7 @@ Done:
     EBPF_RETURN_RESULT(retval);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_update_pinning(const ebpf_handle_t handle, _In_ const ebpf_utf8_string_t* path)
 {
     EBPF_LOG_ENTRY();
@@ -967,7 +974,7 @@ Done:
     EBPF_RETURN_RESULT(retval);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_get_pinned_object(_In_ const ebpf_utf8_string_t* path, _Out_ ebpf_handle_t* handle)
 {
     EBPF_LOG_ENTRY();
@@ -1370,7 +1377,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_get_handle_by_id(ebpf_object_type_t type, ebpf_id_t id, _Out_ ebpf_handle_t* handle)
 {
     EBPF_LOG_ENTRY();
@@ -2018,7 +2025,7 @@ static ebpf_protocol_handler_t _ebpf_protocol_handlers[] = {
     DECLARE_PROTOCOL_HANDLER_FIXED_REQUEST_VARIABLE_REPLY(load_native_programs, data, PROTOCOL_NATIVE_MODE),
 };
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_get_protocol_handler_properties(
     ebpf_operation_id_t operation_id,
     _Out_ size_t* minimum_request_size,
@@ -2070,7 +2077,7 @@ ebpf_core_get_protocol_handler_properties(
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_invoke_protocol_handler(
     ebpf_operation_id_t operation_id,
     _In_reads_bytes_(input_buffer_length) const void* input_buffer,

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -137,7 +137,7 @@ ebpf_general_helper_function_provider_detach_client(_Inout_ void* provider_bindi
     return STATUS_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_core_initiate()
 {
     ebpf_result_t return_value;

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -31,7 +31,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_initiate();
 
     /**
@@ -55,7 +55,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_invoke_protocol_handler(
         ebpf_operation_id_t operation_id,
         _In_reads_bytes_(input_buffer_length) const void* input_buffer,
@@ -76,7 +76,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_SUPPORTED The operation id is not valid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_get_protocol_handler_properties(
         ebpf_operation_id_t operation_id,
         _Out_ size_t* minimum_request_size,
@@ -123,7 +123,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_FOUND No object was pinned to the provided path.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_get_pinned_object(_In_ const ebpf_utf8_string_t* path, _Out_ ebpf_handle_t* handle);
 
     /**
@@ -138,7 +138,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      * @retval EBPF_NOT_FOUND No object was pinned to the provided path.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_update_pinning(const ebpf_handle_t handle, _In_ const ebpf_utf8_string_t* path);
 
     /**
@@ -152,7 +152,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_create_map(
         _In_ const ebpf_utf8_string_t* map_name,
         _In_ const ebpf_map_definition_in_memory_t* ebpf_map_definition,
@@ -171,7 +171,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_load_code(
         ebpf_handle_t program_handle,
         ebpf_code_type_t code_type,
@@ -191,7 +191,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_get_handle_by_id(ebpf_object_type_t type, ebpf_id_t id, _Out_ ebpf_handle_t* handle);
 
     /**
@@ -209,7 +209,7 @@ extern "C"
      * @retval EBPF_INVALID_FD The program is incompatible with the map.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_resolve_maps(
         ebpf_handle_t program_handle,
         uint32_t count_of_maps,
@@ -230,7 +230,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT An invalid argument was supplied.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_core_resolve_helper(
         ebpf_handle_t program_handle,
         const size_t count_of_helpers,

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -43,7 +43,7 @@ _ebpf_link_free(ebpf_core_object_t* object)
     ebpf_epoch_free(link);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_create(ebpf_link_t** link)
 {
     EBPF_LOG_ENTRY();
@@ -63,7 +63,7 @@ ebpf_link_create(ebpf_link_t** link)
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_initialize(
     ebpf_link_t* link, ebpf_attach_type_t attach_type, const uint8_t* context_data, size_t context_data_length)
 {
@@ -127,7 +127,7 @@ Exit:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_attach_program(ebpf_link_t* link, ebpf_program_t* program)
 {
     EBPF_LOG_ENTRY();
@@ -210,7 +210,7 @@ Exit:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_link_get_info(
     _In_ const ebpf_link_t* link, _Out_writes_to_(*info_size, *info_size) uint8_t* buffer, _Inout_ uint16_t* info_size)
 {

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -23,7 +23,7 @@ extern "C"
      *  link object.
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_create(ebpf_link_t** link);
 
     /**
@@ -37,7 +37,7 @@ extern "C"
      *  provider.
      * @retval EBPF_SUCCESS The operation was successful.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_initialize(
         ebpf_link_t* link, ebpf_attach_type_t attach_type, const uint8_t* context_data, size_t context_data_length);
 
@@ -50,7 +50,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT Hook instance has not been
      *  initialized.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_attach_program(ebpf_link_t* link, ebpf_program_t* program);
 
     /**
@@ -72,7 +72,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_link_info.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_link_get_info(
         _In_ const ebpf_link_t* link,
         _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -357,7 +357,7 @@ _next_array_map_key(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key,
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 _associate_inner_map(_Inout_ ebpf_core_object_map_t* object_map, ebpf_handle_t inner_map_handle)
 {
     ebpf_result_t result = EBPF_SUCCESS;
@@ -1209,7 +1209,7 @@ _ebpf_adjust_value_pointer(_In_ ebpf_map_t* map, _Inout_ uint8_t** value)
  * @retval EBPF_INVALID_ARGUMENT Unable to perform this operation due to
  * current CPU > allocated value buffer size.
  */
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 _update_entry_per_cpu(
     _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, ebpf_map_option_t option)
 {
@@ -1521,7 +1521,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_output(_In_ ebpf_core_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length)
 {
     ebpf_result_t result = EBPF_SUCCESS;
@@ -1557,13 +1557,13 @@ _ebpf_ring_buffer_map_cancel_async_query(_In_ _Frees_ptr_ void* cancel_context)
     EBPF_LOG_EXIT();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_query_buffer(_In_ const ebpf_map_t* map, _Outptr_ uint8_t** buffer)
 {
     return ebpf_ring_buffer_map_buffer((ebpf_ring_buffer_t*)map->data, buffer);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_return_buffer(_In_ const ebpf_map_t* map, size_t consumer_offset)
 {
     size_t producer_offset;
@@ -1579,7 +1579,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_async_query(
     _In_ ebpf_map_t* map,
     _Inout_ ebpf_ring_buffer_map_async_query_result_t* async_query_result,
@@ -1869,7 +1869,7 @@ _ebpf_map_delete(_In_ ebpf_core_object_t* object)
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_create(
     _In_ const ebpf_utf8_string_t* map_name,
     _In_ const ebpf_map_definition_in_memory_t* ebpf_map_definition,
@@ -1951,7 +1951,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_find_entry(
     _In_ ebpf_map_t* map,
     size_t key_size,
@@ -2032,7 +2032,7 @@ ebpf_map_find_entry(
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_associate_program(_In_ ebpf_map_t* map, _In_ const ebpf_program_t* program)
 {
     EBPF_LOG_ENTRY();
@@ -2066,7 +2066,7 @@ ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads
     return (ebpf_program_t*)ebpf_map_metadata_tables[type].get_object_from_entry(map, key);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_update_entry(
     _In_ ebpf_map_t* map,
     size_t key_size,
@@ -2129,7 +2129,7 @@ ebpf_map_update_entry(
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_update_entry_with_handle(
     _In_ ebpf_map_t* map,
     size_t key_size,
@@ -2160,7 +2160,7 @@ ebpf_map_update_entry_with_handle(
         map, key, value_handle, option);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags)
 {
     // High volume call - Skip entry/exit logging.
@@ -2187,7 +2187,7 @@ ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size
     return result;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_next_key(
     _In_ ebpf_map_t* map,
     size_t key_size,
@@ -2215,7 +2215,7 @@ ebpf_map_next_key(
     return ebpf_map_metadata_tables[map->ebpf_map_definition.type].next_key(map, previous_key, next_key);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_get_info(
     _In_ const ebpf_map_t* map, _Out_writes_to_(*info_size, *info_size) uint8_t* buffer, _Inout_ uint16_t* info_size)
 {
@@ -2252,7 +2252,7 @@ ebpf_map_get_info(
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_push_entry(_In_ ebpf_map_t* map, size_t value_size, _In_reads_(value_size) const uint8_t* value, int flags)
 {
     if (!(flags & EBPF_MAP_FLAG_HELPER) && (value_size != map->ebpf_map_definition.value_size)) {
@@ -2271,7 +2271,7 @@ ebpf_map_push_entry(_In_ ebpf_map_t* map, size_t value_size, _In_reads_(value_si
     return ebpf_map_metadata_tables[map->ebpf_map_definition.type].update_entry(map, NULL, value, flags);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_pop_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags)
 {
     uint8_t* return_value;
@@ -2299,7 +2299,7 @@ ebpf_map_pop_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_s
     return EBPF_SUCCESS;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_map_peek_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags)
 {
     uint8_t* return_value;

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -28,7 +28,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  map.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_create(
         _In_ const ebpf_utf8_string_t* map_name,
         _In_ const ebpf_map_definition_in_memory_t* ebpf_map_definition,
@@ -63,7 +63,7 @@ extern "C"
      * @param[in] flags Zero or more EBPF_MAP_FIND_ENTRY_FLAG_* flags.
      * @return Pointer to the value if found or NULL.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_find_entry(
         _In_ ebpf_map_t* map,
         size_t key_size,
@@ -84,7 +84,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  entry.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_update_entry(
         _In_ ebpf_map_t* map,
         size_t key_size,
@@ -105,7 +105,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  entry.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_update_entry_with_handle(
         _In_ ebpf_map_t* map,
         size_t key_size,
@@ -122,7 +122,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are
      *  invalid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key, int flags);
 
     /**
@@ -137,7 +137,7 @@ extern "C"
      * @retval EBPF_NO_MORE_KEYS There is no key following the specified
      * key in lexicographically order.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_next_key(
         _In_ ebpf_map_t* map,
         size_t key_size,
@@ -167,7 +167,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_FD The program is incompatible with this map.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_associate_program(_In_ ebpf_map_t* map, _In_ const struct _ebpf_program* program);
 
     /**
@@ -181,7 +181,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_map_info.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_get_info(
         _In_ const ebpf_map_t* map,
         _Out_writes_to_(*info_size, *info_size) uint8_t* buffer,
@@ -195,7 +195,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully mapped the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to map the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_query_buffer(_In_ const ebpf_map_t* map, _Outptr_ uint8_t** buffer);
 
     /**
@@ -206,7 +206,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully returned records to the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to return records to the ring buffer.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_return_buffer(_In_ const ebpf_map_t* map, size_t length);
 
     /**
@@ -218,7 +218,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Insufficient memory to complete this operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_async_query(
         _In_ ebpf_map_t* map,
         _Inout_ ebpf_ring_buffer_map_async_query_result_t* async_query_result,
@@ -233,7 +233,7 @@ extern "C"
      * @retval EPBF_SUCCESS Successfully wrote record into ring buffer.
      * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_output(_In_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length);
 
     /**
@@ -248,7 +248,7 @@ extern "C"
      *  entry.
      * @retval EBPF_OUT_OF_SPACE Map is full and BPF_EXIST was not supplied.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_push_entry(
         _In_ ebpf_map_t* map, size_t value_size, _In_reads_(value_size) const uint8_t* value, int flags);
 
@@ -263,7 +263,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND The map is empty.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_pop_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
 
     /**
@@ -277,7 +277,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND The map is empty.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_map_peek_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
 
     /**

--- a/libs/execution_context/ebpf_native.h
+++ b/libs/execution_context/ebpf_native.h
@@ -20,7 +20,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_initiate();
 
     /**
@@ -46,7 +46,7 @@ extern "C"
      * @retval EBPF_OBJECT_ALREADY_EXISTS Native module for this module ID is already
      *  initialized.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_load(
         _In_reads_(service_name_length) const wchar_t* service_name,
         uint16_t service_name_length,
@@ -72,7 +72,7 @@ extern "C"
      * @retval EBPF_OBJECT_ALREADY_EXISTS Native module for this module ID is already
      *  loaded.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_load_programs(
         _In_ const GUID* module_id,
         size_t count_of_map_handles,
@@ -89,7 +89,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND Specified module was not found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_get_count_of_programs(_In_ const GUID* module_id, _Out_ size_t* count_of_programs);
 
     /**
@@ -101,7 +101,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND Specified module was not found.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_get_count_of_maps(_In_ const GUID* module_id, _Out_ size_t* count_of_maps);
 
     /**
@@ -112,7 +112,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate memory for service name.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_native_unload(_In_ const GUID* module_id);
 
     /**

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -75,7 +75,7 @@ typedef struct _ebpf_program
 static ebpf_result_t
 _ebpf_program_register_helpers(_In_ const ebpf_program_t* program);
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_initiate()
 {
     return ebpf_state_allocate_index(&_ebpf_program_state_index);
@@ -83,7 +83,8 @@ ebpf_program_initiate()
 
 void
 ebpf_program_terminate()
-{}
+{
+}
 
 static void
 _ebpf_program_detach_links(_Inout_ ebpf_program_t* program)
@@ -399,7 +400,7 @@ Done:
     EBPF_RETURN_RESULT(return_value);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_create(_Outptr_ ebpf_program_t** program)
 {
     EBPF_LOG_ENTRY();
@@ -440,7 +441,7 @@ Done:
     EBPF_RETURN_RESULT(retval);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_initialize(_Inout_ ebpf_program_t* program, _In_ const ebpf_program_parameters_t* program_parameters)
 {
     EBPF_LOG_ENTRY();
@@ -523,7 +524,7 @@ ebpf_expected_attach_type(_In_ const ebpf_program_t* program)
     return &ebpf_program_get_parameters(program)->expected_attach_type;
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_associate_additional_map(ebpf_program_t* program, ebpf_map_t* map)
 {
     EBPF_LOG_ENTRY();
@@ -554,7 +555,7 @@ Done:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t maps_count)
 {
     EBPF_LOG_ENTRY();
@@ -755,7 +756,7 @@ Done:
 }
 #endif
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_load_code(
     _Inout_ ebpf_program_t* program,
     ebpf_code_type_t code_type,
@@ -796,7 +797,7 @@ typedef struct _ebpf_program_tail_call_state
     uint32_t count;
 } ebpf_program_tail_call_state_t;
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_set_tail_call(_In_ const ebpf_program_t* next_program)
 {
     // High volume call - Skip entry/exit logging.
@@ -913,7 +914,7 @@ _ebpf_program_get_helper_function_address(
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_get_helper_function_addresses(
     _In_ const ebpf_program_t* program, size_t addresses_count, _Out_writes_(addresses_count) uint64_t* addresses)
 {
@@ -936,7 +937,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_set_helper_function_ids(
     _Inout_ ebpf_program_t* program,
     const size_t helper_function_count,
@@ -973,7 +974,7 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_get_program_info(_In_ const ebpf_program_t* program, _Outptr_ ebpf_program_info_t** program_info)
 {
     EBPF_LOG_ENTRY();
@@ -1095,7 +1096,7 @@ ebpf_program_detach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* l
     EBPF_RETURN_VOID();
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_get_info(
     _In_ const ebpf_program_t* program,
     _In_reads_(*info_size) const uint8_t* input_buffer,
@@ -1152,7 +1153,7 @@ ebpf_program_get_info(
     EBPF_RETURN_RESULT(result);
 }
 
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 ebpf_program_create_and_initialize(
     _In_ const ebpf_program_parameters_t* parameters, _Out_ ebpf_handle_t* program_handle)
 {

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -43,7 +43,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_initiate();
 
     /**
@@ -61,7 +61,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_create(_Outptr_ ebpf_program_t** program);
 
     /**
@@ -75,7 +75,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_initialize(_Inout_ ebpf_program_t* program, _In_ const ebpf_program_parameters_t* program_parameters);
 
     /**
@@ -106,7 +106,7 @@ extern "C"
      * @retval EBPF_ERROR_EXTENSION_FAILED_TO_LOAD The program info isn't
      *  available.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_get_program_info(_In_ const ebpf_program_t* program, _Outptr_ ebpf_program_info_t** program_info);
 
     /**
@@ -127,7 +127,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_associate_maps(ebpf_program_t* program, ebpf_map_t** maps, uint32_t maps_count);
 
     /**
@@ -139,7 +139,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_associate_additional_map(ebpf_program_t* program, ebpf_map_t* map);
 
     /**
@@ -155,7 +155,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_load_code(
         _Inout_ ebpf_program_t* program,
         ebpf_code_type_t code_type,
@@ -185,7 +185,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT The helper function IDs array is already populated.
      * @retval EBPF_NO_MEMORY Could not allocate array of helper function IDs.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_set_helper_function_ids(
         _Inout_ ebpf_program_t* program,
         const size_t helper_function_count,
@@ -202,7 +202,7 @@ extern "C"
      * @retval EBPF_INSUFFICIENT_BUFFER Output array is insufficient.
      * @retval EBPF_INVALID_ARGUMENT At least one helper function id is not valid.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_get_helper_function_addresses(
         _In_ const ebpf_program_t* program,
         const size_t addresses_count,
@@ -234,7 +234,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT Internal error.
      * @retval EBPF_NO_MORE_TAIL_CALLS Program has executed to many tail calls.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_set_tail_call(_In_ const ebpf_program_t* next_program);
 
     /**
@@ -249,7 +249,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INSUFFICIENT_BUFFER The buffer was too small to hold bpf_prog_info.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_get_info(
         _In_ const ebpf_program_t* program,
         _In_reads_(*info_size) const uint8_t* input_buffer,
@@ -268,7 +268,7 @@ extern "C"
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
      */
-    ebpf_result_t
+    _Must_inspect_result_ ebpf_result_t
     ebpf_program_create_and_initialize(
         _In_ const ebpf_program_parameters_t* parameters, _Out_ ebpf_handle_t* program_handle);
 

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -950,7 +950,7 @@ static empty_reply_t _empty_reply;
 typedef std::vector<uint8_t> ebpf_protocol_buffer_t;
 
 template <typename request_t, typename reply_t = empty_reply_t>
-ebpf_result_t
+_Must_inspect_result_ ebpf_result_t
 invoke_protocol(
     ebpf_operation_id_t operation_id,
     request_t& request,
@@ -1426,15 +1426,15 @@ TEST_CASE("EBPF_OPERATION_GET_PINNED_OBJECT short header", "[execution_context][
 
     auto compeltion = [](void*, size_t, ebpf_result_t) {};
 
-    ebpf_result_t result = ebpf_core_invoke_protocol_handler(
-        EBPF_OPERATION_GET_PINNED_OBJECT,
-        request_ptr,
-        static_cast<uint16_t>(request_size),
-        reply_ptr,
-        static_cast<uint16_t>(reply_size),
-        nullptr,
-        compeltion);
-    REQUIRE(result == EBPF_INVALID_ARGUMENT);
+    REQUIRE(
+        ebpf_core_invoke_protocol_handler(
+            EBPF_OPERATION_GET_PINNED_OBJECT,
+            request_ptr,
+            static_cast<uint16_t>(request_size),
+            reply_ptr,
+            static_cast<uint16_t>(reply_size),
+            nullptr,
+            compeltion) == EBPF_INVALID_ARGUMENT);
 }
 
 TEST_CASE("EBPF_OPERATION_LINK_PROGRAM", "[execution_context][negative]")
@@ -1557,15 +1557,15 @@ TEST_CASE("EBPF_OPERATION_LOAD_NATIVE_MODULE short header", "[execution_context]
 
     auto compeltion = [](void*, size_t, ebpf_result_t) {};
 
-    ebpf_result_t result = ebpf_core_invoke_protocol_handler(
-        EBPF_OPERATION_LOAD_NATIVE_MODULE,
-        request_ptr,
-        static_cast<uint16_t>(request_size),
-        reply_ptr,
-        static_cast<uint16_t>(reply_size),
-        nullptr,
-        compeltion);
-    REQUIRE(result == EBPF_ARITHMETIC_OVERFLOW);
+    REQUIRE(
+        ebpf_core_invoke_protocol_handler(
+            EBPF_OPERATION_LOAD_NATIVE_MODULE,
+            request_ptr,
+            static_cast<uint16_t>(request_size),
+            reply_ptr,
+            static_cast<uint16_t>(reply_size),
+            nullptr,
+            compeltion) == EBPF_ARITHMETIC_OVERFLOW);
 }
 
 // TODO: Add more native module loading IOCTL negative tests.

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -1424,7 +1424,7 @@ TEST_CASE("EBPF_OPERATION_GET_PINNED_OBJECT short header", "[execution_context][
     header->id = EBPF_OPERATION_GET_PINNED_OBJECT;
     header->length = 4; // Less than sizeof(ebpf_operation_header_t).
 
-    auto compeltion = [](void*, size_t, ebpf_result_t) {};
+    auto completion = [](void*, size_t, ebpf_result_t) {};
 
     REQUIRE(
         ebpf_core_invoke_protocol_handler(
@@ -1434,7 +1434,7 @@ TEST_CASE("EBPF_OPERATION_GET_PINNED_OBJECT short header", "[execution_context][
             reply_ptr,
             static_cast<uint16_t>(reply_size),
             nullptr,
-            compeltion) == EBPF_INVALID_ARGUMENT);
+            completion) == EBPF_INVALID_ARGUMENT);
 }
 
 TEST_CASE("EBPF_OPERATION_LINK_PROGRAM", "[execution_context][negative]")
@@ -1555,7 +1555,7 @@ TEST_CASE("EBPF_OPERATION_LOAD_NATIVE_MODULE short header", "[execution_context]
     header->id = EBPF_OPERATION_LOAD_NATIVE_MODULE;
     header->length = 12; // Less than sizeof(ebpf_operation_load_native_module_request_t).
 
-    auto compeltion = [](void*, size_t, ebpf_result_t) {};
+    auto completion = [](void*, size_t, ebpf_result_t) {};
 
     REQUIRE(
         ebpf_core_invoke_protocol_handler(
@@ -1565,7 +1565,7 @@ TEST_CASE("EBPF_OPERATION_LOAD_NATIVE_MODULE short header", "[execution_context]
             reply_ptr,
             static_cast<uint16_t>(reply_size),
             nullptr,
-            compeltion) == EBPF_ARITHMETIC_OVERFLOW);
+            completion) == EBPF_ARITHMETIC_OVERFLOW);
 }
 
 // TODO: Add more native module loading IOCTL negative tests.

--- a/tests/fuzz/execution_context.cpp
+++ b/tests/fuzz/execution_context.cpp
@@ -157,7 +157,10 @@ TEST_CASE("execution_context_direct", "[fuzz]")
             std::cout << std::dec << (i * 100) / iterations << "% completed" << std::endl;
         }
 
-        ebpf_core_get_protocol_handler_properties(operation_id, &minimum_request_size, &minimum_reply_size, &async);
+        if (ebpf_core_get_protocol_handler_properties(
+                operation_id, &minimum_request_size, &minimum_reply_size, &async) != EBPF_SUCCESS) {
+            continue;
+        }
 
         // TODO - Add support for fuzzing async requests.
         // https://github.com/microsoft/ebpf-for-windows/issues/897

--- a/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
@@ -156,7 +156,13 @@ fuzz_async_completion(void*, size_t, ebpf_result_t){};
 class fuzz_wrapper
 {
   public:
-    fuzz_wrapper() { ebpf_core_initiate(); }
+    fuzz_wrapper()
+    {
+        ebpf_result_t result = ebpf_core_initiate();
+        if (result != EBPF_SUCCESS) {
+            throw std::runtime_error("ebpf_core_initiate failed");
+        }
+    }
     void
     make_program(const GUID type)
     {

--- a/tests/performance/ExecutionContext.cpp
+++ b/tests/performance/ExecutionContext.cpp
@@ -100,7 +100,7 @@ typedef class _ebpf_map_test_state
 
         for (uint32_t i = 0; i < ebpf_get_cpu_count(); i++) {
             uint64_t value = 0;
-            ebpf_map_update_entry(map, 0, (uint8_t*)&i, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
+            (void)ebpf_map_update_entry(map, 0, (uint8_t*)&i, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
         }
     }
     ~_ebpf_map_test_state()
@@ -116,7 +116,7 @@ typedef class _ebpf_map_test_state
         volatile uint64_t* value = nullptr;
 
         REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
-        ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
+        (void)ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
         uint64_t local = *value;
         UNREFERENCED_PARAMETER(local);
         ebpf_epoch_exit();
@@ -128,7 +128,7 @@ typedef class _ebpf_map_test_state
         uint32_t key = cpu_id;
         uint64_t* value = nullptr;
         REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
-        ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
+        (void)ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
         (*value)++;
         ebpf_epoch_exit();
     }
@@ -139,7 +139,7 @@ typedef class _ebpf_map_test_state
         uint32_t key = cpu_id;
         uint64_t value = 0;
         REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
-        ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
+        (void)ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
         ebpf_epoch_exit();
     }
 
@@ -149,7 +149,7 @@ typedef class _ebpf_map_test_state
         uint32_t key = ebpf_random_uint32();
         uint64_t value = 0;
         REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
-        ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
+        (void)ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
         ebpf_epoch_exit();
     }
 
@@ -217,7 +217,7 @@ typedef class _ebpf_map_lpm_trie_test_state
         volatile uint64_t* value = nullptr;
 
         REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
-        ebpf_map_find_entry(map, sizeof(ipv4_key), (uint8_t*)&ipv4_key, sizeof(value), (uint8_t*)&value, 0);
+        (void)ebpf_map_find_entry(map, sizeof(ipv4_key), (uint8_t*)&ipv4_key, sizeof(value), (uint8_t*)&value, 0);
         UNREFERENCED_PARAMETER(value);
         ebpf_epoch_exit();
     }


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alan.jowett@microsoft.com>

Partially resolves: https://github.com/microsoft/ebpf-for-windows/issues/1542

## Description

Annotate execution context API's with _Must_inspect_result_

## Testing

CI/CD

## Documentation

No.
