### PR TITLE
Assert on deadlock in shutting down

### DIFF
--- a/libs/platform/user/nmr_impl.cpp
+++ b/libs/platform/user/nmr_impl.cpp
@@ -297,7 +297,7 @@ _nmr::remove(_Inout_ collection_t& collection, _In_ collection_t::value_type::fi
     if (it->second.binding_count > 0) {
         for (;;) {
             // Wait NMR_WAIT_TIMEOUT_SECONDS seconds for bindings to reach zero.
-            if (bindings_changed.wait(l, std::chrono::seconds(NMR_WAIT_TIMEOUT_SECONDS), [&]() {
+            if (bindings_changed.wait_for(l, std::chrono::seconds(NMR_WAIT_TIMEOUT_SECONDS), [&]() {
                     return it->second.binding_count == 0;
                 })) {
                 break;


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1642

## Description

Issue #1509 can cause the low-memory tests to hang during CI/CD, which results in a timeout and now dump files. To fix this, assert and loop if NMR deregistration takes > NMR_WAIT_TIMEOUT_SECONDS.

## Testing

CI/CD

## Documentation

No.
