### PR TITLE
Marked exported API's as noexcept

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -41,7 +41,7 @@ extern "C"
         fd_t fd,
         _Out_ ebpf_execution_type_t* execution_type,
         _Outptr_result_z_ const char** file_name,
-        _Outptr_result_z_ const char** section_name);
+        _Outptr_result_z_ const char** section_name) noexcept;
 
     typedef struct _ebpf_stat
     {
@@ -77,14 +77,14 @@ extern "C"
         _In_z_ const char* file,
         bool verbose,
         _Outptr_result_maybenull_ ebpf_section_info_t** infos,
-        _Outptr_result_maybenull_z_ const char** error_message);
+        _Outptr_result_maybenull_z_ const char** error_message) noexcept;
 
     /**
      * @brief Free memory returned from \ref ebpf_enumerate_sections.
      * @param[in] data Memory to free.
      */
     void
-    ebpf_free_sections(_In_opt_ ebpf_section_info_t* infos);
+    ebpf_free_sections(_In_opt_ ebpf_section_info_t* infos) noexcept;
 
     /**
      * @brief Convert an eBPF program to human readable byte code.
@@ -99,7 +99,7 @@ extern "C"
         _In_z_ const char* file,
         _In_z_ const char* section,
         _Outptr_result_maybenull_z_ const char** disassembly,
-        _Outptr_result_maybenull_z_ const char** error_message);
+        _Outptr_result_maybenull_z_ const char** error_message) noexcept;
 
     typedef struct
     {
@@ -130,7 +130,7 @@ extern "C"
         bool verbose,
         _Outptr_result_maybenull_z_ const char** report,
         _Outptr_result_maybenull_z_ const char** error_message,
-        _Out_opt_ ebpf_api_verifier_stats_t* stats);
+        _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept;
 
     /**
      * @brief Verify that the program is safe to execute.
@@ -156,14 +156,14 @@ extern "C"
         bool verbose,
         _Outptr_result_maybenull_z_ const char** report,
         _Outptr_result_maybenull_z_ const char** error_message,
-        _Out_opt_ ebpf_api_verifier_stats_t* stats);
+        _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept;
 
     /**
      * @brief Free memory for a string returned from an eBPF API.
      * @param[in] string Memory to free.
      */
     void
-    ebpf_free_string(_In_opt_ _Post_invalid_ const char* string);
+    ebpf_free_string(_In_opt_ _Post_invalid_ const char* string) noexcept;
 
     /**
      * @brief Dissociate a name with an object handle.
@@ -180,7 +180,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      */
     ebpf_result_t
-    ebpf_object_unpin(_In_z_ const char* path);
+    ebpf_object_unpin(_In_z_ const char* path) noexcept;
 
     /**
      * @brief Detach the eBPF program from the link.
@@ -201,7 +201,7 @@ extern "C"
      * @retval EBPF_INVALID_OBJECT Handle is not valid.
      */
     ebpf_result_t
-    ebpf_api_close_handle(ebpf_handle_t handle);
+    ebpf_api_close_handle(ebpf_handle_t handle) noexcept;
 
     /**
      * @brief Returns an array of \ref ebpf_map_info_t for all pinned maps.
@@ -215,7 +215,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_api_get_pinned_map_info(
-        _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info);
+        _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info) noexcept;
 
     /**
      * @brief Helper Function to free array of \ref ebpf_map_info_t allocated by
@@ -226,7 +226,7 @@ extern "C"
      */
     void
     ebpf_api_map_info_free(
-        uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info);
+        uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info) noexcept;
 
     /**
      * @brief Get the execution type for an eBPF object file.
@@ -248,7 +248,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
      */
     ebpf_result_t
-    ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type);
+    ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type) noexcept;
 
     /**
      * @brief Attach an eBPF program.
@@ -272,7 +272,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
         _In_ size_t attach_params_size,
-        _Outptr_ struct bpf_link** link);
+        _Outptr_ struct bpf_link** link) noexcept;
 
     /**
      * @brief Attach an eBPF program by program file descriptor.
@@ -296,7 +296,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
         _In_ size_t attach_parameters_size,
-        _Outptr_ struct bpf_link** link);
+        _Outptr_ struct bpf_link** link) noexcept;
 
     /**
      * @brief Detach an eBPF program from an attach point represented by
@@ -343,7 +343,7 @@ extern "C"
      * @sa bpf_link_detach
      */
     ebpf_result_t
-    ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link);
+    ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link) noexcept;
 
     /**
      * @brief Close a file descriptor. Also close the underlying handle.
@@ -369,7 +369,7 @@ extern "C"
     ebpf_get_program_type_by_name(
         _In_z_ const char* name,
         _Out_ ebpf_program_type_t* program_type,
-        _Out_ ebpf_attach_type_t* expected_attach_type);
+        _Out_ ebpf_attach_type_t* expected_attach_type) noexcept;
 
     /**
      * @brief Get the name of a given program type.
@@ -379,7 +379,7 @@ extern "C"
      * @returns Name of the program type, or NULL if not found.
      */
     _Ret_maybenull_z_ const char*
-    ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type);
+    ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type) noexcept;
 
     /**
      * @brief Get the name of a given attach type.
@@ -389,7 +389,7 @@ extern "C"
      * @returns Name of the attach type, or NULL if not found.
      */
     _Ret_maybenull_z_ const char*
-    ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type);
+    ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type) noexcept;
 
     /**
      * @brief Gets the next pinned program after a given path.
@@ -402,7 +402,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_get_next_pinned_program_path(
-        _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path);
+        _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) noexcept;
 
     typedef struct _ebpf_program_info ebpf_program_info_t;
 
@@ -416,7 +416,7 @@ extern "C"
      * @retval EBPF_OBJECT_NOT_FOUND No program information was found.
      */
     ebpf_result_t
-    ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info);
+    ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info) noexcept;
 
 #ifdef __cplusplus
 }

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -41,7 +41,7 @@ extern "C"
         fd_t fd,
         _Out_ ebpf_execution_type_t* execution_type,
         _Outptr_result_z_ const char** file_name,
-        _Outptr_result_z_ const char** section_name) noexcept;
+        _Outptr_result_z_ const char** section_name) EBPF_NO_EXCEPT;
 
     typedef struct _ebpf_stat
     {
@@ -77,14 +77,14 @@ extern "C"
         _In_z_ const char* file,
         bool verbose,
         _Outptr_result_maybenull_ ebpf_section_info_t** infos,
-        _Outptr_result_maybenull_z_ const char** error_message) noexcept;
+        _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
 
     /**
      * @brief Free memory returned from \ref ebpf_enumerate_sections.
      * @param[in] data Memory to free.
      */
     void
-    ebpf_free_sections(_In_opt_ ebpf_section_info_t* infos) noexcept;
+    ebpf_free_sections(_In_opt_ ebpf_section_info_t* infos) EBPF_NO_EXCEPT;
 
     /**
      * @brief Convert an eBPF program to human readable byte code.
@@ -99,7 +99,7 @@ extern "C"
         _In_z_ const char* file,
         _In_z_ const char* section,
         _Outptr_result_maybenull_z_ const char** disassembly,
-        _Outptr_result_maybenull_z_ const char** error_message) noexcept;
+        _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
 
     typedef struct
     {
@@ -130,7 +130,7 @@ extern "C"
         bool verbose,
         _Outptr_result_maybenull_z_ const char** report,
         _Outptr_result_maybenull_z_ const char** error_message,
-        _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept;
+        _Out_opt_ ebpf_api_verifier_stats_t* stats) EBPF_NO_EXCEPT;
 
     /**
      * @brief Verify that the program is safe to execute.
@@ -156,14 +156,14 @@ extern "C"
         bool verbose,
         _Outptr_result_maybenull_z_ const char** report,
         _Outptr_result_maybenull_z_ const char** error_message,
-        _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept;
+        _Out_opt_ ebpf_api_verifier_stats_t* stats) EBPF_NO_EXCEPT;
 
     /**
      * @brief Free memory for a string returned from an eBPF API.
      * @param[in] string Memory to free.
      */
     void
-    ebpf_free_string(_In_opt_ _Post_invalid_ const char* string) noexcept;
+    ebpf_free_string(_In_opt_ _Post_invalid_ const char* string) EBPF_NO_EXCEPT;
 
     /**
      * @brief Dissociate a name with an object handle.
@@ -180,7 +180,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      */
     ebpf_result_t
-    ebpf_object_unpin(_In_z_ const char* path) noexcept;
+    ebpf_object_unpin(_In_z_ const char* path) EBPF_NO_EXCEPT;
 
     /**
      * @brief Detach the eBPF program from the link.
@@ -201,7 +201,7 @@ extern "C"
      * @retval EBPF_INVALID_OBJECT Handle is not valid.
      */
     ebpf_result_t
-    ebpf_api_close_handle(ebpf_handle_t handle) noexcept;
+    ebpf_api_close_handle(ebpf_handle_t handle) EBPF_NO_EXCEPT;
 
     /**
      * @brief Returns an array of \ref ebpf_map_info_t for all pinned maps.
@@ -215,7 +215,8 @@ extern "C"
      */
     ebpf_result_t
     ebpf_api_get_pinned_map_info(
-        _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info) noexcept;
+        _Out_ uint16_t* map_count,
+        _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info) EBPF_NO_EXCEPT;
 
     /**
      * @brief Helper Function to free array of \ref ebpf_map_info_t allocated by
@@ -226,7 +227,8 @@ extern "C"
      */
     void
     ebpf_api_map_info_free(
-        uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info) noexcept;
+        uint16_t map_count,
+        _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info) EBPF_NO_EXCEPT;
 
     /**
      * @brief Get the execution type for an eBPF object file.
@@ -248,7 +250,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
      */
     ebpf_result_t
-    ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type) noexcept;
+    ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type) EBPF_NO_EXCEPT;
 
     /**
      * @brief Attach an eBPF program.
@@ -272,7 +274,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
         _In_ size_t attach_params_size,
-        _Outptr_ struct bpf_link** link) noexcept;
+        _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Attach an eBPF program by program file descriptor.
@@ -296,7 +298,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
         _In_ size_t attach_parameters_size,
-        _Outptr_ struct bpf_link** link) noexcept;
+        _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Detach an eBPF program from an attach point represented by
@@ -343,7 +345,7 @@ extern "C"
      * @sa bpf_link_detach
      */
     ebpf_result_t
-    ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link) noexcept;
+    ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Close a file descriptor. Also close the underlying handle.
@@ -369,7 +371,7 @@ extern "C"
     ebpf_get_program_type_by_name(
         _In_z_ const char* name,
         _Out_ ebpf_program_type_t* program_type,
-        _Out_ ebpf_attach_type_t* expected_attach_type) noexcept;
+        _Out_ ebpf_attach_type_t* expected_attach_type) EBPF_NO_EXCEPT;
 
     /**
      * @brief Get the name of a given program type.
@@ -379,7 +381,7 @@ extern "C"
      * @returns Name of the program type, or NULL if not found.
      */
     _Ret_maybenull_z_ const char*
-    ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type) noexcept;
+    ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type) EBPF_NO_EXCEPT;
 
     /**
      * @brief Get the name of a given attach type.
@@ -389,7 +391,7 @@ extern "C"
      * @returns Name of the attach type, or NULL if not found.
      */
     _Ret_maybenull_z_ const char*
-    ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type) noexcept;
+    ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type) EBPF_NO_EXCEPT;
 
     /**
      * @brief Gets the next pinned program after a given path.
@@ -402,7 +404,7 @@ extern "C"
      */
     ebpf_result_t
     ebpf_get_next_pinned_program_path(
-        _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) noexcept;
+        _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) EBPF_NO_EXCEPT;
 
     typedef struct _ebpf_program_info ebpf_program_info_t;
 
@@ -416,7 +418,7 @@ extern "C"
      * @retval EBPF_OBJECT_NOT_FOUND No program information was found.
      */
     ebpf_result_t
-    ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info) noexcept;
+    ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info) EBPF_NO_EXCEPT;
 
 #ifdef __cplusplus
 }

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -448,7 +448,7 @@ ebpf_api_elf_disassemble_section(
     _In_z_ const char* file,
     _In_z_ const char* section,
     _Outptr_result_maybenull_z_ const char** disassembly,
-    _Outptr_result_maybenull_z_ const char** error_message)
+    _Outptr_result_maybenull_z_ const char** error_message) noexcept
 {
     ebpf_verifier_options_t verifier_options = ebpf_verifier_default_options;
     const ebpf_platform_t* platform = &g_ebpf_platform_windows;
@@ -606,7 +606,7 @@ _Success_(return == 0) uint32_t ebpf_api_elf_verify_section_from_file(
     bool verbose,
     _Outptr_result_maybenull_z_ const char** report,
     _Outptr_result_maybenull_z_ const char** error_message,
-    _Out_opt_ ebpf_api_verifier_stats_t* stats)
+    _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept
 {
     *error_message = nullptr;
     *report = nullptr;
@@ -626,7 +626,7 @@ _Success_(return == 0) uint32_t ebpf_api_elf_verify_section_from_memory(
     bool verbose,
     _Outptr_result_maybenull_z_ const char** report,
     _Outptr_result_maybenull_z_ const char** error_message,
-    _Out_opt_ ebpf_api_verifier_stats_t* stats)
+    _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept
 {
     return _verify_section_from_string(
         std::string(data, data_length), "memory", section, program_type, verbose, report, error_message, stats);

--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -10,8 +10,8 @@
         return -1;                                                                          \
     }
 
-int
-bpf(int cmd, union bpf_attr* attr, unsigned int size)
+static int
+_bpf(int cmd, union bpf_attr* attr, unsigned int size) noexcept
 {
     switch (cmd) {
     case BPF_LINK_DETACH:
@@ -86,4 +86,10 @@ bpf(int cmd, union bpf_attr* attr, unsigned int size)
         errno = EINVAL;
         return -1;
     }
+}
+
+int
+bpf(int cmd, union bpf_attr* attr, unsigned int size)
+{
+    return _bpf(cmd, attr, size);
 }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -757,7 +757,7 @@ Exit:
 }
 
 void
-ebpf_free_string(_In_opt_ _Post_invalid_ const char* error_message)
+ebpf_free_string(_In_opt_ _Post_invalid_ const char* error_message) noexcept
 {
     EBPF_LOG_ENTRY();
     free(const_cast<char*>(error_message));
@@ -795,7 +795,7 @@ ebpf_object_pin(fd_t fd, _In_z_ const char* path) noexcept
 }
 
 ebpf_result_t
-ebpf_object_unpin(_In_z_ const char* path)
+ebpf_object_unpin(_In_z_ const char* path) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(path);
@@ -923,7 +923,7 @@ ebpf_program_query_info(
     fd_t fd,
     _Out_ ebpf_execution_type_t* execution_type,
     _Outptr_result_z_ const char** file_name,
-    _Outptr_result_z_ const char** section_name)
+    _Outptr_result_z_ const char** section_name) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result;
@@ -1091,7 +1091,7 @@ ebpf_program_attach(
     _In_opt_ const ebpf_attach_type_t* attach_type,
     _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
     _In_ size_t attach_params_size,
-    _Outptr_ struct bpf_link** link)
+    _Outptr_ struct bpf_link** link) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result = EBPF_SUCCESS;
@@ -1128,7 +1128,7 @@ ebpf_program_attach_by_fd(
     _In_opt_ const ebpf_attach_type_t* attach_type,
     _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
     _In_ size_t attach_parameters_size,
-    _Outptr_ struct bpf_link** link)
+    _Outptr_ struct bpf_link** link) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(attach_parameters || !attach_parameters_size);
@@ -1217,7 +1217,7 @@ Exit:
 }
 
 ebpf_result_t
-ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link)
+ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(link);
@@ -1227,7 +1227,7 @@ ebpf_link_close(_In_ _Post_invalid_ struct bpf_link* link)
 }
 
 ebpf_result_t
-ebpf_api_close_handle(ebpf_handle_t handle)
+ebpf_api_close_handle(ebpf_handle_t handle) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_operation_close_handle_request_t request = {
@@ -1238,7 +1238,7 @@ ebpf_api_close_handle(ebpf_handle_t handle)
 
 ebpf_result_t
 ebpf_api_get_pinned_map_info(
-    _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info)
+    _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result = EBPF_SUCCESS;
@@ -1334,7 +1334,7 @@ Exit:
 
 void
 ebpf_api_map_info_free(
-    const uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info)
+    const uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_map_info_array_free(map_count, const_cast<ebpf_map_info_t*>(map_info));
@@ -1831,7 +1831,7 @@ _ebpf_free_section_info(_In_ _Frees_ptr_ ebpf_section_info_t* info) noexcept
 }
 
 void
-ebpf_free_sections(_In_opt_ ebpf_section_info_t* infos)
+ebpf_free_sections(_In_opt_ ebpf_section_info_t* infos) noexcept
 {
     EBPF_LOG_ENTRY();
     while (infos != nullptr) {
@@ -2146,7 +2146,7 @@ ebpf_enumerate_sections(
     _In_z_ const char* file,
     bool verbose,
     _Outptr_result_maybenull_ ebpf_section_info_t** infos,
-    _Outptr_result_maybenull_z_ const char** error_message)
+    _Outptr_result_maybenull_z_ const char** error_message) noexcept
 {
     EBPF_LOG_ENTRY();
     std::string file_name_string(file);
@@ -2214,7 +2214,7 @@ _ebpf_is_map_in_map(ebpf_map_t* map) noexcept
 }
 
 ebpf_result_t
-ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type)
+ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type) noexcept
 {
     if (Platform::_is_native_program(object->file_name)) {
         if (execution_type == EBPF_EXECUTION_INTERPRET || execution_type == EBPF_EXECUTION_JIT) {
@@ -3163,7 +3163,7 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept
 
 ebpf_result_t
 ebpf_get_next_pinned_program_path(
-    _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path)
+    _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(start_path);
@@ -3262,7 +3262,9 @@ ebpf_object_get_info_by_fd(
 
 ebpf_result_t
 ebpf_get_program_type_by_name(
-    _In_z_ const char* name, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* expected_attach_type)
+    _In_z_ const char* name,
+    _Out_ ebpf_program_type_t* program_type,
+    _Out_ ebpf_attach_type_t* expected_attach_type) noexcept
 {
     ebpf_result_t result = EBPF_SUCCESS;
     EBPF_LOG_ENTRY();
@@ -3276,7 +3278,7 @@ ebpf_get_program_type_by_name(
 }
 
 ebpf_result_t
-ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info)
+ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info) noexcept
 {
     ebpf_result_t result = EBPF_SUCCESS;
     EBPF_LOG_ENTRY();
@@ -3297,7 +3299,7 @@ ebpf_get_ebpf_program_type(bpf_prog_type_t bpf_program_type) noexcept
 }
 
 _Ret_maybenull_z_ const char*
-ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type)
+ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(program_type);
@@ -3311,7 +3313,7 @@ ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type)
 }
 
 _Ret_maybenull_z_ const char*
-ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type)
+ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(attach_type);

--- a/libs/api/libbpf_link.cpp
+++ b/libs/api/libbpf_link.cpp
@@ -6,8 +6,8 @@
 #include "libbpf.h"
 #include "libbpf_internal.h"
 
-int
-bpf_link__pin(struct bpf_link* link, const char* path)
+static int
+_bpf_link__pin(struct bpf_link* link, const char* path) noexcept
 {
     ebpf_result_t result;
 
@@ -28,7 +28,13 @@ bpf_link__pin(struct bpf_link* link, const char* path)
 }
 
 int
-bpf_link__unpin(struct bpf_link* link)
+bpf_link__pin(struct bpf_link* link, const char* path)
+{
+    return _bpf_link__pin(link, path);
+}
+
+static int
+_bpf_link__unpin(struct bpf_link* link) noexcept
 {
     ebpf_result_t result;
 
@@ -45,14 +51,26 @@ bpf_link__unpin(struct bpf_link* link)
     return 0;
 }
 
-void
-bpf_link__disconnect(struct bpf_link* link)
+int
+bpf_link__unpin(struct bpf_link* link)
+{
+    return _bpf_link__unpin(link);
+}
+
+static void
+_bpf_link__disconnect(struct bpf_link* link) noexcept
 {
     link->disconnected = true;
 }
 
-int
-bpf_link__destroy(struct bpf_link* link)
+void
+bpf_link__disconnect(struct bpf_link* link)
+{
+    _bpf_link__disconnect(link);
+}
+
+static int
+_bpf_link__destroy(struct bpf_link* link) noexcept
 {
     if (link == nullptr) {
         return 0;
@@ -68,19 +86,37 @@ bpf_link__destroy(struct bpf_link* link)
 }
 
 int
-bpf_link__fd(const struct bpf_link* link)
+bpf_link__destroy(struct bpf_link* link)
+{
+    return _bpf_link__destroy(link);
+}
+
+static int
+_bpf_link__fd(const struct bpf_link* link) noexcept
 {
     return link->fd;
 }
 
 int
-bpf_link_detach(int link_fd)
+bpf_link__fd(const struct bpf_link* link)
+{
+    return _bpf_link__fd(link);
+}
+
+static int
+_bpf_link_detach(int link_fd) noexcept
 {
     return libbpf_result_err(ebpf_detach_link_by_fd(link_fd));
 }
 
 int
-bpf_link_get_fd_by_id(uint32_t id)
+bpf_link_detach(int link_fd)
+{
+    return _bpf_link_detach(link_fd);
+}
+
+static int
+_bpf_link_get_fd_by_id(uint32_t id) noexcept
 {
     fd_t fd;
     ebpf_result_t result = ebpf_get_link_fd_by_id(id, &fd);
@@ -91,16 +127,34 @@ bpf_link_get_fd_by_id(uint32_t id)
 }
 
 int
-bpf_link_get_next_id(uint32_t start_id, uint32_t* next_id)
+bpf_link_get_fd_by_id(uint32_t id)
+{
+    return _bpf_link_get_fd_by_id(id);
+}
+
+static int
+_bpf_link_get_next_id(uint32_t start_id, uint32_t* next_id) noexcept
 {
     return libbpf_result_err(ebpf_get_next_link_id(start_id, next_id));
 }
 
-const char*
-libbpf_bpf_link_type_str(enum bpf_link_type t)
+int
+bpf_link_get_next_id(uint32_t start_id, uint32_t* next_id)
+{
+    return _bpf_link_get_next_id(start_id, next_id);
+}
+
+static const char*
+_libbpf_bpf_link_type_str(enum bpf_link_type t) noexcept
 {
     if (t < 0 || t >= _countof(_ebpf_link_display_names))
         return nullptr;
 
     return _ebpf_link_display_names[t];
+}
+
+const char*
+libbpf_bpf_link_type_str(enum bpf_link_type t)
+{
+    return _libbpf_bpf_link_type_str(t);
 }

--- a/libs/api/libbpf_map.cpp
+++ b/libs/api/libbpf_map.cpp
@@ -11,14 +11,14 @@
 // minimize diffs until libbpf becomes cross-platform capable.  This is a temporary workaround for
 // issue #351 until we can compile and use libbpf.c directly.
 
-int
-bpf_map_create(
+static int
+_bpf_map_create(
     enum bpf_map_type map_type,
     const char* map_name,
     __u32 key_size,
     __u32 value_size,
     __u32 max_entries,
-    const struct bpf_map_create_opts* opts)
+    const struct bpf_map_create_opts* opts) noexcept
 {
     fd_t map_fd;
     ebpf_result_t result = ebpf_map_create(map_type, map_name, key_size, value_size, max_entries, opts, &map_fd);
@@ -29,7 +29,19 @@ bpf_map_create(
 }
 
 int
-bpf_create_map_xattr(const struct bpf_create_map_attr* create_attr)
+bpf_map_create(
+    enum bpf_map_type map_type,
+    const char* map_name,
+    __u32 key_size,
+    __u32 value_size,
+    __u32 max_entries,
+    const struct bpf_map_create_opts* opts)
+{
+    return _bpf_map_create(map_type, map_name, key_size, value_size, max_entries, opts);
+}
+
+static int
+_bpf_create_map_xattr(const struct bpf_create_map_attr* create_attr) noexcept
 {
     LIBBPF_OPTS(bpf_map_create_opts, p);
 
@@ -51,7 +63,13 @@ bpf_create_map_xattr(const struct bpf_create_map_attr* create_attr)
 }
 
 int
-bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size, int max_entries, uint32_t map_flags)
+bpf_create_map_xattr(const struct bpf_create_map_attr* create_attr)
+{
+    return _bpf_create_map_xattr(create_attr);
+}
+
+static int
+_bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size, int max_entries, uint32_t map_flags) noexcept
 {
     LIBBPF_OPTS(bpf_map_create_opts, opts, .map_flags = map_flags);
 
@@ -59,52 +77,106 @@ bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size, int max
 }
 
 int
-bpf_create_map_in_map(
-    enum bpf_map_type map_type, const char* name, int key_size, int inner_map_fd, int max_entries, __u32 map_flags)
+bpf_create_map(enum bpf_map_type map_type, int key_size, int value_size, int max_entries, uint32_t map_flags)
+{
+    return _bpf_create_map(map_type, key_size, value_size, max_entries, map_flags);
+}
+
+static int
+_bpf_create_map_in_map(
+    enum bpf_map_type map_type,
+    const char* name,
+    int key_size,
+    int inner_map_fd,
+    int max_entries,
+    __u32 map_flags) noexcept
 {
     LIBBPF_OPTS(bpf_map_create_opts, opts, .inner_map_fd = (uint32_t)inner_map_fd, .map_flags = map_flags, );
 
     return bpf_map_create(map_type, name, key_size, 4, max_entries, &opts);
 }
 
-struct bpf_map*
-bpf_map__next(const struct bpf_map* prev, const struct bpf_object* obj)
+int
+bpf_create_map_in_map(
+    enum bpf_map_type map_type, const char* name, int key_size, int inner_map_fd, int max_entries, __u32 map_flags)
+{
+    return _bpf_create_map_in_map(map_type, name, key_size, inner_map_fd, max_entries, map_flags);
+}
+
+static struct bpf_map*
+_bpf_map__next(const struct bpf_map* prev, const struct bpf_object* obj) noexcept
 {
     return bpf_object__next_map(obj, prev);
 }
 
 struct bpf_map*
-bpf_object__next_map(const struct bpf_object* object, const struct bpf_map* previous)
+bpf_map__next(const struct bpf_map* prev, const struct bpf_object* obj)
+{
+    return _bpf_map__next(prev, obj);
+}
+
+static struct bpf_map*
+_bpf_object__next_map(const struct bpf_object* object, const struct bpf_map* previous) noexcept
 {
     return ebpf_map_next(previous, object);
 }
 
 struct bpf_map*
-bpf_map__prev(const struct bpf_map* next, const struct bpf_object* obj)
+bpf_object__next_map(const struct bpf_object* object, const struct bpf_map* previous)
+{
+    return _bpf_object__next_map(object, previous);
+}
+
+static struct bpf_map*
+_bpf_map__prev(const struct bpf_map* next, const struct bpf_object* obj) noexcept
 {
     return bpf_object__prev_map(obj, next);
 }
 
 struct bpf_map*
-bpf_object__prev_map(const struct bpf_object* object, const struct bpf_map* next)
+bpf_map__prev(const struct bpf_map* next, const struct bpf_object* obj)
+{
+    return _bpf_map__prev(next, obj);
+}
+
+static struct bpf_map*
+_bpf_object__prev_map(const struct bpf_object* object, const struct bpf_map* next) noexcept
 {
     return ebpf_map_previous(next, object);
 }
 
-int
-bpf_map__unpin(struct bpf_map* map, const char* path)
+struct bpf_map*
+bpf_object__prev_map(const struct bpf_object* object, const struct bpf_map* next)
+{
+    return _bpf_object__prev_map(object, next);
+}
+
+static int
+_bpf_map__unpin(struct bpf_map* map, const char* path) noexcept
 {
     return libbpf_result_err(ebpf_map_unpin(map, path));
 }
 
 int
-bpf_map__pin(struct bpf_map* map, const char* path)
+bpf_map__unpin(struct bpf_map* map, const char* path)
+{
+    return _bpf_map__unpin(map, path);
+}
+
+static int
+_bpf_map__pin(struct bpf_map* map, const char* path) noexcept
 {
     return libbpf_result_err(ebpf_map_pin(map, path));
 }
 
 int
-bpf_object__pin_maps(struct bpf_object* obj, const char* path)
+bpf_map__pin(struct bpf_map* map, const char* path)
+{
+    return _bpf_map__pin(map, path);
+}
+
+static int
+_bpf_object__pin_maps(struct bpf_object* obj, const char* path) noexcept
 {
     struct bpf_map* map;
     int err;
@@ -148,7 +220,13 @@ err_unpin_maps:
 }
 
 int
-bpf_object__unpin_maps(struct bpf_object* obj, const char* path)
+bpf_object__pin_maps(struct bpf_object* obj, const char* path)
+{
+    return _bpf_object__pin_maps(obj, path);
+}
+
+static int
+_bpf_object__unpin_maps(struct bpf_object* obj, const char* path) noexcept
 {
     struct bpf_map* map;
     int err;
@@ -182,50 +260,98 @@ bpf_object__unpin_maps(struct bpf_object* obj, const char* path)
     return 0;
 }
 
+int
+bpf_object__unpin_maps(struct bpf_object* obj, const char* path)
+{
+    return _bpf_object__unpin_maps(obj, path);
+}
+
+static const char*
+_bpf_map__name(const struct bpf_map* map) noexcept
+{
+    return map ? map->name : NULL;
+}
+
 const char*
 bpf_map__name(const struct bpf_map* map)
 {
-    return map ? map->name : NULL;
+    return _bpf_map__name(map);
+}
+
+static enum bpf_map_type
+_bpf_map__type(const struct bpf_map* map) noexcept
+{
+    return map->map_definition.type;
 }
 
 enum bpf_map_type
 bpf_map__type(const struct bpf_map* map)
 {
-    return map->map_definition.type;
+    return _bpf_map__type(map);
 }
 
-__u32
-bpf_map__key_size(const struct bpf_map* map)
+static __u32
+_bpf_map__key_size(const struct bpf_map* map) noexcept
 {
     return map->map_definition.key_size;
 }
 
 __u32
-bpf_map__value_size(const struct bpf_map* map)
+bpf_map__key_size(const struct bpf_map* map)
+{
+    return _bpf_map__key_size(map);
+}
+
+static __u32
+_bpf_map__value_size(const struct bpf_map* map) noexcept
 {
     return map->map_definition.value_size;
 }
 
 __u32
-bpf_map__max_entries(const struct bpf_map* map)
+bpf_map__value_size(const struct bpf_map* map)
+{
+    return _bpf_map__value_size(map);
+}
+
+static __u32
+_bpf_map__max_entries(const struct bpf_map* map) noexcept
 {
     return map->map_definition.max_entries;
+}
+
+__u32
+bpf_map__max_entries(const struct bpf_map* map)
+{
+    return _bpf_map__max_entries(map);
+}
+
+static bool
+_bpf_map__is_pinned(const struct bpf_map* map) noexcept
+{
+    return map->pinned;
 }
 
 bool
 bpf_map__is_pinned(const struct bpf_map* map)
 {
-    return map->pinned;
+    return _bpf_map__is_pinned(map);
+}
+
+static int
+_bpf_map__fd(const struct bpf_map* map) noexcept
+{
+    return map ? map->map_fd : libbpf_err(-EINVAL);
 }
 
 int
 bpf_map__fd(const struct bpf_map* map)
 {
-    return map ? map->map_fd : libbpf_err(-EINVAL);
+    return _bpf_map__fd(map);
 }
 
-struct bpf_map*
-bpf_object__find_map_by_name(const struct bpf_object* obj, const char* name)
+static struct bpf_map*
+_bpf_object__find_map_by_name(const struct bpf_object* obj, const char* name) noexcept
 {
     struct bpf_map* pos;
 
@@ -237,50 +363,98 @@ bpf_object__find_map_by_name(const struct bpf_object* obj, const char* name)
     return NULL;
 }
 
-int
-bpf_object__find_map_fd_by_name(const struct bpf_object* obj, const char* name)
+struct bpf_map*
+bpf_object__find_map_by_name(const struct bpf_object* obj, const char* name)
+{
+    return _bpf_object__find_map_by_name(obj, name);
+}
+
+static int
+_bpf_object__find_map_fd_by_name(const struct bpf_object* obj, const char* name) noexcept
 {
     return bpf_map__fd(bpf_object__find_map_by_name(obj, name));
 }
 
 int
-bpf_map__set_pin_path(struct bpf_map* map, const char* path)
+bpf_object__find_map_fd_by_name(const struct bpf_object* obj, const char* name)
+{
+    return _bpf_object__find_map_fd_by_name(obj, name);
+}
+
+static int
+_bpf_map__set_pin_path(struct bpf_map* map, const char* path) noexcept
 {
     return libbpf_result_err(ebpf_map_set_pin_path(map, path));
 }
 
 int
-bpf_map_update_elem(int fd, const void* key, const void* value, uint64_t flags)
+bpf_map__set_pin_path(struct bpf_map* map, const char* path)
+{
+    return _bpf_map__set_pin_path(map, path);
+}
+
+static int
+_bpf_map_update_elem(int fd, const void* key, const void* value, uint64_t flags) noexcept
 {
     return libbpf_result_err(ebpf_map_update_element(fd, key, value, flags));
 }
 
 int
-bpf_map_delete_elem(int fd, const void* key)
+bpf_map_update_elem(int fd, const void* key, const void* value, uint64_t flags)
+{
+    return _bpf_map_update_elem(fd, key, value, flags);
+}
+
+static int
+_bpf_map_delete_elem(int fd, const void* key) noexcept
 {
     return libbpf_result_err(ebpf_map_delete_element(fd, key));
 }
 
 int
-bpf_map_lookup_elem(int fd, const void* key, void* value)
+bpf_map_delete_elem(int fd, const void* key)
+{
+    return _bpf_map_delete_elem(fd, key);
+}
+
+static int
+_bpf_map_lookup_elem(int fd, const void* key, void* value) noexcept
 {
     return libbpf_result_err(ebpf_map_lookup_element(fd, key, value));
 }
 
 int
-bpf_map_lookup_and_delete_elem(int fd, const void* key, void* value)
+bpf_map_lookup_elem(int fd, const void* key, void* value)
+{
+    return _bpf_map_lookup_elem(fd, key, value);
+}
+
+static int
+_bpf_map_lookup_and_delete_elem(int fd, const void* key, void* value) noexcept
 {
     return libbpf_result_err(ebpf_map_lookup_and_delete_element(fd, key, value));
 }
 
 int
-bpf_map_get_next_key(int fd, const void* key, void* next_key)
+bpf_map_lookup_and_delete_elem(int fd, const void* key, void* value)
+{
+    return _bpf_map_lookup_and_delete_elem(fd, key, value);
+}
+
+static int
+_bpf_map_get_next_key(int fd, const void* key, void* next_key) noexcept
 {
     return libbpf_result_err(ebpf_map_get_next_key(fd, key, next_key));
 }
 
 int
-bpf_map_get_fd_by_id(uint32_t id)
+bpf_map_get_next_key(int fd, const void* key, void* next_key)
+{
+    return _bpf_map_get_next_key(fd, key, next_key);
+}
+
+static int
+_bpf_map_get_fd_by_id(uint32_t id) noexcept
 {
     fd_t fd;
     ebpf_result_t result = ebpf_get_map_fd_by_id(id, &fd);
@@ -291,9 +465,21 @@ bpf_map_get_fd_by_id(uint32_t id)
 }
 
 int
-bpf_map_get_next_id(uint32_t start_id, uint32_t* next_id)
+bpf_map_get_fd_by_id(uint32_t id)
+{
+    return _bpf_map_get_fd_by_id(id);
+}
+
+static int
+_bpf_map_get_next_id(uint32_t start_id, uint32_t* next_id) noexcept
 {
     return libbpf_result_err(ebpf_get_next_map_id(start_id, next_id));
+}
+
+int
+bpf_map_get_next_id(uint32_t start_id, uint32_t* next_id)
+{
+    return _bpf_map_get_next_id(start_id, next_id);
 }
 
 typedef struct ring_buffer
@@ -301,8 +487,8 @@ typedef struct ring_buffer
     std::vector<ring_buffer_subscription_t*> subscriptions;
 } ring_buffer_t;
 
-struct ring_buffer*
-ring_buffer__new(int map_fd, ring_buffer_sample_fn sample_cb, void* ctx, const struct ring_buffer_opts* opts)
+static struct ring_buffer*
+_ring_buffer__new(int map_fd, ring_buffer_sample_fn sample_cb, void* ctx, const struct ring_buffer_opts* opts) noexcept
 {
     ebpf_result result = EBPF_SUCCESS;
     ring_buffer_subscription_t* subscription = nullptr;
@@ -318,8 +504,14 @@ Exit:
     return ring_buffer;
 }
 
-void
-ring_buffer__free(struct ring_buffer* ring_buffer)
+struct ring_buffer*
+ring_buffer__new(int map_fd, ring_buffer_sample_fn sample_cb, void* ctx, const struct ring_buffer_opts* opts)
+{
+    return _ring_buffer__new(map_fd, sample_cb, ctx, opts);
+}
+
+static void
+_ring_buffer__free(struct ring_buffer* ring_buffer) noexcept
 {
     for (auto it = ring_buffer->subscriptions.begin(); it != ring_buffer->subscriptions.end(); it++)
         (void)ebpf_ring_buffer_map_unsubscribe(*it);
@@ -327,11 +519,23 @@ ring_buffer__free(struct ring_buffer* ring_buffer)
     delete ring_buffer;
 }
 
-const char*
-libbpf_bpf_map_type_str(enum bpf_map_type t)
+void
+ring_buffer__free(struct ring_buffer* ring_buffer)
+{
+    _ring_buffer__free(ring_buffer);
+}
+
+static const char*
+_libbpf_bpf_map_type_str(enum bpf_map_type t) noexcept
 {
     if (t < 0 || t >= _countof(_ebpf_map_display_names))
         return nullptr;
 
     return _ebpf_map_display_names[t];
+}
+
+const char*
+libbpf_bpf_map_type_str(enum bpf_map_type t)
+{
+    return _libbpf_bpf_map_type_str(t);
 }

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -11,14 +11,20 @@
 // minimize diffs until libbpf becomes cross-platform capable.  This is a temporary workaround for
 // issue #351 until we can compile and use libbpf.c directly.
 
-const char*
-bpf_object__name(const struct bpf_object* object)
+static const char*
+_bpf_object__name(const struct bpf_object* object) noexcept
 {
     return object->object_name;
 }
 
-int
-bpf_object__pin(struct bpf_object* obj, const char* path)
+const char*
+bpf_object__name(const struct bpf_object* object)
+{
+    return _bpf_object__name(object);
+}
+
+static int
+_bpf_object__pin(struct bpf_object* obj, const char* path) noexcept
 {
     int err;
 
@@ -35,14 +41,26 @@ bpf_object__pin(struct bpf_object* obj, const char* path)
     return 0;
 }
 
-void
-bpf_object__close(struct bpf_object* object)
+int
+bpf_object__pin(struct bpf_object* obj, const char* path)
+{
+    return _bpf_object__pin(obj, path);
+}
+
+static void
+_bpf_object__close(struct bpf_object* object) noexcept
 {
     ebpf_object_close(object);
 }
 
-struct bpf_program*
-bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
+void
+bpf_object__close(struct bpf_object* object)
+{
+    _bpf_object__close(object);
+}
+
+static struct bpf_program*
+_bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name) noexcept
 {
     struct bpf_program* prog;
 
@@ -54,22 +72,40 @@ bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
     return (struct bpf_program*)libbpf_err_ptr(-ENOENT);
 }
 
-struct bpf_object*
-bpf_object__next(struct bpf_object* prev)
+struct bpf_program*
+bpf_object__find_program_by_name(const struct bpf_object* obj, const char* name)
+{
+    return _bpf_object__find_program_by_name(obj, name);
+}
+
+static struct bpf_object*
+_bpf_object__next(struct bpf_object* prev) noexcept
 {
     return ebpf_object_next(prev);
 }
 
+struct bpf_object*
+bpf_object__next(struct bpf_object* prev)
+{
+    return _bpf_object__next(prev);
+}
+
 // APIs from libbpf's bpf.h.
 
-int
-bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len)
+static int
+_bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len) noexcept
 {
     return libbpf_result_err(ebpf_object_get_info_by_fd((fd_t)bpf_fd, info, info_len));
 }
 
 int
-bpf_obj_pin(int fd, const char* pathname)
+bpf_obj_get_info_by_fd(int bpf_fd, void* info, __u32* info_len)
+{
+    return _bpf_obj_get_info_by_fd(bpf_fd, info, info_len);
+}
+
+static int
+_bpf_obj_pin(int fd, const char* pathname) noexcept
 {
     if (!pathname) {
         return libbpf_result_err(EBPF_INVALID_ARGUMENT);
@@ -78,19 +114,37 @@ bpf_obj_pin(int fd, const char* pathname)
 }
 
 int
-bpf_obj_get(const char* pathname)
+bpf_obj_pin(int fd, const char* pathname)
+{
+    return _bpf_obj_pin(fd, pathname);
+}
+
+static int
+_bpf_obj_get(const char* pathname) noexcept
 {
     return (int)ebpf_object_get(pathname);
 }
 
-struct bpf_object*
-bpf_object__open(const char* path)
+int
+bpf_obj_get(const char* pathname)
+{
+    return _bpf_obj_get(pathname);
+}
+
+static struct bpf_object*
+_bpf_object__open(const char* path) noexcept
 {
     return bpf_object__open_file(path, nullptr);
 }
 
 struct bpf_object*
-bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
+bpf_object__open(const char* path)
+{
+    return _bpf_object__open(path);
+}
+
+static struct bpf_object*
+_bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts) noexcept
 {
     if (!path) {
         return (struct bpf_object*)libbpf_err_ptr(-EINVAL);
@@ -111,22 +165,46 @@ bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
     return object;
 }
 
-int
-bpf_object__load_xattr(struct bpf_object_load_attr* attr)
+struct bpf_object*
+bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
+{
+    return _bpf_object__open_file(path, opts);
+}
+
+static int
+_bpf_object__load_xattr(struct bpf_object_load_attr* attr) noexcept
 {
     ebpf_result_t result = ebpf_object_load(attr->obj);
     return libbpf_result_err(result);
 }
 
 int
-bpf_object__load(struct bpf_object* object)
+bpf_object__load_xattr(struct bpf_object_load_attr* attr)
+{
+    return _bpf_object__load_xattr(attr);
+}
+
+static int
+_bpf_object__load(struct bpf_object* object) noexcept
 {
     ebpf_result_t result = ebpf_object_load(object);
     return libbpf_result_err(result);
 }
 
 int
-bpf_object__unload(struct bpf_object* obj)
+bpf_object__load(struct bpf_object* object)
+{
+    return _bpf_object__load(object);
+}
+
+static int
+_bpf_object__unload(struct bpf_object* obj) noexcept
 {
     return libbpf_result_err(ebpf_object_unload(obj));
+}
+
+int
+bpf_object__unload(struct bpf_object* obj)
+{
+    return _bpf_object__unload(obj);
 }

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -13,8 +13,8 @@
 // minimize diffs until libbpf becomes cross-platform capable.  This is a temporary workaround for
 // issue #351 until we can compile and use libbpf.c directly.
 
-int
-bpf_load_program_xattr(const struct bpf_load_program_attr* load_attr, char* log_buf, size_t log_buf_sz)
+static int
+_bpf_load_program_xattr(const struct bpf_load_program_attr* load_attr, char* log_buf, size_t log_buf_sz) noexcept
 {
     if (load_attr->insns_cnt < 1 || load_attr->insns_cnt > UINT32_MAX) {
         return libbpf_err(-EINVAL);
@@ -42,14 +42,20 @@ bpf_load_program_xattr(const struct bpf_load_program_attr* load_attr, char* log_
 }
 
 int
-bpf_load_program(
+bpf_load_program_xattr(const struct bpf_load_program_attr* load_attr, char* log_buf, size_t log_buf_sz)
+{
+    return _bpf_load_program_xattr(load_attr, log_buf, log_buf_sz);
+}
+
+static int
+_bpf_load_program(
     enum bpf_prog_type type,
     const struct bpf_insn* insns,
     size_t insns_cnt,
     const char* license,
     __u32 kern_version,
     char* log_buf,
-    size_t log_buf_sz)
+    size_t log_buf_sz) noexcept
 {
     if (log_buf_sz > UINT32_MAX) {
         return libbpf_err(-EINVAL);
@@ -60,13 +66,26 @@ bpf_load_program(
 }
 
 int
-bpf_prog_load(
+bpf_load_program(
+    enum bpf_prog_type type,
+    const struct bpf_insn* insns,
+    size_t insns_cnt,
+    const char* license,
+    __u32 kern_version,
+    char* log_buf,
+    size_t log_buf_sz)
+{
+    return _bpf_load_program(type, insns, insns_cnt, license, kern_version, log_buf, log_buf_sz);
+}
+
+static int
+_bpf_prog_load(
     enum bpf_prog_type prog_type,
     const char* prog_name,
     const char* license,
     const struct bpf_insn* insns,
     size_t insn_cnt,
-    const struct bpf_prog_load_opts* opts)
+    const struct bpf_prog_load_opts* opts) noexcept
 {
     UNREFERENCED_PARAMETER(license);
 
@@ -99,7 +118,20 @@ bpf_prog_load(
 }
 
 int
-bpf_prog_load_deprecated(const char* file_name, enum bpf_prog_type type, struct bpf_object** object, int* program_fd)
+bpf_prog_load(
+    enum bpf_prog_type prog_type,
+    const char* prog_name,
+    const char* license,
+    const struct bpf_insn* insns,
+    size_t insn_cnt,
+    const struct bpf_prog_load_opts* opts)
+{
+    return _bpf_prog_load(prog_type, prog_name, license, insns, insn_cnt, opts);
+}
+
+static int
+_bpf_prog_load_deprecated(
+    const char* file_name, enum bpf_prog_type type, struct bpf_object** object, int* program_fd) noexcept
 {
     *object = nullptr;
 
@@ -130,44 +162,86 @@ bpf_prog_load_deprecated(const char* file_name, enum bpf_prog_type type, struct 
 }
 
 int
-bpf_program__fd(const struct bpf_program* program)
+bpf_prog_load_deprecated(const char* file_name, enum bpf_prog_type type, struct bpf_object** object, int* program_fd)
+{
+    return _bpf_prog_load_deprecated(file_name, type, object, program_fd);
+}
+
+static int
+_bpf_program__fd(const struct bpf_program* program) noexcept
 {
     return (int)ebpf_program_get_fd(program);
 }
 
-const char*
-bpf_program__name(const struct bpf_program* prog)
+int
+bpf_program__fd(const struct bpf_program* program)
+{
+    return _bpf_program__fd(program);
+}
+
+static const char*
+_bpf_program__name(const struct bpf_program* prog) noexcept
 {
     return prog->program_name;
 }
 
 const char*
-bpf_program__section_name(const struct bpf_program* program)
+bpf_program__name(const struct bpf_program* prog)
+{
+    return _bpf_program__name(prog);
+}
+
+static const char*
+_bpf_program__section_name(const struct bpf_program* program) noexcept
 {
     return program->section_name;
 }
 
-size_t
-bpf_program__size(const struct bpf_program* program)
+const char*
+bpf_program__section_name(const struct bpf_program* program)
+{
+    return _bpf_program__section_name(program);
+}
+
+static size_t
+_bpf_program__size(const struct bpf_program* program) noexcept
 {
     return program->instruction_count * sizeof(ebpf_inst);
 }
 
 size_t
-bpf_program__insn_cnt(const struct bpf_program* program)
+bpf_program__size(const struct bpf_program* program)
+{
+    return _bpf_program__size(program);
+}
+
+static size_t
+_bpf_program__insn_cnt(const struct bpf_program* program) noexcept
 {
     return program->instruction_count;
 }
 
-const char*
-bpf_program__log_buf(const struct bpf_program* program, size_t* log_size)
+size_t
+bpf_program__insn_cnt(const struct bpf_program* program)
+{
+    return _bpf_program__insn_cnt(program);
+}
+
+static const char*
+_bpf_program__log_buf(const struct bpf_program* program, size_t* log_size) noexcept
 {
     *log_size = program->log_buffer_size;
     return program->log_buffer;
 }
 
-struct bpf_link*
-bpf_program__attach(const struct bpf_program* program)
+const char*
+bpf_program__log_buf(const struct bpf_program* program, size_t* log_size)
+{
+    return _bpf_program__log_buf(program, log_size);
+}
+
+static struct bpf_link*
+_bpf_program__attach(const struct bpf_program* program) noexcept
 {
     if (program == nullptr) {
         errno = EINVAL;
@@ -184,7 +258,13 @@ bpf_program__attach(const struct bpf_program* program)
 }
 
 struct bpf_link*
-bpf_program__attach_xdp(const struct bpf_program* program, int ifindex)
+bpf_program__attach(const struct bpf_program* program)
+{
+    return _bpf_program__attach(program);
+}
+
+static struct bpf_link*
+_bpf_program__attach_xdp(const struct bpf_program* program, int ifindex) noexcept
 {
     if (program == nullptr) {
         errno = EINVAL;
@@ -198,6 +278,12 @@ bpf_program__attach_xdp(const struct bpf_program* program, int ifindex)
     }
 
     return link;
+}
+
+struct bpf_link*
+bpf_program__attach_xdp(const struct bpf_program* program, int ifindex)
+{
+    return _bpf_program__attach_xdp(program, ifindex);
 }
 
 static bool
@@ -218,8 +304,8 @@ _does_attach_type_support_attachable_fd(enum bpf_attach_type type)
     return supported;
 }
 
-int
-bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsigned int flags)
+static int
+_bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsigned int flags) noexcept
 {
     bpf_link* link = nullptr;
     ebpf_result_t result = EBPF_SUCCESS;
@@ -237,7 +323,13 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
 }
 
 int
-bpf_prog_detach2(int prog_fd, int attachable_fd, enum bpf_attach_type type)
+bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsigned int flags)
+{
+    return _bpf_prog_attach(prog_fd, attachable_fd, type, flags);
+}
+
+static int
+_bpf_prog_detach2(int prog_fd, int attachable_fd, enum bpf_attach_type type) noexcept
 {
     ebpf_result_t result = EBPF_SUCCESS;
     const ebpf_attach_type_t* attach_type = get_ebpf_attach_type(type);
@@ -257,37 +349,73 @@ bpf_prog_detach2(int prog_fd, int attachable_fd, enum bpf_attach_type type)
 }
 
 int
-bpf_prog_detach(int attachable_fd, enum bpf_attach_type type)
+bpf_prog_detach2(int prog_fd, int attachable_fd, enum bpf_attach_type type)
+{
+    return _bpf_prog_detach2(prog_fd, attachable_fd, type);
+}
+
+static int
+_bpf_prog_detach(int attachable_fd, enum bpf_attach_type type) noexcept
 {
     return bpf_prog_detach2(ebpf_fd_invalid, attachable_fd, type);
 }
 
-struct bpf_program*
-bpf_program__next(struct bpf_program* prev, const struct bpf_object* obj)
+int
+bpf_prog_detach(int attachable_fd, enum bpf_attach_type type)
+{
+    return _bpf_prog_detach(attachable_fd, type);
+}
+
+static struct bpf_program*
+_bpf_program__next(struct bpf_program* prev, const struct bpf_object* obj) noexcept
 {
     return bpf_object__next_program(obj, prev);
 }
 
 struct bpf_program*
-bpf_object__next_program(const struct bpf_object* obj, struct bpf_program* prev)
+bpf_program__next(struct bpf_program* prev, const struct bpf_object* obj)
+{
+    return _bpf_program__next(prev, obj);
+}
+
+static struct bpf_program*
+_bpf_object__next_program(const struct bpf_object* obj, struct bpf_program* prev) noexcept
 {
     return ebpf_program_next(prev, obj);
 }
 
 struct bpf_program*
-bpf_program__prev(struct bpf_program* next, const struct bpf_object* obj)
+bpf_object__next_program(const struct bpf_object* obj, struct bpf_program* prev)
+{
+    return _bpf_object__next_program(obj, prev);
+}
+
+static struct bpf_program*
+_bpf_program__prev(struct bpf_program* next, const struct bpf_object* obj) noexcept
 {
     return bpf_object__prev_program(obj, next);
 }
 
 struct bpf_program*
-bpf_object__prev_program(const struct bpf_object* obj, struct bpf_program* next)
+bpf_program__prev(struct bpf_program* next, const struct bpf_object* obj)
+{
+    return _bpf_program__prev(next, obj);
+}
+
+static struct bpf_program*
+_bpf_object__prev_program(const struct bpf_object* obj, struct bpf_program* next) noexcept
 {
     return ebpf_program_previous(next, obj);
 }
 
-int
-bpf_program__unpin(struct bpf_program* prog, const char* path)
+struct bpf_program*
+bpf_object__prev_program(const struct bpf_object* obj, struct bpf_program* next)
+{
+    return _bpf_object__prev_program(obj, next);
+}
+
+static int
+_bpf_program__unpin(struct bpf_program* prog, const char* path) noexcept
 {
     ebpf_result_t result;
 
@@ -303,7 +431,13 @@ bpf_program__unpin(struct bpf_program* prog, const char* path)
 }
 
 int
-bpf_program__pin(struct bpf_program* prog, const char* path)
+bpf_program__unpin(struct bpf_program* prog, const char* path)
+{
+    return _bpf_program__unpin(prog, path);
+}
+
+static int
+_bpf_program__pin(struct bpf_program* prog, const char* path) noexcept
 {
     ebpf_result_t result;
 
@@ -319,6 +453,12 @@ bpf_program__pin(struct bpf_program* prog, const char* path)
     return 0;
 }
 
+int
+bpf_program__pin(struct bpf_program* prog, const char* path)
+{
+    return _bpf_program__pin(prog, path);
+}
+
 static char*
 __bpf_program__pin_name(struct bpf_program* prog)
 {
@@ -331,8 +471,8 @@ __bpf_program__pin_name(struct bpf_program* prog)
     return name;
 }
 
-int
-bpf_object__pin_programs(struct bpf_object* obj, const char* path)
+static int
+_bpf_object__pin_programs(struct bpf_object* obj, const char* path) noexcept
 {
     struct bpf_program* prog;
     int err;
@@ -379,7 +519,13 @@ err_unpin_programs:
 }
 
 int
-bpf_object__unpin_programs(struct bpf_object* obj, const char* path)
+bpf_object__pin_programs(struct bpf_object* obj, const char* path)
+{
+    return _bpf_object__pin_programs(obj, path);
+}
+
+static int
+_bpf_object__unpin_programs(struct bpf_object* obj, const char* path) noexcept
 {
     struct bpf_program* prog;
     int err;
@@ -406,14 +552,26 @@ bpf_object__unpin_programs(struct bpf_object* obj, const char* path)
     return 0;
 }
 
-enum bpf_attach_type
-bpf_program__get_expected_attach_type(const struct bpf_program* program)
+int
+bpf_object__unpin_programs(struct bpf_object* obj, const char* path)
+{
+    return _bpf_object__unpin_programs(obj, path);
+}
+
+static enum bpf_attach_type
+_bpf_program__get_expected_attach_type(const struct bpf_program* program) noexcept
 {
     return get_bpf_attach_type(&program->attach_type);
 }
 
-int
-bpf_program__set_expected_attach_type(struct bpf_program* program, enum bpf_attach_type type)
+enum bpf_attach_type
+bpf_program__get_expected_attach_type(const struct bpf_program* program)
+{
+    return _bpf_program__get_expected_attach_type(program);
+}
+
+static int
+_bpf_program__set_expected_attach_type(struct bpf_program* program, enum bpf_attach_type type) noexcept
 {
     if (program->object->loaded)
         return libbpf_err(-EBUSY);
@@ -425,14 +583,26 @@ bpf_program__set_expected_attach_type(struct bpf_program* program, enum bpf_atta
     return 0;
 }
 
-enum bpf_prog_type
-bpf_program__type(const struct bpf_program* program)
+int
+bpf_program__set_expected_attach_type(struct bpf_program* program, enum bpf_attach_type type)
+{
+    return _bpf_program__set_expected_attach_type(program, type);
+}
+
+static enum bpf_prog_type
+_bpf_program__type(const struct bpf_program* program) noexcept
 {
     return get_bpf_program_type(&program->program_type);
 }
 
-int
-bpf_program__set_type(struct bpf_program* program, enum bpf_prog_type type)
+bpf_prog_type
+bpf_program__type(const struct bpf_program* program)
+{
+    return _bpf_program__type(program);
+}
+
+static int
+_bpf_program__set_type(struct bpf_program* program, enum bpf_prog_type type) noexcept
 {
     if (program->object->loaded)
         return libbpf_err(-EBUSY);
@@ -442,7 +612,13 @@ bpf_program__set_type(struct bpf_program* program, enum bpf_prog_type type)
 }
 
 int
-bpf_prog_get_fd_by_id(uint32_t id)
+bpf_program__set_type(struct bpf_program* program, enum bpf_prog_type type)
+{
+    return _bpf_program__set_type(program, type);
+}
+
+static int
+_bpf_prog_get_fd_by_id(uint32_t id) noexcept
 {
     fd_t fd;
     ebpf_result_t result = ebpf_get_program_fd_by_id(id, &fd);
@@ -453,13 +629,25 @@ bpf_prog_get_fd_by_id(uint32_t id)
 }
 
 int
-bpf_prog_get_next_id(uint32_t start_id, uint32_t* next_id)
+bpf_prog_get_fd_by_id(uint32_t id)
+{
+    return _bpf_prog_get_fd_by_id(id);
+}
+
+static int
+_bpf_prog_get_next_id(uint32_t start_id, uint32_t* next_id) noexcept
 {
     return libbpf_result_err(ebpf_get_next_program_id(start_id, next_id));
 }
 
 int
-libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum bpf_attach_type* expected_attach_type)
+bpf_prog_get_next_id(uint32_t start_id, uint32_t* next_id)
+{
+    return _bpf_prog_get_next_id(start_id, next_id);
+}
+
+static int
+_libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum bpf_attach_type* expected_attach_type)
 {
     if (name == nullptr || prog_type == nullptr || expected_attach_type == nullptr) {
         return libbpf_err(-EINVAL);
@@ -475,14 +663,26 @@ libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum b
 }
 
 int
-libbpf_attach_type_by_name(const char* name, enum bpf_attach_type* attach_type)
+libbpf_prog_type_by_name(const char* name, enum bpf_prog_type* prog_type, enum bpf_attach_type* expected_attach_type)
+{
+    return _libbpf_prog_type_by_name(name, prog_type, expected_attach_type);
+}
+
+static int
+_libbpf_attach_type_by_name(const char* name, enum bpf_attach_type* attach_type)
 {
     enum bpf_prog_type prog_type;
     return libbpf_prog_type_by_name(name, &prog_type, attach_type);
 }
 
-void
-bpf_program__unload(struct bpf_program* prog)
+int
+libbpf_attach_type_by_name(const char* name, enum bpf_attach_type* attach_type)
+{
+    return _libbpf_attach_type_by_name(name, attach_type);
+}
+
+static void
+_bpf_program__unload(struct bpf_program* prog) noexcept
 {
     ebpf_result_t result = ebpf_program_unload(prog);
     if (result != EBPF_SUCCESS) {
@@ -490,12 +690,24 @@ bpf_program__unload(struct bpf_program* prog)
     }
 }
 
-int
-bpf_prog_bind_map(int prog_fd, int map_fd, const struct bpf_prog_bind_opts* opts)
+void
+bpf_program__unload(struct bpf_program* prog)
+{
+    _bpf_program__unload(prog);
+}
+
+static int
+_bpf_prog_bind_map(int prog_fd, int map_fd, const struct bpf_prog_bind_opts* opts) noexcept
 {
     UNREFERENCED_PARAMETER(opts);
 
     return libbpf_result_err(ebpf_program_bind_map(prog_fd, map_fd));
+}
+
+int
+bpf_prog_bind_map(int prog_fd, int map_fd, const struct bpf_prog_bind_opts* opts)
+{
+    return _bpf_prog_bind_map(prog_fd, map_fd, opts);
 }
 
 static int
@@ -567,8 +779,8 @@ __bpf_set_link_xdp_fd_replace(int ifindex, int fd, int old_fd, __u32 flags)
     return 0;
 }
 
-int
-bpf_xdp_attach(int ifindex, int prog_fd, __u32 flags, const struct bpf_xdp_attach_opts* opts)
+static int
+_bpf_xdp_attach(int ifindex, int prog_fd, __u32 flags, const struct bpf_xdp_attach_opts* opts) noexcept
 {
     int old_prog_fd, err;
 
@@ -579,13 +791,25 @@ bpf_xdp_attach(int ifindex, int prog_fd, __u32 flags, const struct bpf_xdp_attac
 }
 
 int
-bpf_xdp_detach(int ifindex, __u32 flags, const struct bpf_xdp_attach_opts* opts)
+bpf_xdp_attach(int ifindex, int prog_fd, __u32 flags, const struct bpf_xdp_attach_opts* opts)
+{
+    return _bpf_xdp_attach(ifindex, prog_fd, flags, opts);
+}
+
+static int
+_bpf_xdp_detach(int ifindex, __u32 flags, const struct bpf_xdp_attach_opts* opts) noexcept
 {
     return bpf_xdp_attach(ifindex, -1, flags, opts);
 }
 
 int
-bpf_set_link_xdp_fd(int ifindex, int fd, __u32 flags)
+bpf_xdp_detach(int ifindex, __u32 flags, const struct bpf_xdp_attach_opts* opts)
+{
+    return _bpf_xdp_detach(ifindex, flags, opts);
+}
+
+static int
+_bpf_set_link_xdp_fd(int ifindex, int fd, __u32 flags) noexcept
 {
     int ret;
 
@@ -594,7 +818,13 @@ bpf_set_link_xdp_fd(int ifindex, int fd, __u32 flags)
 }
 
 int
-bpf_xdp_query_id(int ifindex, int flags, __u32* prog_id)
+bpf_set_link_xdp_fd(int ifindex, int fd, __u32 flags)
+{
+    return _bpf_set_link_xdp_fd(ifindex, fd, flags);
+}
+
+static int
+_bpf_xdp_query_id(int ifindex, int flags, __u32* prog_id) noexcept
 {
     UNREFERENCED_PARAMETER(flags);
 
@@ -625,8 +855,14 @@ bpf_xdp_query_id(int ifindex, int flags, __u32* prog_id)
     }
 }
 
-const char*
-libbpf_bpf_attach_type_str(enum bpf_attach_type t)
+int
+bpf_xdp_query_id(int ifindex, int flags, __u32* prog_id)
+{
+    return _bpf_xdp_query_id(ifindex, flags, prog_id);
+}
+
+static const char*
+_libbpf_bpf_attach_type_str(enum bpf_attach_type t) noexcept
 {
     if (t == BPF_ATTACH_TYPE_UNSPEC) {
         return "unspec";
@@ -636,11 +872,23 @@ libbpf_bpf_attach_type_str(enum bpf_attach_type t)
 }
 
 const char*
-libbpf_bpf_prog_type_str(enum bpf_prog_type t)
+libbpf_bpf_attach_type_str(enum bpf_attach_type t)
+{
+    return _libbpf_bpf_attach_type_str(t);
+}
+
+static const char*
+_libbpf_bpf_prog_type_str(enum bpf_prog_type t) noexcept
 {
     if (t == BPF_PROG_TYPE_UNSPEC) {
         return "unspec";
     }
     const ebpf_program_type_t* program_type = ebpf_get_ebpf_program_type(t);
     return (program_type == nullptr) ? nullptr : ebpf_get_program_type_name(program_type);
+}
+
+const char*
+libbpf_bpf_prog_type_str(enum bpf_prog_type t)
+{
+    return _libbpf_bpf_prog_type_str(t);
 }


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1618

## Description

Mark all exported functions as noexcept to catch bugs where exceptions are leaked across DLL boundaries are caught.

## Testing

CI/CD

## Documentation

No.
