### PR TITLE
DO NOT REVIEW (WiP) - Replace program <-> prog array map circular references with uni-directional references

### DIFF
--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -274,6 +274,10 @@ extern "C"
     ebpf_program_create_and_initialize(
         _In_ const ebpf_program_parameters_t* parameters, _Out_ ebpf_handle_t* program_handle);
 
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_program_update_associated_map_index(
+        _Inout_ ebpf_map_t* map, _In_ ebpf_program_t* program, uint32_t index, bool association_flag);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2684,3 +2684,74 @@ TEST_CASE("test_ebpf_object_set_execution_type", "[end_to_end]")
 
     bpf_object__close(jit_object);
 }
+
+TEST_CASE("close_unload_test", "[end_to_end]")
+{
+    _test_helper_end_to_end test_helper;
+
+    const char* error_message = nullptr;
+    int result;
+    bpf_object* object = nullptr;
+    bpf_link* link = nullptr;
+    fd_t program_fd;
+
+    program_info_provider_t bind_program_info(EBPF_PROGRAM_TYPE_BIND);
+
+    const char* file_name = "bindmonitor_tailcall_um.dll";
+    result =
+        ebpf_program_load(file_name, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object, &program_fd, &error_message);
+
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        free((void*)error_message);
+    }
+    REQUIRE(result == 0);
+
+    // Set up tail calls.
+    struct bpf_program* callee0 = bpf_object__find_program_by_name(object, "BindMonitor_Callee0");
+    REQUIRE(callee0 != nullptr);
+    fd_t callee0_fd = bpf_program__fd(callee0);
+    REQUIRE(callee0_fd > 0);
+
+    struct bpf_program* callee1 = bpf_object__find_program_by_name(object, "BindMonitor_Callee1");
+    REQUIRE(callee1 != nullptr);
+    fd_t callee1_fd = bpf_program__fd(callee1);
+    REQUIRE(callee1_fd > 0);
+
+    fd_t prog_map_fd = bpf_object__find_map_fd_by_name(object, "prog_array_map");
+    REQUIRE(prog_map_fd > 0);
+
+    uint32_t index = 0;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee0_fd, 0) == 0);
+    index = 1;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    uint32_t ifindex = 0;
+    REQUIRE(hook.attach_link(program_fd, &ifindex, sizeof(ifindex), &link) == EBPF_SUCCESS);
+
+    hook.detach_link(link);
+    hook.close_link(link);
+
+    // NOTE: This test case deliberately does not remove the program handles stored in the prog_array_map.  If not
+    // performed by a user mode eBPF program (this test, for example), this clean-up should now be performed in the
+    // context of the bpf_object__close() call.  This call should also take care of ensuring that the following maps
+    // are cleaned up as well:
+    // - process_map
+    // - limits_map
+    // - dummy_map
+    // - dummy_inner_map
+    // - dummy_outer_map
+    // - dummy_outer_idx_map
+    // (On test termination, the bpf_map_get_next_id() check in the ~_test_helper_end_to_end() destructor should not
+    // flag any errors)
+
+#if 0
+    index = 0;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+    index = 1;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+#endif
+
+    bpf_object__close(object);
+}


### PR DESCRIPTION
## Description

DRAFT PR (Work In Progress)

This PR replaces the existing circular references created between 'program array maps' and programs.  While this works for well-behaved used node applications, this design choice leads to in-complete clean-up and/or crashes with ill-behaving ones, especially if they crash or exit without explicit clean-up.

## Testing

New tests added (Work in Progress).  Will need some more enhancements to check for complete clean-up.

## Documentation

No changes as of now.

Fixes: #1509, #1510
