### PR TITLE
Add build variant that disables iterator debugging

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,6 +43,16 @@ jobs:
       generate_release_package: true
       build_nuget: true
 
+  # Work around for bug in VC++ STL debug iterators.
+  no_iterator_debugging:
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      build_artifact: Build-no-iterator-debugging-x64
+      cxx_flags: /D_ITERATOR_DEBUG_LEVEL=0
+      build_options: /t:tests\unit_tests
+
   cmake:
     # Always run this job.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
@@ -300,12 +310,12 @@ jobs:
 
   # Run the low memory simulator in GitHub.
   low_memory:
-    needs: regular
+    needs: no_iterator_debugging
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: low_memory
       test_command: .\unit_tests.exe
-      build_artifact: Build-x64
+      build_artifact: Build-no-iterator-debugging-x64
       environment: windows-2022
       code_coverage: true
       gather_dumps: true

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -41,7 +41,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions) $(CXXFLAGS)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1624 

## Description

Add option to build with option to [disable iterator debugging](https://learn.microsoft.com/en-us/cpp/standard-library/debug-iterator-support?view=msvc-170#using-_iterator_debug_level). Iterator debugging causes std::vector's nothrow constructor to throw, which triggers termination. This makes low memory testing with overloaded new operator impossible.

## Testing

CI/CD

## Documentation

No.
