### PR TITLE
Resolve conflict when updating ubpf

### DIFF
--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -63,7 +63,10 @@ ubpf_translate_x86_64(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** 
     return -1;
 }
 
+#pragma warning(push)
+#pragma warning(disable : 28159) // Don't use KeBugCheck
 void __cdecl abort(void) { KeBugCheck(PAGE_FAULT_IN_NONPAGED_AREA); }
+#pragma warning(pop)
 
 #include "ubpf_vm.c"
 #pragma warning(push)

--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -55,6 +55,16 @@ map_register(int r)
     return 0;
 }
 
+// Thunk out JIT related calls.
+// Workaround until https://github.com/iovisor/ubpf/issues/185 is fixed.
+int
+ubpf_translate_x86_64(struct ubpf_vm* vm, uint8_t* buffer, size_t* size, char** errmsg)
+{
+    return -1;
+}
+
+void __cdecl abort(void) { KeBugCheck(PAGE_FAULT_IN_NONPAGED_AREA); }
+
 #include "ubpf_vm.c"
 #pragma warning(push)
 #pragma warning(disable : 6387) // ubpf_jit.c(70): error C6387: 'buffer' could be '0'


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Changes in ubpf to support different JIT backends requires corresponding changes in eBPF for Windows.
Implement kernel mode equivalent of [abort](https://www.man7.org/linux/man-pages/man3/abort.3.html).

## Testing

CI/CD

## Documentation

No.
