### PR TITLE
Add version check to native images

### DIFF
--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -82,11 +82,19 @@ extern "C"
         size_t program_info_hash_length;
     } program_entry_t;
 
+    typedef struct _bpf2c_version
+    {
+        uint32_t major;
+        uint32_t minor;
+        uint32_t revision;
+    } bpf2c_version_t;
+
     typedef struct _metadata_table
     {
         void (*programs)(_Outptr_result_buffer_maybenull_(*count) program_entry_t** programs, _Out_ size_t* count);
         void (*maps)(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count);
         void (*hash)(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size);
+        void (*version)(_Out_ bpf2c_version_t* version);
     } metadata_table_t;
 
     inline uint16_t

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -13,6 +13,9 @@
 
 static const uint32_t _ebpf_native_marker = 'entv';
 
+// Set this value if there is a need to block older version of the native driver.
+static bpf2c_version_t _ebpf_minimum_version = {0, 0, 0};
+
 #ifndef GUID_NULL
 static const GUID GUID_NULL = {0, 0, 0, {0, 0, 0, 0, 0, 0, 0, 0}};
 #endif
@@ -88,6 +91,32 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_native_load_driver(_In_z_ const wchar_t* service_name);
 void
 ebpf_native_unload_driver(_In_z_ const wchar_t* service_name);
+
+static int
+_ebpf_compare_versions(bpf2c_version_t* lhs, bpf2c_version_t* rhs)
+{
+    if (lhs->major < rhs->major) {
+        return -1;
+    }
+    if (lhs->major > rhs->major) {
+        return 1;
+    }
+    ebpf_assert(lhs->major == rhs->major);
+    if (lhs->minor < rhs->major) {
+        return -1;
+    }
+    if (lhs->minor > rhs->major) {
+        return 1;
+    }
+    ebpf_assert(lhs->minor == rhs->minor);
+    if (lhs->revision < rhs->revision) {
+        return -1;
+    }
+    if (lhs->revision > rhs->revision) {
+        return 1;
+    }
+    return 0;
+}
 
 static void
 _ebpf_native_unload_work_item(_In_opt_ const void* service)
@@ -319,6 +348,13 @@ _ebpf_native_provider_attach_client_callback(
     }
     table = (metadata_table_t*)client_registration_instance->NpiSpecificCharacteristics;
     if (!table->programs || !table->maps) {
+        result = EBPF_INVALID_ARGUMENT;
+        goto Done;
+    }
+
+    bpf2c_version_t client_version = {0, 0, 0};
+    table->version(&client_version);
+    if (_ebpf_compare_versions(&client_version, &_ebpf_minimum_version) < 0) {
         result = EBPF_INVALID_ARGUMENT;
         goto Done;
     }

--- a/tests/bpf2c_plugin/CMakeLists.txt
+++ b/tests/bpf2c_plugin/CMakeLists.txt
@@ -9,6 +9,7 @@ add_executable("bpf2c_plugin"
 
 target_include_directories("bpf2c_plugin" PRIVATE
   "${CMAKE_SOURCE_DIR}/include"
+  "${CMAKE_SOURCE_DIR}/resource"
   "${CMAKE_SOURCE_DIR}/tools/bpf2c"
   "${CMAKE_SOURCE_DIR}/external/ubpf/vm"
   "${CMAKE_BINARY_DIR}/external/ubpf/vm"

--- a/tests/bpf2c_plugin/bpf2c_plugin.vcxproj
+++ b/tests/bpf2c_plugin/bpf2c_plugin.vcxproj
@@ -59,7 +59,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)resource;$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -74,7 +74,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)resource;$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/bpf2c_tests/CMakeLists.txt
+++ b/tests/bpf2c_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable("bpf2c_tests"
 
 target_include_directories("bpf2c_tests" PRIVATE
   "${CMAKE_SOURCE_DIR}/include"
+  "${CMAKE_SOURCE_DIR}/resource"
   "${CMAKE_SOURCE_DIR}/tools/bpf2c"
   "${CMAKE_SOURCE_DIR}/external/ubpf/vm"
   "${CMAKE_BINARY_DIR}/external/ubpf/vm"

--- a/tests/bpf2c_tests/bpf2c_tests.vcxproj
+++ b/tests/bpf2c_tests/bpf2c_tests.vcxproj
@@ -72,7 +72,7 @@
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;BPF2C_VERBOSE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)\external\ubpf\build\vm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)resource;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)\external\ubpf\build\vm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>

--- a/tests/bpf2c_tests/bpf2c_tests.vcxproj
+++ b/tests/bpf2c_tests/bpf2c_tests.vcxproj
@@ -57,7 +57,7 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)\external\ubpf\build\vm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)resource;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ubpf\vm;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)external\ubpf\vm\inc;$(SolutionDir)\external\ubpf\build\vm;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -499,4 +499,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -465,4 +465,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -186,4 +186,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -152,4 +152,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -319,4 +319,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -632,4 +632,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -801,4 +801,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 3;
 }
 
-metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -767,4 +767,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 3;
 }
 
-metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -934,4 +934,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 3;
 }
 
-metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -182,4 +182,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -148,4 +148,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -315,4 +315,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -113,4 +113,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_raw.c
@@ -79,4 +79,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -246,4 +246,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -575,4 +575,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -541,4 +541,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -708,4 +708,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -682,4 +682,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 4;
 }
 
-metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -648,4 +648,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 4;
 }
 
-metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -815,4 +815,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 4;
 }
 
-metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -492,4 +492,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
@@ -458,4 +458,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
@@ -625,4 +625,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -189,4 +189,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -155,4 +155,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -322,4 +322,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -324,4 +324,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -290,4 +290,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -457,4 +457,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/empty_dll.c
+++ b/tests/bpf2c_tests/expected/empty_dll.c
@@ -77,4 +77,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 0;
 }
 
-metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/empty_raw.c
+++ b/tests/bpf2c_tests/expected/empty_raw.c
@@ -43,4 +43,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 0;
 }
 
-metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/empty_sys.c
+++ b/tests/bpf2c_tests/expected/empty_sys.c
@@ -210,4 +210,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 0;
 }
 
-metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -1083,4 +1083,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
@@ -1049,4 +1049,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
@@ -1216,4 +1216,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -4356,4 +4356,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_dll.c
@@ -226,4 +226,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_raw.c
@@ -192,4 +192,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_sys.c
@@ -359,4 +359,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
@@ -226,4 +226,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
@@ -192,4 +192,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
@@ -359,4 +359,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -4322,4 +4322,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -283,4 +283,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -249,4 +249,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -416,4 +416,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -283,4 +283,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -249,4 +249,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -416,4 +416,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -4489,4 +4489,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -229,4 +229,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -195,4 +195,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -362,4 +362,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -689,4 +689,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -574,4 +574,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -540,4 +540,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -707,4 +707,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -655,4 +655,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -822,4 +822,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -772,4 +772,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.c
@@ -738,4 +738,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.c
@@ -905,4 +905,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -892,4 +892,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -858,4 +858,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -1025,4 +1025,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -264,4 +264,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -230,4 +230,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -397,4 +397,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -259,4 +259,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -254,4 +254,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -220,4 +220,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -387,4 +387,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -288,4 +288,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 3;
 }
 
-metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -254,4 +254,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 3;
 }
 
-metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -421,4 +421,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 3;
 }
 
-metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -225,4 +225,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -392,4 +392,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -547,4 +547,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -513,4 +513,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -680,4 +680,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 2;
 }
 
-metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -313,4 +313,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -279,4 +279,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -446,4 +446,12 @@ _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ s
     *count = 1;
 }
 
-metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash};
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -181,7 +181,7 @@ TEST_CASE("show sections bpf.sys", "[netsh][sections]")
                   "                                    Size\n"
                   "             Section       Type  (bytes)\n"
                   "====================  =========  =======\n"
-                  "               .text        xdp     1752\n"
+                  "               .text        xdp     1800\n"
                   "\n"
                   "                     Key  Value      Max\n"
                   "          Map Type  Size   Size  Entries  Name\n"

--- a/tests/libfuzzer/bpf2c/bpf2c_fuzzer.vcxproj
+++ b/tests/libfuzzer/bpf2c/bpf2c_fuzzer.vcxproj
@@ -53,7 +53,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\libfuzzer\include;$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)tools\bpf2c;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libfuzzer\include;$(SolutionDir)include;$(SolutionDir)resource;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)tools\bpf2c;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
@@ -65,7 +65,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;NO_CATCH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>$(SolutionDir)tests\libfuzzer\include;$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)tools\bpf2c;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)tests\libfuzzer\include;$(SolutionDir)include;$(SolutionDir)resource;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)tools\bpf2c;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalOptions>/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div %(AdditionalOptions)</AdditionalOptions>
       <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>

--- a/tools/bpf2c/CMakeLists.txt
+++ b/tools/bpf2c/CMakeLists.txt
@@ -13,6 +13,7 @@ add_executable("bpf2c"
 
 target_include_directories("bpf2c" PRIVATE
   "${CMAKE_SOURCE_DIR}/include"
+  "${CMAKE_SOURCE_DIR}/resource"
   "${CMAKE_SOURCE_DIR}/external/ubpf/vm"
   "${CMAKE_BINARY_DIR}/external/ubpf/vm"
 )

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -57,7 +57,7 @@
     <ClCompile>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;ENABLE_SKIP_VERIFY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)resource;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -73,7 +73,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)resource;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <WholeProgramOptimization>false</WholeProgramOptimization>
     </ClCompile>
     <Link>

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -11,19 +11,21 @@
 // Example:
 // .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\
 
+#include <cassert>
+#include <iomanip>
 #include <iostream>
 #include <vector>
+#include <sstream>
 #include <windows.h>
 #undef max
 
 #include "btf_parser.h"
 #include "bpf_code_generator.h"
+#include "ebpf_version.h"
 
 #if !defined(_countof)
 #define _countof(array) (sizeof(array) / sizeof(array[0]))
 #endif
-#include <cassert>
-#include <iomanip>
 
 #define INDENT "    "
 #define LINE_BREAK_WIDTH 120
@@ -1069,8 +1071,26 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
     output_stream << "}" << std::endl;
     output_stream << std::endl;
 
+    std::istringstream version_stream(EBPF_VERSION);
+    std::string version_major;
+    std::string version_minor;
+    std::string version_revision;
+    std::getline(version_stream, version_major, '.');
+    std::getline(version_stream, version_minor, '.');
+    std::getline(version_stream, version_revision, '.');
+
+    output_stream << "static void" << std::endl
+                  << "_get_version(_Out_ bpf2c_version_t* version)" << std::endl
+                  << "{" << std::endl
+                  << INDENT "version->major = " << version_major << ";" << std::endl
+                  << INDENT "version->minor = " << version_minor << ";" << std::endl
+                  << INDENT "version->revision = " << version_revision << ";" << std::endl
+                  << "}" << std::endl
+                  << std::endl;
+
     output_stream << format_string(
-        "metadata_table_t %s = {_get_programs, _get_maps, _get_hash};\n", c_name.c_identifier() + "_metadata_table");
+        "metadata_table_t %s = {_get_programs, _get_maps, _get_hash, _get_version};\n",
+        c_name.c_identifier() + "_metadata_table");
 }
 
 std::string

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -14,8 +14,8 @@
 #include <cassert>
 #include <iomanip>
 #include <iostream>
-#include <vector>
 #include <sstream>
+#include <vector>
 #include <windows.h>
 #undef max
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1718 

## Description

Capture the version of bpf2c used to generate native image in code pages.
Add support for rejecting native images generated by an older version of bpf2c.

## Testing

CI/CD

## Documentation

No.
