### PR TITLE
Fix code analysis annotations for In and In_opt parameters by adding const where appropriate or changing to Inout where appropriate.

### DIFF
--- a/ebpfapi/rpc_client.cpp
+++ b/ebpfapi/rpc_client.cpp
@@ -23,13 +23,17 @@ static bool _binding_initialized = false;
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_rpc_load_program(
-    _In_ ebpf_program_load_info* info,
+    _In_ const ebpf_program_load_info* info,
     _Outptr_result_maybenull_z_ const char** logs,
     _Inout_ uint32_t* logs_size) noexcept
 {
     ebpf_result_t result;
 
-    RpcTryExcept { result = ebpf_client_verify_and_load_program(info, logs_size, const_cast<char**>(logs)); }
+    RpcTryExcept
+    {
+        result = ebpf_client_verify_and_load_program(
+            const_cast<ebpf_program_load_info*>(info), logs_size, const_cast<char**>(logs));
+    }
     RpcExcept(RpcExceptionFilter(RpcExceptionCode()))
     {
         EBPF_LOG_MESSAGE_UINT64(

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -220,7 +220,7 @@ _ebpf_driver_file_close(WDFFILEOBJECT wdf_file_object)
 }
 
 static void
-_ebpf_driver_io_device_control_complete(void* context, size_t output_buffer_length, ebpf_result_t result)
+_ebpf_driver_io_device_control_complete(_Inout_ void* context, size_t output_buffer_length, ebpf_result_t result)
 {
     NTSTATUS status;
     WDFREQUEST request = (WDFREQUEST)context;

--- a/include/bpf/bpf.h
+++ b/include/bpf/bpf.h
@@ -217,7 +217,7 @@ bpf_obj_get(const char* pathname);
  *
  * @param[in] bpf_fd File descriptor referring to an eBPF object.
  * @param[out] info Pointer to memory in which to write the info obtained.
- * @param[in,out] info_len On input, contains the maximum number of bytes to
+ * @param[in, out] info_len On input, contains the maximum number of bytes to
  * write into the info.  On output, contains the actual number of bytes written.
  *
  * @retval 0 The operation was successful.

--- a/include/bpf_helper_defs.h
+++ b/include/bpf_helper_defs.h
@@ -134,7 +134,7 @@ EBPF_HELPER(int, bpf_csum_diff, (void* from, int from_size, void* to, int to_siz
 /**
  * @brief Copy data into the ring buffer map.
  *
- * @param[in,out] map Pointer to ring buffer map.
+ * @param[in, out] map Pointer to ring buffer map.
  * @param[in] data Data to copy into ring buffer map.
  * @param[in] size Length of data.
  * @param[in] flags Flags indicating if notification for new data availability should be sent.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -85,7 +85,7 @@ extern "C"
      * @param[in] data Memory to free.
      */
     void
-    ebpf_free_sections(_In_opt_ ebpf_section_info_t* infos);
+    ebpf_free_sections(_In_opt_ _Post_invalid_ ebpf_section_info_t* infos);
 
     /**
      * @brief Convert an eBPF program to human readable byte code.
@@ -237,19 +237,19 @@ extern "C"
      * @returns Execution type.
      */
     ebpf_execution_type_t
-    ebpf_object_get_execution_type(_In_ struct bpf_object* object);
+    ebpf_object_get_execution_type(_In_ const struct bpf_object* object);
 
     /**
      * @brief Set the execution type for an eBPF object file.
      *
-     * @param[in] object The eBPF object file.
+     * @param[in,out] object The eBPF object file.
      * @param[in] execution_type Execution type to set.
      *
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type);
+    ebpf_object_set_execution_type(_Inout_ struct bpf_object* object, ebpf_execution_type_t execution_type);
 
     /**
      * @brief Attach an eBPF program.
@@ -272,7 +272,7 @@ extern "C"
         _In_ const struct bpf_program* program,
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
-        _In_ size_t attach_params_size,
+        size_t attach_params_size,
         _Outptr_ struct bpf_link** link);
 
     /**
@@ -296,20 +296,20 @@ extern "C"
         fd_t program_fd,
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
-        _In_ size_t attach_parameters_size,
+        size_t attach_parameters_size,
         _Outptr_ struct bpf_link** link);
 
     /**
      * @brief Detach an eBPF program from an attach point represented by
      *  the bpf_link structure.
      *
-     * @param[in] link Pointer to bpf_link structure.
+     * @param[in,out] link Pointer to bpf_link structure.
      *
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_OBJECT Invalid object was passed.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_link_detach(_In_ struct bpf_link* link);
+    ebpf_link_detach(_Inout_ struct bpf_link* link);
 
     /**
      * @brief Detach an eBPF program.

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -242,7 +242,7 @@ extern "C"
     /**
      * @brief Set the execution type for an eBPF object file.
      *
-     * @param[in,out] object The eBPF object file.
+     * @param[in, out] object The eBPF object file.
      * @param[in] execution_type Execution type to set.
      *
      * @retval EBPF_SUCCESS The operation was successful.
@@ -303,7 +303,7 @@ extern "C"
      * @brief Detach an eBPF program from an attach point represented by
      *  the bpf_link structure.
      *
-     * @param[in,out] link Pointer to bpf_link structure.
+     * @param[in, out] link Pointer to bpf_link structure.
      *
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_OBJECT Invalid object was passed.

--- a/include/kernel/ebpf_registry_helper.h
+++ b/include/kernel/ebpf_registry_helper.h
@@ -48,10 +48,7 @@ Exit:
 
 static _Must_inspect_result_ ebpf_registry_result_t
 write_registry_value_binary(
-    ebpf_registry_key_t key,
-    _In_z_ const wchar_t* value_name,
-    _In_reads_(value_size) uint8_t* value,
-    _In_ size_t value_size)
+    ebpf_registry_key_t key, _In_z_ const wchar_t* value_name, _In_reads_(value_size) uint8_t* value, size_t value_size)
 {
     UNICODE_STRING unicode_value_name;
 

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -55,7 +55,7 @@ struct _thread_local_storage_cache
 
 static void
 _get_program_and_map_names(
-    _In_ string& path,
+    _In_ const string& path,
     _Inout_ vector<section_program_map_t>& section_to_program_map,
     _Inout_ vector<section_offset_to_map_t>& map_names,
     uint32_t expected_map_count) noexcept(false)
@@ -162,7 +162,7 @@ _Must_inspect_result_ ebpf_result_t
 load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* section_name,
-    _In_ ebpf_verifier_options_t* verifier_options,
+    _In_ const ebpf_verifier_options_t* verifier_options,
     _In_z_ const char* pin_root_path,
     _Inout_ std::vector<ebpf_program_t*>& programs,
     _Inout_ std::vector<ebpf_map_t*>& maps,

--- a/libs/api/Verifier.h
+++ b/libs/api/Verifier.h
@@ -15,7 +15,7 @@ _Must_inspect_result_ ebpf_result_t
 load_byte_code(
     _In_z_ const char* filename,
     _In_opt_z_ const char* section_name,
-    _In_ ebpf_verifier_options_t* verifier_options,
+    _In_ const ebpf_verifier_options_t* verifier_options,
     _In_z_ const char* pin_root_path,
     _Inout_ std::vector<ebpf_program_t*>& programs,
     _Inout_ std::vector<ebpf_map_t*>& maps,

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -133,13 +133,13 @@ ebpf_program_previous(_In_opt_ const struct bpf_program* next, _In_ const struct
 /**
  * @brief Unload an eBPF program.
  *
- * @param[in] program Program to unload.
+ * @param[in,out] program Program to unload.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  */
 _Must_inspect_result_ ebpf_result_t
-ebpf_program_unload(_In_ struct bpf_program* program) noexcept;
+ebpf_program_unload(_Inout_ struct bpf_program* program) noexcept;
 
 /**
  * @brief Bind a map to a program so that it holds a reference on the map.
@@ -476,7 +476,7 @@ ebpf_object_open(
 /**
  * @brief Load all the programs in a given object.
  *
- * @param[in] object Object from which to load programs.
+ * @param[in,out] object Object from which to load programs.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
@@ -488,13 +488,13 @@ ebpf_object_load(_Inout_ struct bpf_object* object) noexcept;
 /**
  * @brief Unload all the programs in a given object.
  *
- * @param[in] object Object in which to unload programs.
+ * @param[in,out] object Object in which to unload programs.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
  */
 _Must_inspect_result_ ebpf_result_t
-ebpf_object_unload(_In_ struct bpf_object* object) noexcept;
+ebpf_object_unload(_Inout_ struct bpf_object* object) noexcept;
 
 typedef int (*ring_buffer_sample_fn)(void* ctx, void* data, size_t size);
 
@@ -502,7 +502,7 @@ typedef int (*ring_buffer_sample_fn)(void* ctx, void* data, size_t size);
  * @brief Subscribe for notifications from the input ring buffer map.
  *
  * @param[in] ring_buffer_map_fd File descriptor to the ring buffer map.
- * @param[in] sample_callback_context Pointer to supplied context to be passed in notification callback.
+ * @param[in,out] sample_callback_context Pointer to supplied context to be passed in notification callback.
  * @param[in] sample_callback Function pointer to notification handler.
  * @param[out] subscription Opaque pointer to ring buffer subscription object.
  *
@@ -512,7 +512,7 @@ typedef int (*ring_buffer_sample_fn)(void* ctx, void* data, size_t size);
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_subscribe(
     fd_t ring_buffer_map_fd,
-    _In_opt_ void* sample_callback_context,
+    _Inout_opt_ void* sample_callback_context,
     ring_buffer_sample_fn sample_callback,
     _Outptr_ ring_buffer_subscription_t** subscription) noexcept;
 
@@ -522,7 +522,7 @@ ebpf_ring_buffer_map_subscribe(
  * @param[in] subscription Pointer to ring buffer subscription to be canceled.
  */
 bool
-ebpf_ring_buffer_map_unsubscribe(_Inout_ _Post_invalid_ ring_buffer_subscription_t* subscription) noexcept;
+ebpf_ring_buffer_map_unsubscribe(_In_ _Post_invalid_ ring_buffer_subscription_t* subscription) noexcept;
 
 /**
  * @brief Get list of programs and stats in an ELF eBPF file.

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -133,7 +133,7 @@ ebpf_program_previous(_In_opt_ const struct bpf_program* next, _In_ const struct
 /**
  * @brief Unload an eBPF program.
  *
- * @param[in,out] program Program to unload.
+ * @param[in, out] program Program to unload.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
@@ -413,9 +413,9 @@ ebpf_get_next_program_id(ebpf_id_t start_id, ebpf_id_t _Out_* next_id) noexcept;
  * * struct bpf_prog_info
  *
  * @param[in] bpf_fd File descriptor referring to an eBPF object.
- * @param[in,out] info Pointer to memory in which to write the info obtained.
+ * @param[in, out] info Pointer to memory in which to write the info obtained.
  * On input, contains any additional parameters to use.
- * @param[in,out] info_size On input, contains the maximum number of bytes to
+ * @param[in, out] info_size On input, contains the maximum number of bytes to
  * write into the info.  On output, contains the actual number of bytes written.
  *
  * @retval EBPF_SUCCESS The operation was successful.
@@ -476,7 +476,7 @@ ebpf_object_open(
 /**
  * @brief Load all the programs in a given object.
  *
- * @param[in,out] object Object from which to load programs.
+ * @param[in, out] object Object from which to load programs.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
@@ -488,7 +488,7 @@ ebpf_object_load(_Inout_ struct bpf_object* object) noexcept;
 /**
  * @brief Unload all the programs in a given object.
  *
- * @param[in,out] object Object in which to unload programs.
+ * @param[in, out] object Object in which to unload programs.
  *
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
@@ -502,7 +502,7 @@ typedef int (*ring_buffer_sample_fn)(void* ctx, void* data, size_t size);
  * @brief Subscribe for notifications from the input ring buffer map.
  *
  * @param[in] ring_buffer_map_fd File descriptor to the ring buffer map.
- * @param[in,out] sample_callback_context Pointer to supplied context to be passed in notification callback.
+ * @param[in, out] sample_callback_context Pointer to supplied context to be passed in notification callback.
  * @param[in] sample_callback Function pointer to notification handler.
  * @param[out] subscription Opaque pointer to ring buffer subscription object.
  *

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1096,7 +1096,7 @@ ebpf_program_attach(
     _In_ const struct bpf_program* program,
     _In_opt_ const ebpf_attach_type_t* attach_type,
     _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
-    _In_ size_t attach_params_size,
+    size_t attach_params_size,
     _Outptr_ struct bpf_link** link)
 {
     EBPF_LOG_ENTRY();
@@ -1133,7 +1133,7 @@ ebpf_program_attach_by_fd(
     fd_t program_fd,
     _In_opt_ const ebpf_attach_type_t* attach_type,
     _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
-    _In_ size_t attach_parameters_size,
+    size_t attach_parameters_size,
     _Outptr_ struct bpf_link** link)
 {
     EBPF_LOG_ENTRY();
@@ -1173,7 +1173,7 @@ ebpf_api_unlink_program(ebpf_handle_t link_handle)
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_link_detach(_In_ struct bpf_link* link)
+ebpf_link_detach(_Inout_ struct bpf_link* link)
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(link);
@@ -1398,7 +1398,7 @@ clean_up_ebpf_maps(_Inout_ std::vector<ebpf_map_t*>& maps) noexcept
 }
 
 static void
-_clean_up_ebpf_object(_In_opt_ ebpf_object_t* object) noexcept
+_clean_up_ebpf_object(_In_opt_ _Post_invalid_ ebpf_object_t* object) noexcept
 {
     EBPF_LOG_ENTRY();
     if (object != nullptr) {
@@ -1846,7 +1846,7 @@ _ebpf_free_section_info(_In_ _Frees_ptr_ ebpf_section_info_t* info) noexcept
 }
 
 void
-ebpf_free_sections(_In_opt_ ebpf_section_info_t* infos)
+ebpf_free_sections(_In_opt_ _Post_invalid_ ebpf_section_info_t* infos)
 {
     EBPF_LOG_ENTRY();
     while (infos != nullptr) {
@@ -2261,7 +2261,7 @@ Done:
 }
 
 static inline bool
-_ebpf_is_map_in_map(ebpf_map_t* map) noexcept
+_ebpf_is_map_in_map(_In_ const ebpf_map_t* map) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(map);
@@ -2274,7 +2274,7 @@ _ebpf_is_map_in_map(ebpf_map_t* map) noexcept
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_type_t execution_type)
+ebpf_object_set_execution_type(_Inout_ struct bpf_object* object, ebpf_execution_type_t execution_type)
 {
     if (Platform::_is_native_program(object->file_name)) {
         if (execution_type == EBPF_EXECUTION_INTERPRET || execution_type == EBPF_EXECUTION_JIT) {
@@ -2296,13 +2296,13 @@ ebpf_object_set_execution_type(_In_ struct bpf_object* object, ebpf_execution_ty
 }
 
 ebpf_execution_type_t
-ebpf_object_get_execution_type(_In_ struct bpf_object* object)
+ebpf_object_get_execution_type(_In_ const struct bpf_object* object)
 {
     return object->execution_type;
 }
 
 static ebpf_result_t
-_ebpf_validate_map(_In_ ebpf_map_t* map, fd_t original_map_fd) noexcept
+_ebpf_validate_map(_In_ const ebpf_map_t* map, fd_t original_map_fd) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(map);
@@ -2349,7 +2349,7 @@ Exit:
 }
 
 static ebpf_result_t
-_ebpf_object_reuse_map(_In_ ebpf_map_t* map) noexcept
+_ebpf_object_reuse_map(_Inout_ ebpf_map_t* map) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result = EBPF_SUCCESS;
@@ -2683,7 +2683,7 @@ Done:
 
 // This function is intended to work like libbpf's bpf_object__unload().
 _Must_inspect_result_ ebpf_result_t
-ebpf_object_unload(_In_ struct bpf_object* object) noexcept
+ebpf_object_unload(_Inout_ struct bpf_object* object) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(object);
@@ -2708,7 +2708,7 @@ ebpf_object_unload(_In_ struct bpf_object* object) noexcept
 
 // This function is intended to work like libbpf's bpf_program__unload().
 _Must_inspect_result_ ebpf_result_t
-ebpf_program_unload(_In_ struct bpf_program* program) noexcept
+ebpf_program_unload(_Inout_ struct bpf_program* program) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(program);
@@ -3610,7 +3610,7 @@ _ebpf_ring_buffer_map_async_query_completion(_Inout_ void* completion_context) n
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_subscribe(
     fd_t ring_buffer_map_fd,
-    _In_opt_ void* sample_callback_context,
+    _Inout_opt_ void* sample_callback_context,
     ring_buffer_sample_fn sample_callback,
     _Outptr_ ring_buffer_subscription_t** subscription) noexcept
 {
@@ -3689,7 +3689,7 @@ ebpf_ring_buffer_map_subscribe(
 }
 
 bool
-ebpf_ring_buffer_map_unsubscribe(_Inout_ _Post_invalid_ ring_buffer_subscription_t* subscription) noexcept
+ebpf_ring_buffer_map_unsubscribe(_In_ _Post_invalid_ ring_buffer_subscription_t* subscription) noexcept
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(subscription);

--- a/libs/api/rpc_client.h
+++ b/libs/api/rpc_client.h
@@ -14,6 +14,6 @@ clean_up_rpc_binding(void);
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_rpc_load_program(
-    _In_ ebpf_program_load_info* info,
+    _In_ const ebpf_program_load_info* info,
     _Outptr_result_maybenull_z_ const char** logs,
     _Inout_ uint32_t* logs_size) noexcept;

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -212,7 +212,7 @@ Exit:
 }
 
 bool
-cancel_async_ioctl(_In_opt_ OVERLAPPED* overlapped = nullptr)
+cancel_async_ioctl(_Inout_opt_ OVERLAPPED* overlapped = nullptr)
 {
     return Platform::CancelIoEx(get_device_handle(), overlapped);
 }

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -177,7 +177,7 @@ initialize_async_ioctl_operation(
 
     // Set up threadpool wait for the overlapped hEvent and pass the async completion context as wait callback context.
     local_async_ioctl_completion->wait = CreateThreadpoolWait(
-        [](_In_ const PTP_CALLBACK_INSTANCE instance,
+        [](_Inout_ TP_CALLBACK_INSTANCE* instance,
            _Inout_ void* context,
            _Inout_ PTP_WAIT wait,
            TP_WAIT_RESULT wait_result) {

--- a/libs/api_common/device_helper.hpp
+++ b/libs/api_common/device_helper.hpp
@@ -53,7 +53,7 @@ _Ret_notnull_ OVERLAPPED*
 get_async_ioctl_operation_overlapped(_In_ const async_ioctl_completion_t* ioctl_completion);
 
 bool
-cancel_async_ioctl(_In_opt_ OVERLAPPED* overlapped);
+cancel_async_ioctl(_Inout_opt_ OVERLAPPED* overlapped);
 
 _Must_inspect_result_ ebpf_result_t
 get_async_ioctl_result(_In_ const async_ioctl_completion_t* ioctl_completion);

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -56,7 +56,7 @@ _prog_type_supports_interface(bpf_prog_type prog_type)
 }
 
 _Must_inspect_result_ ebpf_result_t
-_process_interface_parameter(_In_ LPWSTR interface_parameter, bpf_prog_type prog_type, _Out_ uint32_t* if_index)
+_process_interface_parameter(_In_ const LPWSTR interface_parameter, bpf_prog_type prog_type, _Out_ uint32_t* if_index)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     if (_prog_type_supports_interface(prog_type)) {
@@ -368,7 +368,8 @@ handle_ebpf_delete_program(
 }
 
 _Must_inspect_result_ ebpf_result_t
-_ebpf_program_attach_by_id(ebpf_id_t program_id, ebpf_attach_type_t attach_type, _In_opt_ LPWSTR interface_parameter)
+_ebpf_program_attach_by_id(
+    ebpf_id_t program_id, ebpf_attach_type_t attach_type, _In_opt_ const LPWSTR interface_parameter)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     uint32_t if_index;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -110,7 +110,7 @@ NTSTATUS
 ebpf_general_helper_function_provider_attach_client(
     HANDLE nmr_binding_handle,
     _Inout_ void* provider_context,
-    _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+    _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Out_ void** provider_binding_context,

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -54,13 +54,13 @@ _ebpf_core_trace_printk5(
     _In_reads_(fmt_size) const char* fmt, size_t fmt_size, uint64_t arg3, uint64_t arg4, uint64_t arg5);
 static int
 _ebpf_core_ring_buffer_output(
-    _In_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length, uint64_t flags);
+    _Inout_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length, uint64_t flags);
 static uint64_t
-_ebpf_core_map_push_elem(_In_ ebpf_map_t* map, _In_ const uint8_t* value, uint64_t flags);
+_ebpf_core_map_push_elem(_Inout_ ebpf_map_t* map, _In_ const uint8_t* value, uint64_t flags);
 static uint64_t
-_ebpf_core_map_pop_elem(_In_ ebpf_map_t* map, _Out_ uint8_t* value);
+_ebpf_core_map_pop_elem(_Inout_ ebpf_map_t* map, _Out_ uint8_t* value);
 static uint64_t
-_ebpf_core_map_peek_elem(_In_ ebpf_map_t* map, _Out_ uint8_t* value);
+_ebpf_core_map_peek_elem(_Inout_ ebpf_map_t* map, _Out_ uint8_t* value);
 static uint64_t
 _ebpf_core_get_pid_tgid();
 
@@ -110,8 +110,8 @@ NTSTATUS
 ebpf_general_helper_function_provider_attach_client(
     HANDLE nmr_binding_handle,
     _Inout_ void* provider_context,
-    _In_ PNPI_REGISTRATION_INSTANCE client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Out_ void** provider_binding_context,
     _Out_ const void** provider_dispatch)
@@ -193,8 +193,8 @@ ebpf_core_initiate()
         &_ebpf_global_helper_function_extension_data,
         NULL,
         NULL,
-        ebpf_general_helper_function_provider_attach_client,
-        ebpf_general_helper_function_provider_detach_client,
+        (PNPI_PROVIDER_ATTACH_CLIENT_FN)ebpf_general_helper_function_provider_attach_client,
+        (PNPI_PROVIDER_DETACH_CLIENT_FN)ebpf_general_helper_function_provider_detach_client,
         NULL);
 
     if (return_value != EBPF_SUCCESS) {
@@ -1295,7 +1295,7 @@ _ebpf_core_protocol_serialize_map_info_reply(
     uint16_t map_count,
     _In_count_(map_count) const ebpf_map_info_internal_t* map_info,
     size_t output_buffer_length,
-    _In_ ebpf_operation_get_pinned_map_info_reply_t* map_info_reply)
+    _Out_ ebpf_operation_get_pinned_map_info_reply_t* map_info_reply)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     size_t serialization_buffer_size;
@@ -1325,7 +1325,7 @@ _ebpf_core_protocol_serialize_map_info_reply(
 static ebpf_result_t
 _ebpf_core_protocol_get_pinned_map_info(
     _In_ const ebpf_operation_get_pinned_map_info_request_t* request,
-    _In_ ebpf_operation_get_pinned_map_info_reply_t* reply,
+    _Inout_ ebpf_operation_get_pinned_map_info_reply_t* reply,
     uint16_t reply_length)
 {
     EBPF_LOG_ENTRY();
@@ -1578,7 +1578,7 @@ _ebpf_core_protocol_ring_buffer_map_async_query(
     _In_ const ebpf_operation_ring_buffer_map_async_query_request_t* request,
     _Inout_ ebpf_operation_ring_buffer_map_async_query_reply_t* reply,
     uint16_t reply_length,
-    _In_ void* async_context)
+    _Inout_ void* async_context)
 {
     UNREFERENCED_PARAMETER(reply_length);
 
@@ -1840,7 +1840,7 @@ Exit:
 
 static int
 _ebpf_core_ring_buffer_output(
-    _In_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length, uint64_t flags)
+    _Inout_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length, uint64_t flags)
 {
     // This function implements bpf_ringbuf_output helper function, which returns negative error in case of failure.
     UNREFERENCED_PARAMETER(flags);
@@ -1848,19 +1848,19 @@ _ebpf_core_ring_buffer_output(
 }
 
 static uint64_t
-_ebpf_core_map_push_elem(_In_ ebpf_map_t* map, _In_ const uint8_t* value, uint64_t flags)
+_ebpf_core_map_push_elem(_Inout_ ebpf_map_t* map, _In_ const uint8_t* value, uint64_t flags)
 {
     return -ebpf_map_push_entry(map, 0, value, (int)flags | EBPF_MAP_FLAG_HELPER);
 }
 
 static uint64_t
-_ebpf_core_map_pop_elem(_In_ ebpf_map_t* map, _Out_ uint8_t* value)
+_ebpf_core_map_pop_elem(_Inout_ ebpf_map_t* map, _Out_ uint8_t* value)
 {
     return -ebpf_map_pop_entry(map, 0, value, EBPF_MAP_FLAG_HELPER);
 }
 
 static uint64_t
-_ebpf_core_map_peek_elem(_In_ ebpf_map_t* map, _Out_ uint8_t* value)
+_ebpf_core_map_peek_elem(_Inout_ ebpf_map_t* map, _Out_ uint8_t* value)
 {
     return -ebpf_map_peek_entry(map, 0, value, EBPF_MAP_FLAG_HELPER);
 }
@@ -1894,7 +1894,7 @@ typedef struct _ebpf_protocol_handler
             _In_ const ebpf_operation_header_t* request,
             _Out_writes_bytes_(output_buffer_length) ebpf_operation_header_t* reply,
             uint16_t output_buffer_length,
-            _In_ void* async_context);
+            _Inout_ void* async_context);
     } dispatch;
     size_t minimum_request_size;
     size_t minimum_reply_size;
@@ -2072,8 +2072,8 @@ ebpf_core_invoke_protocol_handler(
     uint16_t input_buffer_length,
     _Out_writes_bytes_opt_(output_buffer_length) void* output_buffer,
     uint16_t output_buffer_length,
-    _In_opt_ void* async_context,
-    _In_opt_ void (*on_complete)(void*, size_t, ebpf_result_t))
+    _Inout_opt_ void* async_context,
+    _In_opt_ void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t))
 {
     ebpf_result_t retval;
     bool epoch_entered = false;
@@ -2208,7 +2208,7 @@ Done:
 }
 
 bool
-ebpf_core_cancel_protocol_handler(_In_ void* async_context)
+ebpf_core_cancel_protocol_handler(_Inout_ void* async_context)
 {
     return ebpf_async_cancel(async_context);
 }

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -51,6 +51,8 @@ extern "C"
      * @param[out] output_buffer Pointer to memory that will contain the
      *  encoded result parameters for this operation.
      * @param[in] output_buffer_length Length of the output buffer.
+     * @param[in,out] async_context Async context to be passed to on_complete.
+     * @param[in] on_complete Callback to be invoked when the operation is complete.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.
@@ -62,8 +64,8 @@ extern "C"
         uint16_t input_buffer_length,
         _Out_writes_bytes_opt_(output_buffer_length) void* output_buffer,
         uint16_t output_buffer_length,
-        _In_opt_ void* async_context,
-        _In_opt_ void (*on_complete)(_In_ void*, size_t, ebpf_result_t));
+        _Inout_opt_ void* async_context,
+        _In_opt_ void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t));
 
     /**
      * @brief Query properties about an operation.
@@ -86,12 +88,12 @@ extern "C"
     /**
      * @brief Cancel an async protocol operation that returned EBPF_PENDING from ebpf_core_invoke_protocol_handler.
      *
-     * @param[in] async_context Async context passed to ebpf_core_invoke_protocol_handler.
+     * @param[in,out] async_context Async context passed to ebpf_core_invoke_protocol_handler.
      * @retval true Operation was canceled.
      * @retval false Operation was already completed.
      */
     bool
-    ebpf_core_cancel_protocol_handler(_In_ void* async_context);
+    ebpf_core_cancel_protocol_handler(_Inout_ void* async_context);
 
     /**
      * @brief Computes difference of checksum values for two input raw buffers using 1's complement arithmetic.

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -51,7 +51,7 @@ extern "C"
      * @param[out] output_buffer Pointer to memory that will contain the
      *  encoded result parameters for this operation.
      * @param[in] output_buffer_length Length of the output buffer.
-     * @param[in,out] async_context Async context to be passed to on_complete.
+     * @param[in, out] async_context Async context to be passed to on_complete.
      * @param[in] on_complete Callback to be invoked when the operation is complete.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
@@ -88,7 +88,7 @@ extern "C"
     /**
      * @brief Cancel an async protocol operation that returned EBPF_PENDING from ebpf_core_invoke_protocol_handler.
      *
-     * @param[in,out] async_context Async context passed to ebpf_core_invoke_protocol_handler.
+     * @param[in, out] async_context Async context passed to ebpf_core_invoke_protocol_handler.
      * @retval true Operation was canceled.
      * @retval false Operation was already completed.
      */

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -27,7 +27,7 @@ typedef struct _ebpf_link
 
 static ebpf_result_t
 _ebpf_link_instance_invoke(
-    _In_ const void* extension_client_binding_context, _In_ void* program_context, _Out_ uint32_t* result);
+    _In_ const void* extension_client_binding_context, _Inout_ void* program_context, _Out_ uint32_t* result);
 
 static struct
 {
@@ -189,7 +189,7 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
 
 static ebpf_result_t
 _ebpf_link_instance_invoke(
-    _In_ const void* extension_client_binding_context, _In_ void* program_context, _Out_ uint32_t* result)
+    _In_ const void* extension_client_binding_context, _Inout_ void* program_context, _Out_ uint32_t* result)
 {
     // No function entry exit traces as this is a high volume function.
     ebpf_result_t return_value;

--- a/libs/execution_context/ebpf_link.h
+++ b/libs/execution_context/ebpf_link.h
@@ -30,7 +30,7 @@ extern "C"
      * @brief Initialize this link object and load the associated hook
      *  provider if needed.
      *
-     * @param[in,out] link The link object to initialize.
+     * @param[in, out] link The link object to initialize.
      * @param[in] attach_type Attach type to load.
      * @param[in] context_data Data to be passed to the hook provider.
      * @param[in] context_data_length Length of the data to be passed to the hook
@@ -47,8 +47,8 @@ extern "C"
     /**
      * @brief Attach a program to this link object.
      *
-     * @param[in,out] link The link object to attach the program to.
-     * @param[in,out] program The program to attach to this link object.
+     * @param[in, out] link The link object to attach the program to.
+     * @param[in, out] program The program to attach to this link object.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT Hook instance has not been
      *  initialized.
@@ -69,7 +69,7 @@ extern "C"
      *
      * @param[in] link The link object to get info about.
      * @param[out] buffer Buffer to write bpf_link_info into.
-     * @param[in,out] info_size On input, the size in bytes of the buffer.
+     * @param[in, out] info_size On input, the size in bytes of the buffer.
      * On output, the number of bytes actually written.
      *
      * @retval EBPF_SUCCESS The operation was successful.

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -153,14 +153,14 @@ typedef struct _ebpf_core_circular_map
 } ebpf_core_circular_map_t;
 
 static size_t
-_ebpf_core_circular_map_add(_In_ ebpf_core_circular_map_t* map, size_t value, int delta)
+_ebpf_core_circular_map_add(_In_ const ebpf_core_circular_map_t* map, size_t value, int delta)
 {
     return (map->core_map.ebpf_map_definition.max_entries + value + (size_t)delta) %
            map->core_map.ebpf_map_definition.max_entries;
 }
 
 static uint8_t*
-_ebpf_core_circular_map_peek_or_pop(_In_ ebpf_core_circular_map_t* map, bool pop)
+_ebpf_core_circular_map_peek_or_pop(_Inout_ ebpf_core_circular_map_t* map, bool pop)
 {
     uint8_t* return_value = NULL;
 
@@ -193,7 +193,7 @@ Done:
 }
 
 static ebpf_result_t
-_ebpf_core_circular_map_push(_In_ ebpf_core_circular_map_t* map, _In_ const uint8_t* data, bool replace)
+_ebpf_core_circular_map_push(_Inout_ ebpf_core_circular_map_t* map, _In_ const uint8_t* data, bool replace)
 {
     ebpf_result_t return_value;
     uint8_t* new_data = NULL;
@@ -248,19 +248,19 @@ typedef struct _ebpf_map_metadata_table
         _In_ const ebpf_map_definition_in_memory_t* map_definition,
         ebpf_handle_t inner_map_handle,
         _Outptr_ ebpf_core_map_t** map);
-    void (*delete_map)(_In_ ebpf_core_map_t* map);
-    ebpf_result_t (*associate_program)(_In_ ebpf_map_t* map, _In_ const ebpf_program_t* program);
+    void (*delete_map)(_In_ _Post_invalid_ ebpf_core_map_t* map);
+    ebpf_result_t (*associate_program)(_Inout_ ebpf_map_t* map, _In_ const ebpf_program_t* program);
     ebpf_result_t (*find_entry)(
-        _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data);
-    ebpf_core_object_t* (*get_object_from_entry)(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key);
+        _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data);
+    ebpf_core_object_t* (*get_object_from_entry)(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key);
     ebpf_result_t (*update_entry)(
-        _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_ const uint8_t* value, ebpf_map_option_t option);
+        _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_ const uint8_t* value, ebpf_map_option_t option);
     ebpf_result_t (*update_entry_with_handle)(
-        _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, uintptr_t value_handle, ebpf_map_option_t option);
+        _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, uintptr_t value_handle, ebpf_map_option_t option);
     ebpf_result_t (*update_entry_per_cpu)(
-        _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, ebpf_map_option_t option);
-    ebpf_result_t (*delete_entry)(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key);
-    ebpf_result_t (*next_key)(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
+        _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, ebpf_map_option_t option);
+    ebpf_result_t (*delete_entry)(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key);
+    ebpf_result_t (*next_key)(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key, _Out_ uint8_t* next_key);
     int zero_length_key : 1;
     int zero_length_value : 1;
     int per_cpu : 1;
@@ -338,7 +338,7 @@ _delete_array_map(_In_ _Post_invalid_ ebpf_core_map_t* map)
 
 static ebpf_result_t
 _find_array_map_entry(
-    _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data)
+    _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data)
 {
     uint32_t key_value;
     if (!map || !key || delete_on_success)
@@ -356,7 +356,7 @@ _find_array_map_entry(
 
 static ebpf_result_t
 _update_array_map_entry(
-    _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_opt_ const uint8_t* data, ebpf_map_option_t option)
+    _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_opt_ const uint8_t* data, ebpf_map_option_t option)
 {
     uint32_t key_value;
 
@@ -378,7 +378,7 @@ _update_array_map_entry(
 }
 
 static ebpf_result_t
-_delete_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+_delete_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
     uint32_t key_value;
     if (!map || !key)
@@ -396,7 +396,7 @@ _delete_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 }
 
 static ebpf_result_t
-_next_array_map_key(_In_ ebpf_core_map_t* map, _In_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
+_next_array_map_key(_In_ const ebpf_core_map_t* map, _In_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
 {
     uint32_t key_value;
     if (!map || !next_key)
@@ -448,7 +448,7 @@ Exit:
 }
 
 static void
-_delete_object_array_map(_In_ _Post_invalid_ ebpf_core_map_t* map, ebpf_object_type_t value_type)
+_delete_object_array_map(_Inout_ _Post_invalid_ ebpf_core_map_t* map, ebpf_object_type_t value_type)
 {
     ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
 
@@ -469,7 +469,7 @@ _delete_object_array_map(_In_ _Post_invalid_ ebpf_core_map_t* map, ebpf_object_t
 
 static ebpf_result_t
 _create_object_array_map(
-    _In_ const ebpf_map_definition_in_memory_t* map_definition,
+    _Inout_ const ebpf_map_definition_in_memory_t* map_definition,
     ebpf_handle_t inner_map_handle,
     _Outptr_ ebpf_core_map_t** map)
 {
@@ -519,7 +519,7 @@ _delete_map_array_map(_In_ _Post_invalid_ ebpf_core_map_t* map)
 }
 
 static ebpf_result_t
-_associate_program_with_prog_array_map(_In_ ebpf_core_map_t* map, _In_ const ebpf_program_t* program)
+_associate_program_with_prog_array_map(_Inout_ ebpf_core_map_t* map, _In_ const ebpf_program_t* program)
 {
     ebpf_assert(map->ebpf_map_definition.type == BPF_MAP_TYPE_PROG_ARRAY);
     ebpf_core_object_map_t* program_array = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
@@ -567,7 +567,9 @@ _check_value_type(_In_ const ebpf_core_map_t* outer_map, _In_ const ebpf_core_ob
 // Validate that a value object is appropriate for this map.
 // Also set the program type if not yet set.
 static _Requires_lock_held_(object_map->lock) ebpf_result_t _validate_map_value_object(
-    _In_ ebpf_core_object_map_t* object_map, ebpf_object_type_t value_type, _In_ const ebpf_core_object_t* value_object)
+    _Inout_ ebpf_core_object_map_t* object_map,
+    ebpf_object_type_t value_type,
+    _In_ const ebpf_core_object_t* value_object)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     const ebpf_core_map_t* map = &object_map->core_map;
@@ -603,7 +605,7 @@ Error:
 
 static ebpf_result_t
 _update_array_map_entry_with_handle(
-    _In_ ebpf_core_map_t* map,
+    _Inout_ ebpf_core_map_t* map,
     _In_ const uint8_t* key,
     ebpf_object_type_t value_type,
     uintptr_t value_handle,
@@ -661,21 +663,21 @@ Done:
 
 static ebpf_result_t
 _update_prog_array_map_entry_with_handle(
-    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, uintptr_t value_handle, ebpf_map_option_t option)
+    _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, uintptr_t value_handle, ebpf_map_option_t option)
 {
     return _update_array_map_entry_with_handle(map, key, EBPF_OBJECT_PROGRAM, value_handle, option);
 }
 
 static ebpf_result_t
 _update_map_array_map_entry_with_handle(
-    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, uintptr_t value_handle, ebpf_map_option_t option)
+    _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, uintptr_t value_handle, ebpf_map_option_t option)
 {
     return _update_array_map_entry_with_handle(map, key, EBPF_OBJECT_MAP, value_handle, option);
 }
 
 static ebpf_result_t
 _delete_array_map_entry_with_reference(
-    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, ebpf_object_type_t value_type)
+    _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, ebpf_object_type_t value_type)
 {
     if (value_type == EBPF_OBJECT_UNKNOWN)
         return EBPF_INVALID_ARGUMENT;
@@ -697,13 +699,13 @@ _delete_array_map_entry_with_reference(
 }
 
 static ebpf_result_t
-_delete_program_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+_delete_program_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
     return _delete_array_map_entry_with_reference(map, key, EBPF_OBJECT_PROGRAM);
 }
 
 static ebpf_result_t
-_delete_map_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+_delete_map_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
     return _delete_array_map_entry_with_reference(map, key, EBPF_OBJECT_MAP);
 }
@@ -718,7 +720,7 @@ _delete_map_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
  * @returns Object pointer, or NULL if none.
  */
 static _Ret_maybenull_ ebpf_core_object_t*
-_get_object_from_array_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+_get_object_from_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
     uint32_t index = *(uint32_t*)key;
 
@@ -1087,7 +1089,10 @@ _Requires_lock_held_(map->lock) static void _merge_hot_into_cold_list_if_needed(
  */
 static ebpf_result_t
 _update_key_history(
-    _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_opt_ uint8_t* value, ebpf_lru_key_operation_t operation)
+    _Inout_ ebpf_core_map_t* map,
+    _In_ const uint8_t* key,
+    _Inout_opt_ uint8_t* value,
+    ebpf_lru_key_operation_t operation)
 {
     // Fast path:
     // If this map doesn't track key history, return success.
@@ -1178,7 +1183,7 @@ _reap_oldest_map_entry(_Inout_ ebpf_core_map_t* map)
 
 static ebpf_result_t
 _find_hash_map_entry(
-    _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data)
+    _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data)
 {
     uint8_t* value = NULL;
     if (!map || !key)
@@ -1236,7 +1241,7 @@ _get_object_from_hash_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* k
 
 static ebpf_result_t
 _update_hash_map_entry(
-    _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_opt_ const uint8_t* data, ebpf_map_option_t option)
+    _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_opt_ const uint8_t* data, ebpf_map_option_t option)
 {
     ebpf_result_t result;
     ebpf_hash_table_operations_t hash_table_operation;
@@ -1287,7 +1292,7 @@ _update_hash_map_entry(
 
 static ebpf_result_t
 _update_hash_map_entry_with_handle(
-    _In_ ebpf_core_map_t* map,
+    _Inout_ ebpf_core_map_t* map,
     _In_ const uint8_t* key,
     ebpf_object_type_t value_type,
     ebpf_handle_t value_handle,
@@ -1361,13 +1366,13 @@ Done:
 
 static ebpf_result_t
 _update_map_hash_map_entry_with_handle(
-    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, uintptr_t value_handle, ebpf_map_option_t option)
+    _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, uintptr_t value_handle, ebpf_map_option_t option)
 {
     return _update_hash_map_entry_with_handle(map, key, EBPF_OBJECT_MAP, value_handle, option);
 }
 
 static ebpf_result_t
-_delete_map_hash_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+_delete_map_hash_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
     ebpf_result_t result;
     if (!map || !key)
@@ -1402,7 +1407,7 @@ _delete_hash_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 }
 
 static ebpf_result_t
-_next_hash_map_key(_In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
+_next_hash_map_key(_Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* previous_key, _Out_ uint8_t* next_key)
 {
     ebpf_result_t result;
     if (!map || !next_key)
@@ -1413,7 +1418,7 @@ _next_hash_map_key(_In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* previous_k
 }
 
 static ebpf_result_t
-_ebpf_adjust_value_pointer(_In_ ebpf_map_t* map, _Inout_ uint8_t** value)
+_ebpf_adjust_value_pointer(_In_ const ebpf_map_t* map, _Inout_ uint8_t** value)
 {
     uint32_t current_cpu;
     uint32_t max_cpu = map->ebpf_map_definition.value_size / EBPF_PAD_8(map->original_value_size);
@@ -1448,7 +1453,7 @@ _ebpf_adjust_value_pointer(_In_ ebpf_map_t* map, _Inout_ uint8_t** value)
  */
 _Must_inspect_result_ ebpf_result_t
 _update_entry_per_cpu(
-    _In_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, ebpf_map_option_t option)
+    _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, _In_ const uint8_t* value, ebpf_map_option_t option)
 {
     uint8_t* target;
     if (ebpf_map_metadata_tables[map->ebpf_map_definition.type].find_entry(map, key, false, &target) != EBPF_SUCCESS) {
@@ -1516,7 +1521,7 @@ Exit:
 
 static ebpf_result_t
 _find_lpm_map_entry(
-    _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data)
+    _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data)
 {
     if (!map || !key || delete_on_success)
         return EBPF_INVALID_ARGUMENT;
@@ -1545,7 +1550,7 @@ _find_lpm_map_entry(
 }
 
 static ebpf_result_t
-_delete_lpm_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
+_delete_lpm_map_entry(_In_ ebpf_core_map_t* map, _Inout_ const uint8_t* key)
 {
     ebpf_core_lpm_map_t* trie_map = EBPF_FROM_FIELD(ebpf_core_lpm_map_t, core_map, map);
     uint32_t prefix_length = *(uint32_t*)key;
@@ -1558,7 +1563,7 @@ _delete_lpm_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 
 static ebpf_result_t
 _update_lpm_map_entry(
-    _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_opt_ const uint8_t* data, ebpf_map_option_t option)
+    _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_opt_ const uint8_t* data, ebpf_map_option_t option)
 {
     ebpf_core_lpm_map_t* trie_map = EBPF_FROM_FIELD(ebpf_core_lpm_map_t, core_map, map);
     if (!key) {
@@ -1627,7 +1632,7 @@ _delete_circular_map(_In_ _Post_invalid_ ebpf_core_map_t* map)
 
 static ebpf_result_t
 _find_circular_map_entry(
-    _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data)
+    _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, bool delete_on_success, _Outptr_ uint8_t** data)
 {
     if (!map)
         return EBPF_INVALID_ARGUMENT;
@@ -1645,7 +1650,7 @@ _find_circular_map_entry(
 
 static ebpf_result_t
 _update_circular_map_entry(
-    _In_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_opt_ const uint8_t* data, ebpf_map_option_t option)
+    _Inout_ ebpf_core_map_t* map, _In_opt_ const uint8_t* key, _In_opt_ const uint8_t* data, ebpf_map_option_t option)
 {
     ebpf_result_t result;
 
@@ -1664,7 +1669,7 @@ _update_circular_map_entry(
 }
 
 static _Requires_lock_held_(ring_buffer_map->lock) void _ebpf_ring_buffer_map_signal_async_query_complete(
-    _In_ ebpf_core_ring_buffer_map_t* ring_buffer_map)
+    _Inout_ ebpf_core_ring_buffer_map_t* ring_buffer_map)
 {
     EBPF_LOG_ENTRY();
     // Skip if no async_contexts have ever been queued.
@@ -1760,7 +1765,7 @@ Exit:
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_ring_buffer_map_output(_In_ ebpf_core_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length)
+ebpf_ring_buffer_map_output(_Inout_ ebpf_core_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length)
 {
     ebpf_result_t result = EBPF_SUCCESS;
 
@@ -1819,9 +1824,9 @@ Exit:
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_ring_buffer_map_async_query(
-    _In_ ebpf_map_t* map,
+    _Inout_ ebpf_map_t* map,
     _Inout_ ebpf_ring_buffer_map_async_query_result_t* async_query_result,
-    _In_ void* async_context)
+    _Inout_ void* async_context)
 {
     ebpf_result_t result = EBPF_PENDING;
     EBPF_LOG_ENTRY();
@@ -2097,7 +2102,7 @@ const ebpf_map_metadata_table_t ebpf_map_metadata_tables[] = {
 };
 
 static void
-_ebpf_map_delete(_In_ ebpf_core_object_t* object)
+_ebpf_map_delete(_In_ _Post_invalid_ ebpf_core_object_t* object)
 {
     EBPF_LOG_ENTRY();
     ebpf_map_t* map = (ebpf_map_t*)object;
@@ -2191,7 +2196,7 @@ Exit:
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_map_find_entry(
-    _In_ ebpf_map_t* map,
+    _Inout_ ebpf_map_t* map,
     size_t key_size,
     _In_reads_(key_size) const uint8_t* key,
     size_t value_size,
@@ -2271,7 +2276,7 @@ ebpf_map_find_entry(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_map_associate_program(_In_ ebpf_map_t* map, _In_ const ebpf_program_t* program)
+ebpf_map_associate_program(_Inout_ ebpf_map_t* map, _In_ const ebpf_program_t* program)
 {
     EBPF_LOG_ENTRY();
     if (ebpf_map_metadata_tables[map->ebpf_map_definition.type].associate_program)
@@ -2280,7 +2285,7 @@ ebpf_map_associate_program(_In_ ebpf_map_t* map, _In_ const ebpf_program_t* prog
 }
 
 _Ret_maybenull_ ebpf_program_t*
-ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key)
+ebpf_map_get_program_from_entry(_Inout_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key)
 {
     // High volume call - Skip entry/exit logging.
     if (key_size != map->ebpf_map_definition.key_size) {
@@ -2306,7 +2311,7 @@ ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_map_update_entry(
-    _In_ ebpf_map_t* map,
+    _Inout_ ebpf_map_t* map,
     size_t key_size,
     _In_reads_(key_size) const uint8_t* key,
     size_t value_size,
@@ -2369,7 +2374,7 @@ ebpf_map_update_entry(
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_map_update_entry_with_handle(
-    _In_ ebpf_map_t* map,
+    _Inout_ ebpf_map_t* map,
     size_t key_size,
     _In_reads_(key_size) const uint8_t* key,
     uintptr_t value_handle,
@@ -2427,7 +2432,7 @@ ebpf_map_delete_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_map_next_key(
-    _In_ ebpf_map_t* map,
+    _Inout_ ebpf_map_t* map,
     size_t key_size,
     _In_reads_opt_(key_size) const uint8_t* previous_key,
     _Out_writes_(key_size) uint8_t* next_key)
@@ -2491,7 +2496,7 @@ ebpf_map_get_info(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_map_push_entry(_In_ ebpf_map_t* map, size_t value_size, _In_reads_(value_size) const uint8_t* value, int flags)
+ebpf_map_push_entry(_Inout_ ebpf_map_t* map, size_t value_size, _In_reads_(value_size) const uint8_t* value, int flags)
 {
     if (!(flags & EBPF_MAP_FLAG_HELPER) && (value_size != map->ebpf_map_definition.value_size)) {
         return EBPF_INVALID_ARGUMENT;
@@ -2510,7 +2515,7 @@ ebpf_map_push_entry(_In_ ebpf_map_t* map, size_t value_size, _In_reads_(value_si
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_map_pop_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags)
+ebpf_map_pop_entry(_Inout_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags)
 {
     uint8_t* return_value;
     if (!(flags & EBPF_MAP_FLAG_HELPER) && (value_size != map->ebpf_map_definition.value_size)) {
@@ -2538,7 +2543,7 @@ ebpf_map_pop_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_s
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_map_peek_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags)
+ebpf_map_peek_entry(_Inout_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags)
 {
     uint8_t* return_value;
     if (!(flags & EBPF_MAP_FLAG_HELPER) && (value_size != map->ebpf_map_definition.value_size)) {

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -990,8 +990,8 @@ _get_key_state(_In_ const ebpf_core_lru_map_t* map, _In_ const ebpf_lru_entry_t*
 /**
  * @brief Helper function to insert an entry into the hot list if it is in the cold list and update the hot list size.
  *
- * @param[in,out] map Pointer to the map.
- * @param[in,out] entry Entry to insert into the hot list.
+ * @param[in, out] map Pointer to the map.
+ * @param[in, out] entry Entry to insert into the hot list.
  */
 _Requires_lock_held_(map->lock) static void _insert_into_hot_list(
     _Inout_ ebpf_core_lru_map_t* map, _Inout_ ebpf_lru_entry_t* entry)
@@ -1012,8 +1012,8 @@ _Requires_lock_held_(map->lock) static void _insert_into_hot_list(
  * @brief Helper function to initialize an LRU entry that was created when an entry was inserted into the hash table.
  * Sets the current generation, populates the key, and inserts the entry into the hot list.
  *
- * @param[in,out] map Pointer to the map.
- * @param[in,out] entry Entry to initialize.
+ * @param[in, out] map Pointer to the map.
+ * @param[in, out] entry Entry to initialize.
  * @param[in] key Key to initialize the entry with.
  */
 _Requires_lock_held_(map->lock) static void _initialize_lru_entry(
@@ -1036,8 +1036,8 @@ _Requires_lock_held_(map->lock) static void _initialize_lru_entry(
  * list and sets the generation to EBPF_LRU_INVALID_GENERATION so that subsequent access doesn't reinsert it into the
  * hot list.
  *
- * @param[in,out] map Pointer to the map.
- * @param[in,out] entry Entry being deleted.
+ * @param[in, out] map Pointer to the map.
+ * @param[in, out] entry Entry being deleted.
  */
 _Requires_lock_held_(map->lock) static void _uninitialize_lru_entry(
     _Inout_ ebpf_core_lru_map_t* map, _Inout_ ebpf_lru_entry_t* entry)
@@ -1060,7 +1060,7 @@ _Requires_lock_held_(map->lock) static void _uninitialize_lru_entry(
  * @brief Helper function to merge the hot list into the cold list if the hot list size exceeds the hot list limit.
  * Resets the hot list size and increments the current generation.
  *
- * @param[in,out] map Pointer to the map.
+ * @param[in, out] map Pointer to the map.
  */
 _Requires_lock_held_(map->lock) static void _merge_hot_into_cold_list_if_needed(_Inout_ ebpf_core_lru_map_t* map)
 {
@@ -1080,7 +1080,7 @@ _Requires_lock_held_(map->lock) static void _merge_hot_into_cold_list_if_needed(
 /**
  * @brief Helper function to update the LRU key history for a given key if the map tracks key history.
  *
- * @param[in,out] map Pointer to the map.
+ * @param[in, out] map Pointer to the map.
  * @param[in] key Key to update.
  * @param[in] value Optional value for the key. If NULL, the value will be looked up.
  * @param[in] operation Operation to perform on the key.
@@ -1154,7 +1154,7 @@ _delete_hash_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key);
 /**
  * @brief Helper function to reap the oldest entry from the map if the map tracks key history.
  *
- * @param[in,out] map Pointer to the map.
+ * @param[in, out] map Pointer to the map.
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_KEY_NOT_FOUND The key selected for deletion was not found in the map.
  */

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -58,14 +58,14 @@ extern "C"
     /**
      * @brief Get a pointer to an entry in the map.
      *
-     * @param[in] map Map to search.
+     * @param[in,out] map Map to search and update metadata in.
      * @param[in] key Key to use when searching map.
      * @param[in] flags Zero or more EBPF_MAP_FIND_ENTRY_FLAG_* flags.
      * @return Pointer to the value if found or NULL.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_find_entry(
-        _In_ ebpf_map_t* map,
+        _Inout_ ebpf_map_t* map,
         size_t key_size,
         _In_reads_(key_size) const uint8_t* key,
         size_t value_size,
@@ -75,7 +75,7 @@ extern "C"
     /**
      * @brief Insert or update an entry in the map.
      *
-     * @param[in] map Map to update.
+     * @param[in,out] map Map to update.
      * @param[in] key Key to use when searching and updating the map.
      * @param[in] value Value to insert into the map.
      * @param[in] option One of ebpf_map_option_t options.
@@ -85,7 +85,7 @@ extern "C"
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_update_entry(
-        _In_ ebpf_map_t* map,
+        _Inout_ ebpf_map_t* map,
         size_t key_size,
         _In_reads_(key_size) const uint8_t* key,
         size_t value_size,
@@ -96,7 +96,7 @@ extern "C"
     /**
      * @brief Insert or update an entry in the map.
      *
-     * @param[in] map Map to update.
+     * @param[in,out] map Map to update.
      * @param[in] key Key to use when searching and updating the map.
      * @param[in] value_handle Handle associated with the value to insert.
      * @param[in] option One of ebpf_map_option_t options.
@@ -106,7 +106,7 @@ extern "C"
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_update_entry_with_handle(
-        _In_ ebpf_map_t* map,
+        _Inout_ ebpf_map_t* map,
         size_t key_size,
         _In_reads_(key_size) const uint8_t* key,
         uintptr_t value_handle,
@@ -127,7 +127,7 @@ extern "C"
     /**
      * @brief Retrieve the next key from the map.
      *
-     * @param[in] map Map to search.
+     * @param[in,out] map Map to search and update metadata in.
      * @param[in] previous_key The previous key need not be present. This will
      * return the next key lexicographically after the specified key.  A value of
      * null indicates that the first key is to be returned.
@@ -138,7 +138,7 @@ extern "C"
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_next_key(
-        _In_ ebpf_map_t* map,
+        _Inout_ ebpf_map_t* map,
         size_t key_size,
         _In_reads_opt_(key_size) const uint8_t* previous_key,
         _Out_writes_(key_size) uint8_t* next_key);
@@ -148,26 +148,26 @@ extern "C"
      * program returned holds a reference that the caller is responsible for
      * releasing.
      *
-     * @param[in] map Map to search.
+     * @param[in,out] map Map to search and update metadata in.
      * @param[in] key Pointer to key to search for.
      * @param[in] key_size Size of value to search for.
      * @returns Program pointer, or NULL if none.
      */
     _Ret_maybenull_ struct _ebpf_program*
-    ebpf_map_get_program_from_entry(_In_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key);
+    ebpf_map_get_program_from_entry(_Inout_ ebpf_map_t* map, size_t key_size, _In_reads_(key_size) const uint8_t* key);
 
     /**
      * @brief Let a map take any actions when first
      * associated with a program.
      *
-     * @param[in] map Map to update.
+     * @param[in,out] map Map to update.
      * @param[in] program Program being associated with.
      *
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_FD The program is incompatible with this map.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_map_associate_program(_In_ ebpf_map_t* map, _In_ const struct _ebpf_program* program);
+    ebpf_map_associate_program(_Inout_ ebpf_map_t* map, _In_ const struct _ebpf_program* program);
 
     /**
      * @brief Get bpf_map_info about a map.
@@ -211,34 +211,34 @@ extern "C"
     /**
      * @brief Issue an asynchronous query to ring buffer map.
      *
-     * @param[in] map Ring buffer map to issue the async query on.
-     * @param[in, out] async_query_result Pointer to structure for storing result of the async query.
-     * @param[in] async_context Async context associated with the query.
+     * @param[in,out] map Ring buffer map to issue the async query on.
+     * @param[in,out] async_query_result Pointer to structure for storing result of the async query.
+     * @param[in,out] async_context Async context associated with the query.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Insufficient memory to complete this operation.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_ring_buffer_map_async_query(
-        _In_ ebpf_map_t* map,
+        _Inout_ ebpf_map_t* map,
         _Inout_ ebpf_ring_buffer_map_async_query_result_t* async_query_result,
-        _In_ void* async_context);
+        _Inout_ void* async_context);
 
     /**
      * @brief Write out a variable sized record to the ring buffer map.
      *
-     * @param[in] map Pointer to map of type EBPF_MAP_TYPE_RINGBUF.
+     * @param[in,out] map Pointer to map of type EBPF_MAP_TYPE_RINGBUF.
      * @param[in] data Data of record to write into ring buffer map.
      * @param[in] length Length of data.
      * @retval EPBF_SUCCESS Successfully wrote record into ring buffer.
      * @retval EBPF_OUT_OF_SPACE Unable to output to ring buffer due to inadequate space.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_ring_buffer_map_output(_In_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length);
+    ebpf_ring_buffer_map_output(_Inout_ ebpf_map_t* map, _In_reads_bytes_(length) uint8_t* data, size_t length);
 
     /**
      * @brief Insert an element at the end of the map (only valid for stack and queue).
      *
-     * @param[in] map Map to update.
+     * @param[in,out] map Map to update.
      * @param[in] value_size Size of value to insert into the map.
      * @param[in] value Value to insert into the map.
      * @param[in] flags Map flags - BPF_EXIST: If the map is full, the entry at the start of the map is discarded.
@@ -249,35 +249,35 @@ extern "C"
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_map_push_entry(
-        _In_ ebpf_map_t* map, size_t value_size, _In_reads_(value_size) const uint8_t* value, int flags);
+        _Inout_ ebpf_map_t* map, size_t value_size, _In_reads_(value_size) const uint8_t* value, int flags);
 
     /**
      * @brief Copy an entry from the map and remove it from the map (only valid for stack and queue).
      * Queue pops from the beginning of the map.
      * Stack pops from the end of the map.
      *
-     * @param[in] map Map to search.
+     * @param[in,out] map Map to search and update metadata on.
      * @param[in] value_size Size of the value buffer to copy value from map into.
      * @param[out] value Value buffer to copy value from map into.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND The map is empty.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_map_pop_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
+    ebpf_map_pop_entry(_Inout_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
 
     /**
      * @brief Copy an entry from the map (only valid for stack and queue).
      * Queue peeks at the beginning of the map.
      * Stack peeks at the end of the map.
      *
-     * @param[in] map Map to search.
+     * @param[in,out] map Map to search and update metadata on.
      * @param[in] value_size Size of the value buffer to copy value from map into.
      * @param[out] value Value buffer to copy value from map into.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_OBJECT_NOT_FOUND The map is empty.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_map_peek_entry(_In_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
+    ebpf_map_peek_entry(_Inout_ ebpf_map_t* map, size_t value_size, _Out_writes_(value_size) uint8_t* value, int flags);
 
     /**
      * @brief Get the ID of a given map.

--- a/libs/execution_context/ebpf_maps.h
+++ b/libs/execution_context/ebpf_maps.h
@@ -58,7 +58,7 @@ extern "C"
     /**
      * @brief Get a pointer to an entry in the map.
      *
-     * @param[in,out] map Map to search and update metadata in.
+     * @param[in, out] map Map to search and update metadata in.
      * @param[in] key Key to use when searching map.
      * @param[in] flags Zero or more EBPF_MAP_FIND_ENTRY_FLAG_* flags.
      * @return Pointer to the value if found or NULL.
@@ -75,7 +75,7 @@ extern "C"
     /**
      * @brief Insert or update an entry in the map.
      *
-     * @param[in,out] map Map to update.
+     * @param[in, out] map Map to update.
      * @param[in] key Key to use when searching and updating the map.
      * @param[in] value Value to insert into the map.
      * @param[in] option One of ebpf_map_option_t options.
@@ -96,7 +96,7 @@ extern "C"
     /**
      * @brief Insert or update an entry in the map.
      *
-     * @param[in,out] map Map to update.
+     * @param[in, out] map Map to update.
      * @param[in] key Key to use when searching and updating the map.
      * @param[in] value_handle Handle associated with the value to insert.
      * @param[in] option One of ebpf_map_option_t options.
@@ -127,7 +127,7 @@ extern "C"
     /**
      * @brief Retrieve the next key from the map.
      *
-     * @param[in,out] map Map to search and update metadata in.
+     * @param[in, out] map Map to search and update metadata in.
      * @param[in] previous_key The previous key need not be present. This will
      * return the next key lexicographically after the specified key.  A value of
      * null indicates that the first key is to be returned.
@@ -148,7 +148,7 @@ extern "C"
      * program returned holds a reference that the caller is responsible for
      * releasing.
      *
-     * @param[in,out] map Map to search and update metadata in.
+     * @param[in, out] map Map to search and update metadata in.
      * @param[in] key Pointer to key to search for.
      * @param[in] key_size Size of value to search for.
      * @returns Program pointer, or NULL if none.
@@ -160,7 +160,7 @@ extern "C"
      * @brief Let a map take any actions when first
      * associated with a program.
      *
-     * @param[in,out] map Map to update.
+     * @param[in, out] map Map to update.
      * @param[in] program Program being associated with.
      *
      * @retval EBPF_SUCCESS The operation was successful.
@@ -174,7 +174,7 @@ extern "C"
      *
      * @param[in] map The map to get info about.
      * @param[out] buffer Buffer to write bpf_map_info into.
-     * @param[in,out] info_size On input, the size in bytes of the buffer.
+     * @param[in, out] info_size On input, the size in bytes of the buffer.
      * On output, the number of bytes actually written.
      *
      * @retval EBPF_SUCCESS The operation was successful.
@@ -211,9 +211,9 @@ extern "C"
     /**
      * @brief Issue an asynchronous query to ring buffer map.
      *
-     * @param[in,out] map Ring buffer map to issue the async query on.
-     * @param[in,out] async_query_result Pointer to structure for storing result of the async query.
-     * @param[in,out] async_context Async context associated with the query.
+     * @param[in, out] map Ring buffer map to issue the async query on.
+     * @param[in, out] async_query_result Pointer to structure for storing result of the async query.
+     * @param[in, out] async_context Async context associated with the query.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Insufficient memory to complete this operation.
      */
@@ -226,7 +226,7 @@ extern "C"
     /**
      * @brief Write out a variable sized record to the ring buffer map.
      *
-     * @param[in,out] map Pointer to map of type EBPF_MAP_TYPE_RINGBUF.
+     * @param[in, out] map Pointer to map of type EBPF_MAP_TYPE_RINGBUF.
      * @param[in] data Data of record to write into ring buffer map.
      * @param[in] length Length of data.
      * @retval EPBF_SUCCESS Successfully wrote record into ring buffer.
@@ -238,7 +238,7 @@ extern "C"
     /**
      * @brief Insert an element at the end of the map (only valid for stack and queue).
      *
-     * @param[in,out] map Map to update.
+     * @param[in, out] map Map to update.
      * @param[in] value_size Size of value to insert into the map.
      * @param[in] value Value to insert into the map.
      * @param[in] flags Map flags - BPF_EXIST: If the map is full, the entry at the start of the map is discarded.
@@ -256,7 +256,7 @@ extern "C"
      * Queue pops from the beginning of the map.
      * Stack pops from the end of the map.
      *
-     * @param[in,out] map Map to search and update metadata on.
+     * @param[in, out] map Map to search and update metadata on.
      * @param[in] value_size Size of the value buffer to copy value from map into.
      * @param[out] value Value buffer to copy value from map into.
      * @retval EBPF_SUCCESS The operation was successful.
@@ -270,7 +270,7 @@ extern "C"
      * Queue peeks at the beginning of the map.
      * Stack peeks at the end of the map.
      *
-     * @param[in,out] map Map to search and update metadata on.
+     * @param[in, out] map Map to search and update metadata on.
      * @param[in] value_size Size of the value buffer to copy value from map into.
      * @param[out] value Value buffer to copy value from map into.
      * @retval EBPF_SUCCESS The operation was successful.

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -149,7 +149,7 @@ _ebpf_native_clean_up_programs(_In_reads_(count_of_programs) ebpf_native_program
 }
 
 static void
-_ebpf_native_clean_up_module(_In_ ebpf_native_module_t* module)
+_ebpf_native_clean_up_module(_In_ _Post_invalid_ ebpf_native_module_t* module)
 {
     _ebpf_native_clean_up_maps(module->maps, module->map_count, false);
     _ebpf_native_clean_up_programs(module->programs, module->program_count);
@@ -168,7 +168,7 @@ _ebpf_native_clean_up_module(_In_ ebpf_native_module_t* module)
     ebpf_free(module);
 }
 
-_Requires_lock_held_(module->lock) static ebpf_result_t _ebpf_native_unload(_In_ ebpf_native_module_t* module)
+_Requires_lock_held_(module->lock) static ebpf_result_t _ebpf_native_unload(_Inout_ ebpf_native_module_t* module)
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result = EBPF_SUCCESS;
@@ -211,7 +211,7 @@ ebpf_native_acquire_reference(_Inout_ ebpf_native_module_t* module)
 }
 
 void
-ebpf_native_release_reference(_In_opt_ ebpf_native_module_t* module)
+ebpf_native_release_reference(_In_opt_ _Post_invalid_ ebpf_native_module_t* module)
 {
     int32_t new_ref_count;
     ebpf_lock_state_t module_lock_state = 0;
@@ -286,9 +286,9 @@ ebpf_native_terminate()
 static NTSTATUS
 _ebpf_native_provider_attach_client_callback(
     HANDLE nmr_binding_handle,
-    _In_ void* provider_context,
-    _In_ PNPI_REGISTRATION_INSTANCE client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const void* provider_context,
+    _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Out_ void** provider_binding_context,
     _Out_ const void** provider_dispatch)
@@ -371,7 +371,7 @@ Done:
 }
 
 static NTSTATUS
-_ebpf_native_provider_detach_client_callback(_In_ void* provider_binding_context)
+_ebpf_native_provider_detach_client_callback(_In_ const void* provider_binding_context)
 {
     ebpf_native_module_t* context = (ebpf_native_module_t*)provider_binding_context;
 
@@ -440,8 +440,8 @@ ebpf_native_initiate()
         NULL,
         NULL,
         NULL,
-        _ebpf_native_provider_attach_client_callback,
-        _ebpf_native_provider_detach_client_callback,
+        (NPI_PROVIDER_ATTACH_CLIENT_FN*)_ebpf_native_provider_attach_client_callback,
+        (NPI_PROVIDER_DETACH_CLIENT_FN*)_ebpf_native_provider_detach_client_callback,
         NULL);
 
     if (return_value != EBPF_SUCCESS) {
@@ -851,7 +851,8 @@ Done:
 }
 
 static ebpf_result_t
-_ebpf_native_resolve_helpers_for_program(_In_ ebpf_native_module_t* module, _In_ ebpf_native_program_t* program)
+_ebpf_native_resolve_helpers_for_program(
+    _In_ const ebpf_native_module_t* module, _In_ const ebpf_native_program_t* program)
 {
     EBPF_LOG_ENTRY();
     UNREFERENCED_PARAMETER(module);
@@ -905,7 +906,8 @@ Done:
 }
 
 static void
-_ebpf_native_initialize_helpers_for_program(_In_ ebpf_native_module_t* module, _In_ ebpf_native_program_t* program)
+_ebpf_native_initialize_helpers_for_program(
+    _In_ const ebpf_native_module_t* module, _Inout_ ebpf_native_program_t* program)
 {
     UNREFERENCED_PARAMETER(module);
     size_t helper_count = program->entry->helper_count;
@@ -920,7 +922,7 @@ _ebpf_native_initialize_helpers_for_program(_In_ ebpf_native_module_t* module, _
 }
 
 static ebpf_result_t
-_ebpf_native_load_programs(_In_ ebpf_native_module_t* module)
+_ebpf_native_load_programs(_Inout_ ebpf_native_module_t* module)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     ebpf_native_program_t* native_programs = NULL;

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -287,7 +287,7 @@ static NTSTATUS
 _ebpf_native_provider_attach_client_callback(
     HANDLE nmr_binding_handle,
     _In_ const void* provider_context,
-    _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+    _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Out_ void** provider_binding_context,

--- a/libs/execution_context/ebpf_native.h
+++ b/libs/execution_context/ebpf_native.h
@@ -120,7 +120,7 @@ extern "C"
      * @param[in] module Optionally, pointer to native module.
      */
     void
-    ebpf_native_release_reference(_In_opt_ ebpf_native_module_binding_context_t* module);
+    ebpf_native_release_reference(_In_opt_ _Post_invalid_ ebpf_native_module_binding_context_t* module);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -99,7 +99,7 @@ _ebpf_program_detach_links(_Inout_ ebpf_program_t* program)
 
 static void
 _ebpf_program_program_info_provider_changed(
-    _In_ void* client_binding_context,
+    _In_ const void* client_binding_context,
     _In_ const void* provider_binding_context,
     _In_opt_ const ebpf_extension_data_t* provider_data)
 {
@@ -819,7 +819,7 @@ ebpf_program_set_tail_call(_In_ const ebpf_program_t* next_program)
 }
 
 void
-ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out_ uint32_t* result)
+ebpf_program_invoke(_In_ const ebpf_program_t* program, _Inout_ void* context, _Out_ uint32_t* result)
 {
     // High volume call - Skip entry/exit logging.
     ebpf_program_tail_call_state_t state = {0};

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -145,7 +145,7 @@ extern "C"
     /**
      * @brief Load a block of eBPF code into the program instance.
      *
-     * @param[in, out] program Program instance to load the eBPF code into.
+     * @param[in,out] program Program instance to load the eBPF code into.
      * @param[in] code_type Specifies whether eBPF code is JIT compiled or byte code.
      * @param[in] code_context Optionally, pointer to code context.
      * @param[in] code Pointer to memory containing the eBPF code.
@@ -171,14 +171,14 @@ extern "C"
      * @param[out] result Output from the program.
      */
     void
-    ebpf_program_invoke(_In_ const ebpf_program_t* program, _In_ void* context, _Out_ uint32_t* result);
+    ebpf_program_invoke(_In_ const ebpf_program_t* program, _Inout_ void* context, _Out_ uint32_t* result);
 
     /**
      * @brief Store the helper function IDs that are used by the eBPF program in an array
      *  inside the program object. The array index is the helper function ID to be used by
      *  uBPF whereas the array value is the actual helper ID.
      *
-     * @param[in, out] program Program object to query this on.
+     * @param[in,out] program Program object to query this on.
      * @param[in] helper_function_count Count of helper functions.
      * @param[in] helper_function_ids Array of helper function IDs to store.
      * @retval EBPF_SUCCESS The operation was successful.
@@ -211,8 +211,8 @@ extern "C"
     /**
      * @brief Attach a link object to an eBPF program.
      *
-     * @param[in] program Program to attach to the link object.
-     * @param[in] link The link object.
+     * @param[in,out] program Program to attach to the link object.
+     * @param[in,out] link The link object.
      */
     void
     ebpf_program_attach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* link);
@@ -220,8 +220,8 @@ extern "C"
     /**
      * @brief Detach a link object from the eBPF program it is attached to.
      *
-     * @param[in] program Program to detach to the link object from.
-     * @param[in] link The link object.
+     * @param[in,out] program Program to detach to the link object from.
+     * @param[in,out] link The link object.
      */
     void
     ebpf_program_detach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* link);

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -68,7 +68,7 @@ extern "C"
      * @brief Initialize a program instance from the provided program
      *  parameters.
      *
-     * @param[in,out] program Program instance to initialize.
+     * @param[in, out] program Program instance to initialize.
      * @param[in] program_parameters Program parameters to be used to initialize
      *  the program instance.
      * @retval EBPF_SUCCESS The operation was successful.
@@ -145,7 +145,7 @@ extern "C"
     /**
      * @brief Load a block of eBPF code into the program instance.
      *
-     * @param[in,out] program Program instance to load the eBPF code into.
+     * @param[in, out] program Program instance to load the eBPF code into.
      * @param[in] code_type Specifies whether eBPF code is JIT compiled or byte code.
      * @param[in] code_context Optionally, pointer to code context.
      * @param[in] code Pointer to memory containing the eBPF code.
@@ -178,7 +178,7 @@ extern "C"
      *  inside the program object. The array index is the helper function ID to be used by
      *  uBPF whereas the array value is the actual helper ID.
      *
-     * @param[in,out] program Program object to query this on.
+     * @param[in, out] program Program object to query this on.
      * @param[in] helper_function_count Count of helper functions.
      * @param[in] helper_function_ids Array of helper function IDs to store.
      * @retval EBPF_SUCCESS The operation was successful.
@@ -211,8 +211,8 @@ extern "C"
     /**
      * @brief Attach a link object to an eBPF program.
      *
-     * @param[in,out] program Program to attach to the link object.
-     * @param[in,out] link The link object.
+     * @param[in, out] program Program to attach to the link object.
+     * @param[in, out] link The link object.
      */
     void
     ebpf_program_attach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* link);
@@ -220,8 +220,8 @@ extern "C"
     /**
      * @brief Detach a link object from the eBPF program it is attached to.
      *
-     * @param[in,out] program Program to detach to the link object from.
-     * @param[in,out] link The link object.
+     * @param[in, out] program Program to detach to the link object from.
+     * @param[in, out] link The link object.
      */
     void
     ebpf_program_detach_link(_Inout_ ebpf_program_t* program, _Inout_ ebpf_link_t* link);
@@ -243,7 +243,7 @@ extern "C"
      * @param[in] program The program to get info about.
      * @param[in] input_buffer Buffer to read bpf_prog_info from.
      * @param[out] output_buffer Buffer to write bpf_prog_info into.
-     * @param[in,out] info_size On input, the size in bytes of the buffer.
+     * @param[in, out] info_size On input, the size in bytes of the buffer.
      * On output, the number of bytes actually written.
      *
      * @retval EBPF_SUCCESS The operation was successful.

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -728,7 +728,7 @@ TEST_CASE("ring_buffer_async_query", "[execution_context]")
 
     REQUIRE(
         ebpf_async_set_completion_callback(
-            &completion, [](void* context, size_t output_buffer_length, ebpf_result_t result) {
+            &completion, [](_Inout_ void* context, size_t output_buffer_length, ebpf_result_t result) {
                 UNREFERENCED_PARAMETER(output_buffer_length);
                 auto completion = reinterpret_cast<_completion*>(context);
                 auto async_query_result = &completion->async_query_result;

--- a/libs/platform/ebpf_async.c
+++ b/libs/platform/ebpf_async.c
@@ -6,9 +6,9 @@
 
 typedef struct _ebpf_async_tracker
 {
-    void (*on_complete)(_In_ void*, size_t, ebpf_result_t);
+    void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t);
     void* cancellation_context;
-    void (*on_cancel)(_In_ void*);
+    void (*on_cancel)(_Inout_ void*);
 } ebpf_async_tracker_t;
 
 static ebpf_hash_table_t* _ebpf_async_tracker_table = NULL;
@@ -37,7 +37,8 @@ ebpf_async_terminate()
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_async_set_completion_callback(_In_ void* context, _In_ void (*on_complete)(_In_ void*, size_t, ebpf_result_t))
+ebpf_async_set_completion_callback(
+    _In_ const void* context, _In_ void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t))
 {
     EBPF_LOG_ENTRY();
     ebpf_async_tracker_t tracker = {on_complete};
@@ -48,7 +49,7 @@ ebpf_async_set_completion_callback(_In_ void* context, _In_ void (*on_complete)(
 }
 
 static ebpf_async_tracker_t*
-_tracker_from_context(_In_ void* context)
+_tracker_from_context(_In_ const void* context)
 {
     uint8_t* key = (uint8_t*)&context;
     ebpf_async_tracker_t* tracker = NULL;
@@ -61,7 +62,7 @@ _tracker_from_context(_In_ void* context)
 }
 
 static ebpf_result_t
-_remove_tracker(_In_ void* context)
+_remove_tracker(_In_ const void* context)
 {
     uint8_t* key = (uint8_t*)&context;
     return ebpf_hash_table_delete(_ebpf_async_tracker_table, key);
@@ -69,7 +70,9 @@ _remove_tracker(_In_ void* context)
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_async_set_cancel_callback(
-    _In_ void* context, _In_ void* cancellation_context, _In_ void (*on_cancel)(_In_ void* cancellation_context))
+    _In_ const void* context,
+    _Inout_opt_ void* cancellation_context,
+    _In_ void (*on_cancel)(_Inout_opt_ void* cancellation_context))
 {
     EBPF_LOG_ENTRY();
     ebpf_async_tracker_t* tracker = _tracker_from_context(context);
@@ -82,7 +85,7 @@ ebpf_async_set_cancel_callback(
 }
 
 bool
-ebpf_async_cancel(_In_ void* context)
+ebpf_async_cancel(_Inout_ void* context)
 {
     EBPF_LOG_ENTRY();
     ebpf_async_tracker_t* tracker = _tracker_from_context(context);
@@ -90,7 +93,7 @@ ebpf_async_cancel(_In_ void* context)
         EBPF_RETURN_BOOL(false);
 
     void* cancellation_context = tracker->cancellation_context;
-    void (*on_cancellation)(_In_ void* context) = tracker->on_cancel;
+    void (*on_cancellation)(_Inout_ void* context) = tracker->on_cancel;
     if (on_cancellation)
         on_cancellation(cancellation_context);
 
@@ -98,7 +101,7 @@ ebpf_async_cancel(_In_ void* context)
 }
 
 void
-ebpf_async_complete(_In_ void* context, size_t output_buffer_length, ebpf_result_t result)
+ebpf_async_complete(_Inout_ void* context, size_t output_buffer_length, ebpf_result_t result)
 {
     EBPF_LOG_ENTRY();
     ebpf_async_tracker_t* tracker = _tracker_from_context(context);
@@ -106,7 +109,7 @@ ebpf_async_complete(_In_ void* context, size_t output_buffer_length, ebpf_result
         ebpf_assert(!"Async action was double completed");
         EBPF_RETURN_VOID();
     }
-    void (*on_complete)(_In_ void*, size_t, ebpf_result_t) = tracker->on_complete;
+    void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t) = tracker->on_complete;
     if (_remove_tracker(context) != EBPF_SUCCESS) {
         ebpf_assert(!"Async action was double completed");
         EBPF_RETURN_VOID();
@@ -118,7 +121,7 @@ ebpf_async_complete(_In_ void* context, size_t output_buffer_length, ebpf_result
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_async_reset_completion_callback(_In_ void* context)
+ebpf_async_reset_completion_callback(_In_ const void* context)
 {
     return _remove_tracker(context);
 }

--- a/libs/platform/ebpf_async.h
+++ b/libs/platform/ebpf_async.h
@@ -80,7 +80,7 @@ extern "C"
      * @brief Set a cancellation function to be called when actions associated with this context are canceled.
      *
      * @param[in] context Context of action to track.
-     * @param[in,out] cancellation_context Context to pass when this action is canceled.
+     * @param[in, out] cancellation_context Context to pass when this action is canceled.
      * @param[in] on_cancel Function to call if this action is canceled.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT The action context hasn't been registered.
@@ -94,7 +94,7 @@ extern "C"
     /**
      * @brief Cancel the action associated with this context.
      *
-     * @param[in,out] context Context associated with the action.
+     * @param[in, out] context Context associated with the action.
      * @retval true Action was canceled.
      * @retval false Action was already completed.
      */
@@ -104,7 +104,7 @@ extern "C"
     /**
      * @brief Complete the action associated with this context.
      *
-     * @param[in,out] context Context associated with the action.
+     * @param[in, out] context Context associated with the action.
      * @param[in] output_buffer_length Length (in bytes) of the buffer containing the result of the async operation.
      * @param[in] result The outcome of the action.
      */

--- a/libs/platform/ebpf_async.h
+++ b/libs/platform/ebpf_async.h
@@ -65,7 +65,8 @@ extern "C"
      *  operation.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_async_set_completion_callback(_In_ void* context, _In_ void (*on_complete)(_In_ void*, size_t, ebpf_result_t));
+    ebpf_async_set_completion_callback(
+        _In_ const void* context, _In_ void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t));
 
     /**
      * @brief Set a completion function to be called when actions associated with this context complete.
@@ -73,40 +74,42 @@ extern "C"
      * @param[in] context Context of action to stop tracking.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_async_reset_completion_callback(_In_ void* context);
+    ebpf_async_reset_completion_callback(_In_ const void* context);
 
     /**
      * @brief Set a cancellation function to be called when actions associated with this context are canceled.
      *
      * @param[in] context Context of action to track.
-     * @param[in] cancellation_context Context to pass when this action is canceled.
+     * @param[in,out] cancellation_context Context to pass when this action is canceled.
      * @param[in] on_cancel Function to call if this action is canceled.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_INVALID_ARGUMENT The action context hasn't been registered.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_async_set_cancel_callback(
-        _In_ void* context, _In_ void* cancellation_context, _In_ void (*on_cancel)(_In_ void* cancellation_context));
+        _In_ const void* context,
+        _Inout_opt_ const void* cancellation_context,
+        _In_ void (*on_cancel)(_Inout_opt_ void* cancellation_context));
 
     /**
      * @brief Cancel the action associated with this context.
      *
-     * @param[in] context Context associated with the action.
+     * @param[in,out] context Context associated with the action.
      * @retval true Action was canceled.
      * @retval false Action was already completed.
      */
     bool
-    ebpf_async_cancel(_In_ void* context);
+    ebpf_async_cancel(_Inout_ void* context);
 
     /**
      * @brief Complete the action associated with this context.
      *
-     * @param[in] context Context associated with the action.
+     * @param[in,out] context Context associated with the action.
      * @param[in] output_buffer_length Length (in bytes) of the buffer containing the result of the async operation.
      * @param[in] result The outcome of the action.
      */
     void
-    ebpf_async_complete(_In_ void* context, size_t output_buffer_length, ebpf_result_t result);
+    ebpf_async_complete(_Inout_ void* context, size_t output_buffer_length, ebpf_result_t result);
 
 #ifdef __cplusplus
 }

--- a/libs/platform/ebpf_bitmap.h
+++ b/libs/platform/ebpf_bitmap.h
@@ -31,7 +31,7 @@ extern "C"
     /**
      * @brief Set bit at index to true.
      *
-     * @param[in,out] bitmap Pointer to the bitmap.
+     * @param[in, out] bitmap Pointer to the bitmap.
      * @param[in] index Index to modify.
      * @param[in] interlocked Perform the operation using interlocked.
      * @return true if the bit was set, false otherwise.
@@ -42,7 +42,7 @@ extern "C"
     /**
      * @brief Set bit at index to false.
      *
-     * @param[in,out] bitmap Pointer to the bitmap.
+     * @param[in, out] bitmap Pointer to the bitmap.
      * @param[in] index Index to modify.
      * @param[in] interlocked Perform the operation using interlocked.
      * @return true if the bit was set, false otherwise.
@@ -81,7 +81,7 @@ extern "C"
     /**
      * @brief Find the next set bit in the bitmap via forward search.
      *
-     * @param[in,out] cursor Pointer to cursor.
+     * @param[in, out] cursor Pointer to cursor.
      * @return Offset of the next set bit.
      */
     size_t
@@ -90,7 +90,7 @@ extern "C"
     /**
      * @brief Find the next set bit in the bitmap via reverse search.
      *
-     * @param[in,out] cursor Pointer to cursor.
+     * @param[in, out] cursor Pointer to cursor.
      * @return Offset of the next set bit.
      */
     size_t

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -127,7 +127,7 @@ typedef struct _ebpf_epoch_work_item
 {
     ebpf_epoch_allocation_header_t header;
     void* callback_context;
-    void (*callback)(void* context);
+    const void (*callback)(_Inout_ void* context);
 } ebpf_epoch_work_item_t;
 
 typedef enum _ebpf_epoch_get_thread_entry_option
@@ -143,7 +143,7 @@ typedef enum _ebpf_epoch_get_thread_entry_option
  * @param[in] released_epoch The epoch to release.
  */
 static void
-_ebpf_epoch_release_free_list(_In_ ebpf_epoch_cpu_entry_t* cpu_entry, int64_t released_epoch);
+_ebpf_epoch_release_free_list(_Inout_ ebpf_epoch_cpu_entry_t* cpu_entry, int64_t released_epoch);
 
 /**
  * @brief Determine the newest inactive epoch and return it.
@@ -161,7 +161,7 @@ _ebpf_epoch_get_release_epoch(_Out_ int64_t* released_epoch);
  * @param[in] context Unused.
  */
 static void
-_ebpf_flush_worker(_In_ void* context);
+_ebpf_flush_worker(_In_ const void* context);
 
 /**
  * @brief Flush any stale entries from the per-CPU free list.
@@ -170,7 +170,7 @@ _ebpf_flush_worker(_In_ void* context);
  * @param[in] parameter_1 Unused.
  */
 static void
-_ebpf_epoch_stale_worker(_In_ void* work_item_context, _In_ void* parameter_1);
+_ebpf_epoch_stale_worker(_In_ const void* work_item_context, _In_ const void* parameter_1);
 
 /**
  * @brief Find or create a thread entry for the current thread.
@@ -476,7 +476,7 @@ ebpf_epoch_free(_Frees_ptr_opt_ void* memory)
 }
 
 ebpf_epoch_work_item_t*
-ebpf_epoch_allocate_work_item(_In_ void* callback_context, _In_ void (*callback)(void* context))
+ebpf_epoch_allocate_work_item(_In_ void* callback_context, _In_ const void (*callback)(_Inout_ void* context))
 {
     ebpf_epoch_work_item_t* work_item = ebpf_allocate(sizeof(ebpf_epoch_work_item_t));
     if (!work_item) {
@@ -491,7 +491,7 @@ ebpf_epoch_allocate_work_item(_In_ void* callback_context, _In_ void (*callback)
 }
 
 void
-ebpf_epoch_schedule_work_item(_In_ ebpf_epoch_work_item_t* work_item)
+ebpf_epoch_schedule_work_item(_Inout_ ebpf_epoch_work_item_t* work_item)
 {
     ebpf_lock_state_t lock_state;
     uint32_t current_cpu;
@@ -544,7 +544,7 @@ ebpf_epoch_is_free_list_empty(uint32_t cpu_id)
 }
 
 static void
-_ebpf_epoch_release_free_list(_In_ ebpf_epoch_cpu_entry_t* cpu_entry, int64_t released_epoch)
+_ebpf_epoch_release_free_list(_Inout_ ebpf_epoch_cpu_entry_t* cpu_entry, int64_t released_epoch)
 {
     ebpf_lock_state_t lock_state;
     ebpf_list_entry_t* entry;
@@ -688,7 +688,7 @@ Exit:
 }
 
 static void
-_ebpf_flush_worker(_In_ void* context)
+_ebpf_flush_worker(_In_ const void* context)
 {
     UNREFERENCED_PARAMETER(context);
 
@@ -737,7 +737,7 @@ static _Requires_lock_held_(cpu_entry->lock) void _ebpf_epoch_arm_timer_if_neede
 }
 
 static void
-_ebpf_epoch_stale_worker(_In_ void* work_item_context, _In_ void* parameter_1)
+_ebpf_epoch_stale_worker(_In_ const void* work_item_context, _In_ const void* parameter_1)
 {
     UNREFERENCED_PARAMETER(work_item_context);
     UNREFERENCED_PARAMETER(parameter_1);

--- a/libs/platform/ebpf_epoch.h
+++ b/libs/platform/ebpf_epoch.h
@@ -74,16 +74,17 @@ extern "C"
      * @return Pointer to work item that can be scheduled.
      */
     ebpf_epoch_work_item_t*
-    ebpf_epoch_allocate_work_item(_In_ void* callback_context, _In_ void (*callback)(void* context));
+    ebpf_epoch_allocate_work_item(
+        _In_ const void* callback_context, _In_ const void (*callback)(_Inout_ void* context));
 
     /**
      * @brief Schedule a previously allocated work-item to run when the current
      * epoch ends.
      *
-     * @param[in] work_item Pointer to work item to run on epoch end.
+     * @param[in,out] work_item Pointer to work item to run on epoch end.
      */
     void
-    ebpf_epoch_schedule_work_item(_In_ ebpf_epoch_work_item_t* work_item);
+    ebpf_epoch_schedule_work_item(_Inout_ ebpf_epoch_work_item_t* work_item);
 
     /**
      * @brief Free an epoch work item.

--- a/libs/platform/ebpf_epoch.h
+++ b/libs/platform/ebpf_epoch.h
@@ -81,7 +81,7 @@ extern "C"
      * @brief Schedule a previously allocated work-item to run when the current
      * epoch ends.
      *
-     * @param[in,out] work_item Pointer to work item to run on epoch end.
+     * @param[in, out] work_item Pointer to work item to run on epoch end.
      */
     void
     ebpf_epoch_schedule_work_item(_Inout_ ebpf_epoch_work_item_t* work_item);

--- a/libs/platform/ebpf_extension.c
+++ b/libs/platform/ebpf_extension.c
@@ -156,7 +156,7 @@ _ebpf_extension_client_detach_provider(void* client_binding_context)
 }
 
 static void
-_ebpf_extension_client_cleanup_binding_context(_In_opt_ void* client_binding_context)
+_ebpf_extension_client_cleanup_binding_context(_In_opt_ _Post_invalid_ void* client_binding_context)
 {
     EBPF_LOG_ENTRY();
     if (client_binding_context != NULL) {
@@ -177,7 +177,7 @@ ebpf_extension_load(
     _In_ const GUID* interface_id,
     _In_ const GUID* expected_provider_module_id,
     _In_ const GUID* client_module_id,
-    _In_ void* extension_client_context,
+    _In_ const void* extension_client_context,
     _In_opt_ const ebpf_extension_data_t* client_data,
     _In_opt_ const ebpf_extension_dispatch_table_t* client_dispatch_table,
     _Outptr_opt_ void** provider_binding_context,
@@ -207,7 +207,7 @@ ebpf_extension_load(
 
     local_client_context->client_data = client_data;
     local_client_context->npi_id = *interface_id;
-    local_client_context->extension_client_context = extension_client_context;
+    local_client_context->extension_client_context = (void*)extension_client_context;
     local_client_context->client_module_id.Length = sizeof(local_client_context->client_module_id);
     local_client_context->client_module_id.Type = MIT_GUID;
     local_client_context->client_module_id.Guid = *client_module_id;
@@ -333,10 +333,10 @@ ebpf_provider_load(
     _Outptr_ ebpf_extension_provider_t** provider_context,
     _In_ const GUID* interface_id,
     _In_ const GUID* provider_module_id,
-    _In_opt_ void* provider_binding_context,
+    _Inout_opt_ void* provider_binding_context,
     _In_opt_ const ebpf_extension_data_t* provider_data,
     _In_opt_ const ebpf_extension_dispatch_table_t* provider_dispatch_table,
-    _In_opt_ void* callback_context,
+    _Inout_opt_ void* callback_context,
     _In_ PNPI_PROVIDER_ATTACH_CLIENT_FN provider_attach_client_callback,
     _In_ PNPI_PROVIDER_DETACH_CLIENT_FN provider_detach_client_callback,
     _In_opt_ PNPI_PROVIDER_CLEANUP_BINDING_CONTEXT_FN provider_cleanup_binding_context_callback)

--- a/libs/platform/ebpf_handle.h
+++ b/libs/platform/ebpf_handle.h
@@ -32,7 +32,7 @@ extern "C"
      * @brief Create a handle that holds a reference on the object.
      *
      * @param[out] handle Pointer to memory that contains the handle on success.
-     * @param[in,out] object Object to write to.
+     * @param[in, out] object Object to write to.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  operation.

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -234,7 +234,7 @@ _ebpf_hash_table_compute_hash(_In_ const ebpf_hash_table_t* hash_table, _In_ con
  * @return Pointer to the ebpf_hash_bucket_entry_t.
  */
 static ebpf_hash_bucket_entry_t*
-_ebpf_hash_table_bucket_entry(size_t key_size, _In_ ebpf_hash_bucket_header_t* bucket, size_t index)
+_ebpf_hash_table_bucket_entry(size_t key_size, _In_ const ebpf_hash_bucket_header_t* bucket, size_t index)
 {
     uint8_t* offset = (uint8_t*)bucket->entries;
     size_t entry_size = EBPF_OFFSET_OF(ebpf_hash_bucket_entry_t, key) + key_size;
@@ -250,17 +250,17 @@ _ebpf_hash_table_bucket_entry(size_t key_size, _In_ ebpf_hash_bucket_header_t* b
  * @param[in] hash_table The hash table.
  * @param[in] old_bucket The immutable bucket to copy.
  * @param[in] key The key to insert.
- * @param[in] data The copy of the value to insert. On success the new_bucket owns this memory.
+ * @param[in,out] data The copy of the value to insert. On success the new_bucket owns this memory.
  * @param[out] new_bucket The new bucket with the entry inserted. On success the caller owns this memory.
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
  */
 static ebpf_result_t
 _ebpf_hash_table_bucket_insert(
-    _In_ ebpf_hash_table_t* hash_table,
+    _Inout_ ebpf_hash_table_t* hash_table,
     _In_opt_ const ebpf_hash_bucket_header_t* old_bucket,
     _In_ const uint8_t* key,
-    _In_opt_ uint8_t* data,
+    _Inout_opt_ uint8_t* data,
     _Outptr_ ebpf_hash_bucket_header_t** new_bucket)
 {
     ebpf_result_t result;
@@ -337,9 +337,9 @@ Done:
  */
 static void
 _ebpf_hash_table_bucket_delete(
-    _In_ ebpf_hash_table_t* hash_table,
-    _In_ ebpf_hash_bucket_header_t* old_bucket,
-    _In_ size_t key_index,
+    _Inout_ ebpf_hash_table_t* hash_table,
+    _In_ const ebpf_hash_bucket_header_t* old_bucket,
+    size_t key_index,
     _Outptr_result_maybenull_ ebpf_hash_bucket_header_t** new_bucket)
 {
     ebpf_hash_bucket_header_t* backup_bucket =
@@ -398,7 +398,7 @@ Done:
  * @param[in] hash_table Hash table.
  * @param[in] old_bucket The immutable old bucket to copy.
  * @param[in] key_index The location of the key to update.
- * @param[in] data A copy of the data to update.
+ * @param[in,out] data A copy of the data to update.
  * @param[out] new_bucket The new bucket with the entry updated. On success the caller owns this memory.
  *
  * @retval EBPF_SUCCESS The operation was successful.
@@ -406,10 +406,10 @@ Done:
  */
 static ebpf_result_t
 _ebpf_hash_table_bucket_update(
-    _In_ ebpf_hash_table_t* hash_table,
+    _Inout_ ebpf_hash_table_t* hash_table,
     _In_ const ebpf_hash_bucket_header_t* old_bucket,
-    _In_ size_t key_index,
-    _In_opt_ uint8_t* data,
+    size_t key_index,
+    _Inout_opt_ uint8_t* data,
     _Outptr_ ebpf_hash_bucket_header_t** new_bucket)
 {
     ebpf_result_t result;
@@ -455,7 +455,7 @@ Done:
  */
 static ebpf_result_t
 _ebpf_hash_table_replace_bucket(
-    _In_ ebpf_hash_table_t* hash_table,
+    _Inout_ ebpf_hash_table_t* hash_table,
     _In_ const uint8_t* key,
     _In_opt_ const uint8_t* value,
     ebpf_hash_bucket_operation_t operation)
@@ -633,7 +633,7 @@ ebpf_hash_table_destroy(_In_opt_ _Post_ptr_invalid_ ebpf_hash_table_t* hash_tabl
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_hash_table_find(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _Outptr_ uint8_t** value)
+ebpf_hash_table_find(_In_ const ebpf_hash_table_t* hash_table, _In_ const uint8_t* key, _Outptr_ uint8_t** value)
 {
     ebpf_result_t retval;
     uint32_t hash;
@@ -674,7 +674,7 @@ Done:
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_hash_table_update(
-    _In_ ebpf_hash_table_t* hash_table,
+    _Inout_ ebpf_hash_table_t* hash_table,
     _In_ const uint8_t* key,
     _In_opt_ const uint8_t* value,
     ebpf_hash_table_operations_t operation)
@@ -708,7 +708,7 @@ Done:
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_hash_table_delete(_In_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key)
+ebpf_hash_table_delete(_Inout_ ebpf_hash_table_t* hash_table, _In_ const uint8_t* key)
 {
     ebpf_result_t retval;
 

--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -250,7 +250,7 @@ _ebpf_hash_table_bucket_entry(size_t key_size, _In_ const ebpf_hash_bucket_heade
  * @param[in] hash_table The hash table.
  * @param[in] old_bucket The immutable bucket to copy.
  * @param[in] key The key to insert.
- * @param[in,out] data The copy of the value to insert. On success the new_bucket owns this memory.
+ * @param[in, out] data The copy of the value to insert. On success the new_bucket owns this memory.
  * @param[out] new_bucket The new bucket with the entry inserted. On success the caller owns this memory.
  * @retval EBPF_SUCCESS The operation was successful.
  * @retval EBPF_NO_MEMORY Unable to allocate resources for this operation.
@@ -398,7 +398,7 @@ Done:
  * @param[in] hash_table Hash table.
  * @param[in] old_bucket The immutable old bucket to copy.
  * @param[in] key_index The location of the key to update.
- * @param[in,out] data A copy of the data to update.
+ * @param[in, out] data A copy of the data to update.
  * @param[out] new_bucket The new bucket with the entry updated. On success the caller owns this memory.
  *
  * @retval EBPF_SUCCESS The operation was successful.

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -67,7 +67,7 @@ extern "C"
     /**
      * @brief Initialize an ebpf_core_object_t structure.
      *
-     * @param[in,out] object ebpf_core_object_t structure to initialize.
+     * @param[in, out] object ebpf_core_object_t structure to initialize.
      * @param[in] object_type The type of the object.
      * @param[in] free_function The function used to free the object.
      * @param[in] get_program_type_function The function used to get a program type, or NULL.  Each program

--- a/libs/platform/ebpf_pinning_table.c
+++ b/libs/platform/ebpf_pinning_table.c
@@ -229,7 +229,7 @@ ebpf_pinning_table_delete(ebpf_pinning_table_t* pinning_table, const ebpf_utf8_s
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_pinning_table_enumerate_entries(
-    _In_ ebpf_pinning_table_t* pinning_table,
+    _Inout_ ebpf_pinning_table_t* pinning_table,
     ebpf_object_type_t object_type,
     _Out_ uint16_t* entry_count,
     _Outptr_result_buffer_maybenull_(*entry_count) ebpf_pinning_entry_t** pinning_entries)
@@ -326,7 +326,7 @@ Exit:
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_pinning_table_get_next_path(
-    _In_ ebpf_pinning_table_t* pinning_table,
+    _Inout_ ebpf_pinning_table_t* pinning_table,
     ebpf_object_type_t object_type,
     _In_ const ebpf_utf8_string_t* start_path,
     _Inout_ ebpf_utf8_string_t* next_path)

--- a/libs/platform/ebpf_pinning_table.h
+++ b/libs/platform/ebpf_pinning_table.h
@@ -86,7 +86,7 @@ extern "C"
     /**
      * @brief Returns all entries in the pinning table of specified object type after acquiring a reference.
      *
-     * @param[in] pinning_table Pinning table to enumerate.
+     * @param[in,out] pinning_table Pinning table to enumerate.
      * @param[in] object_type eBPF object type that will be used to filter pinning entries.
      * @param[out] entry_count Number of pinning entries being returned.
      * @param[out] pinning_entries Array of pinning entries being returned. Must be freed by caller
@@ -96,7 +96,7 @@ extern "C"
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_enumerate_entries(
-        _In_ ebpf_pinning_table_t* pinning_table,
+        _Inout_ ebpf_pinning_table_t* pinning_table,
         ebpf_object_type_t object_type,
         _Out_ uint16_t* entry_count,
         _Outptr_result_buffer_maybenull_(*entry_count) ebpf_pinning_entry_t** pinning_entries);
@@ -104,16 +104,16 @@ extern "C"
     /**
      * @brief Gets the next path in the pinning table after a given path.
      *
-     * @param[in] pinning_table Pinning table to enumerate.
+     * @param[in,out] pinning_table Pinning table to enumerate.
      * @param[in] object_type Object type.
      * @param[in] start_path Path to look for an entry greater than.
-     * @param[out] next_path Returns the next path, if one exists.
+     * @param[in,out] next_path Returns the next path, if one exists.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MORE_KEYS No more entries found.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_pinning_table_get_next_path(
-        _In_ ebpf_pinning_table_t* pinning_table,
+        _Inout_ ebpf_pinning_table_t* pinning_table,
         ebpf_object_type_t object_type,
         _In_ const ebpf_utf8_string_t* start_path,
         _Inout_ ebpf_utf8_string_t* next_path);

--- a/libs/platform/ebpf_pinning_table.h
+++ b/libs/platform/ebpf_pinning_table.h
@@ -86,7 +86,7 @@ extern "C"
     /**
      * @brief Returns all entries in the pinning table of specified object type after acquiring a reference.
      *
-     * @param[in,out] pinning_table Pinning table to enumerate.
+     * @param[in, out] pinning_table Pinning table to enumerate.
      * @param[in] object_type eBPF object type that will be used to filter pinning entries.
      * @param[out] entry_count Number of pinning entries being returned.
      * @param[out] pinning_entries Array of pinning entries being returned. Must be freed by caller
@@ -104,10 +104,10 @@ extern "C"
     /**
      * @brief Gets the next path in the pinning table after a given path.
      *
-     * @param[in,out] pinning_table Pinning table to enumerate.
+     * @param[in, out] pinning_table Pinning table to enumerate.
      * @param[in] object_type Object type.
      * @param[in] start_path Path to look for an entry greater than.
-     * @param[in,out] next_path Returns the next path, if one exists.
+     * @param[in, out] next_path Returns the next path, if one exists.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MORE_KEYS No more entries found.
      */

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -426,7 +426,7 @@ extern "C"
     ebpf_allocate_non_preemptible_work_item(
         _Outptr_ ebpf_non_preemptible_work_item_t** work_item,
         uint32_t cpu_id,
-        _In_ const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1),
+        _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1),
         _Inout_opt_ void* work_item_context);
 
     /**

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -356,7 +356,7 @@ extern "C"
 
     /**
      * @brief Acquire exclusive access to the lock.
-     * @param[in,out] lock Pointer to memory location that contains the lock.
+     * @param[in, out] lock Pointer to memory location that contains the lock.
      * @returns The previous lock_state required for unlock.
      */
     _Requires_lock_not_held_(*lock) _Acquires_lock_(*lock) _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_
@@ -364,7 +364,7 @@ extern "C"
 
     /**
      * @brief Release exclusive access to the lock.
-     * @param[in,out] lock Pointer to memory location that contains the lock.
+     * @param[in, out] lock Pointer to memory location that contains the lock.
      * @param[in] state The state returned from ebpf_lock_lock.
      */
     _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVEL) void ebpf_lock_unlock(
@@ -417,7 +417,7 @@ extern "C"
      *  the non-preemptible work item on success.
      * @param[in] cpu_id Associate the work item with this CPU.
      * @param[in] work_item_routine Routine to execute as a work item.
-     * @param[in,out] work_item_context Context to pass to the routine.
+     * @param[in, out] work_item_context Context to pass to the routine.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  work item.
@@ -440,8 +440,8 @@ extern "C"
     /**
      * @brief Schedule a non-preemptible work item to run.
      *
-     * @param[in,out] work_item Work item to schedule.
-     * @param[in,out] parameter_1 Parameter to pass to work item.
+     * @param[in, out] work_item Work item to schedule.
+     * @param[in, out] parameter_1 Parameter to pass to work item.
      * @retval true Work item was queued.
      * @retval false Work item is already queued.
      */
@@ -455,7 +455,7 @@ extern "C"
      * @param[out] work_item Pointer to memory that will contain the pointer to
      *  the preemptible work item on success.
      * @param[in] work_item_routine Routine to execute as a work item.
-     * @param[in,out] work_item_context Context to pass to the routine.
+     * @param[in, out] work_item_context Context to pass to the routine.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  work item.
@@ -477,7 +477,7 @@ extern "C"
     /**
      * @brief Schedule a preemptible work item to run.
      *
-     * @param[in,out] work_item Work item to schedule.
+     * @param[in, out] work_item Work item to schedule.
      */
     void
     ebpf_queue_preemptible_work_item(_Inout_ ebpf_preemptible_work_item_t* work_item);
@@ -487,7 +487,7 @@ extern "C"
      *
      * @param[out] timer Pointer to memory that will contain timer on success.
      * @param[in] work_item_routine Routine to execute when time expires.
-     * @param[in,out] work_item_context Context to pass to routine.
+     * @param[in, out] work_item_context Context to pass to routine.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  timer.
@@ -501,7 +501,7 @@ extern "C"
     /**
      * @brief Schedule a work item to be executed after elapsed_microseconds.
      *
-     * @param[in,out] timer Pointer to timer to schedule.
+     * @param[in, out] timer Pointer to timer to schedule.
      * @param[in] elapsed_microseconds Microseconds to delay before executing
      *   work item.
      */
@@ -578,7 +578,7 @@ extern "C"
     /**
      * @brief Insert or update an entry in the hash table.
      *
-     * @param[in,out] hash_table Hash-table to update.
+     * @param[in, out] hash_table Hash-table to update.
      * @param[in] key Key to find and insert or update.
      * @param[in] value Value to insert into hash table or NULL to insert zero entry.
      * @param[in] operation One of ebpf_hash_table_operations_t operations.
@@ -597,7 +597,7 @@ extern "C"
     /**
      * @brief Remove an entry from the hash table.
      *
-     * @param[in,out] hash_table Hash-table to update.
+     * @param[in, out] hash_table Hash-table to update.
      * @param[in] key Key to find and remove.
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NOT_FOUND Key not found in hash table.
@@ -668,7 +668,7 @@ extern "C"
      * @brief Atomically increase the value of addend by 1 and return the new
      *  value.
      *
-     * @param[in,out] addend Value to increase by 1.
+     * @param[in, out] addend Value to increase by 1.
      * @return The new value.
      */
     int32_t
@@ -678,7 +678,7 @@ extern "C"
      * @brief Atomically decrease the value of addend by 1 and return the new
      *  value.
      *
-     * @param[in,out] addend Value to decrease by 1.
+     * @param[in, out] addend Value to decrease by 1.
      * @return The new value.
      */
     int32_t
@@ -688,7 +688,7 @@ extern "C"
      * @brief Atomically increase the value of addend by 1 and return the new
      *  value.
      *
-     * @param[in,out] addend Value to increase by 1.
+     * @param[in, out] addend Value to increase by 1.
      * @return The new value.
      */
     int64_t
@@ -698,7 +698,7 @@ extern "C"
      * @brief Atomically decrease the value of addend by 1 and return the new
      *  value.
      *
-     * @param[in,out] addend Value to increase by 1.
+     * @param[in, out] addend Value to increase by 1.
      * @return The new value.
      */
     int64_t
@@ -709,7 +709,7 @@ extern "C"
      *  to by destination with the value of comparand and replaces it with
      *  exchange.
      *
-     * @param[in,out] destination A pointer to the input value that is compared
+     * @param[in, out] destination A pointer to the input value that is compared
      *  with the value of comparand.
      * @param[in] exchange Specifies the output value pointed to by destination
      *  if the input value pointed to by destination equals the value of
@@ -727,7 +727,7 @@ extern "C"
      *  to by destination with the value of comparand and replaces it with
      *  exchange.
      *
-     * @param[in,out] destination A pointer to the input value that is compared
+     * @param[in, out] destination A pointer to the input value that is compared
      *  with the value of comparand.
      * @param[in] exchange Specifies the output value pointed to by destination
      *  if the input value pointed to by destination equals the value of
@@ -744,7 +744,7 @@ extern "C"
     /**
      * @brief Performs an atomic OR of the value stored at destination with mask and stores the result in destination.
      *
-     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in, out] destination A pointer to the memory for this operation to be applied to.
      * @param[in] mask Value to be applied to the value stored at the destination.
      * @return The original value stored at destination.
      */
@@ -754,7 +754,7 @@ extern "C"
     /**
      * @brief Performs an atomic AND of the value stored at destination with mask and stores the result in destination.
      *
-     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in, out] destination A pointer to the memory for this operation to be applied to.
      * @param[in] mask Value to be applied to the value stored at the destination.
      * @return The original value stored at destination.
      */
@@ -764,7 +764,7 @@ extern "C"
     /**
      * @brief Performs an atomic XOR of the value stored at destination with mask and stores the result in destination.
      *
-     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in, out] destination A pointer to the memory for this operation to be applied to.
      * @param[in] mask Value to be applied to the value stored at the destination.
      * @return The original value stored at destination.
      */
@@ -774,7 +774,7 @@ extern "C"
     /**
      * @brief Performs an atomic OR of the value stored at destination with mask and stores the result in destination.
      *
-     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in, out] destination A pointer to the memory for this operation to be applied to.
      * @param[in] mask Value to be applied to the value stored at the destination.
      * @return The original value stored at destination.
      */
@@ -784,7 +784,7 @@ extern "C"
     /**
      * @brief Performs an atomic AND of the value stored at destination with mask and stores the result in destination.
      *
-     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in, out] destination A pointer to the memory for this operation to be applied to.
      * @param[in] mask Value to be applied to the value stored at the destination.
      * @return The original value stored at destination.
      */
@@ -794,7 +794,7 @@ extern "C"
     /**
      * @brief Performs an atomic XOR of the value stored at destination with mask and stores the result in destination.
      *
-     * @param[in,out] destination A pointer to the memory for this operation to be applied to.
+     * @param[in, out] destination A pointer to the memory for this operation to be applied to.
      * @param[in] mask Value to be applied to the value stored at the destination.
      * @return The original value stored at destination.
      */
@@ -874,11 +874,11 @@ extern "C"
      * @param[out] provider_context Context used to unload the provider.
      * @param[in] interface_id GUID representing the identity of the interface.
      * @param[in] provider_module_id GUID representing the identity of the provider.
-     * @param[in,out] provider_binding_context Provider binding context.
+     * @param[in, out] provider_binding_context Provider binding context.
      * @param[in] provider_data Opaque provider data.
      * @param[in] provider_dispatch_table Table of function pointers the
      *  provider exposes.
-     * @param[in,out] callback_context Opaque per-instance pointer passed to the callback functions.
+     * @param[in, out] callback_context Opaque per-instance pointer passed to the callback functions.
      * @param[in] attach_client_callback Function invoked when a client attaches.
      * @param[in] detach_client_callback Function invoked when a client detaches.
      * @param[in] provider_cleanup_binding_context_callback Function invoked when a binding context can be cleaned up.
@@ -939,7 +939,7 @@ extern "C"
     /**
      * @brief Populate the function pointers in a trampoline table.
      *
-     * @param[in,out] trampoline_table Trampoline table to populate.
+     * @param[in, out] trampoline_table Trampoline table to populate.
      * @param[in] helper_function_count Count of helper functions.
      * @param[in] helper_function_ids Array of helper function IDs.
      * @param[in] dispatch_table Dispatch table to populate from.

--- a/libs/platform/ebpf_ring_buffer.c
+++ b/libs/platform/ebpf_ring_buffer.c
@@ -257,8 +257,7 @@ ebpf_ring_buffer_discard(_Frees_ptr_opt_ uint8_t* data)
 }
 
 const ebpf_ring_buffer_record_t*
-ebpf_ring_buffer_next_record(
-    _In_ const uint8_t* buffer, _In_ size_t buffer_length, _In_ size_t consumer, _In_ size_t producer)
+ebpf_ring_buffer_next_record(_In_ const uint8_t* buffer, size_t buffer_length, size_t consumer, size_t producer)
 {
     if (producer == consumer) {
         return NULL;

--- a/libs/platform/ebpf_ring_buffer.h
+++ b/libs/platform/ebpf_ring_buffer.h
@@ -45,7 +45,7 @@ extern "C"
     /**
      * @brief Write out a variable sized record to the ring buffer.
      *
-     * @param[in,out] ring_buffer Ring buffer to write to.
+     * @param[in, out] ring_buffer Ring buffer to write to.
      * @param[in] data Data to copy into record.
      * @param[in] length Length of data to copy.
      * @retval EPBF_SUCCESS Successfully wrote record ring buffer.
@@ -68,7 +68,7 @@ extern "C"
     /**
      * @brief Mark one or more records in the ring buffer as returned to the ring.
      *
-     * @param[in,out] ring_buffer Ring buffer to update.
+     * @param[in, out] ring_buffer Ring buffer to update.
      * @param[in] length Length of bytes to return to the ring buffer.
      * @retval EPBF_SUCCESS Successfully returned records to the ring buffer.
      * @retval EBPF_INVALID_ARGUMENT Unable to return records to the ring buffer.
@@ -91,7 +91,7 @@ extern "C"
      * @brief Reserve a buffer in the ring buffer. Buffer is valid until either ebpf_ring_buffer_submit,
      * ebpf_ring_buffer_discard, or the end of the current epoch.
      *
-     * @param[in,out] ring_buffer Ring buffer to update.
+     * @param[in, out] ring_buffer Ring buffer to update.
      * @param[out] data Pointer to start of reserved buffer on success.
      * @param[in] length Length of buffer to reserve.
      * @retval EPBF_SUCCESS Successfully reserved space in the ring buffer.

--- a/libs/platform/ebpf_ring_buffer.h
+++ b/libs/platform/ebpf_ring_buffer.h
@@ -132,8 +132,7 @@ extern "C"
      * @return Pointer to the next record or NULL if no more records.
      */
     const ebpf_ring_buffer_record_t*
-    ebpf_ring_buffer_next_record(
-        _In_ const uint8_t* buffer, _In_ size_t buffer_length, _In_ size_t consumer, _In_ size_t producer);
+    ebpf_ring_buffer_next_record(_In_ const uint8_t* buffer, size_t buffer_length, size_t consumer, size_t producer);
 
 #ifdef __cplusplus
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -489,7 +489,7 @@ typedef struct _ebpf_preemptible_work_item
 } ebpf_preemptible_work_item_t;
 
 void
-_ebpf_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ const PVOID context)
+_ebpf_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ const void* context)
 {
     UNREFERENCED_PARAMETER(device_object);
     if (context == NULL) {

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -63,8 +63,8 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
     return p;
 }
 
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
-    _Post_writable_byte_size_(new_size) void* ebpf_reallocate(_In_ void* memory, size_t old_size, size_t new_size)
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_ _Post_writable_byte_size_(new_size) void* ebpf_reallocate(
+    _In_ _Post_invalid_ void* memory, size_t old_size, size_t new_size)
 {
     void* p = ebpf_allocate(new_size);
     if (p) {
@@ -282,13 +282,13 @@ ebpf_free_ring_buffer_memory(_Frees_ptr_opt_ ebpf_ring_descriptor_t* ring)
 }
 
 void*
-ebpf_ring_descriptor_get_base_address(_In_ ebpf_ring_descriptor_t* memory_descriptor)
+ebpf_ring_descriptor_get_base_address(_In_ const ebpf_ring_descriptor_t* memory_descriptor)
 {
     return memory_descriptor->base_address;
 }
 
 _Ret_maybenull_ void*
-ebpf_ring_map_readonly_user(_In_ ebpf_ring_descriptor_t* ring)
+ebpf_ring_map_readonly_user(_In_ const ebpf_ring_descriptor_t* ring)
 {
     __try {
         return MmMapLockedPagesSpecifyCache(
@@ -368,19 +368,19 @@ ebpf_lock_create(_Out_ ebpf_lock_t* lock)
 }
 
 void
-ebpf_lock_destroy(_In_ ebpf_lock_t* lock)
+ebpf_lock_destroy(_In_ _Post_invalid_ ebpf_lock_t* lock)
 {
     UNREFERENCED_PARAMETER(lock);
 }
 
 _Requires_lock_not_held_(*lock) _Acquires_lock_(*lock) _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_
-    _IRQL_raises_(DISPATCH_LEVEL) ebpf_lock_state_t ebpf_lock_lock(_In_ ebpf_lock_t* lock)
+    _IRQL_raises_(DISPATCH_LEVEL) ebpf_lock_state_t ebpf_lock_lock(_Inout_ ebpf_lock_t* lock)
 {
     return KeAcquireSpinLockRaiseToDpc(lock);
 }
 
 _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVEL) void ebpf_lock_unlock(
-    _In_ ebpf_lock_t* lock, _IRQL_restores_ ebpf_lock_state_t state)
+    _Inout_ ebpf_lock_t* lock, _IRQL_restores_ ebpf_lock_state_t state)
 {
     KeReleaseSpinLock(lock, state);
 }
@@ -433,7 +433,7 @@ ebpf_get_current_thread_id()
 typedef struct _ebpf_non_preemptible_work_item
 {
     KDPC deferred_procedure_call;
-    void (*work_item_routine)(void* work_item_context, void* parameter_1);
+    const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1);
 } ebpf_non_preemptible_work_item_t;
 
 static void
@@ -450,8 +450,8 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_allocate_non_preemptible_work_item(
     _Outptr_ ebpf_non_preemptible_work_item_t** work_item,
     uint32_t cpu_id,
-    _In_ void (*work_item_routine)(void* work_item_context, void* parameter_1),
-    _In_opt_ void* work_item_context)
+    _In_ const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1),
+    _Inout_opt_ void* work_item_context)
 {
     *work_item = ebpf_allocate(sizeof(ebpf_non_preemptible_work_item_t));
     if (*work_item == NULL) {
@@ -476,7 +476,7 @@ ebpf_free_non_preemptible_work_item(_Frees_ptr_opt_ ebpf_non_preemptible_work_it
 }
 
 bool
-ebpf_queue_non_preemptible_work_item(_In_ ebpf_non_preemptible_work_item_t* work_item, _In_opt_ void* parameter_1)
+ebpf_queue_non_preemptible_work_item(_Inout_ ebpf_non_preemptible_work_item_t* work_item, _Inout_opt_ void* parameter_1)
 {
     return KeInsertQueueDpc(&work_item->deferred_procedure_call, parameter_1, NULL);
 }
@@ -484,12 +484,12 @@ ebpf_queue_non_preemptible_work_item(_In_ ebpf_non_preemptible_work_item_t* work
 typedef struct _ebpf_preemptible_work_item
 {
     PIO_WORKITEM io_work_item;
-    void (*work_item_routine)(_In_opt_ void* work_item_context);
+    void (*work_item_routine)(_Inout_opt_ void* work_item_context);
     void* work_item_context;
 } ebpf_preemptible_work_item_t;
 
 void
-_ebpf_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ PVOID context)
+_ebpf_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ const PVOID context)
 {
     UNREFERENCED_PARAMETER(device_object);
     if (context == NULL) {
@@ -515,8 +515,8 @@ ebpf_free_preemptible_work_item(_Frees_ptr_opt_ ebpf_preemptible_work_item_t* wo
 _Must_inspect_result_ ebpf_result_t
 ebpf_allocate_preemptible_work_item(
     _Outptr_ ebpf_preemptible_work_item_t** work_item,
-    _In_ void (*work_item_routine)(_In_opt_ const void* work_item_context),
-    _In_opt_ void* work_item_context)
+    _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context),
+    _Inout_opt_ void* work_item_context)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     *work_item = ebpf_allocate(sizeof(ebpf_preemptible_work_item_t));
@@ -541,7 +541,7 @@ Done:
 }
 
 void
-ebpf_queue_preemptible_work_item(_In_ ebpf_preemptible_work_item_t* work_item)
+ebpf_queue_preemptible_work_item(_Inout_ ebpf_preemptible_work_item_t* work_item)
 {
     IoQueueWorkItem(work_item->io_work_item, _ebpf_preemptible_routine, DelayedWorkQueue, work_item);
 }
@@ -550,7 +550,7 @@ typedef struct _ebpf_timer_work_item
 {
     KDPC deferred_procedure_call;
     KTIMER timer;
-    void (*work_item_routine)(void* work_item_context);
+    void (*work_item_routine)(_Inout_opt_ void* work_item_context);
     void* work_item_context;
 } ebpf_timer_work_item_t;
 
@@ -567,8 +567,8 @@ _ebpf_timer_routine(
 _Must_inspect_result_ ebpf_result_t
 ebpf_allocate_timer_work_item(
     _Outptr_ ebpf_timer_work_item_t** timer_work_item,
-    _In_ void (*work_item_routine)(void* work_item_context),
-    _In_opt_ void* work_item_context)
+    _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context),
+    _Inout_opt_ void* work_item_context)
 {
     *timer_work_item = ebpf_allocate(sizeof(ebpf_timer_work_item_t));
     if (*timer_work_item == NULL)
@@ -587,7 +587,7 @@ ebpf_allocate_timer_work_item(
 #define MICROSECONDS_PER_MILLISECOND 1000
 
 void
-ebpf_schedule_timer_work_item(_In_ ebpf_timer_work_item_t* work_item, uint32_t elapsed_microseconds)
+ebpf_schedule_timer_work_item(_Inout_ ebpf_timer_work_item_t* work_item, uint32_t elapsed_microseconds)
 {
     LARGE_INTEGER due_time;
     due_time.QuadPart = -((int64_t)elapsed_microseconds * MICROSECONDS_PER_TICK);
@@ -628,9 +628,9 @@ ebpf_log_function(_In_ void* context, _In_z_ const char* format_string, ...)
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_access_check(
-    _In_ ebpf_security_descriptor_t* security_descriptor,
+    _In_ const ebpf_security_descriptor_t* security_descriptor,
     ebpf_security_access_mask_t request_access,
-    _In_ ebpf_security_generic_mapping_t* generic_mapping)
+    _In_ const ebpf_security_generic_mapping_t* generic_mapping)
 {
     ebpf_result_t result;
     NTSTATUS status;
@@ -640,13 +640,13 @@ ebpf_access_check(
     SeCaptureSubjectContext(&subject_context);
     SeLockSubjectContext(&subject_context);
     if (!SeAccessCheck(
-            security_descriptor,
+            (ebpf_security_descriptor_t*)security_descriptor,
             &subject_context,
             true,
             request_access,
             0,
             NULL,
-            generic_mapping,
+            (ebpf_security_generic_mapping_t*)generic_mapping,
             KernelMode,
             &granted_access,
             &status)) {
@@ -661,7 +661,7 @@ ebpf_access_check(
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_validate_security_descriptor(
-    _In_ ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length)
+    _In_ const ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length)
 {
     ebpf_result_t result;
     if ((security_descriptor->Control & SE_SELF_RELATIVE) == 0) {
@@ -670,7 +670,7 @@ ebpf_validate_security_descriptor(
     }
 
     if (!RtlValidRelativeSecurityDescriptor(
-            security_descriptor,
+            (ebpf_security_descriptor_t*)security_descriptor,
             (ULONG)security_descriptor_length,
             DACL_SECURITY_INFORMATION | OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION)) {
         result = EBPF_INVALID_ARGUMENT;

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -433,7 +433,7 @@ ebpf_get_current_thread_id()
 typedef struct _ebpf_non_preemptible_work_item
 {
     KDPC deferred_procedure_call;
-    const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1);
+    void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1);
 } ebpf_non_preemptible_work_item_t;
 
 static void
@@ -450,7 +450,7 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_allocate_non_preemptible_work_item(
     _Outptr_ ebpf_non_preemptible_work_item_t** work_item,
     uint32_t cpu_id,
-    _In_ const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1),
+    _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1),
     _Inout_opt_ void* work_item_context)
 {
     *work_item = ebpf_allocate(sizeof(ebpf_non_preemptible_work_item_t));

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -489,7 +489,7 @@ typedef struct _ebpf_preemptible_work_item
 } ebpf_preemptible_work_item_t;
 
 void
-_ebpf_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ const void* context)
+_ebpf_preemptible_routine(_In_ PDEVICE_OBJECT device_object, _In_opt_ void* context)
 {
     UNREFERENCED_PARAMETER(device_object);
     if (context == NULL) {

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -419,8 +419,8 @@ static NTSTATUS
 test_provider_attach_client(
     HANDLE nmr_binding_handle,
     _Inout_ void* provider_context,
-    _In_ PNPI_REGISTRATION_INSTANCE client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Out_ void** provider_binding_context,
     _Out_ const void** provider_dispatch)
@@ -437,7 +437,7 @@ test_provider_attach_client(
 };
 
 static NTSTATUS
-test_provider_detach_client(_In_ void* provider_binding_context)
+test_provider_detach_client(_In_ const void* provider_binding_context)
 {
     UNREFERENCED_PARAMETER(provider_binding_context);
     return STATUS_SUCCESS;
@@ -477,8 +477,8 @@ TEST_CASE("extension_test", "[platform]")
             &provider_data,
             &test_provider_dispatch_table,
             &callback_context,
-            test_provider_attach_client,
-            test_provider_detach_client,
+            (NPI_PROVIDER_ATTACH_CLIENT_FN*)test_provider_attach_client,
+            (NPI_PROVIDER_DETACH_CLIENT_FN*)test_provider_detach_client,
             nullptr) == EBPF_SUCCESS);
 
     REQUIRE(

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -419,7 +419,7 @@ static NTSTATUS
 test_provider_attach_client(
     HANDLE nmr_binding_handle,
     _Inout_ void* provider_context,
-    _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+    _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Out_ void** provider_binding_context,

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -773,7 +773,7 @@ typedef struct _ebpf_preemptible_work_item
 } ebpf_preemptible_work_item_t;
 
 static void
-_ebpf_preemptible_routine(_Inout_ PTP_CALLBACK_INSTANCE instance, _In_opt_ const PVOID parameter, _Inout_ PTP_WORK work)
+_ebpf_preemptible_routine(_Inout_ PTP_CALLBACK_INSTANCE instance, _Inout_opt_ void* parameter, _Inout_ PTP_WORK work)
 {
     UNREFERENCED_PARAMETER(instance);
     UNREFERENCED_PARAMETER(work);

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -196,7 +196,7 @@ class _ebpf_emulated_dpc
     /**
      * @brief Insert a work item into its associated queue.
      *
-     * @param[in,out] work_item Work item to be enqueued.
+     * @param[in, out] work_item Work item to be enqueued.
      * @param[in] parameter_1 Parameter to pass to worker function.
      * @retval true Work item wasn't already queued.
      * @retval false Work item is already queued.

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -114,7 +114,7 @@ typedef struct _ebpf_non_preemptible_work_item
     void* context;
     _ebpf_emulated_dpc* queue;
     void* parameter_1;
-    const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1);
+    void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1);
 } ebpf_non_preemptible_work_item_t;
 
 class _ebpf_emulated_dpc;
@@ -736,7 +736,7 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_allocate_non_preemptible_work_item(
     _Outptr_ ebpf_non_preemptible_work_item_t** work_item,
     uint32_t cpu_id,
-    _In_ const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1),
+    _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1),
     _Inout_opt_ void* work_item_context)
 {
     auto local_work_item =

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -114,7 +114,7 @@ typedef struct _ebpf_non_preemptible_work_item
     void* context;
     _ebpf_emulated_dpc* queue;
     void* parameter_1;
-    void (*work_item_routine)(_In_ void* work_item_context, _In_opt_ void* parameter_1);
+    const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1);
 } ebpf_non_preemptible_work_item_t;
 
 class _ebpf_emulated_dpc;
@@ -196,13 +196,13 @@ class _ebpf_emulated_dpc
     /**
      * @brief Insert a work item into its associated queue.
      *
-     * @param[in] work_item Work item to be enqueued.
+     * @param[in,out] work_item Work item to be enqueued.
      * @param[in] parameter_1 Parameter to pass to worker function.
      * @retval true Work item wasn't already queued.
      * @retval false Work item is already queued.
      */
     static bool
-    insert(_In_ ebpf_non_preemptible_work_item_t* work_item, _In_opt_ void* parameter_1)
+    insert(_Inout_ ebpf_non_preemptible_work_item_t* work_item, _Inout_opt_ void* parameter_1)
     {
         auto& dpc_queue = *(work_item->queue);
         std::unique_lock<std::mutex> l(dpc_queue.mutex);
@@ -318,8 +318,8 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
     return memory;
 }
 
-__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
-    _Post_writable_byte_size_(new_size) void* ebpf_reallocate(_In_ void* memory, size_t old_size, size_t new_size)
+__drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_ _Post_writable_byte_size_(new_size) void* ebpf_reallocate(
+    _In_ _Post_invalid_ void* memory, size_t old_size, size_t new_size)
 {
     UNREFERENCED_PARAMETER(old_size);
     if (new_size > ebpf_fuzzing_memory_limit) {
@@ -563,13 +563,13 @@ ebpf_free_ring_buffer_memory(_Frees_ptr_opt_ ebpf_ring_descriptor_t* ring)
 }
 
 void*
-ebpf_ring_descriptor_get_base_address(_In_ ebpf_ring_descriptor_t* ring_descriptor)
+ebpf_ring_descriptor_get_base_address(_In_ const ebpf_ring_descriptor_t* ring_descriptor)
 {
     return ring_descriptor->primary_view;
 }
 
 _Ret_maybenull_ void*
-ebpf_ring_map_readonly_user(_In_ ebpf_ring_descriptor_t* ring)
+ebpf_ring_map_readonly_user(_In_ const ebpf_ring_descriptor_t* ring)
 {
     EBPF_LOG_ENTRY();
     EBPF_RETURN_POINTER(void*, ebpf_ring_descriptor_get_base_address(ring));
@@ -637,20 +637,20 @@ ebpf_lock_create(_Out_ ebpf_lock_t* lock)
 }
 
 void
-ebpf_lock_destroy(_In_ ebpf_lock_t* lock)
+ebpf_lock_destroy(_In_ _Post_invalid_ ebpf_lock_t* lock)
 {
     UNREFERENCED_PARAMETER(lock);
 }
 
 _Requires_lock_not_held_(*lock) _Acquires_lock_(*lock) _IRQL_requires_max_(DISPATCH_LEVEL) _IRQL_saves_
-    _IRQL_raises_(DISPATCH_LEVEL) ebpf_lock_state_t ebpf_lock_lock(_In_ ebpf_lock_t* lock)
+    _IRQL_raises_(DISPATCH_LEVEL) ebpf_lock_state_t ebpf_lock_lock(_Inout_ ebpf_lock_t* lock)
 {
     AcquireSRWLockExclusive(reinterpret_cast<PSRWLOCK>(lock));
     return 0;
 }
 
 _Requires_lock_held_(*lock) _Releases_lock_(*lock) _IRQL_requires_(DISPATCH_LEVEL) void ebpf_lock_unlock(
-    _In_ ebpf_lock_t* lock, _IRQL_restores_ ebpf_lock_state_t state)
+    _Inout_ ebpf_lock_t* lock, _IRQL_restores_ ebpf_lock_state_t state)
 {
     UNREFERENCED_PARAMETER(state);
     ReleaseSRWLockExclusive(reinterpret_cast<PSRWLOCK>(lock));
@@ -736,8 +736,8 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_allocate_non_preemptible_work_item(
     _Outptr_ ebpf_non_preemptible_work_item_t** work_item,
     uint32_t cpu_id,
-    _In_ void (*work_item_routine)(void* work_item_context, void* parameter_1),
-    _In_opt_ void* work_item_context)
+    _In_ const void (*work_item_routine)(_Inout_opt_ void* work_item_context, _Inout_opt_ void* parameter_1),
+    _Inout_opt_ void* work_item_context)
 {
     auto local_work_item =
         reinterpret_cast<ebpf_non_preemptible_work_item_t*>(ebpf_allocate(sizeof(ebpf_non_preemptible_work_item_t)));
@@ -760,7 +760,7 @@ ebpf_free_non_preemptible_work_item(_Frees_ptr_opt_ ebpf_non_preemptible_work_it
 }
 
 bool
-ebpf_queue_non_preemptible_work_item(_In_ ebpf_non_preemptible_work_item_t* work_item, _In_opt_ void* parameter_1)
+ebpf_queue_non_preemptible_work_item(_Inout_ ebpf_non_preemptible_work_item_t* work_item, _Inout_opt_ void* parameter_1)
 {
     return _ebpf_emulated_dpc::insert(work_item, parameter_1);
 }
@@ -768,12 +768,12 @@ ebpf_queue_non_preemptible_work_item(_In_ ebpf_non_preemptible_work_item_t* work
 typedef struct _ebpf_preemptible_work_item
 {
     PTP_WORK work;
-    void (*work_item_routine)(_In_opt_ const void* work_item_context);
+    void (*work_item_routine)(_Inout_opt_ void* work_item_context);
     void* work_item_context;
 } ebpf_preemptible_work_item_t;
 
 static void
-_ebpf_preemptible_routine(_Inout_ PTP_CALLBACK_INSTANCE instance, _In_opt_ PVOID parameter, _Inout_ PTP_WORK work)
+_ebpf_preemptible_routine(_Inout_ PTP_CALLBACK_INSTANCE instance, _In_opt_ const PVOID parameter, _Inout_ PTP_WORK work)
 {
     UNREFERENCED_PARAMETER(instance);
     UNREFERENCED_PARAMETER(work);
@@ -801,7 +801,7 @@ ebpf_free_preemptible_work_item(_Frees_ptr_opt_ ebpf_preemptible_work_item_t* wo
 }
 
 void
-ebpf_queue_preemptible_work_item(_In_ ebpf_preemptible_work_item_t* work_item)
+ebpf_queue_preemptible_work_item(_Inout_ ebpf_preemptible_work_item_t* work_item)
 {
     SubmitThreadpoolWork(work_item->work);
 }
@@ -809,8 +809,8 @@ ebpf_queue_preemptible_work_item(_In_ ebpf_preemptible_work_item_t* work_item)
 _Must_inspect_result_ ebpf_result_t
 ebpf_allocate_preemptible_work_item(
     _Outptr_ ebpf_preemptible_work_item_t** work_item,
-    _In_ void (*work_item_routine)(_In_opt_ const void* work_item_context),
-    _In_opt_ void* work_item_context)
+    _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context),
+    _Inout_opt_ void* work_item_context)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     *work_item = (ebpf_preemptible_work_item_t*)ebpf_allocate(sizeof(ebpf_preemptible_work_item_t));
@@ -837,7 +837,7 @@ Done:
 typedef struct _ebpf_timer_work_item
 {
     TP_TIMER* threadpool_timer;
-    void (*work_item_routine)(void* work_item_context);
+    void (*work_item_routine)(_Inout_opt_ void* work_item_context);
     void* work_item_context;
 } ebpf_timer_work_item_t;
 
@@ -854,8 +854,8 @@ _ebpf_timer_callback(_Inout_ TP_CALLBACK_INSTANCE* instance, _Inout_opt_ void* c
 _Must_inspect_result_ ebpf_result_t
 ebpf_allocate_timer_work_item(
     _Outptr_ ebpf_timer_work_item_t** work_item,
-    _In_ void (*work_item_routine)(void* work_item_context),
-    _In_opt_ void* work_item_context)
+    _In_ void (*work_item_routine)(_Inout_opt_ void* work_item_context),
+    _Inout_opt_ void* work_item_context)
 {
     *work_item = (ebpf_timer_work_item_t*)ebpf_allocate(sizeof(ebpf_timer_work_item_t));
 
@@ -885,7 +885,7 @@ Error:
 #define MICROSECONDS_PER_MILLISECOND 1000
 
 void
-ebpf_schedule_timer_work_item(_In_ ebpf_timer_work_item_t* timer, uint32_t elapsed_microseconds)
+ebpf_schedule_timer_work_item(_Inout_ ebpf_timer_work_item_t* timer, uint32_t elapsed_microseconds)
 {
     int64_t due_time;
     due_time = -static_cast<int64_t>(elapsed_microseconds) * MICROSECONDS_PER_TICK;
@@ -936,9 +936,9 @@ ebpf_log_function(_In_ void* context, _In_z_ const char* format_string, ...)
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_access_check(
-    _In_ ebpf_security_descriptor_t* security_descriptor,
+    _In_ const ebpf_security_descriptor_t* security_descriptor,
     ebpf_security_access_mask_t request_access,
-    _In_ ebpf_security_generic_mapping_t* generic_mapping)
+    _In_ const ebpf_security_generic_mapping_t* generic_mapping)
 {
     ebpf_result_t result;
     HANDLE token = INVALID_HANDLE_VALUE;
@@ -959,10 +959,10 @@ ebpf_access_check(
     }
 
     if (!AccessCheck(
-            security_descriptor,
+            const_cast<_SECURITY_DESCRIPTOR*>(security_descriptor),
             token,
             request_access,
-            generic_mapping,
+            const_cast<GENERIC_MAPPING*>(generic_mapping),
             &privilege_set,
             &privilege_set_size,
             &granted_access,
@@ -985,18 +985,19 @@ Done:
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_validate_security_descriptor(
-    _In_ ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length)
+    _In_ const ebpf_security_descriptor_t* security_descriptor, size_t security_descriptor_length)
 {
     ebpf_result_t result;
     SECURITY_DESCRIPTOR_CONTROL security_descriptor_control;
     DWORD version;
     DWORD length;
-    if (!IsValidSecurityDescriptor(security_descriptor)) {
+    if (!IsValidSecurityDescriptor(const_cast<_SECURITY_DESCRIPTOR*>(security_descriptor))) {
         result = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
 
-    if (!GetSecurityDescriptorControl(security_descriptor, &security_descriptor_control, &version)) {
+    if (!GetSecurityDescriptorControl(
+            const_cast<_SECURITY_DESCRIPTOR*>(security_descriptor), &security_descriptor_control, &version)) {
         result = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
@@ -1006,7 +1007,7 @@ ebpf_validate_security_descriptor(
         goto Done;
     }
 
-    length = GetSecurityDescriptorLength(security_descriptor);
+    length = GetSecurityDescriptorLength(const_cast<_SECURITY_DESCRIPTOR*>(security_descriptor));
     if (length != security_descriptor_length) {
         result = EBPF_INVALID_ARGUMENT;
         goto Done;

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -773,7 +773,7 @@ typedef struct _ebpf_preemptible_work_item
 } ebpf_preemptible_work_item_t;
 
 static void
-_ebpf_preemptible_routine(_Inout_ PTP_CALLBACK_INSTANCE instance, _Inout_opt_ void* parameter, _Inout_ PTP_WORK work)
+_ebpf_preemptible_routine(_Inout_ PTP_CALLBACK_INSTANCE instance, _In_opt_ void* parameter, _Inout_ PTP_WORK work)
 {
     UNREFERENCED_PARAMETER(instance);
     UNREFERENCED_PARAMETER(work);

--- a/libs/platform/user/framework.h
+++ b/libs/platform/user/framework.h
@@ -70,7 +70,7 @@ extern "C"
     }
 
     inline bool
-    ebpf_list_remove_entry(_In_ ebpf_list_entry_t* entry)
+    ebpf_list_remove_entry(_Inout_ ebpf_list_entry_t* entry)
     {
         ebpf_list_entry_t* previous_entry;
         ebpf_list_entry_t* next_entry;

--- a/libs/platform/user/nmr_impl.h
+++ b/libs/platform/user/nmr_impl.h
@@ -161,7 +161,7 @@ typedef class _nmr
     /**
      * @brief Add a provider or client to the correct collection.
      *
-     * @param[in,out] collection Collection to add to.
+     * @param[in, out] collection Collection to add to.
      * @param[in] characteristics Characteristics of the provider or client.
      * @param[in] context Context handle to return to the caller.
      * @return Handle to the provider or client.
@@ -173,7 +173,7 @@ typedef class _nmr
     /**
      * @brief Begin the process of deregistering a provider or client.
      *
-     * @param[in,out] collection Collection to deregister from.
+     * @param[in, out] collection Collection to deregister from.
      * @param[in] handle Handle to the provider or client.
      */
     template <typename collection_t>
@@ -183,7 +183,7 @@ typedef class _nmr
     /**
      * @brief Finish removing a provider or client from the correct collection.
      *
-     * @param[in,out] collection Collection to remove from.
+     * @param[in, out] collection Collection to remove from.
      * @param[in] handle Handle to the provider or client.
      */
     template <typename collection_t>
@@ -194,9 +194,9 @@ typedef class _nmr
      * @brief Perform a bind using an entry from the initiator_collection
      * and all entries from the target_collection.
      *
-     * @param[in,out] initiator_collection Collection containing the initiator (can be either provider or client).
+     * @param[in, out] initiator_collection Collection containing the initiator (can be either provider or client).
      * @param[in] handle Handle to the initiator.
-     * @param[in,out] target_collection Collection containing all the targets (can be either provider or client).
+     * @param[in, out] target_collection Collection containing all the targets (can be either provider or client).
      */
     template <typename initiator_collection_t, typename target_collection_t>
     void
@@ -208,7 +208,7 @@ typedef class _nmr
     /**
      * @brief Unbind a provider or client from all other providers or clients.
      *
-     * @param[in,out] initiator_collection Collection containing the initiator (can be either provider or client).
+     * @param[in, out] initiator_collection Collection containing the initiator (can be either provider or client).
      * @param[in] handle Handle to the initiator (can be either provider or client).
      * @retval true One or more bindings returned pending.
      * @retval false All bindings where successfully removed.
@@ -222,8 +222,8 @@ typedef class _nmr
     /**
      * @brief Attempt to bind a client to a provider.
      *
-     * @param[in,out] client Client to attempt to bind.
-     * @param[in,out] provider Provider to attempt to bind to.
+     * @param[in, out] client Client to attempt to bind.
+     * @param[in, out] provider Provider to attempt to bind to.
      * @return Contains a function to perform the bind if successful.
      */
     std::optional<pending_action_t>

--- a/libs/thunk/mock/mock.cpp
+++ b/libs/thunk/mock/mock.cpp
@@ -191,7 +191,8 @@ RPC_STATUS
 clean_up_rpc_binding() { return RPC_S_OK; }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_rpc_load_program(ebpf_program_load_info* info, const char** logs, uint32_t* logs_size)
+ebpf_rpc_load_program(
+    _In_ const ebpf_program_load_info* info, _Outptr_result_maybenull_z_ const char** logs, _Inout_ uint32_t* logs_size)
 {
     // Set the handle of program being verified in thread-local storage.
     set_program_under_verification(reinterpret_cast<ebpf_handle_t>(info->program_handle));

--- a/libs/ubpf/kernel/ubpf_kernel.c
+++ b/libs/ubpf/kernel/ubpf_kernel.c
@@ -39,7 +39,7 @@ fprintf(void* stream, const char* format, ...)
     return -1;
 }
 
-inline char* __cdecl place_holder_strerror(_In_ int error) { return NULL; }
+inline char* __cdecl place_holder_strerror(int error) { return NULL; }
 
 inline int
 place_holder_errno()

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -361,7 +361,7 @@ net_ebpf_extension_add_wfp_filters(
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,
     uint32_t condition_count,
     _In_opt_count_(condition_count) const FWPM_FILTER_CONDITION* conditions,
-    _In_ net_ebpf_extension_wfp_filter_context_t* filter_context,
+    _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context,
     _Outptr_result_buffer_maybenull_(filter_count) uint64_t** filter_ids)
 {
     NTSTATUS status = STATUS_SUCCESS;

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -183,7 +183,7 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
  * @param[in]  parameters Filter parameters.
  * @param[in]  condition_count Count of filter conditions.
  * @param[in]  conditions Common filter conditions to be applied to each filter.
- * @param[in]  filter_context Caller supplied context to be associated with the WFP filter.
+ * @param[in,out]  filter_context Caller supplied context to be associated with the WFP filter.
  * @param[out] filter_ids Output buffer where the added filter IDs are stored.
  *
  * @retval EBPF_SUCCESS The operation completed successfully.
@@ -195,7 +195,7 @@ net_ebpf_extension_add_wfp_filters(
     _In_count_(filter_count) const net_ebpf_extension_wfp_filter_parameters_t* parameters,
     uint32_t condition_count,
     _In_opt_count_(condition_count) const FWPM_FILTER_CONDITION* conditions,
-    _In_ net_ebpf_extension_wfp_filter_context_t* filter_context,
+    _Inout_ net_ebpf_extension_wfp_filter_context_t* filter_context,
     _Outptr_result_buffer_maybenull_(filter_count) uint64_t** filter_ids);
 
 /**

--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -183,7 +183,7 @@ net_ebpf_extension_get_callout_id_for_hook(net_ebpf_extension_hook_id_t hook_id)
  * @param[in]  parameters Filter parameters.
  * @param[in]  condition_count Count of filter conditions.
  * @param[in]  conditions Common filter conditions to be applied to each filter.
- * @param[in,out]  filter_context Caller supplied context to be associated with the WFP filter.
+ * @param[in, out]  filter_context Caller supplied context to be associated with the WFP filter.
  * @param[out] filter_ids Output buffer where the added filter IDs are stored.
  *
  * @retval EBPF_SUCCESS The operation completed successfully.

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -282,7 +282,7 @@ Exit:
  */
 static NTSTATUS
 _net_ebpf_extension_hook_provider_attach_client(
-    _In_ const HANDLE nmr_binding_handle,
+    _In_ HANDLE nmr_binding_handle,
     _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,
@@ -417,8 +417,8 @@ net_ebpf_extension_hook_provider_unregister(_Frees_ptr_opt_ net_ebpf_extension_h
 NTSTATUS
 net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_parameters_t* parameters,
-    _In_ const net_ebpf_extension_hook_on_client_attach attach_callback,
-    _In_ const net_ebpf_extension_hook_on_client_detach detach_callback,
+    _In_ net_ebpf_extension_hook_on_client_attach attach_callback,
+    _In_ net_ebpf_extension_hook_on_client_detach detach_callback,
     _In_opt_ const void* custom_data,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context)
 {

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -80,7 +80,7 @@ typedef struct _net_ebpf_extension_hook_provider
 /**
  * @brief Initialize the hook client rundown state.
  *
- * @param[in, out] hook_client Pointer to the attached hook NPI client.
+ * @param[in,out] hook_client Pointer to the attached hook NPI client.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
  * @retval STATUS_INSUFFICIENT_RESOURCES IO work item could not be allocated.
@@ -110,7 +110,7 @@ Exit:
 /**
  * @brief Block execution of the thread until all invocations are completed.
  *
- * @param[in, out] rundown Rundown object to wait for.
+ * @param[in,out] rundown Rundown object to wait for.
  *
  */
 static void
@@ -200,7 +200,7 @@ net_ebpf_extension_hook_provider_get_custom_data(_In_ const net_ebpf_extension_h
 
 _Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_hook_invoke_program(
-    _In_ const net_ebpf_extension_hook_client_t* client, _In_ void* context, _Out_ uint32_t* result)
+    _In_ const net_ebpf_extension_hook_client_t* client, _In_ const void* context, _Out_ uint32_t* result)
 {
     ebpf_invoke_program_function_t invoke_program = client->invoke_program;
     const void* client_binding_context = client->client_binding_context;
@@ -216,7 +216,7 @@ net_ebpf_extension_hook_check_attach_parameter(
     size_t attach_parameter_size,
     _In_reads_(attach_parameter_size) const void* attach_parameter,
     _In_reads_(attach_parameter_size) const void* wild_card_attach_parameter,
-    _In_ net_ebpf_extension_hook_provider_t* provider_context)
+    _Inout_ net_ebpf_extension_hook_provider_t* provider_context)
 {
     ebpf_result_t result = EBPF_SUCCESS;
     bool using_wild_card_attach_parameter = FALSE;
@@ -282,10 +282,10 @@ Exit:
  */
 static NTSTATUS
 _net_ebpf_extension_hook_provider_attach_client(
-    _In_ HANDLE nmr_binding_handle,
-    _In_ void* provider_context,
+    _In_ const HANDLE nmr_binding_handle,
+    _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Outptr_ void** provider_binding_context,
     _Outptr_result_maybenull_ const void** provider_dispatch)
@@ -361,7 +361,7 @@ Exit:
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
 static NTSTATUS
-_net_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context)
+_net_ebpf_extension_hook_provider_detach_client(_In_ const void* provider_binding_context)
 {
     NTSTATUS status = STATUS_PENDING;
 
@@ -417,8 +417,8 @@ net_ebpf_extension_hook_provider_unregister(_Frees_ptr_opt_ net_ebpf_extension_h
 NTSTATUS
 net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_parameters_t* parameters,
-    _In_ net_ebpf_extension_hook_on_client_attach attach_callback,
-    _In_ net_ebpf_extension_hook_on_client_detach detach_callback,
+    _In_ const net_ebpf_extension_hook_on_client_attach attach_callback,
+    _In_ const net_ebpf_extension_hook_on_client_detach detach_callback,
     _In_opt_ const void* custom_data,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context)
 {
@@ -439,8 +439,10 @@ net_ebpf_extension_hook_provider_register(
 
     characteristics = &local_provider_context->characteristics;
     characteristics->Length = sizeof(NPI_PROVIDER_CHARACTERISTICS);
-    characteristics->ProviderAttachClient = _net_ebpf_extension_hook_provider_attach_client;
-    characteristics->ProviderDetachClient = _net_ebpf_extension_hook_provider_detach_client;
+    characteristics->ProviderAttachClient =
+        (PNPI_PROVIDER_ATTACH_CLIENT_FN)_net_ebpf_extension_hook_provider_attach_client;
+    characteristics->ProviderDetachClient =
+        (PNPI_PROVIDER_DETACH_CLIENT_FN)_net_ebpf_extension_hook_provider_detach_client;
     characteristics->ProviderCleanupBindingContext = _net_ebpf_extension_hook_provider_cleanup_binding_context;
     characteristics->ProviderRegistrationInstance.Size = sizeof(NPI_REGISTRATION_INSTANCE);
     characteristics->ProviderRegistrationInstance.NpiId = &EBPF_HOOK_EXTENSION_IID;
@@ -466,7 +468,7 @@ Exit:
 }
 
 net_ebpf_extension_hook_client_t*
-net_ebpf_extension_hook_get_attached_client(_In_ net_ebpf_extension_hook_provider_t* provider_context)
+net_ebpf_extension_hook_get_attached_client(_Inout_ net_ebpf_extension_hook_provider_t* provider_context)
 {
     net_ebpf_extension_hook_client_t* client_context = NULL;
     ACQUIRE_PUSH_LOCK_SHARED(&provider_context->lock);
@@ -479,7 +481,7 @@ net_ebpf_extension_hook_get_attached_client(_In_ net_ebpf_extension_hook_provide
 
 net_ebpf_extension_hook_client_t*
 net_ebpf_extension_hook_get_next_attached_client(
-    _In_ net_ebpf_extension_hook_provider_t* provider_context,
+    _Inout_ net_ebpf_extension_hook_provider_t* provider_context,
     _In_opt_ const net_ebpf_extension_hook_client_t* client_context)
 {
     net_ebpf_extension_hook_client_t* next_client = NULL;

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -80,7 +80,7 @@ typedef struct _net_ebpf_extension_hook_provider
 /**
  * @brief Initialize the hook client rundown state.
  *
- * @param[in,out] hook_client Pointer to the attached hook NPI client.
+ * @param[in, out] hook_client Pointer to the attached hook NPI client.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
  * @retval STATUS_INSUFFICIENT_RESOURCES IO work item could not be allocated.
@@ -110,7 +110,7 @@ Exit:
 /**
  * @brief Block execution of the thread until all invocations are completed.
  *
- * @param[in,out] rundown Rundown object to wait for.
+ * @param[in, out] rundown Rundown object to wait for.
  *
  */
 static void

--- a/netebpfext/net_ebpf_ext_hook_provider.h
+++ b/netebpfext/net_ebpf_ext_hook_provider.h
@@ -14,7 +14,7 @@ typedef struct _net_ebpf_extension_hook_client net_ebpf_extension_hook_client_t;
 /**
  * @brief Attempt to acquire rundown.
  *
- * @param[in,out] hook_client Pointer to attached hook NPI client.
+ * @param[in, out] hook_client Pointer to attached hook NPI client.
  *
  * @retval true The caller should proceed.
  * @retval false Rundown has occurred.
@@ -25,7 +25,7 @@ net_ebpf_extension_hook_client_enter_rundown(_Inout_ net_ebpf_extension_hook_cli
 /**
  * @brief Release rundown.
  *
- * @param[in,out] hook_client Pointer to attached hook NPI client.
+ * @param[in, out] hook_client Pointer to attached hook NPI client.
 
  */
 void
@@ -124,7 +124,7 @@ typedef struct _net_ebpf_extension_hook_provider_parameters
  * @param[in] attach_callback Pointer to callback function to be invoked when a client attaches.
  * @param[in] detach_callback Pointer to callback function to be invoked when a client detaches.
  * @param[in] custom_data (Optional) Opaque pointer to hook-specific custom data.
- * @param[in,out] provider_context Pointer to the provider context being registered.
+ * @param[in, out] provider_context Pointer to the provider context being registered.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
  * @retval STATUS_NO_MEMORY Not enough memory to allocate resources.
@@ -154,7 +154,7 @@ net_ebpf_extension_hook_invoke_program(
 
 /**
  * @brief Return client attached to the hook NPI provider.
- * @param[in,out] provider_context Provider module's context.
+ * @param[in, out] provider_context Provider module's context.
  * @returns Attached client.
  * (Note: this is a temporary helper routine that will be re-written when multiple attached clients are supported as fix
  * to #754)
@@ -164,7 +164,7 @@ net_ebpf_extension_hook_get_attached_client(_Inout_ net_ebpf_extension_hook_prov
 
 /**
  * @brief Return the next client attached to the hook NPI provider.
- * @param[in,out] provider_context Provider module's context.
+ * @param[in, out] provider_context Provider module's context.
  * @param[in] client_context Caller supplied pointer to client_context. May be NULL.
  * @returns The next client after the one passed in client_context parameter. If the input client context is NULL, then
  * the first attached client context (if any) is returned.
@@ -180,7 +180,7 @@ net_ebpf_extension_hook_get_next_attached_client(
  * @param[in] attach_parameter_size The expected length (in bytes) of attach parameter for this type of hook.
  * @param[in] attach_parameter The attach parameter supplied by the client requesting to be attached.
  * @param[in] wild_card_attach_parameter Pointer to wild card parameter for this type of hook.
- * @param[in,out] provider_context Provider module's context.
+ * @param[in, out] provider_context Provider module's context.
  * @retval EBPF_SUCCESS The operation succeeded.
  * @retval EBPF_ACCESS_DENIED Request to attach client is denied by the provider.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.

--- a/netebpfext/net_ebpf_ext_hook_provider.h
+++ b/netebpfext/net_ebpf_ext_hook_provider.h
@@ -14,7 +14,7 @@ typedef struct _net_ebpf_extension_hook_client net_ebpf_extension_hook_client_t;
 /**
  * @brief Attempt to acquire rundown.
  *
- * @param[in, out] hook_client Pointer to attached hook NPI client.
+ * @param[in,out] hook_client Pointer to attached hook NPI client.
  *
  * @retval true The caller should proceed.
  * @retval false Rundown has occurred.
@@ -25,7 +25,7 @@ net_ebpf_extension_hook_client_enter_rundown(_Inout_ net_ebpf_extension_hook_cli
 /**
  * @brief Release rundown.
  *
- * @param[in, out] hook_client Pointer to attached hook NPI client.
+ * @param[in,out] hook_client Pointer to attached hook NPI client.
 
  */
 void
@@ -132,8 +132,8 @@ typedef struct _net_ebpf_extension_hook_provider_parameters
 NTSTATUS
 net_ebpf_extension_hook_provider_register(
     _In_ const net_ebpf_extension_hook_provider_parameters_t* parameters,
-    _In_ net_ebpf_extension_hook_on_client_attach attach_callback,
-    _In_ net_ebpf_extension_hook_on_client_detach detach_callback,
+    _In_ const net_ebpf_extension_hook_on_client_attach attach_callback,
+    _In_ const net_ebpf_extension_hook_on_client_detach detach_callback,
     _In_opt_ const void* custom_data,
     _Outptr_ net_ebpf_extension_hook_provider_t** provider_context);
 
@@ -150,28 +150,28 @@ net_ebpf_extension_hook_provider_register(
  */
 _Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_hook_invoke_program(
-    _In_ const net_ebpf_extension_hook_client_t* client, _In_ void* context, _Out_ uint32_t* result);
+    _In_ const net_ebpf_extension_hook_client_t* client, _In_ const void* context, _Out_ uint32_t* result);
 
 /**
  * @brief Return client attached to the hook NPI provider.
- * @param[in] provider_context Provider module's context.
+ * @param[in,out] provider_context Provider module's context.
  * @returns Attached client.
  * (Note: this is a temporary helper routine that will be re-written when multiple attached clients are supported as fix
  * to #754)
  */
 net_ebpf_extension_hook_client_t*
-net_ebpf_extension_hook_get_attached_client(_In_ net_ebpf_extension_hook_provider_t* provider_context);
+net_ebpf_extension_hook_get_attached_client(_Inout_ net_ebpf_extension_hook_provider_t* provider_context);
 
 /**
  * @brief Return the next client attached to the hook NPI provider.
- * @param[in] provider_context Provider module's context.
+ * @param[in,out] provider_context Provider module's context.
  * @param[in] client_context Caller supplied pointer to client_context. May be NULL.
  * @returns The next client after the one passed in client_context parameter. If the input client context is NULL, then
  * the first attached client context (if any) is returned.
  */
 net_ebpf_extension_hook_client_t*
 net_ebpf_extension_hook_get_next_attached_client(
-    _In_ net_ebpf_extension_hook_provider_t* provider_context,
+    _Inout_ net_ebpf_extension_hook_provider_t* provider_context,
     _In_opt_ const net_ebpf_extension_hook_client_t* client_context);
 
 /**
@@ -180,7 +180,7 @@ net_ebpf_extension_hook_get_next_attached_client(
  * @param[in] attach_parameter_size The expected length (in bytes) of attach parameter for this type of hook.
  * @param[in] attach_parameter The attach parameter supplied by the client requesting to be attached.
  * @param[in] wild_card_attach_parameter Pointer to wild card parameter for this type of hook.
- * @param[in] provider_context Provider module's context.
+ * @param[in,out] provider_context Provider module's context.
  * @retval EBPF_SUCCESS The operation succeeded.
  * @retval EBPF_ACCESS_DENIED Request to attach client is denied by the provider.
  * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
@@ -190,4 +190,4 @@ net_ebpf_extension_hook_check_attach_parameter(
     size_t attach_parameter_size,
     _In_reads_(attach_parameter_size) const void* attach_parameter,
     _In_reads_(attach_parameter_size) const void* wild_card_attach_parameter,
-    _In_ net_ebpf_extension_hook_provider_t* provider_context);
+    _Inout_ net_ebpf_extension_hook_provider_t* provider_context);

--- a/netebpfext/net_ebpf_ext_prog_info_provider.c
+++ b/netebpfext/net_ebpf_ext_prog_info_provider.c
@@ -43,7 +43,7 @@ typedef struct _net_ebpf_extension_program_info_provider
  */
 static NTSTATUS
 _net_ebpf_extension_program_info_provider_attach_client(
-    _In_ const HANDLE nmr_binding_handle,
+    _In_ HANDLE nmr_binding_handle,
     _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,

--- a/netebpfext/net_ebpf_ext_prog_info_provider.c
+++ b/netebpfext/net_ebpf_ext_prog_info_provider.c
@@ -43,10 +43,10 @@ typedef struct _net_ebpf_extension_program_info_provider
  */
 static NTSTATUS
 _net_ebpf_extension_program_info_provider_attach_client(
-    _In_ HANDLE nmr_binding_handle,
-    _In_ void* provider_context,
+    _In_ const HANDLE nmr_binding_handle,
+    _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Outptr_ void** provider_binding_context,
     _Outptr_result_maybenull_ const void** provider_dispatch)
@@ -98,7 +98,7 @@ Exit:
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
 static NTSTATUS
-_net_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_binding_context)
+_net_ebpf_extension_program_info_provider_detach_client(_In_ const void* provider_binding_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
 
@@ -146,8 +146,10 @@ net_ebpf_extension_program_info_provider_register(
 
     characteristics = &local_provider_context->characteristics;
     characteristics->Length = sizeof(NPI_PROVIDER_CHARACTERISTICS);
-    characteristics->ProviderAttachClient = _net_ebpf_extension_program_info_provider_attach_client;
-    characteristics->ProviderDetachClient = _net_ebpf_extension_program_info_provider_detach_client;
+    characteristics->ProviderAttachClient =
+        (PNPI_PROVIDER_ATTACH_CLIENT_FN)_net_ebpf_extension_program_info_provider_attach_client;
+    characteristics->ProviderDetachClient =
+        (PNPI_PROVIDER_DETACH_CLIENT_FN)_net_ebpf_extension_program_info_provider_detach_client;
     characteristics->ProviderCleanupBindingContext = _net_ebpf_extension_program_info_provider_cleanup_binding_context;
     characteristics->ProviderRegistrationInstance.Size = sizeof(NPI_REGISTRATION_INSTANCE);
     characteristics->ProviderRegistrationInstance.NpiId = &EBPF_PROGRAM_INFO_EXTENSION_IID;

--- a/netebpfext/net_ebpf_ext_prog_info_provider.h
+++ b/netebpfext/net_ebpf_ext_prog_info_provider.h
@@ -20,7 +20,7 @@ typedef struct _net_ebpf_extension_program_info_provider_parameters
  * @brief Register the program information NPI provider.
  *
  * @param[in] provider_characteristics Pointer to the NPI provider characteristics struct.
- * @param[in,out] provider_context Pointer to the provider context being registered.
+ * @param[in, out] provider_context Pointer to the provider context being registered.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
  * @retval STATUS_NO_MEMORY Not enough memory to allocate resources.

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -538,7 +538,7 @@ _net_ebpf_ext_purge_lru_contexts(bool delete_all)
 }
 
 static void
-_net_ebpf_ext_insert_connection_context_to_list(_In_ net_ebpf_extension_connection_context_t* connection_context)
+_net_ebpf_ext_insert_connection_context_to_list(_Inout_ net_ebpf_extension_connection_context_t* connection_context)
 {
     KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock);
 

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -447,7 +447,7 @@ Exit:
 //
 
 static void
-_net_ebpf_ext_l2_receive_inject_complete(_In_ void* context, _Inout_ NET_BUFFER_LIST* nbl, BOOLEAN dispatch_level)
+_net_ebpf_ext_l2_receive_inject_complete(_In_ const void* context, _Inout_ NET_BUFFER_LIST* nbl, BOOLEAN dispatch_level)
 {
     UNREFERENCED_PARAMETER(context);
     UNREFERENCED_PARAMETER(dispatch_level);
@@ -472,7 +472,7 @@ _net_ebpf_ext_receive_inject_cloned_nbl(
         interface_index,
         ndis_port,
         (NET_BUFFER_LIST*)cloned_nbl,
-        _net_ebpf_ext_l2_receive_inject_complete,
+        (FWPS_INJECT_COMPLETE)_net_ebpf_ext_l2_receive_inject_complete,
         NULL);
 
     if (!NT_SUCCESS(status)) {
@@ -488,7 +488,7 @@ Exit:
 }
 
 static void
-_net_ebpf_ext_l2_inject_send_complete(_In_ void* context, _Inout_ NET_BUFFER_LIST* nbl, BOOLEAN dispatch_level)
+_net_ebpf_ext_l2_inject_send_complete(_In_ const void* context, _Inout_ NET_BUFFER_LIST* nbl, BOOLEAN dispatch_level)
 {
     if ((BOOLEAN)(uintptr_t)context == FALSE)
         // Free clone allocated using _net_ebpf_ext_allocate_cloned_nbl.
@@ -532,7 +532,7 @@ _net_ebpf_ext_handle_xdp_tx(
         interface_index,
         ndis_port,
         nbl,
-        _net_ebpf_ext_l2_inject_send_complete,
+        (FWPS_INJECT_COMPLETE)_net_ebpf_ext_l2_inject_send_complete,
         (void*)(uintptr_t)cloned_packet);
 
     if (status != STATUS_SUCCESS) {

--- a/netebpfext/sys/net_ebpf_ext_drv.c
+++ b/netebpfext/sys/net_ebpf_ext_drv.c
@@ -59,7 +59,7 @@ _net_ebpf_ext_driver_uninitialize_objects()
 }
 
 static _Function_class_(EVT_WDF_DRIVER_UNLOAD) _IRQL_requires_same_
-    _IRQL_requires_max_(PASSIVE_LEVEL) void _net_ebpf_ext_driver_unload(_In_ WDFDRIVER driver_object)
+    _IRQL_requires_max_(PASSIVE_LEVEL) void _net_ebpf_ext_driver_unload(_In_ const WDFDRIVER driver_object)
 {
     UNREFERENCED_PARAMETER(driver_object);
     _net_ebpf_ext_driver_uninitialize_objects();

--- a/tests/bpftool_tests/bpftool_tests.cpp
+++ b/tests/bpftool_tests/bpftool_tests.cpp
@@ -12,7 +12,7 @@
 
 // Run a given command and return the output and exit code.
 std::string
-run_command(_In_ const PCSTR command_line, _Out_ int* result)
+run_command(_In_ _Null_terminated_ const char* command_line, _Out_ int* result)
 {
     printf("Running command: %s\n\n", command_line);
 

--- a/tests/bpftool_tests/bpftool_tests.cpp
+++ b/tests/bpftool_tests/bpftool_tests.cpp
@@ -12,7 +12,7 @@
 
 // Run a given command and return the output and exit code.
 std::string
-run_command(_In_ PCSTR command_line, _Out_ int* result)
+run_command(_In_ const PCSTR command_line, _Out_ int* result)
 {
     printf("Running command: %s\n\n", command_line);
 

--- a/tests/bpftool_tests/bpftool_tests.cpp
+++ b/tests/bpftool_tests/bpftool_tests.cpp
@@ -12,7 +12,7 @@
 
 // Run a given command and return the output and exit code.
 std::string
-run_command(_In_ _Null_terminated_ const char* command_line, _Out_ int* result)
+run_command(_In_z_ const char* command_line, _Out_ int* result)
 {
     printf("Running command: %s\n\n", command_line);
 

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -614,9 +614,8 @@ bindmonitor_test(ebpf_execution_type_t execution_type)
     // Apply policy of maximum 2 binds per process
     set_bind_limit(limit_map_fd, 2);
 
-    std::function<ebpf_result_t(void*, int*)> invoke = [&hook](void* context, int* result) -> ebpf_result_t {
-        return hook.fire(context, result);
-    };
+    std::function<ebpf_result_t(void*, int*)> invoke =
+        [&hook](_Inout_ void* context, _Out_ int* result) -> ebpf_result_t { return hook.fire(context, result); };
     // Bind first port - success
     REQUIRE(emulate_bind(invoke, fake_pid, "fake_app_1") == BIND_PERMIT);
     REQUIRE(get_bind_count_for_pid(process_map_fd, fake_pid) == 1);
@@ -730,9 +729,8 @@ bindmonitor_tailcall_test(ebpf_execution_type_t execution_type)
     // Apply policy of maximum 2 binds per process
     set_bind_limit(limit_map_fd, 2);
 
-    std::function<ebpf_result_t(void*, int*)> invoke = [&hook](void* context, int* result) -> ebpf_result_t {
-        return hook.fire(context, result);
-    };
+    std::function<ebpf_result_t(void*, int*)> invoke =
+        [&hook](_Inout_ void* context, _Out_ int* result) -> ebpf_result_t { return hook.fire(context, result); };
     // Bind first port - success
     REQUIRE(emulate_bind(invoke, fake_pid, "fake_app_1") == BIND_PERMIT);
     REQUIRE(get_bind_count_for_pid(process_map_fd, fake_pid) == 1);
@@ -821,9 +819,8 @@ bindmonitor_ring_buffer_test(ebpf_execution_type_t execution_type)
     }
 
     uint64_t fake_pid = 12345;
-    std::function<ebpf_result_t(void*, int*)> invoke = [&hook](void* context, int* result) -> ebpf_result_t {
-        return hook.fire(context, result);
-    };
+    std::function<ebpf_result_t(void*, int*)> invoke =
+        [&hook](_Inout_ void* context, _Out_ int* result) -> ebpf_result_t { return hook.fire(context, result); };
 
     ring_buffer_api_test_helper(process_map_fd, fake_app_ids, [&](int i) {
         // Emulate bind operation.

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -180,7 +180,7 @@ typedef class _single_instance_hook : public _hook_helper
     provider_attach_client_callback(
         HANDLE nmr_binding_handle,
         _Inout_ void* provider_context,
-        _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+        _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
         _In_ const void* client_binding_context,
         _In_ const void* client_dispatch,
         _Out_ void** provider_binding_context,
@@ -385,7 +385,7 @@ typedef class _program_info_provider
     provider_attach_client_callback(
         HANDLE nmr_binding_handle,
         _Inout_ void* provider_context,
-        _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+        _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
         _In_ const void* client_binding_context,
         _In_ const void* client_dispatch,
         _Out_ void** provider_binding_context,

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -164,12 +164,12 @@ typedef class _single_instance_hook : public _hook_helper
     }
 
     _Must_inspect_result_ ebpf_result_t
-    fire(void* context, int* result)
+    fire(_Inout_ void* context, _Out_ int* result)
     {
         if (client_binding_context == nullptr) {
             return EBPF_EXTENSION_FAILED_TO_LOAD;
         }
-        ebpf_result_t (*invoke_program)(_In_ const void* link, void* context, int* result) =
+        ebpf_result_t (*invoke_program)(_In_ const void* link, _Inout_ void* context, _Out_ int* result) =
             reinterpret_cast<decltype(invoke_program)>(client_dispatch_table->function[0]);
 
         return invoke_program(client_binding_context, context, result);

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -75,7 +75,7 @@ typedef class _hook_helper
     attach_link(
         fd_t program_fd,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
-        _In_ size_t attach_parameters_size,
+        size_t attach_parameters_size,
         _Outptr_ bpf_link** link)
     {
         return ebpf_program_attach_by_fd(program_fd, &_attach_type, attach_parameters, attach_parameters_size, link);
@@ -106,8 +106,8 @@ typedef class _single_instance_hook : public _hook_helper
                 &provider_data,
                 nullptr,
                 this,
-                provider_attach_client_callback,
-                provider_detach_client_callback,
+                (NPI_PROVIDER_ATTACH_CLIENT_FN*)provider_attach_client_callback,
+                (NPI_PROVIDER_DETACH_CLIENT_FN*)provider_detach_client_callback,
                 nullptr) == EBPF_SUCCESS);
     }
     ~_single_instance_hook()
@@ -143,9 +143,7 @@ typedef class _single_instance_hook : public _hook_helper
 
     _Must_inspect_result_ ebpf_result_t
     detach(
-        fd_t program_fd,
-        _In_reads_bytes_(attach_parameter_size) void* attach_parameter,
-        _In_ size_t attach_parameter_size)
+        fd_t program_fd, _In_reads_bytes_(attach_parameter_size) void* attach_parameter, size_t attach_parameter_size)
     {
         return ebpf_program_detach(program_fd, &attach_type, attach_parameter, attach_parameter_size);
     }
@@ -171,7 +169,7 @@ typedef class _single_instance_hook : public _hook_helper
         if (client_binding_context == nullptr) {
             return EBPF_EXTENSION_FAILED_TO_LOAD;
         }
-        ebpf_result_t (*invoke_program)(void* link, void* context, int* result) =
+        ebpf_result_t (*invoke_program)(_In_ const void* link, void* context, int* result) =
             reinterpret_cast<decltype(invoke_program)>(client_dispatch_table->function[0]);
 
         return invoke_program(client_binding_context, context, result);
@@ -182,8 +180,8 @@ typedef class _single_instance_hook : public _hook_helper
     provider_attach_client_callback(
         HANDLE nmr_binding_handle,
         _Inout_ void* provider_context,
-        _In_ PNPI_REGISTRATION_INSTANCE client_registration_instance,
-        _In_ void* client_binding_context,
+        _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+        _In_ const void* client_binding_context,
         _In_ const void* client_dispatch,
         _Out_ void** provider_binding_context,
         _Out_ const void** provider_dispatch)
@@ -205,7 +203,7 @@ typedef class _single_instance_hook : public _hook_helper
     };
 
     static NTSTATUS
-    provider_detach_client_callback(_In_ void* provider_binding_context)
+    provider_detach_client_callback(_Inout_ void* provider_binding_context)
     {
         auto hook = reinterpret_cast<_single_instance_hook*>(provider_binding_context);
         hook->client_binding_context = nullptr;
@@ -223,7 +221,7 @@ typedef class _single_instance_hook : public _hook_helper
         EBPF_ATTACH_PROVIDER_DATA_VERSION, sizeof(attach_provider_data), &attach_provider_data};
     ebpf_extension_provider_t* provider;
     PNPI_REGISTRATION_INSTANCE client_registration_instance;
-    void* client_binding_context;
+    const void* client_binding_context;
     const ebpf_extension_data_t* client_data;
     const ebpf_extension_dispatch_table_t* client_dispatch_table;
     HANDLE nmr_binding_handle;
@@ -298,7 +296,7 @@ typedef class _test_xdp_helper
 {
   public:
     static int
-    adjust_head(_In_ xdp_md_t* ctx, int delta)
+    adjust_head(_In_ const xdp_md_t* ctx, int delta)
     {
         return ((xdp_md_helper_t*)ctx)->adjust_head(delta);
     }
@@ -376,8 +374,8 @@ typedef class _program_info_provider
                 provider_data,
                 nullptr,
                 this,
-                provider_attach_client_callback,
-                provider_detach_client_callback,
+                (NPI_PROVIDER_ATTACH_CLIENT_FN*)provider_attach_client_callback,
+                (NPI_PROVIDER_DETACH_CLIENT_FN*)provider_detach_client_callback,
                 nullptr) == EBPF_SUCCESS);
     }
     ~_program_info_provider() { ebpf_provider_unload(provider); }
@@ -387,8 +385,8 @@ typedef class _program_info_provider
     provider_attach_client_callback(
         HANDLE nmr_binding_handle,
         _Inout_ void* provider_context,
-        _In_ PNPI_REGISTRATION_INSTANCE client_registration_instance,
-        _In_ void* client_binding_context,
+        _In_ const PNPI_REGISTRATION_INSTANCE client_registration_instance,
+        _In_ const void* client_binding_context,
         _In_ const void* client_dispatch,
         _Out_ void** provider_binding_context,
         _Out_ const void** provider_dispatch)
@@ -405,7 +403,7 @@ typedef class _program_info_provider
     };
 
     static NTSTATUS
-    provider_detach_client_callback(_In_ void* provider_binding_context)
+    provider_detach_client_callback(_Inout_ void* provider_binding_context)
     {
         auto hook = reinterpret_cast<_program_info_provider*>(provider_binding_context);
         UNREFERENCED_PARAMETER(hook);

--- a/tests/end_to_end/netsh_test_helper.h
+++ b/tests/end_to_end/netsh_test_helper.h
@@ -22,12 +22,12 @@ DWORD WINAPI
 PreprocessCommand(
     _In_opt_ const HANDLE hModule,
     _Inout_updates_(dwArgCount) LPWSTR* ppwcArguments,
-    _In_ const DWORD dwCurrentIndex,
-    _In_ const DWORD dwArgCount,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
     _Inout_updates_opt_(dwTagCount) TAG_TYPE* pttTags,
-    _In_ const DWORD dwTagCount,
-    _In_ const DWORD dwMinArgs,
-    _In_ const DWORD dwMaxArgs,
+    DWORD dwTagCount,
+    DWORD dwMinArgs,
+    DWORD dwMaxArgs,
     _Out_writes_opt_(dwArgCount - dwCurrentIndex) DWORD* pdwTagType);
 
 DWORD

--- a/tests/end_to_end/netsh_test_helper.h
+++ b/tests/end_to_end/netsh_test_helper.h
@@ -20,14 +20,14 @@
 
 DWORD WINAPI
 PreprocessCommand(
-    _In_opt_ HANDLE hModule,
+    _In_opt_ const HANDLE hModule,
     _Inout_updates_(dwArgCount) LPWSTR* ppwcArguments,
-    _In_ DWORD dwCurrentIndex,
-    _In_ DWORD dwArgCount,
+    _In_ const DWORD dwCurrentIndex,
+    _In_ const DWORD dwArgCount,
     _Inout_updates_opt_(dwTagCount) TAG_TYPE* pttTags,
-    _In_ DWORD dwTagCount,
-    _In_ DWORD dwMinArgs,
-    _In_ DWORD dwMaxArgs,
+    _In_ const DWORD dwTagCount,
+    _In_ const DWORD dwMinArgs,
+    _In_ const DWORD dwMaxArgs,
     _Out_writes_opt_(dwArgCount - dwCurrentIndex) DWORD* pdwTagType);
 
 DWORD

--- a/tests/end_to_end/netsh_test_helper.h
+++ b/tests/end_to_end/netsh_test_helper.h
@@ -18,16 +18,17 @@
 #pragma region
 // Mock Netsh.exe APIs.
 
+// This function has incorrect SAL annotations, but it's declared in public headers so we can't fix it.
 DWORD WINAPI
 PreprocessCommand(
-    _In_opt_ const HANDLE hModule,
+    _In_opt_ HANDLE hModule,
     _Inout_updates_(dwArgCount) LPWSTR* ppwcArguments,
-    DWORD dwCurrentIndex,
-    DWORD dwArgCount,
+    _In_ DWORD dwCurrentIndex,
+    _In_ DWORD dwArgCount,
     _Inout_updates_opt_(dwTagCount) TAG_TYPE* pttTags,
-    DWORD dwTagCount,
-    DWORD dwMinArgs,
-    DWORD dwMaxArgs,
+    _In_ DWORD dwTagCount,
+    _In_ DWORD dwMinArgs,
+    _In_ DWORD dwMaxArgs,
     _Out_writes_opt_(dwArgCount - dwCurrentIndex) DWORD* pdwTagType);
 
 DWORD

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -215,7 +215,7 @@ _complete_overlapped(void* context, size_t output_buffer_length, ebpf_result_t r
 }
 
 BOOL
-GlueCancelIoEx(_In_ const HANDLE hFile, _In_opt_ LPOVERLAPPED lpOverlapped)
+GlueCancelIoEx(_In_ HANDLE hFile, _In_opt_ LPOVERLAPPED lpOverlapped)
 {
     UNREFERENCED_PARAMETER(hFile);
     BOOL return_value = FALSE;

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -215,7 +215,7 @@ _complete_overlapped(void* context, size_t output_buffer_length, ebpf_result_t r
 }
 
 BOOL
-GlueCancelIoEx(_In_ HANDLE hFile, _In_opt_ LPOVERLAPPED lpOverlapped)
+GlueCancelIoEx(_In_ const HANDLE hFile, _In_opt_ LPOVERLAPPED lpOverlapped)
 {
     UNREFERENCED_PARAMETER(hFile);
     BOOL return_value = FALSE;

--- a/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
@@ -280,7 +280,7 @@ void
 fuzz_program(
     fuzz_wrapper& fuzz_state,
     ebpf_handle_t program_handle,
-    _In_ ebpf_program_t* program,
+    _In_ const ebpf_program_t* program,
     _In_reads_(data_left_size) const uint8_t* data_left,
     size_t data_left_size)
 {

--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -111,7 +111,7 @@ ring_buffer_test_event_context_t::unsubscribe()
 }
 
 int
-ring_buffer_test_event_handler(_In_ void* ctx, _In_opt_ void* data, size_t size)
+ring_buffer_test_event_handler(_Inout_ void* ctx, _In_opt_ const void* data, size_t size)
 {
     ring_buffer_test_event_context_t* event_context = reinterpret_cast<ring_buffer_test_event_context_t*>(ctx);
 
@@ -131,7 +131,7 @@ ring_buffer_test_event_handler(_In_ void* ctx, _In_opt_ void* data, size_t size)
         // Required number of event notifications already received.
         return 0;
 
-    std::vector<char> event_record(reinterpret_cast<char*>(data), reinterpret_cast<char*>(data) + size);
+    std::vector<char> event_record(reinterpret_cast<const char*>(data), reinterpret_cast<const char*>(data) + size);
     // Check if indicated event record matches an entry in the context records.
     auto records = event_context->records;
     auto it = std::find(records->begin(), records->end(), event_record);
@@ -165,7 +165,8 @@ ring_buffer_api_test_helper(
 
     // Create a new ring buffer manager and subscribe to ring buffer events.
     // The notifications for the events that were generated before should occur after the subscribe call.
-    context->ring_buffer = ring_buffer__new(ring_buffer_map, ring_buffer_test_event_handler, context.get(), nullptr);
+    context->ring_buffer = ring_buffer__new(
+        ring_buffer_map, (ring_buffer_sample_fn)ring_buffer_test_event_handler, context.get(), nullptr);
     REQUIRE(context->ring_buffer != nullptr);
 
     // Generate more events, post-subscription.

--- a/tests/libs/common/common_tests.h
+++ b/tests/libs/common/common_tests.h
@@ -35,7 +35,7 @@ typedef struct _ring_buffer_test_event_context
 } ring_buffer_test_event_context_t;
 
 int
-ring_buffer_test_event_handler(_In_ void* ctx, _In_opt_ void* data, size_t size);
+ring_buffer_test_event_handler(_Inout_ void* ctx, _In_opt_ const void* data, size_t size);
 
 void
 ring_buffer_api_test_helper(

--- a/tests/libs/util/netsh_helper.cpp
+++ b/tests/libs/util/netsh_helper.cpp
@@ -16,12 +16,12 @@ DWORD WINAPI
 PreprocessCommand(
     _In_opt_ const HANDLE hModule,
     _Inout_updates_(dwArgCount) LPWSTR* ppwcArguments,
-    _In_ const DWORD dwCurrentIndex,
-    _In_ const DWORD dwArgCount,
+    DWORD dwCurrentIndex,
+    DWORD dwArgCount,
     _Inout_updates_opt_(dwTagCount) TAG_TYPE* pttTags,
-    _In_ const DWORD dwTagCount,
-    _In_ const DWORD dwMinArgs,
-    _In_ const DWORD dwMaxArgs,
+    DWORD dwTagCount,
+    DWORD dwMinArgs,
+    DWORD dwMaxArgs,
     _Out_writes_opt_(dwArgCount - dwCurrentIndex) DWORD* pdwTagType)
 {
     UNREFERENCED_PARAMETER(hModule);

--- a/tests/libs/util/netsh_helper.cpp
+++ b/tests/libs/util/netsh_helper.cpp
@@ -12,16 +12,17 @@
 #pragma region
 // Mock Netsh.exe APIs.
 
+// This function has incorrect SAL annotations, but it's declared in public headers so we can't fix it.
 DWORD WINAPI
 PreprocessCommand(
-    _In_opt_ const HANDLE hModule,
+    _In_opt_ HANDLE hModule,
     _Inout_updates_(dwArgCount) LPWSTR* ppwcArguments,
-    DWORD dwCurrentIndex,
-    DWORD dwArgCount,
+    _In_ DWORD dwCurrentIndex,
+    _In_ DWORD dwArgCount,
     _Inout_updates_opt_(dwTagCount) TAG_TYPE* pttTags,
-    DWORD dwTagCount,
-    DWORD dwMinArgs,
-    DWORD dwMaxArgs,
+    _In_ DWORD dwTagCount,
+    _In_ DWORD dwMinArgs,
+    _In_ DWORD dwMaxArgs,
     _Out_writes_opt_(dwArgCount - dwCurrentIndex) DWORD* pdwTagType)
 {
     UNREFERENCED_PARAMETER(hModule);

--- a/tests/libs/util/netsh_helper.cpp
+++ b/tests/libs/util/netsh_helper.cpp
@@ -14,14 +14,14 @@
 
 DWORD WINAPI
 PreprocessCommand(
-    _In_opt_ HANDLE hModule,
+    _In_opt_ const HANDLE hModule,
     _Inout_updates_(dwArgCount) LPWSTR* ppwcArguments,
-    _In_ DWORD dwCurrentIndex,
-    _In_ DWORD dwArgCount,
+    _In_ const DWORD dwCurrentIndex,
+    _In_ const DWORD dwArgCount,
     _Inout_updates_opt_(dwTagCount) TAG_TYPE* pttTags,
-    _In_ DWORD dwTagCount,
-    _In_ DWORD dwMinArgs,
-    _In_ DWORD dwMaxArgs,
+    _In_ const DWORD dwTagCount,
+    _In_ const DWORD dwMinArgs,
+    _In_ const DWORD dwMaxArgs,
     _Out_writes_opt_(dwArgCount - dwCurrentIndex) DWORD* pdwTagType)
 {
     UNREFERENCED_PARAMETER(hModule);

--- a/tests/libs/util/program_helper.cpp
+++ b/tests/libs/util/program_helper.cpp
@@ -10,7 +10,7 @@ _program_load_attach_helper::_program_load_attach_helper(
     _In_z_ const char* program_name,
     ebpf_execution_type_t execution_type,
     _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
-    _In_ size_t attach_parameters_size,
+    size_t attach_parameters_size,
     hook_helper_t& hook)
     : _file_name(file_name), _program_type(program_type), _program_name(program_name), _execution_type(execution_type),
       _link(nullptr), _object(nullptr)

--- a/tests/libs/util/program_helper.h
+++ b/tests/libs/util/program_helper.h
@@ -18,7 +18,7 @@ typedef class _program_load_attach_helper
         _In_z_ const char* program_name,
         ebpf_execution_type_t execution_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
-        _In_ size_t attach_parameters_size,
+        size_t attach_parameters_size,
         hook_helper_t& hook);
 
     ~_program_load_attach_helper();

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -40,13 +40,13 @@ get_address_from_string(
 }
 
 std::string
-get_string_from_address(_In_ const PSOCKADDR sockaddr)
+get_string_from_address(_In_ const SOCKADDR* sockaddr)
 {
     char ip_string[MAXIMUM_IP_BUFFER_SIZE] = {0};
 
     DWORD length = sizeof(ip_string);
-    int error =
-        WSAAddressToStringA(sockaddr, (DWORD)INET_SOCKADDR_LENGTH(sockaddr->sa_family), nullptr, ip_string, &length);
+    int error = WSAAddressToStringA(
+        const_cast<SOCKADDR*>(sockaddr), (DWORD)INET_SOCKADDR_LENGTH(sockaddr->sa_family), nullptr, ip_string, &length);
     if (error != 0) {
         error = WSAGetLastError();
         printf("Failure calling WSAAddressToStringA with error code %d\n", error);
@@ -220,7 +220,7 @@ _datagram_client_socket::send_message_to_remote_host(
         1,
         reinterpret_cast<LPDWORD>(&bytes_sent),
         send_flags,
-        (const PSOCKADDR)&remote_address,
+        (const SOCKADDR*)&remote_address,
         sizeof(remote_address),
         nullptr,
         nullptr);

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -95,7 +95,7 @@ _base_socket::~_base_socket()
 }
 
 void
-_base_socket::get_local_address(_Out_ PSOCKADDR& address, _Out_ int& address_length)
+_base_socket::get_local_address(_Out_ PSOCKADDR& address, _Out_ int& address_length) const
 {
     address = (PSOCKADDR)&local_address;
     address_length = local_address_size;
@@ -204,7 +204,7 @@ _datagram_client_socket::_datagram_client_socket(int _sock_type, int _protocol, 
 
 void
 _datagram_client_socket::send_message_to_remote_host(
-    _In_z_ const char* message, sockaddr_storage& remote_address, uint16_t remote_port)
+    _In_z_ const char* message, _Inout_ sockaddr_storage& remote_address, uint16_t remote_port)
 {
     int error = 0;
 
@@ -220,7 +220,7 @@ _datagram_client_socket::send_message_to_remote_host(
         1,
         reinterpret_cast<LPDWORD>(&bytes_sent),
         send_flags,
-        (PSOCKADDR)&remote_address,
+        (const PSOCKADDR)&remote_address,
         sizeof(remote_address),
         nullptr,
         nullptr);
@@ -265,7 +265,7 @@ _stream_client_socket::_stream_client_socket(int _sock_type, int _protocol, uint
 
 void
 _stream_client_socket::send_message_to_remote_host(
-    _In_z_ const char* message, sockaddr_storage& remote_address, uint16_t remote_port)
+    _In_z_ const char* message, _Inout_ sockaddr_storage& remote_address, uint16_t remote_port)
 {
     // Send a message to the remote host using the sender socket.
     ((PSOCKADDR_IN6)&remote_address)->sin6_port = htons(remote_port);

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -38,7 +38,7 @@ get_address_from_string(
     _Out_opt_ ADDRESS_FAMILY* address_family = nullptr);
 
 std::string
-get_string_from_address(_In_ const PSOCKADDR sockaddr);
+get_string_from_address(_In_ SOCKADDR* sockaddr);
 
 typedef enum _expected_result
 {

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -57,7 +57,7 @@ typedef class _base_socket
     virtual ~_base_socket();
 
     void
-    get_local_address(_Out_ PSOCKADDR& address, _Out_ int& address_length);
+    get_local_address(_Out_ PSOCKADDR& address, _Out_ int& address_length) const;
 
     void
     get_received_message(_Out_ uint32_t& message_size, _Outref_result_buffer_(message_size) char*& message);
@@ -85,7 +85,8 @@ typedef class _client_socket : public _base_socket
   public:
     _client_socket(int _sock_type, int _protocol, uint16_t port, socket_family_t family);
     virtual void
-    send_message_to_remote_host(_In_z_ const char* message, sockaddr_storage& remote_address, uint16_t remote_port) = 0;
+    send_message_to_remote_host(
+        _In_z_ const char* message, _Inout_ sockaddr_storage& remote_address, uint16_t remote_port) = 0;
     virtual void
     complete_async_send(int timeout_in_ms, expected_result_t expected_result = expected_result_t::SUCCESS) = 0;
     virtual void
@@ -110,7 +111,8 @@ typedef class _datagram_client_socket : public _client_socket
   public:
     _datagram_client_socket(int _sock_type, int _protocol, uint16_t port, socket_family_t family = Dual);
     void
-    send_message_to_remote_host(_In_z_ const char* message, sockaddr_storage& remote_address, uint16_t remote_port);
+    send_message_to_remote_host(
+        _In_z_ const char* message, _Inout_ sockaddr_storage& remote_address, uint16_t remote_port);
     void
     cancel_send_message();
     void
@@ -125,7 +127,8 @@ typedef class _stream_client_socket : public _client_socket
   public:
     _stream_client_socket(int _sock_type, int _protocol, uint16_t port, socket_family_t family = Dual);
     void
-    send_message_to_remote_host(_In_z_ const char* message, sockaddr_storage& remote_address, uint16_t remote_port);
+    send_message_to_remote_host(
+        _In_z_ const char* message, _Inout_ sockaddr_storage& remote_address, uint16_t remote_port);
     void
     cancel_send_message();
     void

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -75,7 +75,7 @@ _netebpf_ext_helper::get_program_info_provider_data(const GUID& program_info_pro
 
 NTSTATUS
 _netebpf_ext_helper::_program_info_client_attach_provider(
-    _In_ const HANDLE nmr_binding_handle,
+    _In_ HANDLE nmr_binding_handle,
     _Inout_ void* client_context,
     _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
 {

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -75,9 +75,9 @@ _netebpf_ext_helper::get_program_info_provider_data(const GUID& program_info_pro
 
 NTSTATUS
 _netebpf_ext_helper::_program_info_client_attach_provider(
-    _In_ HANDLE nmr_binding_handle,
-    _In_ PVOID client_context,
-    _In_ PNPI_REGISTRATION_INSTANCE provider_registration_instance)
+    _In_ const HANDLE nmr_binding_handle,
+    _In_ const PVOID client_context,
+    _In_ const PNPI_REGISTRATION_INSTANCE provider_registration_instance)
 {
     auto& helper = *reinterpret_cast<_netebpf_ext_helper*>(client_context);
     auto client_binding_context = std::make_unique<program_info_provider_t>();
@@ -101,7 +101,7 @@ _netebpf_ext_helper::_program_info_client_attach_provider(
 }
 
 NTSTATUS
-_netebpf_ext_helper::_program_info_client_detach_provider(_In_ PVOID client_binding_context)
+_netebpf_ext_helper::_program_info_client_detach_provider(_In_ const PVOID client_binding_context)
 {
     auto& program_info_provider = *reinterpret_cast<program_info_provider_t*>(client_binding_context);
     program_info_provider.parent->program_info_providers.erase(program_info_provider.module_id.Guid);
@@ -109,7 +109,7 @@ _netebpf_ext_helper::_program_info_client_detach_provider(_In_ PVOID client_bind
 }
 
 void
-_netebpf_ext_helper::_program_info_client_cleanup_binding_context(_In_ PVOID client_binding_context)
+_netebpf_ext_helper::_program_info_client_cleanup_binding_context(_In_ const PVOID client_binding_context)
 {
     UNREFERENCED_PARAMETER(client_binding_context);
 }

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -76,8 +76,8 @@ _netebpf_ext_helper::get_program_info_provider_data(const GUID& program_info_pro
 NTSTATUS
 _netebpf_ext_helper::_program_info_client_attach_provider(
     _In_ const HANDLE nmr_binding_handle,
-    _In_ const PVOID client_context,
-    _In_ const PNPI_REGISTRATION_INSTANCE provider_registration_instance)
+    _Inout_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
 {
     auto& helper = *reinterpret_cast<_netebpf_ext_helper*>(client_context);
     auto client_binding_context = std::make_unique<program_info_provider_t>();
@@ -101,7 +101,7 @@ _netebpf_ext_helper::_program_info_client_attach_provider(
 }
 
 NTSTATUS
-_netebpf_ext_helper::_program_info_client_detach_provider(_In_ const PVOID client_binding_context)
+_netebpf_ext_helper::_program_info_client_detach_provider(_Inout_ void* client_binding_context)
 {
     auto& program_info_provider = *reinterpret_cast<program_info_provider_t*>(client_binding_context);
     program_info_provider.parent->program_info_providers.erase(program_info_provider.module_id.Guid);
@@ -109,7 +109,7 @@ _netebpf_ext_helper::_program_info_client_detach_provider(_In_ const PVOID clien
 }
 
 void
-_netebpf_ext_helper::_program_info_client_cleanup_binding_context(_In_ const PVOID client_binding_context)
+_netebpf_ext_helper::_program_info_client_cleanup_binding_context(_In_ _Post_invalid_ void* client_binding_context)
 {
     UNREFERENCED_PARAMETER(client_binding_context);
 }

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -69,7 +69,7 @@ typedef class _netebpf_ext_helper
 
     static NTSTATUS
     _program_info_client_attach_provider(
-        _In_ const HANDLE nmr_binding_handle,
+        _In_ HANDLE nmr_binding_handle,
         _Inout_ void* client_context,
         _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance);
 

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -69,15 +69,15 @@ typedef class _netebpf_ext_helper
 
     static NTSTATUS
     _program_info_client_attach_provider(
-        _In_ HANDLE nmr_binding_handle,
-        _In_ PVOID client_context,
-        _In_ PNPI_REGISTRATION_INSTANCE provider_registration_instance);
+        _In_ const HANDLE nmr_binding_handle,
+        _In_ const PVOID client_context,
+        _In_ const PNPI_REGISTRATION_INSTANCE provider_registration_instance);
 
     static NTSTATUS
-    _program_info_client_detach_provider(_In_ PVOID client_binding_context);
+    _program_info_client_detach_provider(_In_ const PVOID client_binding_context);
 
     static void
-    _program_info_client_cleanup_binding_context(_In_ PVOID client_binding_context);
+    _program_info_client_cleanup_binding_context(_In_ const PVOID client_binding_context);
 
     NPI_MODULEID module_id = {};
     NPI_CLIENT_CHARACTERISTICS client{

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -70,14 +70,14 @@ typedef class _netebpf_ext_helper
     static NTSTATUS
     _program_info_client_attach_provider(
         _In_ const HANDLE nmr_binding_handle,
-        _In_ const PVOID client_context,
-        _In_ const PNPI_REGISTRATION_INSTANCE provider_registration_instance);
+        _Inout_ void* client_context,
+        _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance);
 
     static NTSTATUS
-    _program_info_client_detach_provider(_In_ const PVOID client_binding_context);
+    _program_info_client_detach_provider(_Inout_ void* client_binding_context);
 
     static void
-    _program_info_client_cleanup_binding_context(_In_ const PVOID client_binding_context);
+    _program_info_client_cleanup_binding_context(_In_ _Post_invalid_ void* client_binding_context);
 
     NPI_MODULEID module_id = {};
     NPI_CLIENT_CHARACTERISTICS client{

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -61,7 +61,7 @@ netebpfext_unit_invoke_program(
 NTSTATUS
 netebpf_unit_attach_extension(
     _In_ const HANDLE nmr_binding_handle,
-    _In_ const void* client_context,
+    _Inout_ void* client_context,
     _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
 {
     const void* provider_dispatch_table;
@@ -85,7 +85,7 @@ netebpf_unit_attach_extension(
 
 // Detach from netebpfext.
 NTSTATUS
-netebpf_unit_detach_extension(_In_ const void* client_binding_context)
+netebpf_unit_detach_extension(_Inout_ void* client_binding_context)
 {
     auto test_client_context = (test_client_context_t*)client_binding_context;
     UNREFERENCED_PARAMETER(test_client_context);
@@ -114,8 +114,8 @@ TEST_CASE("classify_packet", "[netebpfext]")
     NET_IFINDEX if_index = 0;
     ebpf_extension_data_t npi_specific_characteristics = {.size = sizeof(if_index), .data = &if_index};
     client_characteristics.ClientRegistrationInstance.NpiSpecificCharacteristics = &npi_specific_characteristics;
-    client_characteristics.ClientAttachProvider = (NPI_CLIENT_ATTACH_PROVIDER_FN*)netebpf_unit_attach_extension;
-    client_characteristics.ClientDetachProvider = (NPI_CLIENT_DETACH_PROVIDER_FN*)netebpf_unit_detach_extension;
+    client_characteristics.ClientAttachProvider = netebpf_unit_attach_extension;
+    client_characteristics.ClientDetachProvider = netebpf_unit_detach_extension;
     client_characteristics.ClientCleanupBindingContext =
         (NPI_CLIENT_CLEANUP_BINDING_CONTEXT_FN*)netebpfext_unit_cleanup_binding_context;
     test_client_context_t client_context = {.desired_attach_type = BPF_XDP};

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -60,7 +60,7 @@ netebpfext_unit_invoke_program(
 // Netebpfext is ready for us to attach to it as if we were ebpfcore.
 NTSTATUS
 netebpf_unit_attach_extension(
-    _In_ const HANDLE nmr_binding_handle,
+    _In_ HANDLE nmr_binding_handle,
     _Inout_ void* client_context,
     _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
 {

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -71,10 +71,10 @@ NPI_MODULEID DECLSPEC_SELECTANY _sample_ebpf_extension_program_info_provider_mod
  */
 static NTSTATUS
 _sample_ebpf_extension_program_info_provider_attach_client(
-    _In_ HANDLE nmr_binding_handle,
-    _In_ void* provider_context,
+    _In_ const HANDLE nmr_binding_handle,
+    _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Outptr_ void** provider_binding_context,
     _Outptr_result_maybenull_ const void** provider_dispatch);
@@ -87,7 +87,7 @@ _sample_ebpf_extension_program_info_provider_attach_client(
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
 static NTSTATUS
-_sample_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_binding_context);
+_sample_ebpf_extension_program_info_provider_detach_client(_In_ const void* provider_binding_context);
 
 /**
  * @brief Callback invoked after the provider module and a client module have detached from one another.
@@ -156,10 +156,10 @@ NPI_MODULEID DECLSPEC_SELECTANY _sample_ebpf_extension_hook_provider_moduleid = 
  */
 static NTSTATUS
 _sample_ebpf_extension_hook_provider_attach_client(
-    _In_ HANDLE nmr_binding_handle,
-    _In_ void* provider_context,
+    _In_ const HANDLE nmr_binding_handle,
+    _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Outptr_ void** provider_binding_context,
     _Outptr_result_maybenull_ const void** provider_dispatch);
@@ -172,7 +172,7 @@ _sample_ebpf_extension_hook_provider_attach_client(
  * @retval STATUS_INVALID_PARAMETER One or more parameters are invalid.
  */
 static NTSTATUS
-_sample_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context);
+_sample_ebpf_extension_hook_provider_detach_client(_In_ const void* provider_binding_context);
 
 /**
  * @brief Callback invoked after the provider module and a client module have detached from one another.
@@ -238,10 +238,10 @@ static sample_ebpf_extension_hook_provider_t _sample_ebpf_extension_hook_provide
 
 static NTSTATUS
 _sample_ebpf_extension_program_info_provider_attach_client(
-    _In_ HANDLE nmr_binding_handle,
-    _In_ void* provider_context,
+    _In_ const HANDLE nmr_binding_handle,
+    _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Outptr_ void** provider_binding_context,
     _Outptr_result_maybenull_ const void** provider_dispatch)
@@ -282,7 +282,7 @@ Exit:
 }
 
 static NTSTATUS
-_sample_ebpf_extension_program_info_provider_detach_client(_In_ void* provider_binding_context)
+_sample_ebpf_extension_program_info_provider_detach_client(_In_ const void* provider_binding_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
 
@@ -379,10 +379,10 @@ Exit:
 
 static NTSTATUS
 _sample_ebpf_extension_hook_provider_attach_client(
-    _In_ HANDLE nmr_binding_handle,
-    _In_ void* provider_context,
+    _In_ const HANDLE nmr_binding_handle,
+    _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
-    _In_ void* client_binding_context,
+    _In_ const void* client_binding_context,
     _In_ const void* client_dispatch,
     _Outptr_ void** provider_binding_context,
     _Outptr_result_maybenull_ const void** provider_dispatch)
@@ -439,7 +439,7 @@ Exit:
 }
 
 static NTSTATUS
-_sample_ebpf_extension_hook_provider_detach_client(_In_ void* provider_binding_context)
+_sample_ebpf_extension_hook_provider_detach_client(_In_ const void* provider_binding_context)
 {
     NTSTATUS status = STATUS_SUCCESS;
 
@@ -527,7 +527,7 @@ Exit:
 
 _Must_inspect_result_ ebpf_result_t
 sample_ebpf_extension_profile_program(
-    _In_ sample_ebpf_ext_profile_request_t* request,
+    _Inout_ sample_ebpf_ext_profile_request_t* request,
     size_t request_length,
     _Inout_ sample_ebpf_ext_profile_reply_t* reply)
 {

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -71,7 +71,7 @@ NPI_MODULEID DECLSPEC_SELECTANY _sample_ebpf_extension_program_info_provider_mod
  */
 static NTSTATUS
 _sample_ebpf_extension_program_info_provider_attach_client(
-    _In_ const HANDLE nmr_binding_handle,
+    _In_ HANDLE nmr_binding_handle,
     _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,
@@ -156,7 +156,7 @@ NPI_MODULEID DECLSPEC_SELECTANY _sample_ebpf_extension_hook_provider_moduleid = 
  */
 static NTSTATUS
 _sample_ebpf_extension_hook_provider_attach_client(
-    _In_ const HANDLE nmr_binding_handle,
+    _In_ HANDLE nmr_binding_handle,
     _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,
@@ -238,7 +238,7 @@ static sample_ebpf_extension_hook_provider_t _sample_ebpf_extension_hook_provide
 
 static NTSTATUS
 _sample_ebpf_extension_program_info_provider_attach_client(
-    _In_ const HANDLE nmr_binding_handle,
+    _In_ HANDLE nmr_binding_handle,
     _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,
@@ -379,7 +379,7 @@ Exit:
 
 static NTSTATUS
 _sample_ebpf_extension_hook_provider_attach_client(
-    _In_ const HANDLE nmr_binding_handle,
+    _In_ HANDLE nmr_binding_handle,
     _In_ const void* provider_context,
     _In_ const NPI_REGISTRATION_INSTANCE* client_registration_instance,
     _In_ const void* client_binding_context,

--- a/tests/sample/ext/drv/sample_ext.h
+++ b/tests/sample/ext/drv/sample_ext.h
@@ -60,15 +60,15 @@ sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* contex
 /**
  * @brief Invoke eBPF program attached to a hook provider instance and measure the execution time.
  *
- * @param[in] request Request containing the parameters of the sample.
+ * @param[in,out] request Request containing the parameters of the sample.
  * @param[in] request_length Length of the request buffer.
- * @param[out] reply Reply containing the results of the sample.
+ * @param[in,out] reply Reply containing the results of the sample.
  *
  * @retval EBPF_SUCCESS Operation succeeded.
  * @retval EBPF_OPERATION_NOT_SUPPORTED Operation not supported.
  */
 _Must_inspect_result_ ebpf_result_t
 sample_ebpf_extension_profile_program(
-    _In_ sample_ebpf_ext_profile_request_t* request,
+    _Inout_ sample_ebpf_ext_profile_request_t* request,
     size_t request_length,
     _Inout_ sample_ebpf_ext_profile_reply_t* reply);

--- a/tests/sample/ext/drv/sample_ext.h
+++ b/tests/sample/ext/drv/sample_ext.h
@@ -60,9 +60,9 @@ sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* contex
 /**
  * @brief Invoke eBPF program attached to a hook provider instance and measure the execution time.
  *
- * @param[in,out] request Request containing the parameters of the sample.
+ * @param[in, out] request Request containing the parameters of the sample.
  * @param[in] request_length Length of the request buffer.
- * @param[in,out] reply Reply containing the results of the sample.
+ * @param[in, out] reply Reply containing the results of the sample.
  *
  * @retval EBPF_SUCCESS Operation succeeded.
  * @retval EBPF_OPERATION_NOT_SUPPORTED Operation not supported.

--- a/tests/sample/ext/drv/sample_ext_drv.c
+++ b/tests/sample/ext/drv/sample_ext_drv.c
@@ -36,14 +36,14 @@ ebpf_driver_get_device_object()
 
 static void
 _sample_ebpf_ext_driver_io_device_control(
-    _In_ WDFQUEUE queue,
-    _In_ WDFREQUEST request,
+    _In_ const WDFQUEUE queue,
+    _In_ const WDFREQUEST request,
     size_t output_buffer_length,
     size_t input_buffer_length,
     ULONG io_control_code);
 
 static _Function_class_(EVT_WDF_DRIVER_UNLOAD) _IRQL_requires_same_
-    _IRQL_requires_max_(PASSIVE_LEVEL) void _sample_ebpf_ext_driver_unload(_In_ WDFDRIVER driver_object)
+    _IRQL_requires_max_(PASSIVE_LEVEL) void _sample_ebpf_ext_driver_unload(_In_ const WDFDRIVER driver_object)
 {
     UNREFERENCED_PARAMETER(driver_object);
 
@@ -204,8 +204,8 @@ Exit:
 
 static VOID
 _sample_ebpf_ext_driver_io_device_control(
-    _In_ WDFQUEUE queue,
-    _In_ WDFREQUEST request,
+    _In_ const WDFQUEUE queue,
+    _In_ const WDFREQUEST request,
     size_t output_buffer_length,
     size_t input_buffer_length,
     ULONG io_control_code)

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -26,8 +26,8 @@ using namespace std::chrono_literals;
 void
 connection_test(
     ADDRESS_FAMILY address_family,
-    _In_ client_socket_t& sender_socket,
-    _In_ receiver_socket_t& receiver_socket,
+    _Inout_ client_socket_t& sender_socket,
+    _Inout_ receiver_socket_t& receiver_socket,
     uint32_t protocol)
 {
     struct bpf_object* object = bpf_object__open("cgroup_sock_addr.o");
@@ -243,8 +243,8 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
 void
 connection_monitor_test(
     ADDRESS_FAMILY address_family,
-    _In_ client_socket_t& sender_socket,
-    _In_ receiver_socket_t& receiver_socket,
+    _Inout_ client_socket_t& sender_socket,
+    _Inout_ receiver_socket_t& receiver_socket,
     uint32_t protocol,
     bool disconnect)
 {
@@ -312,8 +312,8 @@ connection_monitor_test(
     // Create a new ring buffer manager and subscribe to ring buffer events.
     bpf_map* ring_buffer_map = bpf_object__find_map_by_name(object, "audit_map");
     REQUIRE(ring_buffer_map != nullptr);
-    context->ring_buffer =
-        ring_buffer__new(bpf_map__fd(ring_buffer_map), ring_buffer_test_event_handler, context.get(), nullptr);
+    context->ring_buffer = ring_buffer__new(
+        bpf_map__fd(ring_buffer_map), (ring_buffer_sample_fn)ring_buffer_test_event_handler, context.get(), nullptr);
     REQUIRE(context->ring_buffer != nullptr);
 
     bpf_map* connection_map = bpf_object__find_map_by_name(object, "connection_map");

--- a/tests/tcp_udp_listener/tcp_udp_listener.cpp
+++ b/tests/tcp_udp_listener/tcp_udp_listener.cpp
@@ -22,7 +22,7 @@ _get_protocol_from_string(std::string protocol)
 }
 
 void
-create_listener(_In_ receiver_socket_t* receiver_socket)
+create_listener(_Inout_ receiver_socket_t* receiver_socket)
 {
     _global_counter++;
     // Post a receive. Wait for client to connect.


### PR DESCRIPTION
Resolves: #1746 

Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description
Fix code analysis annotations for _In_ and _In_opt_ parameters by adding const where appropriate or changing to _Inout_ where appropriate.

The following regex expressions were used to find the problems:
Find ```_In_``` or ```_In_opt_``` that are not const and are not followed by ```_Post_invalid_``` or ```_Frees_ptr_``` or ```_Post_ptr_invalid_```:
```_In_[ ]+(?!.*(const|_Post_invalid_|_Frees_ptr_|_Post_ptr_invalid_))```
```_In_opt_[ ]+(?!.*(const|_Post_invalid_|_Frees_ptr_|_Post_ptr_invalid_))```

Some of the ```_In_``` and ```_In_opt_``` parameters are not const due to required compatibility with the Windows API.
Pointers to functions are const by definition, so the const qualifier is not required.

## Testing

CI/CD

## Documentation

No.
