### PR TITLE
Store last failed allocation stack

### DIFF
--- a/libs/platform/user/ebpf_low_memory_test.cpp
+++ b/libs/platform/user/ebpf_low_memory_test.cpp
@@ -92,12 +92,15 @@ _ebpf_low_memory_test::log_stack_trace(
     }
     _log_file << std::endl;
 
+    _last_failure_stack.resize(0);
+
     std::vector<uint8_t> symbol_buffer(sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR));
     SYMBOL_INFO* symbol = reinterpret_cast<SYMBOL_INFO*>(symbol_buffer.data());
     IMAGEHLP_LINE64 line;
     symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
     symbol->MaxNameLen = MAX_SYM_NAME;
     for (auto frame : stack) {
+        std::string string_stack_frame;
         if (frame == 0) {
             break;
         }
@@ -105,14 +108,18 @@ _ebpf_low_memory_test::log_stack_trace(
         _log_file << "# ";
         if (SymFromAddr(GetCurrentProcess(), frame, &displacement, symbol)) {
             _log_file << std::hex << frame << " " << symbol->Name << " + " << displacement;
+            string_stack_frame = std::string(symbol->Name) + " + " + std::to_string(displacement);
             DWORD displacement32 = (DWORD)displacement;
             if (SymGetLineFromAddr64(GetCurrentProcess(), frame, &displacement32, &line)) {
                 _log_file << " " << line.FileName << std::dec << " " << line.LineNumber;
+                string_stack_frame += " " + std::string(line.FileName) + " " + std::to_string(line.LineNumber);
             }
             _log_file << std::endl;
         } else {
             _log_file << std::hex << frame << std::endl;
+            string_stack_frame = std::to_string(frame);
         }
+        _last_failure_stack.push_back(string_stack_frame);
     }
     _log_file << std::endl;
     // Flush the file after every write to prevent loss on crash.

--- a/libs/platform/user/ebpf_low_memory_test.h
+++ b/libs/platform/user/ebpf_low_memory_test.h
@@ -102,4 +102,5 @@ typedef class _ebpf_low_memory_test
     std::mutex _mutex;
 
     size_t _stack_depth;
+    std::vector<std::string> _last_failure_stack;
 } ebpf_low_memory_test_t;


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1644 

## Description

Store the last failed allocation stack in memory to make debugging crash dumps easier.

## Testing

CI/CD

## Documentation

No.
