### PR TITLE
Replace _strdup with instrumented ebpf_duplicate_string and fix bugs uncovered

### DIFF
--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -224,7 +224,7 @@ load_byte_code(
 
             program->handle = ebpf_handle_invalid;
             program->program_type = *(const GUID*)raw_program.info.type.platform_specific_data;
-            program->section_name = _strdup(raw_program.section.c_str());
+            program->section_name = ebpf_duplicate_string(raw_program.section.c_str());
             if (program->section_name == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -294,7 +294,7 @@ load_byte_code(
                 goto Exit;
             }
             initialize_map(map, descriptor);
-            map->name = _strdup(map_names[index].map_name.c_str());
+            map->name = ebpf_duplicate_string(map_names[index].map_name.c_str());
             if (map->name == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -306,7 +306,7 @@ load_byte_code(
                     result = EBPF_INVALID_ARGUMENT;
                     goto Exit;
                 }
-                map->pin_path = _strdup(buffer);
+                map->pin_path = ebpf_duplicate_string(buffer);
                 if (map->pin_path == nullptr) {
                     result = EBPF_NO_MEMORY;
                     goto Exit;
@@ -318,7 +318,7 @@ load_byte_code(
 
         int index = 0;
         for (auto& iterator : programs) {
-            iterator->program_name = _strdup(section_to_program_map[index].program_name.c_str());
+            iterator->program_name = ebpf_duplicate_string(section_to_program_map[index].program_name.c_str());
             if (iterator->program_name == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
@@ -365,7 +365,7 @@ _ebpf_add_stat(_Inout_ ebpf_section_info_t* info, std::string key, int value) no
     if (stat == nullptr) {
         throw std::runtime_error("Out of memory");
     }
-    stat->key = _strdup(key.c_str());
+    stat->key = ebpf_duplicate_string(key.c_str());
     if (stat->key == nullptr) {
         ebpf_free(stat);
         throw std::runtime_error("Out of memory");
@@ -416,8 +416,8 @@ ebpf_api_elf_enumerate_sections(
                 _ebpf_add_stat(info, "Instructions", (int)raw_program.prog.size());
             }
 
-            info->section_name = _strdup(raw_program.section.c_str());
-            info->program_type_name = _strdup(raw_program.info.type.name.c_str());
+            info->section_name = ebpf_duplicate_string(raw_program.section.c_str());
+            info->program_type_name = ebpf_duplicate_string(raw_program.info.type.name.c_str());
 
             std::vector<uint8_t> raw_data = convert_ebpf_program_to_bytes(raw_program.prog);
             info->raw_data_size = raw_data.size();

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -831,7 +831,7 @@ ebpf_map_pin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noexcept
             EBPF_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
         }
         ebpf_free(map->pin_path);
-        map->pin_path = _strdup(path);
+        map->pin_path = ebpf_duplicate_string(path);
         if (map->pin_path == nullptr) {
             EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
         }
@@ -853,7 +853,7 @@ ebpf_map_set_pin_path(_In_ struct bpf_map* map, _In_opt_z_ const char* path) noe
     ebpf_assert(map);
     char* old_path = map->pin_path;
     if (path != nullptr) {
-        path = _strdup(path);
+        path = ebpf_duplicate_string(path);
         if (path == nullptr) {
             EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
         }
@@ -1663,13 +1663,13 @@ _initialize_ebpf_object_from_native_file(
         program->program_type = info->program_type;
         program->attach_type = info->expected_attach_type;
 
-        program->section_name = _strdup(info->section_name);
+        program->section_name = ebpf_duplicate_string(info->section_name);
         if (program->section_name == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
 
-        program->program_name = _strdup(info->program_name);
+        program->program_name = ebpf_duplicate_string(info->program_name);
         if (program->program_name == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -1741,13 +1741,13 @@ _initialize_ebpf_object_from_file(
 {
     ebpf_result_t result = EBPF_SUCCESS;
 
-    new_object->file_name = _strdup(path);
+    new_object->file_name = ebpf_duplicate_string(path);
     if (new_object->file_name == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Done;
     }
 
-    new_object->object_name = _strdup(object_name ? object_name : path);
+    new_object->object_name = ebpf_duplicate_string(object_name ? object_name : path);
     if (new_object->object_name == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Done;
@@ -1934,7 +1934,7 @@ _ebpf_pe_get_map_definitions(
 
                 const char* map_name =
                     _ebpf_get_section_string(pe_context, (uintptr_t)entry->name, section_header, buffer);
-                map->name = _strdup(map_name);
+                map->name = ebpf_duplicate_string(map_name);
                 if (map->name == nullptr) {
                     pe_context->result = EBPF_NO_MEMORY;
                     goto Error;
@@ -1951,7 +1951,7 @@ _ebpf_pe_get_map_definitions(
                         pe_context->result = EBPF_INVALID_ARGUMENT;
                         goto Error;
                     }
-                    map->pin_path = _strdup(pin_path_buffer);
+                    map->pin_path = ebpf_duplicate_string(pin_path_buffer);
                     if (map->pin_path == nullptr) {
                         pe_context->result = EBPF_NO_MEMORY;
                         goto Error;
@@ -2095,8 +2095,8 @@ _ebpf_pe_add_section(
     }
 
     memset(info, 0, sizeof(*info));
-    info->section_name = _strdup(elf_section_name.c_str());
-    info->program_name = _strdup(program_name.c_str());
+    info->section_name = ebpf_duplicate_string(elf_section_name.c_str());
+    info->program_name = ebpf_duplicate_string(program_name.c_str());
     info->program_type = pe_context->section_program_types[pe_section_name];
     info->expected_attach_type = pe_context->section_attach_types[pe_section_name];
     info->program_type_name = ebpf_get_program_type_name(&pe_context->section_program_types[pe_section_name]);
@@ -2105,7 +2105,7 @@ _ebpf_pe_add_section(
         EBPF_LOG_EXIT();
         return 1;
     }
-    info->program_type_name = _strdup(info->program_type_name);
+    info->program_type_name = ebpf_duplicate_string(info->program_type_name);
     info->raw_data_size = section_header.Misc.VirtualSize;
     info->raw_data = (char*)ebpf_allocate(section_header.Misc.VirtualSize);
     if (info->raw_data == nullptr || info->program_type_name == nullptr || info->section_name == nullptr) {
@@ -2156,7 +2156,7 @@ _ebpf_enumerate_native_sections(
     DestructParsedPE(pe);
 
     if (context.result != EBPF_SUCCESS) {
-        *error_message = _strdup("Failed to parse PE file.");
+        *error_message = ebpf_duplicate_string("Failed to parse PE file.");
         while (context.infos) {
             ebpf_section_info_t* next = context.infos->next;
             _ebpf_free_section_info(context.infos);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2079,6 +2079,7 @@ _ebpf_pe_add_section(
         return 0;
     }
     ebpf_pe_context_t* pe_context = (ebpf_pe_context_t*)context;
+    const char* program_type_name = nullptr;
 
     // Get ELF section name.
     if (!pe_context->section_names.contains(pe_section_name)) {
@@ -2115,14 +2116,14 @@ _ebpf_pe_add_section(
     info->program_type = pe_context->section_program_types[pe_section_name];
     info->expected_attach_type = pe_context->section_attach_types[pe_section_name];
 
-    info->program_type_name = ebpf_get_program_type_name(&pe_context->section_program_types[pe_section_name]);
-    if (info->program_type_name == nullptr) {
+    program_type_name = ebpf_get_program_type_name(&pe_context->section_program_types[pe_section_name]);
+    if (program_type_name == nullptr) {
         pe_context->result = EBPF_NO_MEMORY;
         return_value = 1;
         goto Exit;
     }
 
-    info->program_type_name = ebpf_duplicate_string(info->program_type_name);
+    info->program_type_name = ebpf_duplicate_string(program_type_name);
     if (info->program_type_name == nullptr) {
         pe_context->result = EBPF_NO_MEMORY;
         return_value = 1;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2096,7 +2096,17 @@ _ebpf_pe_add_section(
 
     memset(info, 0, sizeof(*info));
     info->section_name = ebpf_duplicate_string(elf_section_name.c_str());
+    if (info->section_name == nullptr) {
+        pe_context->result = EBPF_NO_MEMORY;
+        EBPF_LOG_EXIT();
+        return 1;
+    }
     info->program_name = ebpf_duplicate_string(program_name.c_str());
+    if (info->program_name == nullptr) {
+        pe_context->result = EBPF_NO_MEMORY;
+        EBPF_LOG_EXIT();
+        return 1;
+    }
     info->program_type = pe_context->section_program_types[pe_section_name];
     info->expected_attach_type = pe_context->section_attach_types[pe_section_name];
     info->program_type_name = ebpf_get_program_type_name(&pe_context->section_program_types[pe_section_name]);
@@ -2106,6 +2116,11 @@ _ebpf_pe_add_section(
         return 1;
     }
     info->program_type_name = ebpf_duplicate_string(info->program_type_name);
+    if (info->program_type_name == nullptr) {
+        pe_context->result = EBPF_NO_MEMORY;
+        EBPF_LOG_EXIT();
+        return 1;
+    }
     info->raw_data_size = section_header.Misc.VirtualSize;
     info->raw_data = (char*)ebpf_allocate(section_header.Misc.VirtualSize);
     if (info->raw_data == nullptr || info->program_type_name == nullptr || info->section_name == nullptr) {

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -58,7 +58,7 @@ _load_helper_prototype(
         memcpy(&helper_prototype->arguments, serialized_data + offset, sizeof(helper_prototype->arguments));
         offset += sizeof(helper_prototype->arguments);
 
-        helper_prototype->name = _strdup(ebpf_down_cast_from_wstring(std::wstring(helper_name)).c_str());
+        helper_prototype->name = ebpf_duplicate_string(ebpf_down_cast_from_wstring(std::wstring(helper_name)).c_str());
         if (helper_prototype->name == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -165,7 +165,7 @@ _load_program_data_information(
             goto Exit;
         }
 
-        program_information->program_type_descriptor.name = _strdup(program_type_name_string.c_str());
+        program_information->program_type_descriptor.name = ebpf_duplicate_string(program_type_name_string.c_str());
         if (program_information->program_type_descriptor.name == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -431,7 +431,7 @@ _load_section_data_information(
             result = EBPF_SUCCESS;
         }
 
-        section_prefix = _strdup(ebpf_down_cast_from_wstring(section_name).c_str());
+        section_prefix = ebpf_duplicate_string(ebpf_down_cast_from_wstring(section_name).c_str());
         if (section_prefix == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -134,7 +134,7 @@ _get_program_descriptor_from_info(_In_ const ebpf_program_info_t* info, _Outptr_
             goto Exit;
         }
 
-        name = _strdup(info->program_type_descriptor.name);
+        name = ebpf_duplicate_string(info->program_type_descriptor.name);
         if (name == nullptr) {
             result = EBPF_NO_MEMORY;
             goto Exit;
@@ -504,7 +504,7 @@ _update_global_helpers_for_program_information(
         // Copy the global helpers to the new helpers.
         for (uint32_t i = 0; i < global_helper_count; i++) {
             new_helpers[i] = global_helpers[i];
-            auto name = _strdup(global_helpers[i].name);
+            auto name = ebpf_duplicate_string(global_helpers[i].name);
             if (name == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -504,6 +504,7 @@ _update_global_helpers_for_program_information(
         // Copy the global helpers to the new helpers.
         for (uint32_t i = 0; i < global_helper_count; i++) {
             new_helpers[i] = global_helpers[i];
+            new_helpers[i].name = nullptr;
             auto name = ebpf_duplicate_string(global_helpers[i].name);
             if (name == nullptr) {
                 result = EBPF_NO_MEMORY;
@@ -523,6 +524,8 @@ _update_global_helpers_for_program_information(
 
         program_info->helper_prototype = new_helpers;
         program_info->count_of_helpers = (uint32_t)total_helper_count;
+        new_helpers = nullptr;
+        total_helper_count = 0;
     }
 
 Exit:

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -358,7 +358,7 @@ ebpf_object_reference_by_handle(
 }
 
 _Must_inspect_result_ char*
-ebpf_duplicate_string(_In_ const char* source)
+ebpf_duplicate_string(_In_z_ const char* source)
 {
     size_t length = strlen(source) + 1;
     char* destination = ebpf_allocate(length);

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -356,3 +356,15 @@ ebpf_object_reference_by_handle(
     return ebpf_reference_base_object_by_handle(
         handle, _ebpf_object_compare, &object_type, (ebpf_base_object_t**)object);
 }
+
+_Must_inspect_result_ char*
+ebpf_duplicate_string(_In_ const char* source)
+{
+    size_t length = strlen(source) + 1;
+    char* destination = ebpf_allocate(length);
+    if (destination == NULL) {
+        return NULL;
+    }
+    memcpy(destination, source, length);
+    return destination;
+}

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -280,6 +280,15 @@ extern "C"
     ebpf_duplicate_utf8_string(_Out_ ebpf_utf8_string_t* destination, _In_ const ebpf_utf8_string_t* source);
 
     /**
+     * @brief Duplicate a null-terminated string.
+     *
+     * @param[in] source String to duplicate.
+     * @return Pointer to the duplicated string or NULL if out of memory.
+     */
+    _Must_inspect_result_ char*
+    ebpf_duplicate_string(_In_ const char* source);
+
+    /**
      * @brief Get the code integrity state from the platform.
      * @param[out] state The code integrity state being enforced.
      * @retval EBPF_SUCCESS The operation was successful.

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -286,7 +286,7 @@ extern "C"
      * @return Pointer to the duplicated string or NULL if out of memory.
      */
     _Must_inspect_result_ char*
-    ebpf_duplicate_string(_In_ const char* source);
+    ebpf_duplicate_string(_In_z_ const char* source);
 
     /**
      * @brief Get the code integrity state from the platform.

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -355,7 +355,7 @@ ebpf_program_load(
             if (program != nullptr) {
                 const char* log_buffer_str = bpf_program__log_buf(program, &log_buffer_size);
                 if (log_buffer_str != nullptr) {
-                    *log_buffer = _strdup(log_buffer_str);
+                    *log_buffer = ebpf_duplicate_string(log_buffer_str);
                 }
             }
         }


### PR DESCRIPTION
## Description

Replace _strdup with ebpf_duplicate_string, which is instrumented to test low-memory conditions.
Fix bugs in _update_global_helpers_for_program_information uncovered by low-memory testing.

Resolves: #1699

## Testing

CI/CD

## Documentation

No.
