### PR TITLE
Switch to release of bpf_conformance

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -114,7 +114,8 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      test_command: .\bpf_conformance_runner.exe --test_file_directory tests --plugin_path bpf2c_plugin.exe --cpu_version v2 --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.1/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\bpf_conformance\tests --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include" --exclude_regex "(lock|call-local)"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2019

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -114,8 +114,8 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.1/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\bpf_conformance\tests --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include" --exclude_regex "(lock|call-local)"
+      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.2/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\bpf_conformance\tests --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include" --exclude_regex "(lock|call-local|j.*32)"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2019

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -114,8 +114,8 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.2/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\bpf_conformance\tests --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include" --exclude_regex "(lock|call-local|j.*32)"
+      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.3/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\bpf_conformance\tests --plugin_path bpf2c_plugin.exe --cpu_version v2 --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2019

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -143,30 +143,11 @@ jobs:
         search_artifacts: false
         skip_unpack: true
 
-    - name: Download demo bpf_conformance repository artifacts
-      uses: dawidd6/action-download-artifact@e6e25ac3a2b93187502a8be1ef9e9603afc34925
-      with:
-        github_token: ${{secrets.GITHUB_TOKEN}}
-        workflow: CICD.yml
-        workflow_conclusion: success
-        name: bpf_conformance-${{ matrix.configurations }}
-        path: ${{github.workspace}}
-        repo: Alan-Jowett/bpf_conformance
-        check_artifacts:  false
-        search_artifacts: false
-        skip_unpack: true
-
     - name: Extract artifacts to build path
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
         cd ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
         tar -xf ..\..\x64-${{ matrix.configurations }}-cilium-xdp.zip
-
-    - name: Extract bpf_conformance repository artifacts to build path
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      run: |
-        cd ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-        tar -xf ..\..\bpf_conformance-${{ matrix.configurations }}.zip
 
     - name: Upload Build Output
       uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 [submodule "external/pe-parse"]
 	path = external/pe-parse
 	url = https://github.com/trailofbits/pe-parse.git
+[submodule "external/bpf_conformance"]
+	path = external/bpf_conformance
+	url = https://github.com/Alan-Jowett/bpf_conformance.git

--- a/docs/isa-support.rst
+++ b/docs/isa-support.rst
@@ -99,7 +99,7 @@ opcode  src  imm   description                                          PREVAIL 
 0x7f    any  0x00  dst >>= src                                             Y      Y      Y    rsh-reg
 0x84    0x0  0x00  dst = (uint32_t)-dst                                    Y      Y      Y    neg
 0x85    0x0  any   call helper function imm                                Y      Y      Y    call_unwind_fail
-0x85    0x1  any   call PC += offset                                       no     no     no   ???
+0x85    0x1  any   call PC += offset                                       no     no     no   call_local
 0x85    0x2  any   call runtime function imm                               no     no     no   ???
 0x87    0x0  0x00  dst = -dst                                              Y      Y      Y    neg64
 0x94    0x0  any   dst = (uint32_t)((imm != 0) ? (dst % imm) : dst)        Y      Y      Y    mod
@@ -124,22 +124,22 @@ opcode  src  imm   description                                          PREVAIL 
 0xbe    any  0x00  if (uint32_t)dst <= (uint32_t)src goto +offset          Y      Y      no   jle32-reg
 0xbf    any  0x00  dst = src                                               Y      Y      Y    ldxb-all
 0xc3    any  0x00  lock \*(uint32_t \*)(dst + offset) += src               no     no     no   lock_add32
-0xc3    any  0x01  lock::                                                  no     no     no   ???
+0xc3    any  0x01  lock::                                                  no     no     no   lock_fetch_add32
 
                        *(uint32_t *)(dst + offset) += src
                        src = *(uint32_t *)(dst + offset)
 0xc3    any  0x40  \*(uint32_t \*)(dst + offset) \|= src                   no     no     no   lock_or32
-0xc3    any  0x41  lock::                                                  no     no     no   ???
+0xc3    any  0x41  lock::                                                  no     no     no   lock_fetch_or32
 
                        *(uint32_t *)(dst + offset) |= src
                        src = *(uint32_t *)(dst + offset)
 0xc3    any  0x50  \*(uint32_t \*)(dst + offset) &= src                    no     no     no   lock_and32
-0xc3    any  0x51  lock::                                                  no     no     no   ???
+0xc3    any  0x51  lock::                                                  no     no     no   lock_fetch_and32
 
                        *(uint32_t *)(dst + offset) &= src
                        src = *(uint32_t *)(dst + offset)
 0xc3    any  0xa0  \*(uint32_t \*)(dst + offset) ^= src                    no     no     no   lock_xor32
-0xc3    any  0xa1  lock::                                                  no     no     no   ???
+0xc3    any  0xa1  lock::                                                  no     no     no   lock_fetch_xor32
 
                        *(uint32_t *)(dst + offset) ^= src
                        src = *(uint32_t *)(dst + offset)
@@ -168,22 +168,22 @@ opcode  src  imm   description                                          PREVAIL 
 0xd5    0x0  any   if dst s<= imm goto +offset                             Y      Y      Y    jsle-imm
 0xd6    0x0  any   if (int32_t)dst s<= (int32_t)imm goto +offset           Y      Y      no   jsle32-imm
 0xdb    any  0x00  lock \*(uint64_t \*)(dst + offset) += src               no     no     no   lock_add
-0xdb    any  0x01  lock::                                                  no     no     no   ???
+0xdb    any  0x01  lock::                                                  no     no     no   lock_fetch_add
 
                        *(uint64_t *)(dst + offset) += src
                        src = *(uint64_t *)(dst + offset)
 0xdb    any  0x40  \*(uint64_t \*)(dst + offset) \|= src                   no     no     no   lock_or
-0xdb    any  0x41  lock::                                                  no     no     no   ???
+0xdb    any  0x41  lock::                                                  no     no     no   lock_fetch_or
 
                        *(uint64_t *)(dst + offset) |= src
                        lock src = *(uint64_t *)(dst + offset)
 0xdb    any  0x50  \*(uint64_t \*)(dst + offset) &= src                    no     no     no   lock_and
-0xdb    any  0x51  lock::                                                  no     no     no   ???
+0xdb    any  0x51  lock::                                                  no     no     no   lock_fetch_and
 
                        *(uint64_t *)(dst + offset) &= src
                        src = *(uint64_t *)(dst + offset)
 0xdb    any  0xa0  \*(uint64_t \*)(dst + offset) ^= src                    no     no     no   lock_xor
-0xdb    any  0xa1  lock::                                                  no     no     no   ???
+0xdb    any  0xa1  lock::                                                  no     no     no   lock_fetch_xor
 
                        *(uint64_t *)(dst + offset) ^= src
                        src = *(uint64_t *)(dst + offset)
@@ -216,7 +216,3 @@ Some takeaways:
   as they will not be generated by clang when an older "cpu version" is specified on the command line.
 * The conformance suite does not support most 64-bit immediate instructions
   (https://github.com/Alan-Jowett/bpf_conformance/issues/59).
-* The conformance suite does not support extended call instructions
-  (https://github.com/Alan-Jowett/bpf_conformance/issues/60).
-* The conformance suite does not support atomic instructions with BPF_FETCH set
-  (https://github.com/Alan-Jowett/bpf_conformance/issues/61).


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Use the release bits of bpf_conformance instead of build artifacts.

## Testing

CI/CD

## Documentation

No.
