### PR TITLE
bpf_object__open should fail if it hits low memory failure

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2074,6 +2074,7 @@ _ebpf_pe_add_section(
 
     ebpf_section_info_t* info = (ebpf_section_info_t*)malloc(sizeof(*info));
     if (info == nullptr) {
+        pe_context->result = EBPF_NO_MEMORY;
         EBPF_LOG_EXIT();
         return 1;
     }
@@ -2085,6 +2086,7 @@ _ebpf_pe_add_section(
     info->expected_attach_type = pe_context->section_attach_types[pe_section_name];
     info->program_type_name = ebpf_get_program_type_name(&pe_context->section_program_types[pe_section_name]);
     if (info->program_type_name == nullptr) {
+        pe_context->result = EBPF_NO_MEMORY;
         EBPF_LOG_EXIT();
         return 1;
     }
@@ -2137,7 +2139,16 @@ _ebpf_enumerate_native_sections(
 
     DestructParsedPE(pe);
 
-    *infos = context.infos;
+    if (context.result != EBPF_SUCCESS) {
+        *error_message = _strdup("Failed to parse PE file.");
+        while (context.infos) {
+            ebpf_section_info_t* next = context.infos->next;
+            _ebpf_free_section_info(context.infos);
+            context.infos = next;
+        }
+    } else {
+        *infos = context.infos;
+    }
     EBPF_RETURN_RESULT(context.result);
 }
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1614 
Resolves: #1615 

## Description

bpf_object__open should fail if it hits a low-memory failure. 

## Testing

CI/CD

## Documentation

No.
