### PR TITLE
Add support for j*32 instructions

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -130,7 +130,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.3/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\bpf_conformance\tests --plugin_path bpf2c_plugin.exe --cpu_version v2 --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2022

--- a/docs/NativeCodeGeneration.md
+++ b/docs/NativeCodeGeneration.md
@@ -205,3 +205,17 @@ contract.
 
 8) When the OS calls unload on the driver, the driver unregisters all of its contracts and waits for the
 notification that the eBPF execution context has detached before completing unloading.
+
+### Note about native code generation samples shipped with ebpf-for-windows.
+The ```ebpf-for-windows\test\bpf2c_tests\expected``` directory contains the native source files generated
+from the ebpf sample programs shipped with this project.  These samples (especially the generated ```.c``` sources in
+this directory) are used for test automation during CI/CD workflows.  If the ```.o``` -> ```.c``` code generation logic
+changes for any reason, the source files in this directory may need to be regenerated as well. Not doing so could
+result in failures in the CI/CD test passes.
+
+Furthermore, the generated source files also contain references to local file paths in the embedded comments, which can
+differ for each person regenerating them.
+
+These paths therefore need to be canonicalized to make them portable and this is done by running the following command
+from the ```ebpf-for-windows``` project root directory:
+``` .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\```

--- a/tests/bpf2c_plugin/bpf2c_plugin.cpp
+++ b/tests/bpf2c_plugin/bpf2c_plugin.cpp
@@ -116,7 +116,7 @@ compile_c_file(const std::filesystem::path& file_path, const std::string& includ
         while (std::getline(log, line)) {
             error << line << std::endl;
         }
-        throw std::runtime_error("Failed to compiler: " + error.str());
+        throw std::runtime_error("Failed to compile: " + error.str());
     }
 }
 

--- a/tests/bpf2c_plugin/bpf2c_plugin.vcxproj
+++ b/tests/bpf2c_plugin/bpf2c_plugin.vcxproj
@@ -60,6 +60,8 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)resource;$(SolutionDir)tools\bpf2c;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -1,0 +1,193 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from bad_map_name.o
+
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+// Windows Header Files
+#include <windows.h>
+
+#include <stdio.h>
+
+#include "bpf2c.h"
+
+#define metadata_table bad_map_name##_metadata_table
+extern metadata_table_t metadata_table;
+
+BOOL APIENTRY
+DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpReserved)
+{
+    UNREFERENCED_PARAMETER(hModule);
+    UNREFERENCED_PARAMETER(lpReserved);
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+void
+division_by_zero(uint32_t address)
+{
+    fprintf(stderr, "Divide by zero at address %d\n", address);
+}
+
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
+     },
+     "this_map_has_a_name_that_is_longer_than_what_the_ebpfcore_driver_can_support"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 1;
+}
+
+static helper_function_entry_t lookup_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+};
+
+static GUID lookup_program_type_guid = {0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID lookup_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+static uint16_t lookup_maps[] = {
+    0,
+};
+
+#pragma code_seg(push, "xdp_prog")
+static uint64_t
+lookup(void* context)
+#line 20 "sample/bad_map_name.c"
+{
+#line 20 "sample/bad_map_name.c"
+    // Prologue
+#line 20 "sample/bad_map_name.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r0 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r1 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r2 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r3 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r4 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r5 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r10 = 0;
+
+#line 20 "sample/bad_map_name.c"
+    r1 = (uintptr_t)context;
+#line 20 "sample/bad_map_name.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=0
+#line 20 "sample/bad_map_name.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r1 offset=-4 imm=0
+#line 22 "sample/bad_map_name.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 22 "sample/bad_map_name.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-4
+#line 22 "sample/bad_map_name.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 24 "sample/bad_map_name.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 24 "sample/bad_map_name.c"
+    r0 = lookup_helpers[0].address
+#line 24 "sample/bad_map_name.c"
+         (r1, r2, r3, r4, r5);
+#line 24 "sample/bad_map_name.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 24 "sample/bad_map_name.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 24 "sample/bad_map_name.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
+#line 24 "sample/bad_map_name.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
+#line 25 "sample/bad_map_name.c"
+    if (r1 == IMMEDIATE(0))
+#line 25 "sample/bad_map_name.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 25 "sample/bad_map_name.c"
+    r0 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
+#line 25 "sample/bad_map_name.c"
+    return r0;
+#line 25 "sample/bad_map_name.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        lookup,
+        "xdp_prog",
+        "xdp_prog",
+        "lookup",
+        lookup_maps,
+        1,
+        lookup_helpers,
+        1,
+        12,
+        &lookup_program_type_guid,
+        &lookup_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bad_map_name_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bad_map_name_raw.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_raw.c
@@ -1,0 +1,159 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from bad_map_name.o
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
+     },
+     "this_map_has_a_name_that_is_longer_than_what_the_ebpfcore_driver_can_support"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 1;
+}
+
+static helper_function_entry_t lookup_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+};
+
+static GUID lookup_program_type_guid = {0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID lookup_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+static uint16_t lookup_maps[] = {
+    0,
+};
+
+#pragma code_seg(push, "xdp_prog")
+static uint64_t
+lookup(void* context)
+#line 20 "sample/bad_map_name.c"
+{
+#line 20 "sample/bad_map_name.c"
+    // Prologue
+#line 20 "sample/bad_map_name.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r0 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r1 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r2 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r3 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r4 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r5 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r10 = 0;
+
+#line 20 "sample/bad_map_name.c"
+    r1 = (uintptr_t)context;
+#line 20 "sample/bad_map_name.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=0
+#line 20 "sample/bad_map_name.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r1 offset=-4 imm=0
+#line 22 "sample/bad_map_name.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 22 "sample/bad_map_name.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-4
+#line 22 "sample/bad_map_name.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 24 "sample/bad_map_name.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 24 "sample/bad_map_name.c"
+    r0 = lookup_helpers[0].address
+#line 24 "sample/bad_map_name.c"
+         (r1, r2, r3, r4, r5);
+#line 24 "sample/bad_map_name.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 24 "sample/bad_map_name.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 24 "sample/bad_map_name.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
+#line 24 "sample/bad_map_name.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
+#line 25 "sample/bad_map_name.c"
+    if (r1 == IMMEDIATE(0))
+#line 25 "sample/bad_map_name.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 25 "sample/bad_map_name.c"
+    r0 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
+#line 25 "sample/bad_map_name.c"
+    return r0;
+#line 25 "sample/bad_map_name.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        lookup,
+        "xdp_prog",
+        "xdp_prog",
+        "lookup",
+        lookup_maps,
+        1,
+        lookup_helpers,
+        1,
+        12,
+        &lookup_program_type_guid,
+        &lookup_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bad_map_name_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -1,0 +1,326 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from bad_map_name.o
+
+#include <guiddef.h>
+#include <wdm.h>
+#include <wsk.h>
+
+#define NO_CRT
+#include "bpf2c.h"
+
+DRIVER_INITIALIZE DriverEntry;
+DRIVER_UNLOAD DriverUnload;
+RTL_QUERY_REGISTRY_ROUTINE static _bpf2c_query_registry_routine;
+
+#define metadata_table bad_map_name##_metadata_table
+
+static GUID _bpf2c_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
+                             0xc847aac8,
+                             0xa6f2,
+                             0x4b53,
+                             {0xae, 0xa3, 0xf4, 0xa9, 0x4b, 0x9a, 0x80, 0xcb}};
+static NPI_MODULEID _bpf2c_module_id = {sizeof(_bpf2c_module_id), MIT_GUID, {0}};
+static HANDLE _bpf2c_nmr_client_handle;
+static HANDLE _bpf2c_nmr_provider_handle;
+extern metadata_table_t metadata_table;
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance);
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context);
+
+static const NPI_CLIENT_CHARACTERISTICS _bpf2c_npi_client_characteristics = {
+    0,                                  // Version
+    sizeof(NPI_CLIENT_CHARACTERISTICS), // Length
+    _bpf2c_npi_client_attach_provider,
+    _bpf2c_npi_client_detach_provider,
+    NULL,
+    {0,                                 // Version
+     sizeof(NPI_REGISTRATION_INSTANCE), // Length
+     &_bpf2c_npi_id,
+     &_bpf2c_module_id,
+     0,
+     &metadata_table}};
+
+static NTSTATUS
+_bpf2c_query_npi_module_id(
+    _In_ const wchar_t* value_name,
+    unsigned long value_type,
+    _In_ const void* value_data,
+    unsigned long value_length,
+    _Inout_ void* context,
+    _Inout_ void* entry_context)
+{
+    UNREFERENCED_PARAMETER(value_name);
+    UNREFERENCED_PARAMETER(context);
+    UNREFERENCED_PARAMETER(entry_context);
+
+    if (value_type != REG_BINARY) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (value_length != sizeof(_bpf2c_module_id.Guid)) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    memcpy(&_bpf2c_module_id.Guid, value_data, value_length);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+DriverEntry(_In_ DRIVER_OBJECT* driver_object, _In_ UNICODE_STRING* registry_path)
+{
+    NTSTATUS status;
+    RTL_QUERY_REGISTRY_TABLE query_table[] = {
+        {
+            NULL,                      // Query routine
+            RTL_QUERY_REGISTRY_SUBKEY, // Flags
+            L"Parameters",             // Name
+            NULL,                      // Entry context
+            REG_NONE,                  // Default type
+            NULL,                      // Default data
+            0,                         // Default length
+        },
+        {
+            _bpf2c_query_npi_module_id,  // Query routine
+            RTL_QUERY_REGISTRY_REQUIRED, // Flags
+            L"NpiModuleId",              // Name
+            NULL,                        // Entry context
+            REG_NONE,                    // Default type
+            NULL,                        // Default data
+            0,                           // Default length
+        },
+        {0}};
+
+    status = RtlQueryRegistryValues(RTL_REGISTRY_ABSOLUTE, registry_path->Buffer, query_table, NULL, NULL);
+    if (!NT_SUCCESS(status)) {
+        goto Exit;
+    }
+
+    status = NmrRegisterClient(&_bpf2c_npi_client_characteristics, NULL, &_bpf2c_nmr_client_handle);
+
+Exit:
+    if (NT_SUCCESS(status)) {
+        driver_object->DriverUnload = DriverUnload;
+    }
+
+    return status;
+}
+
+void
+DriverUnload(_In_ DRIVER_OBJECT* driver_object)
+{
+    NTSTATUS status = NmrDeregisterClient(_bpf2c_nmr_client_handle);
+    if (status == STATUS_PENDING) {
+        NmrWaitForClientDeregisterComplete(_bpf2c_nmr_client_handle);
+    }
+    UNREFERENCED_PARAMETER(driver_object);
+}
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
+{
+    NTSTATUS status = STATUS_SUCCESS;
+    void* provider_binding_context = NULL;
+    void* provider_dispatch_table = NULL;
+
+    UNREFERENCED_PARAMETER(client_context);
+    UNREFERENCED_PARAMETER(provider_registration_instance);
+
+    if (_bpf2c_nmr_provider_handle != NULL) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+#pragma warning(push)
+#pragma warning( \
+    disable : 6387) // Param 3 does not adhere to the specification for the function 'NmrClientAttachProvider'
+    // As per MSDN, client dispatch can be NULL, but SAL does not allow it.
+    // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nf-netioddk-nmrclientattachprovider
+    status = NmrClientAttachProvider(
+        nmr_binding_handle, client_context, NULL, &provider_binding_context, &provider_dispatch_table);
+    if (status != STATUS_SUCCESS) {
+        goto Done;
+    }
+#pragma warning(pop)
+    _bpf2c_nmr_provider_handle = nmr_binding_handle;
+
+Done:
+    return status;
+}
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
+{
+    _bpf2c_nmr_provider_handle = NULL;
+    UNREFERENCED_PARAMETER(client_binding_context);
+    return STATUS_SUCCESS;
+}
+
+void
+division_by_zero(uint32_t address)
+{
+    UNREFERENCED_PARAMETER(address);
+}
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH, // Type of map.
+         4,                 // Size in bytes of a map key.
+         4,                 // Size in bytes of a map value.
+         1,                 // Maximum number of entries allowed in the map.
+         0,                 // Inner map index.
+         PIN_NONE,          // Pinning type for the map.
+         0,                 // Identifier for a map template.
+         0,                 // The id of the inner map template.
+     },
+     "this_map_has_a_name_that_is_longer_than_what_the_ebpfcore_driver_can_support"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 1;
+}
+
+static helper_function_entry_t lookup_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+};
+
+static GUID lookup_program_type_guid = {0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID lookup_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+static uint16_t lookup_maps[] = {
+    0,
+};
+
+#pragma code_seg(push, "xdp_prog")
+static uint64_t
+lookup(void* context)
+#line 20 "sample/bad_map_name.c"
+{
+#line 20 "sample/bad_map_name.c"
+    // Prologue
+#line 20 "sample/bad_map_name.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r0 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r1 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r2 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r3 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r4 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r5 = 0;
+#line 20 "sample/bad_map_name.c"
+    register uint64_t r10 = 0;
+
+#line 20 "sample/bad_map_name.c"
+    r1 = (uintptr_t)context;
+#line 20 "sample/bad_map_name.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r1 src=r0 offset=0 imm=0
+#line 20 "sample/bad_map_name.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1 dst=r10 src=r1 offset=-4 imm=0
+#line 22 "sample/bad_map_name.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 22 "sample/bad_map_name.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-4
+#line 22 "sample/bad_map_name.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 24 "sample/bad_map_name.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 24 "sample/bad_map_name.c"
+    r0 = lookup_helpers[0].address
+#line 24 "sample/bad_map_name.c"
+         (r1, r2, r3, r4, r5);
+#line 24 "sample/bad_map_name.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 24 "sample/bad_map_name.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=7 dst=r1 src=r0 offset=0 imm=0
+#line 24 "sample/bad_map_name.c"
+    r1 = r0;
+    // EBPF_OP_MOV64_IMM pc=8 dst=r0 src=r0 offset=0 imm=1
+#line 24 "sample/bad_map_name.c"
+    r0 = IMMEDIATE(1);
+    // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=1 imm=0
+#line 25 "sample/bad_map_name.c"
+    if (r1 == IMMEDIATE(0))
+#line 25 "sample/bad_map_name.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
+#line 25 "sample/bad_map_name.c"
+    r0 = IMMEDIATE(0);
+label_1:
+    // EBPF_OP_EXIT pc=11 dst=r0 src=r0 offset=0 imm=0
+#line 25 "sample/bad_map_name.c"
+    return r0;
+#line 25 "sample/bad_map_name.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        lookup,
+        "xdp_prog",
+        "xdp_prog",
+        "lookup",
+        lookup_maps,
+        1,
+        lookup_helpers,
+        1,
+        12,
+        &lookup_program_type_guid,
+        &lookup_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 5;
+    version->revision = 0;
+}
+
+metadata_table_t bad_map_name_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -365,7 +365,7 @@ test_maps(void* context)
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=45 dst=r6 src=r0 offset=2 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_2;
 label_1:
@@ -554,7 +554,7 @@ label_2:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=101 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_4;
 label_3:
@@ -743,7 +743,7 @@ label_4:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=157 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_6;
 label_5:
@@ -903,7 +903,7 @@ label_6:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=204 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_8;
 label_7:
@@ -1060,7 +1060,7 @@ label_8:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=250 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_10;
 label_9:
@@ -1246,7 +1246,7 @@ label_10:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=305 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_12;
 label_11:
@@ -1379,7 +1379,7 @@ label_14:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=345 dst=r1 src=r0 offset=-25 imm=-1
 #line 123 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 123 "sample/map.c"
         goto label_13;
         // EBPF_OP_JA pc=346 dst=r0 src=r0 offset=-301 imm=0
@@ -1498,7 +1498,7 @@ label_16:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=381 dst=r1 src=r0 offset=-35 imm=-1
 #line 123 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 123 "sample/map.c"
         goto label_15;
         // EBPF_OP_JA pc=382 dst=r0 src=r0 offset=-337 imm=0
@@ -2747,7 +2747,7 @@ label_27:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=749 dst=r1 src=r0 offset=-704 imm=-1
 #line 209 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 209 "sample/map.c"
         goto label_1;
 label_28:

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -331,7 +331,7 @@ test_maps(void* context)
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=45 dst=r6 src=r0 offset=2 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_2;
 label_1:
@@ -520,7 +520,7 @@ label_2:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=101 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_4;
 label_3:
@@ -709,7 +709,7 @@ label_4:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=157 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_6;
 label_5:
@@ -869,7 +869,7 @@ label_6:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=204 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_8;
 label_7:
@@ -1026,7 +1026,7 @@ label_8:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=250 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_10;
 label_9:
@@ -1212,7 +1212,7 @@ label_10:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=305 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_12;
 label_11:
@@ -1345,7 +1345,7 @@ label_14:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=345 dst=r1 src=r0 offset=-25 imm=-1
 #line 123 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 123 "sample/map.c"
         goto label_13;
         // EBPF_OP_JA pc=346 dst=r0 src=r0 offset=-301 imm=0
@@ -1464,7 +1464,7 @@ label_16:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=381 dst=r1 src=r0 offset=-35 imm=-1
 #line 123 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 123 "sample/map.c"
         goto label_15;
         // EBPF_OP_JA pc=382 dst=r0 src=r0 offset=-337 imm=0
@@ -2713,7 +2713,7 @@ label_27:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=749 dst=r1 src=r0 offset=-704 imm=-1
 #line 209 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 209 "sample/map.c"
         goto label_1;
 label_28:

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -498,7 +498,7 @@ test_maps(void* context)
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=45 dst=r6 src=r0 offset=2 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_2;
 label_1:
@@ -687,7 +687,7 @@ label_2:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=101 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_4;
 label_3:
@@ -876,7 +876,7 @@ label_4:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=157 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_6;
 label_5:
@@ -1036,7 +1036,7 @@ label_6:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=204 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_8;
 label_7:
@@ -1193,7 +1193,7 @@ label_8:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=250 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_10;
 label_9:
@@ -1379,7 +1379,7 @@ label_10:
     r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=305 dst=r6 src=r0 offset=1 imm=-1
 #line 95 "sample/map.c"
-    if ((int64_t)r6 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r6 > IMMEDIATE(-1))
 #line 95 "sample/map.c"
         goto label_12;
 label_11:
@@ -1512,7 +1512,7 @@ label_14:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=345 dst=r1 src=r0 offset=-25 imm=-1
 #line 123 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 123 "sample/map.c"
         goto label_13;
         // EBPF_OP_JA pc=346 dst=r0 src=r0 offset=-301 imm=0
@@ -1631,7 +1631,7 @@ label_16:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=381 dst=r1 src=r0 offset=-35 imm=-1
 #line 123 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 123 "sample/map.c"
         goto label_15;
         // EBPF_OP_JA pc=382 dst=r0 src=r0 offset=-337 imm=0
@@ -2880,7 +2880,7 @@ label_27:
     r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
     // EBPF_OP_JSGT_IMM pc=749 dst=r1 src=r0 offset=-704 imm=-1
 #line 209 "sample/map.c"
-    if ((int64_t)r1 > (int64_t)IMMEDIATE(-1))
+    if ((int64_t)r1 > IMMEDIATE(-1))
 #line 209 "sample/map.c"
         goto label_1;
 label_28:

--- a/tests/bpf2c_tests/raw_bpf.cpp
+++ b/tests/bpf2c_tests/raw_bpf.cpp
@@ -402,12 +402,6 @@ TEST_CASE("BE/LE", "[raw_bpf_code_gen][negative]")
     verify_invalid_opcode_sequence({{EBPF_OP_BE, 0, 0, 0, 15}}, "invalid operand at offset 0");
 }
 
-TEST_CASE("unknown op-class", "[raw_bpf_code_gen][negative]")
-{
-    // EBPF_CLS_JMP+1 isn't a valid op class
-    verify_invalid_opcode_sequence({{EBPF_CLS_JMP + 1, 0, 0, 0, 0}}, "invalid operand at offset 0");
-}
-
 TEST_CASE("unknown EBPF_CLS_ALU operation", "[raw_bpf_code_gen][negative]")
 {
     // EBPF_CLS_ALU + operations 0xe0 doesn't exist

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -58,6 +58,8 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;ENABLE_SKIP_VERIFY;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)external\ebpf-verifier\external\ELFIO;$(SolutionDir)external\ubpf\vm;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)resource;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -12,6 +12,7 @@
 // .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\
 
 #include <cassert>
+#include <format>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -63,20 +64,20 @@ enum class AluOperations
 };
 
 static const std::string _predicate_format_string[] = {
-    "",                           // JA
-    "%s == %s",                   // JEQ
-    "%s > %s",                    // JGT
-    "%s >= %s",                   // JGE
-    "%s & %s",                    // JSET
-    "%s != %s",                   // JNE
-    "(int64_t)%s > (int64_t)%s",  // JSGT
-    "(int64_t)%s >= (int64_t)%s", // JSGE
-    "",                           // CALL
-    "",                           // EXIT
-    "%s < %s",                    // JLT
-    "%s <= %s",                   // JLE
-    "(int64_t)%s < (int64_t)%s",  // JSLT
-    "(int64_t)%s <= (int64_t)%s", // JSLE
+    "",             // JA
+    "{}{} == {}{}", // JEQ
+    "{}{} > {}{}",  // JGT
+    "{}{} >= {}{}", // JGE
+    "{}{} & {}{}",  // JSET
+    "{}{} != {}{}", // JNE
+    "{}{} > {}{}",  // JSGT
+    "{}{} >= {}{}", // JSGE
+    "",             // CALL
+    "",             // EXIT
+    "{}{} < {}{}",  // JLT
+    "{}{} <= {}{}", // JLE
+    "{}{} < {}{}",  // JSLT
+    "{}{} <= {}{}", // JSLE
 };
 
 #define ADD_OPCODE(X)                            \
@@ -115,6 +116,15 @@ static std::map<uint8_t, std::string> _opcode_name_strings = {
     ADD_OPCODE(EBPF_OP_JLE_IMM),    ADD_OPCODE(EBPF_OP_JLE_REG),   ADD_OPCODE(EBPF_OP_JSLT_IMM),
     ADD_OPCODE(EBPF_OP_JSLT_REG),   ADD_OPCODE(EBPF_OP_JSLE_IMM),  ADD_OPCODE(EBPF_OP_JSLE_REG),
 };
+
+#define IS_JMP_CLASS_OPCODE(_opcode) \
+    (((_opcode)&EBPF_CLS_MASK) == EBPF_CLS_JMP || ((_opcode)&EBPF_CLS_MASK) == EBPF_CLS_JMP32)
+
+#define IS_JMP32_CLASS_OPCODE(_opcode) (((_opcode)&EBPF_CLS_MASK) == EBPF_CLS_JMP32)
+
+#define IS_SIGNED_CMP_OPCODE(_opcode)                                                          \
+    (((_opcode) >> 4) == (EBPF_MODE_JSGT >> 4) || ((_opcode) >> 4) == (EBPF_MODE_JSGE >> 4) || \
+     ((_opcode) >> 4) == (EBPF_MODE_JSLT >> 4) || ((_opcode) >> 4) == (EBPF_MODE_JSLE >> 4))
 
 /**
  * @brief Global operator to permit concatenating a safe and unsafe string.
@@ -438,7 +448,7 @@ bpf_code_generator::generate_labels()
     // Tag jump targets
     for (size_t i = 0; i < program_output.size(); i++) {
         auto& output = program_output[i];
-        if ((output.instruction.opcode & EBPF_CLS_MASK) != EBPF_CLS_JMP) {
+        if (!IS_JMP_CLASS_OPCODE(output.instruction.opcode)) {
             continue;
         }
         if (output.instruction.opcode == EBPF_OP_CALL) {
@@ -493,7 +503,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
 {
     std::vector<output_instruction_t>& program_output = current_section->output;
     auto program_name = !current_section->program_name.empty() ? current_section->program_name : section_name;
-    auto helper_array_prefix = program_name.c_identifier() + "_helpers[%s]";
+    auto helper_array_prefix = program_name.c_identifier() + "_helpers[{}]";
 
     // Encode instructions
     for (size_t i = 0; i < program_output.size(); i++) {
@@ -514,51 +524,51 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             std::string swap_function;
             switch (operation) {
             case AluOperations::Add:
-                output.lines.push_back(format_string("%s += %s;", destination, source));
+                output.lines.push_back(std::format("{} += {};", destination, source));
                 break;
             case AluOperations::Sub:
-                output.lines.push_back(format_string("%s -= %s;", destination, source));
+                output.lines.push_back(std::format("{} -= {};", destination, source));
                 break;
             case AluOperations::Mul:
-                output.lines.push_back(format_string("%s *= %s;", destination, source));
+                output.lines.push_back(std::format("{} *= {};", destination, source));
                 break;
             case AluOperations::Div:
                 if (is64bit)
                     output.lines.push_back(
-                        format_string("%s = %s ? (%s / %s) : 0;", destination, source, destination, source));
+                        std::format("{} = {} ? ({} / {}) : 0;", destination, source, destination, source));
                 else
-                    output.lines.push_back(format_string(
-                        "%s = (uint32_t)%s ? (uint32_t)%s / (uint32_t)%s : 0;",
+                    output.lines.push_back(std::format(
+                        "{} = (uint32_t){} ? (uint32_t){} / (uint32_t){} : 0;",
                         destination,
                         source,
                         destination,
                         source));
                 break;
             case AluOperations::Or:
-                output.lines.push_back(format_string("%s |= %s;", destination, source));
+                output.lines.push_back(std::format("{} |= {};", destination, source));
                 break;
             case AluOperations::And:
-                output.lines.push_back(format_string("%s &= %s;", destination, source));
+                output.lines.push_back(std::format("{} &= {};", destination, source));
                 break;
             case AluOperations::Lsh:
-                output.lines.push_back(format_string("%s <<= %s;", destination, source));
+                output.lines.push_back(std::format("{} <<= {};", destination, source));
                 break;
             case AluOperations::Rsh:
                 if (is64bit)
-                    output.lines.push_back(format_string("%s >>= %s;", destination, source));
+                    output.lines.push_back(std::format("{} >>= {};", destination, source));
                 else
-                    output.lines.push_back(format_string("%s = (uint32_t)%s >> %s;", destination, destination, source));
+                    output.lines.push_back(std::format("{} = (uint32_t){} >> {};", destination, destination, source));
                 break;
             case AluOperations::Neg:
-                output.lines.push_back(format_string("%s = -(int64_t)%s;", destination, destination));
+                output.lines.push_back(std::format("{} = -(int64_t){};", destination, destination));
                 break;
             case AluOperations::Mod:
                 if (is64bit)
-                    output.lines.push_back(format_string(
-                        "%s = %s ? (%s %% %s): %s ;", destination, source, destination, source, destination));
+                    output.lines.push_back(std::format(
+                        "{} = {} ? ({} % {}): {} ;", destination, source, destination, source, destination));
                 else
-                    output.lines.push_back(format_string(
-                        "%s = (uint32_t)%s ? ((uint32_t)%s %% (uint32_t)%s) : (uint32_t)%s;",
+                    output.lines.push_back(std::format(
+                        "{} = (uint32_t){} ? ((uint32_t){} % (uint32_t){}) : (uint32_t){};",
                         destination,
                         source,
                         destination,
@@ -566,17 +576,17 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                         destination));
                 break;
             case AluOperations::Xor:
-                output.lines.push_back(format_string("%s ^= %s;", destination, source));
+                output.lines.push_back(std::format("{} ^= {};", destination, source));
                 break;
             case AluOperations::Mov:
-                output.lines.push_back(format_string("%s = %s;", destination, source));
+                output.lines.push_back(std::format("{} = {};", destination, source));
                 break;
             case AluOperations::Ashr:
                 if (is64bit)
                     output.lines.push_back(
-                        format_string("%s = (int64_t)%s >> (uint32_t)%s;", destination, destination, source));
+                        std::format("{} = (int64_t){} >> (uint32_t){};", destination, destination, source));
                 else
-                    output.lines.push_back(format_string("%s = (int32_t)%s >> %s;", destination, destination, source));
+                    output.lines.push_back(std::format("{} = (int32_t){} >> {};", destination, destination, source));
                 break;
             case AluOperations::ByteOrder: {
                 std::string size_type = "";
@@ -618,13 +628,13 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                     }
                 }
                 output.lines.push_back(
-                    format_string("%s = %s((%s)%s);", destination, swap_function, size_type, destination));
+                    std::format("{} = {}(({}){});", destination, swap_function, size_type, destination));
             } break;
             default:
                 throw bpf_code_generator_exception("invalid operand", output.instruction_offset);
             }
             if (!is64bit)
-                output.lines.push_back(format_string("%s &= UINT32_MAX;", destination));
+                output.lines.push_back(std::format("{} &= UINT32_MAX;", destination));
 
         } break;
         case EBPF_CLS_LD: {
@@ -642,7 +652,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 imm |= static_cast<uint32_t>(output.instruction.imm);
                 std::string source;
                 source = "(uint64_t)" + std::to_string(imm);
-                output.lines.push_back(format_string("%s = %s;", destination, source));
+                output.lines.push_back(std::format("{} = {};", destination, source));
             } else {
                 std::string source;
                 auto map_definition = map_definitions.find(output.relocation);
@@ -650,8 +660,8 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                     throw bpf_code_generator_exception(
                         "Map " + output.relocation + " doesn't exist", output.instruction_offset);
                 }
-                source = format_string("_maps[%s].address", std::to_string(map_definition->second.index));
-                output.lines.push_back(format_string("%s = POINTER(%s);", destination, source));
+                source = std::format("_maps[{}].address", std::to_string(map_definition->second.index));
+                output.lines.push_back(std::format("{} = POINTER({});", destination, source));
                 current_section->referenced_map_indices.insert(map_definitions[output.relocation].index);
             }
         } break;
@@ -675,7 +685,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 break;
             }
             output.lines.push_back(
-                format_string("%s = *(%s*)(uintptr_t)(%s + %s);", destination, size_type, source, offset));
+                std::format("{} = *({}*)(uintptr_t)({} + {});", destination, size_type, source, offset));
         } break;
         case EBPF_CLS_ST:
         case EBPF_CLS_STX: {
@@ -704,19 +714,34 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             }
             source = "(" + size_type + ")" + source;
             output.lines.push_back(
-                format_string("*(%s*)(uintptr_t)(%s + %s) = %s;", size_type, destination, offset, source));
+                std::format("*({}*)(uintptr_t)({} + {}) = {};", size_type, destination, offset, source));
         } break;
-        case EBPF_CLS_JMP: {
+        case EBPF_CLS_JMP:
+        case EBPF_CLS_JMP32: {
             std::string destination = get_register_name(inst.dst);
+            std::string destination_cast;
+            if (IS_JMP32_CLASS_OPCODE(inst.opcode)) {
+                destination_cast = IS_SIGNED_CMP_OPCODE(inst.opcode) ? "(int32_t)" : "(uint32_t)";
+            } else {
+                destination_cast = IS_SIGNED_CMP_OPCODE(inst.opcode) ? "(int64_t)" : "";
+            }
+
             std::string source;
+            std::string source_cast;
             if (inst.opcode & EBPF_SRC_REG) {
                 source = get_register_name(inst.src);
+                if (IS_JMP32_CLASS_OPCODE(inst.opcode)) {
+                    source_cast = IS_SIGNED_CMP_OPCODE(inst.opcode) ? "(int32_t)" : "(uint32_t)";
+                } else {
+                    source_cast = IS_SIGNED_CMP_OPCODE(inst.opcode) ? "(int64_t)" : "";
+                }
             } else {
                 source = "IMMEDIATE(" + std::to_string(inst.imm) + ")";
             }
             if ((inst.opcode >> 4) >= _countof(_predicate_format_string)) {
                 throw bpf_code_generator_exception("invalid operand", output.instruction_offset);
             }
+
             auto& format = _predicate_format_string[inst.opcode >> 4];
             if (inst.opcode == EBPF_OP_JA) {
                 std::string target = program_output[i + inst.offset + 1].label;
@@ -724,24 +749,24 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             } else if (inst.opcode == EBPF_OP_CALL) {
                 std::string function_name;
                 if (output.relocation.empty()) {
-                    function_name = format_string(
+                    function_name = std::vformat(
                         helper_array_prefix,
-                        std::to_string(
+                        make_format_args(std::to_string(
                             current_section->helper_functions["helper_id_" + std::to_string(output.instruction.imm)]
-                                .index));
+                                .index)));
                 } else {
                     auto helper_function = current_section->helper_functions.find(output.relocation);
                     assert(helper_function != current_section->helper_functions.end());
-                    function_name = format_string(
+                    function_name = std::vformat(
                         helper_array_prefix,
-                        std::to_string(current_section->helper_functions[output.relocation].index));
+                        make_format_args(std::to_string(current_section->helper_functions[output.relocation].index)));
                 }
                 output.lines.push_back(get_register_name(0) + " = " + function_name + ".address");
                 output.lines.push_back(
                     INDENT " (" + get_register_name(1) + ", " + get_register_name(2) + ", " + get_register_name(3) +
                     ", " + get_register_name(4) + ", " + get_register_name(5) + ");");
                 output.lines.push_back(
-                    format_string("if ((%s.tail_call) && (%s == 0))", function_name, get_register_name(0)));
+                    std::format("if (({}.tail_call) && ({} == 0))", function_name, get_register_name(0)));
                 output.lines.push_back(INDENT "return 0;");
             } else if (inst.opcode == EBPF_OP_EXIT) {
                 output.lines.push_back("return " + get_register_name(0) + ";");
@@ -750,11 +775,14 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 if (target.empty()) {
                     throw bpf_code_generator_exception("invalid jump target", output.instruction_offset);
                 }
-                std::string predicate = format_string(format, destination, source);
-                output.lines.push_back(format_string("if (%s)", predicate));
-                output.lines.push_back(format_string(INDENT "goto %s;", target));
+
+                std::string predicate =
+                    vformat(format, make_format_args(destination_cast, destination, source_cast, source));
+                output.lines.push_back(vformat("if ({})", make_format_args(predicate)));
+                output.lines.push_back(vformat(INDENT "goto {};", make_format_args(target)));
             }
         } break;
+
         default:
             throw bpf_code_generator_exception("invalid operand", output.instruction_offset);
         }
@@ -913,22 +941,21 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         std::string program_info_hash_name = program_name.c_identifier() + "_program_info_hash";
 
         auto guid_declaration =
-            format_string("static GUID %s = %s;", program_type_name, format_guid(&section.program_type, false));
+            std::format("static GUID {} = {};", program_type_name, format_guid(&section.program_type, false));
 
         if (guid_declaration.length() <= LINE_BREAK_WIDTH) {
             output_stream << guid_declaration << std::endl;
         } else {
-            output_stream << format_string(
-                                 "static GUID %s = %s;", program_type_name, format_guid(&section.program_type, true))
+            output_stream << format("static GUID {} = {};", program_type_name, format_guid(&section.program_type, true))
                           << std::endl;
         }
         guid_declaration =
-            format_string("static GUID %s = %s;", attach_type_name, format_guid(&section.expected_attach_type, false));
+            std::format("static GUID {} = {};", attach_type_name, format_guid(&section.expected_attach_type, false));
         if (guid_declaration.length() <= LINE_BREAK_WIDTH) {
             output_stream << guid_declaration << std::endl;
         } else {
-            output_stream << format_string(
-                                 "static GUID %s = %s;",
+            output_stream << std::format(
+                                 "static GUID {} = {};",
                                  attach_type_name,
                                  format_guid(&section.expected_attach_type, true))
                           << std::endl;
@@ -951,7 +978,7 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         if (section.referenced_map_indices.size() > 0) {
             // Emit the array for the maps used.
             std::string map_array_name = program_name.c_identifier() + "_maps";
-            output_stream << format_string("static uint16_t %s[] = {", map_array_name) << std::endl;
+            output_stream << std::format("static uint16_t {}[] = {{\n", map_array_name);
             for (const auto& map_index : section.referenced_map_indices) {
                 output_stream << INDENT << std::to_string(map_index) << "," << std::endl;
             }
@@ -963,15 +990,15 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         auto first_line_info = line_info.find(section.output.front().instruction_offset);
         std::string prolog_line_info;
         if (first_line_info != line_info.end() && !first_line_info->second.file_name.empty()) {
-            prolog_line_info = format_string(
-                "#line %s %s\n",
+            prolog_line_info = std::format(
+                "#line {} {}\n",
                 std::to_string(first_line_info->second.line_number),
                 first_line_info->second.file_name.quoted_filename());
         }
 
         // Emit entry point
         output_stream << "#pragma code_seg(push, " << section.pe_section_name.quoted() << ")" << std::endl;
-        output_stream << format_string("static uint64_t\n%s(void* context)", program_name.c_identifier()) << std::endl;
+        output_stream << std::format("static uint64_t\n{}(void* context)", program_name.c_identifier()) << std::endl;
         output_stream << prolog_line_info << "{" << std::endl;
 
         // Emit prologue
@@ -1000,8 +1027,8 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
             auto current_line = line_info.find(output.instruction_offset);
             if (current_line != line_info.end() && !current_line->second.file_name.empty() &&
                 current_line->second.line_number != 0) {
-                prolog_line_info = format_string(
-                    "#line %s %s\n",
+                prolog_line_info = std::format(
+                    "#line {} {}\n",
                     std::to_string(current_line->second.line_number),
                     current_line->second.file_name.quoted_filename());
             }
@@ -1088,9 +1115,8 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
                   << "}" << std::endl
                   << std::endl;
 
-    output_stream << format_string(
-        "metadata_table_t %s = {_get_programs, _get_maps, _get_hash, _get_version};\n",
-        c_name.c_identifier() + "_metadata_table");
+    output_stream << "metadata_table_t " << (c_name.c_identifier() + "_metadata_table")
+                  << " = {_get_programs, _get_maps, _get_hash, _get_version};\n";
 }
 
 std::string
@@ -1123,57 +1149,6 @@ bpf_code_generator::format_guid(const GUID* guid, bool split)
         throw bpf_code_generator_exception("Error formatting GUID");
     }
 
-    output.resize(strlen(output.c_str()));
-    return output;
-}
-
-std::string
-bpf_code_generator::format_string(
-    const std::string& format,
-    const std::string insert_1,
-    const std::string insert_2,
-    const std::string insert_3,
-    const std::string insert_4,
-    const std::string insert_5)
-{
-    std::string output(200, '\0');
-    if (insert_2.empty()) {
-        auto count = snprintf(output.data(), output.size(), format.c_str(), insert_1.c_str());
-        if (count < 0)
-            throw bpf_code_generator_exception("Error formatting string");
-    } else if (insert_3.empty()) {
-        auto count = snprintf(output.data(), output.size(), format.c_str(), insert_1.c_str(), insert_2.c_str());
-        if (count < 0)
-            throw bpf_code_generator_exception("Error formatting string");
-    } else if (insert_4.empty()) {
-        auto count = snprintf(
-            output.data(), output.size(), format.c_str(), insert_1.c_str(), insert_2.c_str(), insert_3.c_str());
-        if (count < 0)
-            throw bpf_code_generator_exception("Error formatting string");
-    } else if (insert_5.empty()) {
-        auto count = snprintf(
-            output.data(),
-            output.size(),
-            format.c_str(),
-            insert_1.c_str(),
-            insert_2.c_str(),
-            insert_3.c_str(),
-            insert_4.c_str());
-        if (count < 0)
-            throw bpf_code_generator_exception("Error formatting string");
-    } else {
-        auto count = snprintf(
-            output.data(),
-            output.size(),
-            format.c_str(),
-            insert_1.c_str(),
-            insert_2.c_str(),
-            insert_3.c_str(),
-            insert_4.c_str(),
-            insert_5.c_str());
-        if (count < 0)
-            throw bpf_code_generator_exception("Error formatting string");
-    }
     output.resize(strlen(output.c_str()));
     return output;
 }

--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -351,25 +351,6 @@ class bpf_code_generator
     void
     encode_instructions(const unsafe_string& section_name);
 
-    /**
-     * @brief Format a string and insert up to 4 strings in it.
-     *
-     * @param[in] format Format string.
-     * @param[in] insert_1 First string to insert.
-     * @param[in] insert_2 Second string to insert or empty.
-     * @param[in] insert_3 Third string to insert or empty.
-     * @param[in] insert_4 Fourth string to insert or empty.
-     * @return The formatted string.
-     */
-    std::string
-    format_string(
-        const std::string& format,
-        const std::string insert_1,
-        const std::string insert_2 = "",
-        const std::string insert_3 = "",
-        const std::string insert_4 = "",
-        const std::string insert_5 = "");
-
 #if defined(_MSC_VER)
     /**
      * @brief Format a GUID as a string.


### PR DESCRIPTION
## Description

This PR adds support for the 32-bit ```JMP``` instruction variants.

## Testing

Existing tests are sufficient to test this change-set. No new tests needed.

Results of the command ```bpf_conformance_runner.exe --test_file_directory D:\wrk\ebpf-for-windows\external\bpf_conformance\tests\ --exclude_regex lock* --plugin_path .\bpf2c_plugin.exe --plugin_options "--include d:\wrk\ebpf-for-windows\include"``` attached.

## Documentation

No documentation changes needed

Fixes #1667

[bpf_conformance_test_results.txt](https://github.com/microsoft/ebpf-for-windows/files/10322498/bpf_conformance_test_results.txt)
