### PR TITLE
Fix memory leak in bpf_prog_attach 

### DIFF
--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -233,6 +233,11 @@ bpf_prog_attach(int prog_fd, int attachable_fd, enum bpf_attach_type type, unsig
 
     if (result != EBPF_SUCCESS)
         return libbpf_result_err(result);
+
+    ebpf_assert(link != nullptr);
+    bpf_link__disconnect(link);
+    bpf_link__destroy(link);
+
     return 0;
 }
 


### PR DESCRIPTION
Fixes #1800 

## Description

Fix memory leak in `bpf_prog_attach`. 

## Testing

Existing tests cover this code path.

## Documentation

NA
