### PR TITLE
dependabot's tracking for 'pip' is failing

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,12 +27,6 @@ updates:
       interval: "weekly"
       day: "saturday"
 
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "saturday"
-
   - package-ecosystem: "docker"
     directory: "/images"
     schedule:


### PR DESCRIPTION
## Description

This PR will remove the dependency for pip module. Dependebot relies on the dependebot.yml file to check for dependencies and their updates. However, in ebpf-for-windows, we don't have dependencies with python packages. In order to verify that, I used `pip freeze` to check for the directories and packages related to python code. However, this was empty. 

## Testing

The yml file is modified. Now, if we take these steps, we see that pip dependency is removed. 

- Enable dependabot for the forked repo via 'github->Security->Dependabot'. (This option is available only on forked repos).

- Select the 'Dependabot' tab @ 'github->Insights->Dependency Graph'.

- (OPTIONAL) - Trigger a dependabot scan for pip (by clicking 'last checked xxx -> 'Check for updates' link)

issue related #1492 
