### PR TITLE
Re-enable low memory test

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -283,16 +283,6 @@ jobs:
       gather_dumps: true
       capture_etw: true
 
-  # Additional jobs to on a schedule only (skip push and pull request).
-  # ---------------------------------------------------------------------------
-  codeql:
-    # Only run during daily scheduled run
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-CodeQl
-      build_codeql: true
-
   # Run the low memory simulator in GitHub.
   low_memory:
     needs: regular
@@ -305,3 +295,13 @@ jobs:
       code_coverage: true
       gather_dumps: true
       low_memory: true
+
+  # Additional jobs to on a schedule only (skip push and pull request).
+  # ---------------------------------------------------------------------------
+  codeql:
+    # Only run during daily scheduled run
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      build_artifact: Build-x64-CodeQl
+      build_codeql: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -296,9 +296,6 @@ jobs:
   # Run the low memory simulator in GitHub.
   low_memory:
     needs: regular
-    #if: github.event_name == 'schedule' || github.event_name == 'pull_request'
-    # Disable running this on PR until all low memory issues are fixed.
-    if: github.event_name == 'schedule'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: low_memory


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Now that the low-memory test passes, re-enable it on pull, push, and schedule.

## Testing

CI/CD

## Documentation

No.
