### PR TITLE
Fix ASAN issue on sanitize_unit_tests

### DIFF
--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -353,7 +353,10 @@ ebpf_program_load(
         if (log_buffer) {
             size_t log_buffer_size;
             if (program != nullptr) {
-                *log_buffer = _strdup(bpf_program__log_buf(program, &log_buffer_size));
+                const char* log_buffer_str = bpf_program__log_buf(program, &log_buffer_size);
+                if (log_buffer_str != nullptr) {
+                    *log_buffer = _strdup(log_buffer_str);
+                }
             }
         }
         bpf_object__close(new_object);


### PR DESCRIPTION
Closes #1710

## Description
Adds missing nullptr check on string before duplication.

## Testing
CI/CD pipeline.

## Documentation
None.
