### PR TITLE
Add support for logging leaked allocations

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,6 +76,21 @@ jobs:
       gather_dumps: true
       capture_etw: true
 
+  unit_tests_leak_detection:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests_with_leak_detection
+      test_command: .\unit_tests.exe -d yes
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
   # Run the netebpfext unit tests in GitHub.
   netebpf_ext_unit_tests:
     # Always run this job.

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -48,6 +48,9 @@ on:
       low_memory:
         required: false
         type: boolean
+      leak_detection:
+        required: false
+        type: boolean
 
 permissions:
   checks: read  # Required by fountainhead/action-wait-for-check to wait for another GitHub check to complete.
@@ -71,6 +74,7 @@ jobs:
       TEST_COMMAND: ${{inputs.test_command}}
       PRE_COMMAND: ${{inputs.pre_test}}
       POST_COMMAND: ${{inputs.post_test}}
+      EBPF_MEMORY_LEAK_DETECTION: ${{inputs.leak_detection}}
 
     # Checking out the branch is needed to gather correct code coverage data.
     steps:

--- a/libs/platform/CMakeLists.txt
+++ b/libs/platform/CMakeLists.txt
@@ -106,6 +106,7 @@ add_library("platform_user" STATIC
   ${platform_user_sources}
   user/framework.h
   user/ebpf_handle_user.c
+  user/ebpf_leak_detector.cpp
   user/ebpf_low_memory_test.cpp
   user/ebpf_platform_user.cpp
   user/ebpf_native_user.c

--- a/libs/platform/user/ebpf_leak_detector.cpp
+++ b/libs/platform/user/ebpf_leak_detector.cpp
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include <iostream>
+
+#include "ebpf_leak_detector.h"
+#include "ebpf_symbol_decoder.h"
+
+void
+_ebpf_leak_detector::register_allocation(uintptr_t address, size_t size)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    allocation_t allocation = {address, size, 0};
+    std::vector<uintptr_t> stack(1 + _stack_depth);
+    if (CaptureStackBackTrace(
+            1,
+            static_cast<unsigned int>(stack.size()),
+            reinterpret_cast<void**>(stack.data()),
+            &allocation.stack_hash) == 0) {
+        allocation.stack_hash = 0;
+    }
+    _allocations[address] = allocation;
+    if (!_stack_hashes.contains(allocation.stack_hash)) {
+        _stack_hashes[allocation.stack_hash] = stack;
+    }
+}
+
+void
+_ebpf_leak_detector::unregister_allocation(uintptr_t address)
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    _allocations.erase(address);
+}
+
+void
+_ebpf_leak_detector::dump_leaks()
+{
+    std::unique_lock<std::mutex> lock(_mutex);
+    for (auto& allocation : _allocations) {
+        std::vector<uintptr_t> stack = _stack_hashes[allocation.second.stack_hash];
+        std::cout << "Leak of " << allocation.second.size << " bytes at " << allocation.second.address << std::endl;
+        std::string name;
+        uint64_t displacement;
+        std::optional<uint32_t> line_number;
+        std::optional<std::string> file_name;
+        for (auto address : stack) {
+            if (_ebpf_decode_symbol(address, name, displacement, line_number, file_name) == EBPF_SUCCESS) {
+                std::cout << "    " << name << " + " << displacement;
+                if (line_number.has_value() && file_name.has_value()) {
+                    std::cout << " (" << file_name.value() << ":" << line_number.value() << ")";
+                }
+                std::cout << std::endl;
+            }
+        }
+        std::cout << std::endl;
+    }
+
+    _allocations.clear();
+    _stack_hashes.clear();
+}

--- a/libs/platform/user/ebpf_leak_detector.h
+++ b/libs/platform/user/ebpf_leak_detector.h
@@ -33,7 +33,7 @@ typedef class _ebpf_leak_detector
     std::unordered_map<unsigned long, std::vector<uintptr_t>> _stack_hashes;
     std::unordered_map<uintptr_t, allocation_t> _allocations;
     std::mutex _mutex;
-    const unsigned long _stack_depth = 32;
+    const size_t _stack_depth = 32;
 } ebpf_leak_detector_t;
 
 typedef std::unique_ptr<ebpf_leak_detector_t> ebpf_leak_detector_ptr;

--- a/libs/platform/user/ebpf_leak_detector.h
+++ b/libs/platform/user/ebpf_leak_detector.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+#include <unordered_map>
+#include <vector>
+#include <mutex>
+
+#include "ebpf_platform.h"
+
+typedef class _ebpf_leak_detector
+{
+  public:
+    _ebpf_leak_detector() = default;
+    ~_ebpf_leak_detector() = default;
+
+    void
+    register_allocation(uintptr_t address, size_t size);
+
+    void
+    unregister_allocation(uintptr_t address);
+
+    void
+    dump_leaks();
+
+  private:
+    typedef struct _allocation
+    {
+        uintptr_t address;
+        size_t size;
+        unsigned long stack_hash;
+    } allocation_t;
+
+    std::unordered_map<unsigned long, std::vector<uintptr_t>> _stack_hashes;
+    std::unordered_map<uintptr_t, allocation_t> _allocations;
+    std::mutex _mutex;
+    const unsigned long _stack_depth = 32;
+} ebpf_leak_detector_t;
+
+typedef std::unique_ptr<ebpf_leak_detector_t> ebpf_leak_detector_ptr;

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -365,10 +365,10 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_ _Post_writable_byt
 void
 ebpf_free(_Frees_ptr_opt_ void* memory)
 {
-    free(memory);
     if (_ebpf_leak_detector_ptr) {
         _ebpf_leak_detector_ptr->unregister_allocation(reinterpret_cast<uintptr_t>(memory));
     }
+    free(memory);
 }
 
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -16,7 +16,9 @@
 #include <TraceLoggingProvider.h>
 #include <vector>
 
+#include "ebpf_leak_detector.h"
 #include "ebpf_low_memory_test.h"
+#include "ebpf_symbol_decoder.h"
 #include "ebpf_utilities.h"
 
 // Global variables used to override behavior for testing.
@@ -29,12 +31,14 @@ extern "C" bool ebpf_fuzzing_enabled = false;
 extern "C" size_t ebpf_fuzzing_memory_limit = MAXSIZE_T;
 
 std::unique_ptr<ebpf_low_memory_test_t> _ebpf_low_memory_test_ptr;
+ebpf_leak_detector_ptr _ebpf_leak_detector_ptr;
 
 /**
  * @brief Environment variable to enable low memory testing.
  *
  */
 #define EBPF_LOW_MEMORY_SIMULATION_ENVIRONMENT_VARIABLE_NAME "EBPF_LOW_MEMORY_SIMULATION"
+#define EBPF_MEMORY_LEAK_DETECTION_ENVIRONMENT_VARIABLE_NAME "EBPF_MEMORY_LEAK_DETECTION"
 
 // Thread pool related globals.
 static TP_CALLBACK_ENVIRON _callback_environment;
@@ -247,11 +251,19 @@ ebpf_platform_initiate()
         _ebpf_platform_maximum_group_count = GetMaximumProcessorGroupCount();
         _ebpf_platform_maximum_processor_count = GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS);
         auto low_memory_stack_depth = _get_environment_variable(EBPF_LOW_MEMORY_SIMULATION_ENVIRONMENT_VARIABLE_NAME);
+        auto leak_detector = _get_environment_variable(EBPF_MEMORY_LEAK_DETECTION_ENVIRONMENT_VARIABLE_NAME);
+        if (!low_memory_stack_depth.empty() || !leak_detector.empty()) {
+            _ebpf_symbol_decoder_initialize();
+        }
         if (!low_memory_stack_depth.empty() && !_ebpf_low_memory_test_ptr) {
             _ebpf_low_memory_test_ptr =
                 std::make_unique<ebpf_low_memory_test_t>(std::strtoul(low_memory_stack_depth.c_str(), nullptr, 10));
             // Set flag to remove some asserts that fire from incorrect client behavior.
             ebpf_fuzzing_enabled = true;
+        }
+
+        if (!leak_detector.empty()) {
+            _ebpf_leak_detector_ptr = std::make_unique<ebpf_leak_detector_t>();
         }
 
         for (size_t i = 0; i < ebpf_get_cpu_count(); i++) {
@@ -276,6 +288,10 @@ ebpf_platform_terminate()
 {
     _clean_up_thread_pool();
     _ebpf_emulated_dpcs.resize(0);
+    if (_ebpf_leak_detector_ptr) {
+        _ebpf_leak_detector_ptr->dump_leaks();
+        _ebpf_leak_detector_ptr.reset();
+    }
 }
 
 _Must_inspect_result_ ebpf_result_t
@@ -315,6 +331,10 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_
     if (memory != nullptr)
         memset(memory, 0, size);
 
+    if (memory && _ebpf_leak_detector_ptr) {
+        _ebpf_leak_detector_ptr->register_allocation(reinterpret_cast<uintptr_t>(memory), size);
+    }
+
     return memory;
 }
 
@@ -333,6 +353,12 @@ __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_ _Post_writable_byt
     void* p = realloc(memory, new_size);
     if (p && (new_size > old_size))
         memset(((char*)p) + old_size, 0, new_size - old_size);
+
+    if (_ebpf_leak_detector_ptr) {
+        _ebpf_leak_detector_ptr->unregister_allocation(reinterpret_cast<uintptr_t>(memory));
+        _ebpf_leak_detector_ptr->register_allocation(reinterpret_cast<uintptr_t>(p), new_size);
+    }
+
     return p;
 }
 
@@ -340,6 +366,9 @@ void
 ebpf_free(_Frees_ptr_opt_ void* memory)
 {
     free(memory);
+    if (_ebpf_leak_detector_ptr) {
+        _ebpf_leak_detector_ptr->unregister_allocation(reinterpret_cast<uintptr_t>(memory));
+    }
 }
 
 __drv_allocatesMem(Mem) _Must_inspect_result_ _Ret_maybenull_

--- a/libs/platform/user/ebpf_symbol_decoder.h
+++ b/libs/platform/user/ebpf_symbol_decoder.h
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include <DbgHelp.h>
+#include <optional>
+
+#include "ebpf_platform.h"
+
+inline ebpf_result_t
+_ebpf_symbol_decoder_initialize()
+{
+    // Initialize DbgHelp.dll.
+    SymSetOptions(SYMOPT_UNDNAME | SYMOPT_DEFERRED_LOADS | SYMOPT_LOAD_LINES);
+    if (!SymInitialize(GetCurrentProcess(), nullptr, TRUE)) {
+        return EBPF_NO_MEMORY;
+    }
+    return EBPF_SUCCESS;
+}
+
+inline void
+_ebpf_symbol_decoder_deinitialize()
+{
+    SymCleanup(GetCurrentProcess());
+}
+
+inline ebpf_result_t
+_ebpf_decode_symbol(
+    uintptr_t address,
+    std::string& name,
+    uint64_t& displacement,
+    std::optional<uint32_t>& line_number,
+    std::optional<std::string>& file_name)
+{
+    try {
+
+        std::vector<uint8_t> symbol_buffer(sizeof(SYMBOL_INFO) + MAX_SYM_NAME * sizeof(TCHAR));
+        SYMBOL_INFO* symbol = reinterpret_cast<SYMBOL_INFO*>(symbol_buffer.data());
+        IMAGEHLP_LINE64 line;
+        symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
+        symbol->MaxNameLen = MAX_SYM_NAME;
+
+        if (!SymFromAddr(GetCurrentProcess(), address, &displacement, symbol)) {
+            return EBPF_NO_MEMORY;
+        }
+
+        name = symbol->Name;
+        DWORD displacement32 = (DWORD)displacement;
+
+        if (!SymGetLineFromAddr64(GetCurrentProcess(), address, &displacement32, &line)) {
+            line_number = std::nullopt;
+            file_name = std::nullopt;
+            return EBPF_SUCCESS;
+        }
+
+        line_number = line.LineNumber;
+        file_name = line.FileName;
+        return EBPF_SUCCESS;
+    } catch (std::bad_alloc&) {
+        return EBPF_NO_MEMORY;
+    }
+}

--- a/libs/platform/user/platform_user.vcxproj
+++ b/libs/platform/user/platform_user.vcxproj
@@ -31,6 +31,7 @@
     <ClCompile Include="..\ebpf_state.c" />
     <ClCompile Include="..\ebpf_trampoline.c" />
     <ClCompile Include="ebpf_handle_user.c" />
+    <ClCompile Include="ebpf_leak_detector.cpp" />
     <ClCompile Include="ebpf_low_memory_test.cpp" />
     <ClCompile Include="ebpf_native_user.c" />
     <ClCompile Include="ebpf_platform_user.cpp" />
@@ -46,7 +47,9 @@
     <ClInclude Include="..\ebpf_platform.h" />
     <ClInclude Include="..\ebpf_ring_buffer.h" />
     <ClInclude Include="..\ebpf_state.h" />
+    <ClInclude Include="ebpf_leak_detector.h" />
     <ClInclude Include="ebpf_low_memory_test.h" />
+    <ClInclude Include="ebpf_symbol_decoder.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="kernel_um.h" />
     <ClInclude Include="nmr_impl.h" />

--- a/libs/platform/user/platform_user.vcxproj.filters
+++ b/libs/platform/user/platform_user.vcxproj.filters
@@ -88,6 +88,9 @@
     <ClCompile Include="ebpf_low_memory_test.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ebpf_leak_detector.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <Midl Include="..\ebpf_program_types.idl">
@@ -137,6 +140,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="ebpf_low_memory_test.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ebpf_leak_detector.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="ebpf_symbol_decoder.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Capture list of allocations made via ebpf_allocate that haven't been freed by ebpf_free.
At ebpf_platform_terminate, log list of outstanding allocations along with stack trace of when the allocation was made.

Future:
Fail tests if there are outstanding allocations. 

## Testing

CI/CD

## Documentation

No.
