### PR TITLE
Resolve duplicate definition of _ebpf_objects

### DIFF
--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -47,7 +47,7 @@ static TOKEN_VALUE _ebpf_pinned_type_enum[] = {
     {L"all", PT_ALL},
 };
 
-std::vector<struct bpf_object*> _ebpf_objects;
+std::vector<struct bpf_object*> _ebpf_netsh_objects;
 
 bool
 _prog_type_supports_interface(bpf_prog_type prog_type)
@@ -240,7 +240,7 @@ handle_ebpf_add_program(
     std::cout << "Loaded with ID " << info.id << std::endl;
 
     ebpf_link_close(link);
-    _ebpf_objects.push_back(object);
+    _ebpf_netsh_objects.push_back(object);
 
     return ERROR_SUCCESS;
 }
@@ -288,7 +288,7 @@ _unpin_program_by_id(ebpf_id_t id)
 static std::vector<struct bpf_object*>::const_iterator
 _find_object_with_program(ebpf_id_t id)
 {
-    for (auto object = _ebpf_objects.begin(); object != _ebpf_objects.end(); object++) {
+    for (auto object = _ebpf_netsh_objects.begin(); object != _ebpf_netsh_objects.end(); object++) {
         bpf_program* program;
         bpf_object__for_each_program(program, *object)
         {
@@ -303,7 +303,7 @@ _find_object_with_program(ebpf_id_t id)
             }
         }
     }
-    return _ebpf_objects.end();
+    return _ebpf_netsh_objects.end();
 }
 
 DWORD
@@ -356,9 +356,9 @@ handle_ebpf_delete_program(
     // Remove from our list of programs to release our own reference if we took one.
     // If there are no other references to the program, it will be unloaded.
     std::vector<struct bpf_object*>::const_iterator object = _find_object_with_program(id);
-    if (object != _ebpf_objects.end()) {
+    if (object != _ebpf_netsh_objects.end()) {
         bpf_object__close(*object);
-        _ebpf_objects.erase(object);
+        _ebpf_netsh_objects.erase(object);
     }
 
     // TODO: see if the program is still loaded, in which case some other process holds

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -17,6 +17,22 @@
 #include "platform.h"
 #include "test_helper.hpp"
 
+extern std::vector<struct bpf_object*> _ebpf_netsh_objects;
+
+class _test_helper_netsh
+{
+  public:
+    _test_helper_netsh();
+    ~_test_helper_netsh();
+
+  private:
+    _test_helper_libbpf test_helper_libbpf;
+};
+
+_test_helper_netsh::_test_helper_netsh() { _ebpf_netsh_objects.clear(); }
+
+_test_helper_netsh::~_test_helper_netsh() { REQUIRE(_ebpf_netsh_objects.empty()); }
+
 std::string
 strip_paths(const std::string& orignal_string)
 {
@@ -33,7 +49,7 @@ strip_paths(const std::string& orignal_string)
 TEST_CASE("show disassembly bpf_call.o", "[netsh][disassembly]")
 {
     // Start the test helper so the netsh command can get helper prototypes.
-    _test_helper_end_to_end test_helper;
+    _test_helper_netsh test_helper;
 
     int result;
     std::string output = _run_netsh_command(handle_ebpf_show_disassembly, L"bpf_call.o", nullptr, nullptr, &result);
@@ -143,7 +159,7 @@ TEST_CASE("show sections bpf.o .text", "[netsh][sections]")
 // Test a .sys file.
 TEST_CASE("show sections bpf.sys", "[netsh][sections]")
 {
-    _test_helper_end_to_end test_helper;
+    _test_helper_netsh test_helper;
     int result;
     std::string output = _run_netsh_command(handle_ebpf_show_sections, L"bpf.sys", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
@@ -163,7 +179,7 @@ TEST_CASE("show sections bpf.sys", "[netsh][sections]")
 // Test a DLL with multiple maps in the map section.
 TEST_CASE("show sections map_reuse_um.dll", "[netsh][sections]")
 {
-    _test_helper_end_to_end test_helper;
+    _test_helper_netsh test_helper;
     int result;
     std::string output = _run_netsh_command(handle_ebpf_show_sections, L"map_reuse_um.dll", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
@@ -185,7 +201,7 @@ TEST_CASE("show sections map_reuse_um.dll", "[netsh][sections]")
 // Test a .dll file with multiple programs.
 TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
 {
-    _test_helper_end_to_end test_helper;
+    _test_helper_netsh test_helper;
     int result;
     std::string output =
         _run_netsh_command(handle_ebpf_show_sections, L"tail_call_multiple_um.dll", nullptr, nullptr, &result);
@@ -208,7 +224,7 @@ TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
 // Test a .sys file with multiple programs, including ones with long names.
 TEST_CASE("show sections cgroup_sock_addr.sys", "[netsh][sections]")
 {
-    _test_helper_end_to_end test_helper;
+    _test_helper_netsh test_helper;
     int result;
     std::string output =
         _run_netsh_command(handle_ebpf_show_sections, L"cgroup_sock_addr.sys", nullptr, nullptr, &result);
@@ -240,7 +256,7 @@ TEST_CASE("show verification nosuchfile.o", "[netsh][verification]")
 
 TEST_CASE("show verification bpf.o", "[netsh][verification]")
 {
-    _test_helper_end_to_end test_helper;
+    _test_helper_netsh test_helper;
     int result;
     std::string output = _run_netsh_command(handle_ebpf_show_verification, L"bpf.o", L".text", L"xdp", &result);
     REQUIRE(result == NO_ERROR);
@@ -253,7 +269,7 @@ TEST_CASE("show verification bpf.o", "[netsh][verification]")
 
 TEST_CASE("show verification droppacket.o", "[netsh][verification]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     int result;
     std::string output = _run_netsh_command(handle_ebpf_show_verification, L"droppacket.o", L"xdp", nullptr, &result);
@@ -267,7 +283,7 @@ TEST_CASE("show verification droppacket.o", "[netsh][verification]")
 
 TEST_CASE("show verification droppacket_unsafe.o", "[netsh][verification]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     int result;
     std::string output =
@@ -292,7 +308,7 @@ TEST_CASE("show verification droppacket_unsafe.o", "[netsh][verification]")
 
 TEST_CASE("show verification printk_unsafe.o", "[netsh][verification]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     int result;
     std::string output =
@@ -326,7 +342,7 @@ verify_no_programs_exist()
 
 TEST_CASE("pin first program", "[netsh][programs]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     // Load a program to show.
     int result;
@@ -353,7 +369,7 @@ TEST_CASE("pin first program", "[netsh][programs]")
 
 TEST_CASE("pin all programs", "[netsh][programs]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     // Load programs to show.
     int result;
@@ -385,7 +401,7 @@ TEST_CASE("pin all programs", "[netsh][programs]")
 
 TEST_CASE("show programs", "[netsh][programs]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     // Load a program to show.
     int result;
@@ -475,7 +491,7 @@ TEST_CASE("show programs", "[netsh][programs]")
 
 TEST_CASE("set program", "[netsh][programs]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     int result;
     std::string output = _run_netsh_command(handle_ebpf_add_program, L"tail_call.o", L"pinned=none", nullptr, &result);
@@ -528,7 +544,7 @@ TEST_CASE("set program", "[netsh][programs]")
 
 TEST_CASE("show maps", "[netsh][maps]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     int result;
     std::string output = _run_netsh_command(handle_ebpf_add_program, L"map_in_map.o", nullptr, nullptr, &result);
@@ -563,7 +579,7 @@ TEST_CASE("show maps", "[netsh][maps]")
 
 TEST_CASE("show links", "[netsh][links]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     // Load and attach a program.
     int result;
@@ -596,7 +612,7 @@ TEST_CASE("show links", "[netsh][links]")
 
 TEST_CASE("show pins", "[netsh][pins]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     // Load and pin programs.
     int result;
@@ -627,7 +643,7 @@ TEST_CASE("show pins", "[netsh][pins]")
 
 TEST_CASE("delete pinned program", "[netsh][programs]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     // Load a program unpinned.
     int result;
@@ -656,7 +672,7 @@ TEST_CASE("delete pinned program", "[netsh][programs]")
 
 TEST_CASE("unpin program", "[netsh][programs]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     // Load a program pinned.
     int result;
@@ -680,7 +696,7 @@ TEST_CASE("unpin program", "[netsh][programs]")
 
 TEST_CASE("xdp interface parameter", "[netsh][programs]")
 {
-    _test_helper_libbpf test_helper;
+    _test_helper_netsh test_helper;
 
     // Load a program pinned.
     int result;


### PR DESCRIPTION
Clear the _ebpf_netsh_objects at the start of the test and verify objects are removed.

Resolves: #1655

Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Remove ODR violation on _ebpf_objects.
Cleanup netsh's list of bpf_object pointers at the start of the test and check that all are closed at the end of the test.
Orphaned objects in netsh's list of bpf_objects causes use after free when tests fail.

## Testing

CI/CD

## Documentation

No.
