### PR TITLE
Remove bpf_conformance submodule

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -130,7 +130,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.3/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2022

--- a/.gitmodules
+++ b/.gitmodules
@@ -20,6 +20,3 @@
 [submodule "external/pe-parse"]
 	path = external/pe-parse
 	url = https://github.com/trailofbits/pe-parse.git
-[submodule "external/bpf_conformance"]
-	path = external/bpf_conformance
-	url = https://github.com/Alan-Jowett/bpf_conformance.git


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1806 

## Description

The bpf_conformance test uses artifacts from the bpf_conformance repo instead of building them. Hence there is no need to include this as a submodule.

## Testing

CI/Cd

## Documentation

No.
