### PR TITLE
Clean up leaked BPF objects when running low-memory tests

### DIFF
--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -31,7 +31,19 @@ class _test_helper_netsh
 
 _test_helper_netsh::_test_helper_netsh() { _ebpf_netsh_objects.clear(); }
 
-_test_helper_netsh::~_test_helper_netsh() { REQUIRE(_ebpf_netsh_objects.empty()); }
+extern bool
+ebpf_low_memory_test_in_progress();
+
+_test_helper_netsh::~_test_helper_netsh()
+{
+    if (ebpf_low_memory_test_in_progress()) {
+        for (auto& object : _ebpf_netsh_objects) {
+            bpf_object__close(object);
+        }
+        _ebpf_netsh_objects.clear();
+    }
+    REQUIRE(_ebpf_netsh_objects.size() == 0);
+}
 
 std::string
 strip_paths(const std::string& original_string)


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1684

## Description

Low memory tests fail due to leaked BPF objects in netsh libraries. This fix frees them when running under low memory testing (normal behavior is that the test should free all objects).

## Testing

CI/Cd

## Documentation

No.
