### PR TITLE
Delaramamiri/pe doc

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,6 +69,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
+      test_command: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       test_command: .\unit_tests.exe -d yes
       build_artifact: Build-x64
       environment: windows-2019

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -69,7 +69,6 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
-      test_command: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       test_command: .\unit_tests.exe -d yes
       build_artifact: Build-x64
       environment: windows-2019

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -42,6 +42,10 @@ This section outlines the steps to build, prepare and build the eBPF-For-Windows
 1. ```git clone --recurse-submodules https://github.com/microsoft/ebpf-for-windows.git```.
 By default this will clone the project under the `ebpf-for-windows` directory.
 
+#### Exclusion of PE parse directory from Windows Security
+1. Select Start , then open Settings. Under Privacy & security, select Virus & threat protection.
+2. Under Virus & threat protection settings, select Manage settings, and then under Exclusions, select Add or remove exclusions.
+3. Select Add an exclusion, and then select from files, folders, file types, or process. Choose the following direcory ```ebpf-for-windows/external/pe-parse``` to exclude the folder and sub folders to get flagged by anti virus. 
 #### Prepare for first build
 The following steps need to be executed _once_ before the first build on a new clone.
 1. Launch `Developer Command Prompt for VS 2019` by running `"C:\Program Files (x86)\Microsoft Visual Studio\2019\BuildTools\Common7\Tools\VsDevCmd.bat"`.


### PR DESCRIPTION
## Description

This PR addresses the exclusion of pe-parse directory from windows security in the documentation. 
The issue was detected when in ebf-for-windows repo:
```ebpf-for-windows/external/pe-parse/tests/assets/corkami-poc-dataset/aes-gcm/out/jpg-jpg2.jpg: Heuristics.Exploit.W32.MS04-028 FOUND
ebpf-for-windows/external/pe-parse/tests/assets/corkami-poc-dataset/polymocks/multi: Win.Exploit.CVE_2012_1434-1 FOUND
ebpf-for-windows/external/pe-parse/tests/assets/corkami-poc-dataset/rar/eicar14.rar: Win.Trojan.Agent-6786841-0 FOUND```

## Documentation

"GettingStarted.md" is updated 
Resolve_issue #1682 
