### PR TITLE
Mark pe_context as failed on low-memory failure

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2109,6 +2109,7 @@ _ebpf_pe_add_section(
     info->raw_data_size = section_header.Misc.VirtualSize;
     info->raw_data = (char*)ebpf_allocate(section_header.Misc.VirtualSize);
     if (info->raw_data == nullptr || info->program_type_name == nullptr || info->section_name == nullptr) {
+        pe_context->result = EBPF_NO_MEMORY;
         _ebpf_free_section_info(info);
         EBPF_LOG_EXIT();
         return 1;


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1649

## Description

The function peparse::IterSec relies on returning failure info via the context, but _ebpf_pe_add_section fails to set the failed status in some paths.

## Testing

CI/CD

## Documentation

No.
