### PR TITLE
Expression short circuiting causes skipping of ebpf_api_close_handle

### DIFF
--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -458,7 +458,11 @@ Glue_close(int file_descriptor)
         if (!found) {
             // No duplicates. Close the handle.
             ebpf_result_t result = ebpf_api_close_handle(it->second);
-            REQUIRE((ebpf_fuzzing_enabled || result == EBPF_SUCCESS));
+            if (ebpf_fuzzing_enabled) {
+                (void)result;
+            } else {
+                REQUIRE(result == EBPF_SUCCESS);
+            }
         }
         _fd_to_handle_map.erase(file_descriptor);
         return 0;

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -455,9 +455,11 @@ Glue_close(int file_descriptor)
         return -1;
     } else {
         bool found = _duplicate_handles.dereference_if_found(it->second);
-        if (!found)
+        if (!found) {
             // No duplicates. Close the handle.
-            REQUIRE((ebpf_fuzzing_enabled || ebpf_api_close_handle(it->second) == EBPF_SUCCESS));
+            ebpf_result_t result = ebpf_api_close_handle(it->second);
+            REQUIRE((ebpf_fuzzing_enabled || result == EBPF_SUCCESS));
+        }
         _fd_to_handle_map.erase(file_descriptor);
         return 0;
     }

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -457,12 +457,7 @@ Glue_close(int file_descriptor)
         bool found = _duplicate_handles.dereference_if_found(it->second);
         if (!found) {
             // No duplicates. Close the handle.
-            ebpf_result_t result = ebpf_api_close_handle(it->second);
-            if (ebpf_fuzzing_enabled) {
-                (void)result;
-            } else {
-                REQUIRE(result == EBPF_SUCCESS);
-            }
+            REQUIRE((ebpf_api_close_handle(it->second) == EBPF_SUCCESS || ebpf_fuzzing_enabled));
         }
         _fd_to_handle_map.erase(file_descriptor);
         return 0;


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1662

## Description

Expression short circuiting causes skipping of ebpf_api_close_handle.

## Testing

CI/CD (low memory fuzzing)

## Documentation

No.
