### PR TITLE
dependabot's tracking for 'gitmodules' is failing 

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,7 +12,6 @@
 [submodule "external/win-c"]
 	path = external/win-c
 	url = https://github.com/takamin/win-c.git
-	branch = windows
 [submodule "external/Catch2"]
 	path = external/Catch2
 	url = https://github.com/catchorg/Catch2.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,7 @@
 [submodule "external/ubpf"]
 	path = external/ubpf
 	url = https://github.com/iovisor/ubpf.git
-	branch = master
+	branch = main
 [submodule "external/bpftool"]
 	path = external/bpftool
 	url = https://github.com/dthaler/bpftool-1.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,6 @@
 [submodule "external/ubpf"]
 	path = external/ubpf
 	url = https://github.com/iovisor/ubpf.git
-	branch = main
 [submodule "external/bpftool"]
 	path = external/bpftool
 	url = https://github.com/dthaler/bpftool-1.git


### PR DESCRIPTION
Dependabot was showing the following errors due to the nonexistence branches :
` Dependabot couldn't fetch the branch/reference for external/ubpf
Your dependency file specified a branch or reference for external/ubpf, but Dependabot couldn't find it at the project's source. Has it been removed?

 Dependabot couldn't fetch the branch/reference for external/win-c
Your dependency file specified a branch or reference for external/win-c, but Dependabot couldn't find it at the project's source. Has it been removed? `

This PR will remove the dependency for branches of external/win-c and external/ubpf. Dependebot relies on the .gitmodules file to check for dependencies and their updates. However, in ebpf-for-windows, we use default branches for the following github repos
1. The windows branch in https://github.com/takamin/win-c.git has been deleted.
2. The master branch for external/ubpf doesn't exist and we use the default branch. 

Testing
The .gitmodules file is modified. Now, if we take these steps, we see that pip dependency is removed.

Enable dependabot for the forked repo via 'github->Security->Dependabot'. (This option is available only on forked repos).

Select the 'Dependabot' tab @ 'github->Insights->Dependency Graph'.

(OPTIONAL) - Trigger a dependabot scan for pip (by clicking 'last checked xxx -> 'Check for updates' link)

[issue related #1490 ](https://github.com/microsoft/ebpf-for-windows/issues/1490)