### PR TITLE
Switch to storing native module handle via fd

### DIFF
--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -70,7 +70,7 @@ typedef struct bpf_object
 {
     char* object_name = nullptr;
     char* file_name = nullptr;
-    ebpf_handle_t native_module_handle = ebpf_handle_invalid;
+    fd_t native_module_fd = ebpf_fd_invalid;
     std::vector<ebpf_program_t*> programs;
     std::vector<ebpf_map_t*> maps;
     bool loaded = false;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1405,10 +1405,10 @@ _clean_up_ebpf_object(_In_opt_ ebpf_object_t* object) noexcept
         clean_up_ebpf_programs(object->programs);
         clean_up_ebpf_maps(object->maps);
 
-        if (object->native_module_handle != ebpf_handle_invalid) {
+        if (object->native_module_fd != ebpf_fd_invalid) {
             ebpf_assert(object->execution_type == EBPF_EXECUTION_NATIVE);
-            Platform::CloseHandle(object->native_module_handle);
-            object->native_module_handle = ebpf_handle_invalid;
+            Platform::_close(object->native_module_fd);
+            object->native_module_fd = ebpf_fd_invalid;
         }
 
         ebpf_free(object->object_name);
@@ -1593,7 +1593,7 @@ _initialize_ebpf_object_native(
     ebpf_assert(map_handles);
     ebpf_assert(program_handles);
 
-    object.native_module_handle = native_module_handle;
+    object.native_module_fd = _create_file_descriptor_for_handle(native_module_handle);
 
     result = _initialize_ebpf_programs_native(count_of_programs, program_handles, object.programs);
     if (result != EBPF_SUCCESS) {

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1581,7 +1581,7 @@ Exit:
 
 static ebpf_result_t
 _initialize_ebpf_object_native(
-    ebpf_handle_t native_module_handle,
+    fd_t native_module_fd,
     size_t count_of_maps,
     _In_reads_(count_of_maps) ebpf_handle_t* map_handles,
     size_t count_of_programs,
@@ -1593,7 +1593,7 @@ _initialize_ebpf_object_native(
     ebpf_assert(map_handles);
     ebpf_assert(program_handles);
 
-    object.native_module_fd = _create_file_descriptor_for_handle(native_module_handle);
+    object.native_module_fd = native_module_fd;
 
     result = _initialize_ebpf_programs_native(count_of_programs, program_handles, object.programs);
     if (result != EBPF_SUCCESS) {
@@ -2863,6 +2863,7 @@ _ebpf_program_load_native(
     size_t count_of_maps = 0;
     size_t count_of_programs = 0;
     ebpf_handle_t native_module_handle = ebpf_handle_invalid;
+    fd_t native_module_fd = ebpf_fd_invalid;
     ebpf_handle_t* map_handles = nullptr;
     ebpf_handle_t* program_handles = nullptr;
 
@@ -2919,6 +2920,15 @@ _ebpf_program_load_native(
             goto Done;
         }
 
+        // Create a file descriptor for the native module.
+        native_module_fd = _create_file_descriptor_for_handle(native_module_handle);
+        if (native_module_fd == ebpf_fd_invalid) {
+            result = EBPF_NO_MEMORY;
+            goto Done;
+        }
+
+        native_module_handle = ebpf_handle_invalid;
+
         if (count_of_programs == 0) {
             result = EBPF_INVALID_OBJECT;
             EBPF_LOG_MESSAGE_STRING(
@@ -2951,11 +2961,11 @@ _ebpf_program_load_native(
         }
 
         result = _initialize_ebpf_object_native(
-            native_module_handle, count_of_maps, map_handles, count_of_programs, program_handles, *object);
+            native_module_fd, count_of_maps, map_handles, count_of_programs, program_handles, *object);
         if (result != EBPF_SUCCESS) {
             goto Done;
         }
-        native_module_handle = ebpf_handle_invalid;
+        native_module_fd = ebpf_fd_invalid;
 
         *program_fd = object->programs[0]->fd;
     } catch (const std::bad_alloc&) {
@@ -2986,7 +2996,9 @@ Done:
             }
         }
 #pragma warning(pop)
-        if (native_module_handle != ebpf_handle_invalid) {
+        if (native_module_fd != ebpf_fd_invalid) {
+            Platform::_close(native_module_fd);
+        } else if (native_module_handle != ebpf_handle_invalid) {
             Platform::CloseHandle(native_module_handle);
         }
 

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -660,8 +660,8 @@ TEST_CASE("native_module_handle_test", "[native_tests]")
     REQUIRE(result == 0);
     REQUIRE(program_fd != ebpf_fd_invalid);
 
-    ebpf_handle_t native_module_handle = object->native_module_handle;
-    REQUIRE(native_module_handle != ebpf_handle_invalid);
+    fd_t native_module_fd = object->native_module_fd;
+    REQUIRE(native_module_fd != ebpf_fd_invalid);
 
     // Bindmonitor has 2 maps and 1 program. Fetch and close all these fds.
     bpf_map* map1 = bpf_object__find_map_by_name(object, "process_map");
@@ -688,8 +688,8 @@ TEST_CASE("native_module_handle_test", "[native_tests]")
     REQUIRE(result == -ENOENT);
 
     // Close the native module handle. That should result in the module to be unloaded.
-    REQUIRE(ebpf_api_close_handle(native_module_handle) == EBPF_SUCCESS);
-    object->native_module_handle = ebpf_handle_invalid;
+    REQUIRE(_close(native_module_fd) == 0);
+    object->native_module_fd = ebpf_fd_invalid;
 
     // Add a sleep to allow the previous driver to be unloaded successfully.
     Sleep(1000);


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1694

## Description

Store module handle as an fd. All of the existing tests rundown open fds during cleanup but have no way of tracking open handles. By switching this to store the handle via fd, it permits the test to automatically close this handle on test assertion faliure.

## Testing

CI/CD

## Documentation

No.
