### PR TITLE
Check for NULL return from ebpf_enumerate_sections and ebpf_api_elf_disassemble_section

### DIFF
--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -60,7 +60,9 @@ handle_ebpf_show_disassembly(
     const char* disassembly = nullptr;
     const char* error_message = nullptr;
     if (ebpf_api_elf_disassemble_section(filename.c_str(), section.c_str(), &disassembly, &error_message) != 0) {
-        std::cerr << error_message << std::endl;
+        if (error_message != nullptr) {
+            std::cerr << error_message << std::endl;
+        }
         ebpf_free_string(error_message);
         return ERROR_SUPPRESS_OUTPUT;
     } else {
@@ -136,7 +138,9 @@ handle_ebpf_show_sections(
     ebpf_section_info_t* section_data = nullptr;
     const char* error_message = nullptr;
     if (ebpf_enumerate_sections(filename.c_str(), level == VL_VERBOSE, &section_data, &error_message) != 0) {
-        std::cerr << error_message << std::endl;
+        if (error_message != nullptr) {
+            std::cerr << error_message << std::endl;
+        }
         ebpf_free_string(error_message);
         ebpf_free_sections(section_data);
         return ERROR_SUPPRESS_OUTPUT;


### PR DESCRIPTION
Resolves: #1605

Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

handle_ebpf_show_disassembly and handle_ebpf_show_sections fail to check for NULL being returned from eBPF API.

## Testing

CI/CD

## Documentation

No.
