### PR TITLE
Add bpf_prog_test_run_opts support

### DIFF
--- a/docs/Fuzzing.md
+++ b/docs/Fuzzing.md
@@ -32,19 +32,19 @@ will then use the provided seed instead of generating a new one, which results
 in the tests repeating the sequence of steps that resulted in the crash.
 
 ## Reproducing a failure from artifacts
-When a crash happens, a folder containing the unique crash will be created. Click on *Summary* in the build section. The following example shows the process of debugging for *verifier_fuzzer* which can then be used for other CI/CD steps as well. 
-Download the artifact and the associated build.  For example, if verifier_fuzzer "run_test (Release)" failed, download *Artifacts-verifier_fuzzer-x64-Release* and *Build-x64-fuzzer Release*. 
+When a crash happens, a folder containing the unique crash will be created. Click on *Summary* in the build section. The following example shows the process of debugging for *verifier_fuzzer* which can then be used for other CI/CD steps as well.
+Download the artifact and the associated build.  For example, if verifier_fuzzer "run_test (Release)" failed, download *Artifacts-verifier_fuzzer-x64-Release* and *Build-x64-fuzzer Release*.
 
-Copy the crash file from the artifact folder to a separate directory,  *verifier_fuzzer* files including *verifier_fuzzer.pdb*, *verifier_fuzzer.lib*, *verifier_fuzzer.exp*, and *verifier_fuzzer.exe* from debug directory. The C Runtime library, entitled, *ucrtbased.dll*, and address sanitizer files, marked by ASAN need to be included, *clang_rt.asan_dbg_dynamic-x86_64.dll* ,and *clang_rt.asan_dynamic-x86_64.dll*. 
+Copy the crash file from the artifact folder to a separate directory,  *verifier_fuzzer* files including *verifier_fuzzer.pdb*, *verifier_fuzzer.lib*, *verifier_fuzzer.exp*, and *verifier_fuzzer.exe* from debug directory. The C Runtime library, entitled, *ucrtbased.dll*, and address sanitizer files, marked by ASAN need to be included, *clang_rt.asan_dbg_dynamic-x86_64.dll* ,and *clang_rt.asan_dynamic-x86_64.dll*.
 
 Run a desired admin CMD locating to the copied files in the new directory, and enter with the following command:
 ```
 windbgx -y SRV*;. -srcpath <your-path-to-ebpf-for-windows> verifier_fuzzer.exe <crash-file-name>
 ```
-A window containing the windbg debugger opens up and enter ```g``` in the command box of windbg. If an access violation indicating ```Access violation - code c0000005 (first chance)``` shows up, please use ```sxi c0000005``` to ignore this error. Please use ```g``` again to see the line that crashes. 
+A window containing the windbg debugger opens up and enter ```g``` in the command box of windbg. If an access violation indicating ```Access violation - code c0000005 (first chance)``` shows up, please use ```sxi c0000005``` to ignore this error. Please use ```g``` again to see the line that crashes.
 
-An alternative of running an admin CMD is to reproduce a crash to use the local latest build and run 
+An alternative of running an admin CMD is to reproduce a crash to use the local latest build and run
 ```
 verifier_fuzzer.exe <crash-file-name>
 ```
-This method will show the line of crash in the source file. 
+This method will show the line of crash in the source file.

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -55,7 +55,11 @@ When registering itself to the NMR, the Program Information NPI Provider should 
 #### `ebpf_program_data_t` Struct
 The various fields of this structure should be set as follows:
 * `program_info`: Pointer to `ebpf_program_info_t`.
-* `helper_function_addresses`: Pointer to `ebpf_helper_function_addresses_t`.
+* `program_type_specific_helper_function_addresses`: Pointer to `ebpf_helper_function_addresses_t`. This structure provides the helper functions that are exclusive to this program type.
+* `global_helper_function_addresses`:  Pointer to `ebpf_helper_function_addresses_t`. This structure provides helper functions that override the global helper functions provided by the eBPF runtime.
+* `context_create`: Pointer to `ebpf_program_context_create_t` function that creates a program type specific context structure from provided data and context buffers.
+* `context_destroy`: Pointer to `ebpf_program_context_destroy_t` function that destroys a program type specific context structure and populates the returned data and context buffers.
+* `required_irql`: IRQL that the eBPF program runs at.
 
 #### `ebpf_program_info_t` Struct
 The various fields of this structure should be set as follows:
@@ -142,6 +146,14 @@ typedef enum _ebpf_return_type {
 This structure is used to specify the address at which the various helper functions implemented by the extension reside. If an eBPF program is JIT compiled, then the generated machine code will have `call` instructions to these addresses. For interpreted mode, the eBPF Execution Engine will invoke the functions at these addresses. The fields of this struct should be set as follows:
 * `helper_function_count`: Number of helper functions implemented by the extension for the given program type.
 * `helper_function_address`: Array of addresses (64-bit unsigned integer) for the helper functions. The addresses must be arranged in the array in the *same order* as the array of helper function prototypes denoted by the `helper_prototype` field in `ebpf_program_info_t` struct.  For the correct execution of eBPF programs, the helper function addresses cannot change while a loaded eBPF program is executing.
+
+There are two sets of helper function addresses that the extension can return. The first are helper functions that are only callable during execution of an eBPF program that matches this program type. The second are helper function implementations that override the global helper function implementations provided by the eBPF runtime.
+
+### `ebpf_program_context_create_t` Function
+This optional function is used to build a program type specific context structure that is used when an application calls `bpf_prog_test_run_opts`. The application optionally passes in flat buffers representing the data and the context structure to be passed to the eBPF program. The extension then constructs a context structure to be passed to the eBPF program. Note: If `ebpf_program_context_create_t` is present, then `ebpf_program_context_destroy_t` and `required_irql` must be set.
+
+### `ebpf_program_context_destroy_t` Function
+This optional function is used to populate the flat buffers representing the data and context structures that are returned to the application when the `bpf_prog_test_run_opts` call completes. In addition, the function frees any resources allocated in the `ebpf_program_context_create_t` call.
 
 ### 2.2 Program Information NPI Client Attach and Detach Callbacks
 The eBPF Execution Context registers a Program Information NPI client module with the NMR for every eBPF program that gets loaded. The Execution Context will use the program type GUID of the program as the NPI ID of the client module. And as a result, upon eBPF program load, the associated Program Information NPI client module will attach with the corresponding Program Information NPI provider module in the extension. The Program Information NPI does not have any client or provider dispatch tables. Neither does the client's `NpiSpecificCharacteristics` have any data. So, no special processing is required in the client attach and detach callback handler on the provider module. An extension must not unload until there are no more attached Program Information NPI clients.

--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -69,6 +69,7 @@ EXPORTS
     bpf_prog_load
     bpf_prog_load_deprecated
     bpf_prog_get_next_id
+    bpf_prog_test_run_opts
     bpf_program__attach
     bpf_program__attach_xdp
     bpf_program__fd

--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -417,6 +417,35 @@ extern "C"
     _Must_inspect_result_ ebpf_result_t
     ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info);
 
+    typedef struct _ebpf_test_run_options
+    {
+        _Readable_bytes_(data_size_in) const uint8_t* data_in; ///< Input data to the program.
+        _Writable_bytes_(data_size_out) uint8_t* data_out;     ///< Output data from the program.
+        size_t data_size_in;                                   ///< Size of input data.
+        size_t data_size_out; ///< Maximum length of data_out on input and actual length of data_out on output.
+        _Readable_bytes_(context_size_in) const uint8_t* context_in; ///< Input context to the program.
+        _Writable_bytes_(context_size_out) uint8_t* context_out;     ///< Output context from the program.
+        size_t context_size_in;                                      ///< Size of input context.
+        size_t context_size_out; ///< Maximum length of context_out on input and actual length of context_out on output.
+        uint64_t return_value;   ///< Return value from the program.
+        size_t repeat_count;     ///< Number of times to repeat the program.
+        uint64_t duration;       ///< Duration in nanoseconds of the program execution.
+        uint32_t flags;          ///< Flags to control the test run.
+        uint32_t cpu;            ///< CPU to run the program on.
+        size_t batch_size;       ///< Number of times to repeat the program in a batch.
+    } ebpf_test_run_options_t;
+
+    /**
+     * @brief Run the program in the eBPF VM, measure the execution time, and return the result.
+     *
+     * @param[in] program_fd File descriptor of the program to run.
+     * @param[in,out] options Options to control the test run and results.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_OBJECT Invalid object was passed.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -44,11 +44,31 @@ typedef struct _ebpf_helper_function_addresses
     uint64_t* helper_function_address;
 } ebpf_helper_function_addresses_t;
 
+typedef uint64_t (*ebpf_program_context_create_t)(
+    _In_reads_bytes_opt_(data_size_in) const uint8_t* data_in,
+    _In_ size_t data_size_in,
+    _In_reads_bytes_opt_(context_size_in) const uint8_t* context_in,
+    _In_ size_t context_size_in,
+    _Outptr_ void** context);
+
+typedef void (*ebpf_program_context_destroy_t)(
+    _In_ void* context,
+    _Out_writes_bytes_to_(*data_size_out, *data_size_out) uint8_t* data_out,
+    _Inout_ size_t* data_size_out,
+    _Out_writes_bytes_to_(*context_size_out, *context_size_out) uint8_t* context_out,
+    _Inout_ size_t* context_size_out);
+
 typedef struct _ebpf_program_data
 {
-    ebpf_program_info_t* program_info;
-    ebpf_helper_function_addresses_t* program_type_specific_helper_function_addresses;
-    ebpf_helper_function_addresses_t* global_helper_function_addresses;
+    ebpf_program_info_t* program_info; ///< Pointer to program information.
+    ebpf_helper_function_addresses_t*
+        program_type_specific_helper_function_addresses; ///< Pointer to program type specific helper function
+                                                         ///< addresses.
+    ebpf_helper_function_addresses_t*
+        global_helper_function_addresses;           ///< Pointer to global helper function addresses being overriden.
+    ebpf_program_context_create_t context_create;   ///< Pointer to context create function.
+    ebpf_program_context_destroy_t context_destroy; ///< Pointer to context destroy function.
+    uint8_t required_irql;                          ///< IRQL at which the program is invoked.
 } ebpf_program_data_t;
 
 typedef struct _ebpf_program_section_info

--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -109,6 +109,9 @@ extern "C"
 
         /// Invalid pointer.
         EBPF_INVALID_POINTER,
+
+        /// Operation timed out.
+        EBPF_TIMEOUT,
     } ebpf_result_t;
 
 #define EBPF_RESULT_COUNT (EBPF_INVALID_POINTER + 1)

--- a/include/linux/bpf.h
+++ b/include/linux/bpf.h
@@ -64,6 +64,7 @@ enum bpf_cmd_id
     BPF_OBJ_GET_INFO_BY_FD,
     BPF_LINK_DETACH,
     BPF_PROG_BIND_MAP,
+    BPF_PROG_TEST_RUN,
 };
 
 /// Attributes used by BPF_OBJ_GET_INFO_BY_FD.
@@ -173,6 +174,23 @@ union bpf_attr
 
     // BPF_PROG_BIND_MAP
     bpf_prog_bind_map_attr_t prog_bind_map; ///< Attributes used by BPF_PROG_BIND_MAP.
+
+    // BPF_PROG_TEST_RUN
+    struct
+    {
+        uint32_t prog_fd;       ///< File descriptor of program to run.
+        uint32_t retval;        ///< On return, contains the return value of the program.
+        uint32_t data_size_in;  ///< Size in bytes of input data.
+        uint32_t data_size_out; ///< Size in bytes of output data.
+        uint64_t data_in;       ///< Pointer to input data.
+        uint64_t data_out;      ///< Pointer to output data.
+        uint32_t repeat;        ///< Number of times to repeat the program.
+        uint32_t duration;      ///< Duration in milliseconds to run the program.
+        uint32_t ctx_size_in;   ///< Size in bytes of input context.
+        uint32_t ctx_size_out;  ///< Size in bytes of output context.
+        uint64_t ctx_in;        ///< Pointer to input context.
+        uint64_t ctx_out;       ///< Pointer to output context.
+    } test;                     ///< Attributes used by BPF_PROG_TEST_RUN.
 };
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/libs/api/bpf_syscall.cpp
+++ b/libs/api/bpf_syscall.cpp
@@ -82,6 +82,28 @@ bpf(int cmd, union bpf_attr* attr, unsigned int size)
             attr->insn_cnt,
             &opts);
     }
+    case BPF_PROG_TEST_RUN: {
+        bpf_test_run_opts test_run_opts = {
+            .sz = sizeof(bpf_test_run_opts),
+            .data_in = (void*)attr->test.data_in,
+            .data_out = (void*)attr->test.data_out,
+            .data_size_in = attr->test.data_size_in,
+            .data_size_out = attr->test.data_size_out,
+            .ctx_in = (void*)attr->test.ctx_in,
+            .ctx_out = (void*)attr->test.ctx_out,
+            .ctx_size_in = attr->test.ctx_size_in,
+            .ctx_size_out = attr->test.ctx_size_out,
+            .repeat = (int)(attr->test.repeat),
+        };
+        int retval = bpf_prog_test_run_opts(attr->test.prog_fd, &test_run_opts);
+        if (retval == 0) {
+            attr->test.data_size_out = test_run_opts.data_size_out;
+            attr->test.ctx_size_out = test_run_opts.ctx_size_out;
+            attr->test.retval = test_run_opts.retval;
+            attr->test.duration = test_run_opts.duration;
+        }
+        return retval;
+    }
     default:
         errno = EINVAL;
         return -1;

--- a/libs/api/libbpf_program.cpp
+++ b/libs/api/libbpf_program.cpp
@@ -649,3 +649,35 @@ libbpf_bpf_prog_type_str(enum bpf_prog_type t)
     const ebpf_program_type_t* program_type = ebpf_get_ebpf_program_type(t);
     return (program_type == nullptr) ? nullptr : ebpf_get_program_type_name(program_type);
 }
+
+int
+bpf_prog_test_run_opts(int prog_fd, struct bpf_test_run_opts* opts)
+{
+    ebpf_test_run_options_t options = {
+        .data_in = (const uint8_t*)opts->data_in,
+        .data_out = (uint8_t*)opts->data_out,
+        .data_size_in = opts->data_size_in,
+        .data_size_out = opts->data_size_out,
+        .context_in = (const uint8_t*)opts->ctx_in,
+        .context_out = (uint8_t*)opts->ctx_out,
+        .context_size_in = opts->ctx_size_in,
+        .context_size_out = opts->ctx_size_out,
+        .repeat_count = (size_t)opts->repeat,
+        .flags = opts->flags,
+        .cpu = opts->cpu,
+        .batch_size = opts->batch_size,
+    };
+
+    ebpf_result_t result = ebpf_program_test_run(prog_fd, &options);
+
+    if (result != EBPF_SUCCESS) {
+        return libbpf_result_err(result);
+    }
+
+    opts->data_size_out = (uint32_t)options.data_size_out;
+    opts->ctx_size_out = (uint32_t)options.context_size_out;
+    opts->retval = (uint32_t)options.return_value;
+    opts->duration = (uint32_t)options.duration;
+
+    return 0;
+}

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -897,9 +897,10 @@ _ebpf_core_protocol_program_test_run(
         goto Done;
 
     options.data_size_in = request->context_offset;
-    options.data_size_out = (size_t)reply_length - EBPF_OFFSET_OF(ebpf_operation_program_test_run_reply_t, data);
     options.context_size_in = (size_t)(request->header.length) - data_in_end;
     options.context_size_out = options.context_size_in;
+    options.data_size_out =
+        (size_t)reply_length - EBPF_OFFSET_OF(ebpf_operation_program_test_run_reply_t, data) - options.context_size_out;
     options.repeat_count = request->repeat_count;
     options.flags = request->flags;
     options.cpu = request->cpu;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -76,6 +76,10 @@ typedef struct _ebpf_program
     uint32_t link_count;
     ebpf_map_t** maps;
     uint32_t count_of_maps;
+
+    ebpf_program_context_create_t context_create;
+    ebpf_program_context_destroy_t context_destroy;
+    uint8_t required_irql;
 } ebpf_program_t;
 
 static ebpf_result_t
@@ -140,6 +144,10 @@ _ebpf_program_program_info_provider_changed(
             // An extension cannot have empty program_data.
             goto Exit;
         }
+
+        program->context_create = program_data->context_create;
+        program->context_destroy = program_data->context_destroy;
+        program->required_irql = program_data->required_irql;
 
         helper_function_addresses = program_data->program_type_specific_helper_function_addresses;
         global_helper_function_addresses = program_data->global_helper_function_addresses;
@@ -1475,4 +1483,112 @@ Exit:
     ebpf_program_free_program_info((ebpf_program_info_t*)program_info);
 
     EBPF_RETURN_RESULT(result);
+}
+
+typedef struct _ebpf_program_test_run_context
+{
+    ebpf_program_t* program;
+    void* context;
+    ebpf_program_test_run_options_t* options;
+    ebpf_signal_t* completion_event;
+} ebpf_program_test_run_context_t;
+
+static void
+_ebpf_program_test_run_work_item(_Inout_opt_ void* work_item_context)
+{
+    _Analysis_assume_(work_item_context != NULL);
+
+    ebpf_program_test_run_context_t* context = (ebpf_program_test_run_context_t*)work_item_context;
+    ebpf_program_test_run_options_t* options = context->options;
+    uint64_t end_time;
+    ebpf_result_t result;
+    uint32_t return_value = 0;
+    uint8_t old_irql;
+    uintptr_t old_thread_affinity;
+
+    result = ebpf_set_current_thread_affinity((uintptr_t)1 << options->cpu, &old_thread_affinity);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    old_irql = ebpf_raise_irql(context->program->required_irql);
+
+    uint64_t start_time = ebpf_query_time_since_boot(false);
+    for (size_t i = 0; i < options->repeat_count; i++) {
+        result = ebpf_epoch_enter();
+        if (result != EBPF_SUCCESS)
+            break;
+        ebpf_program_invoke(context->program, context->context, &return_value);
+        ebpf_epoch_exit();
+    }
+    end_time = ebpf_query_time_since_boot(false);
+
+    options->duration = end_time - start_time;
+    options->return_value = return_value;
+
+    ebpf_lower_irql(old_irql);
+    ebpf_restore_current_thread_affinity(old_thread_affinity);
+
+Done:
+    ebpf_signal_set(context->completion_event);
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_program_execute_test_run(_In_ ebpf_program_t* program, _Inout_ ebpf_program_test_run_options_t* options)
+{
+    if (program->context_create == NULL || program->context_destroy == NULL) {
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    ebpf_result_t return_value = EBPF_SUCCESS;
+    ebpf_signal_t* signal = NULL;
+    ebpf_program_test_run_context_t* test_run_context = NULL;
+    void* context = NULL;
+    ebpf_preemptible_work_item_t* work_item = NULL;
+
+    // Convert the input buffer to a program type specific context structure.
+    return_value = program->context_create(
+        options->data_in, options->data_size_in, options->context_in, options->context_size_in, &context);
+    if (return_value != 0) {
+        return_value = EBPF_INVALID_ARGUMENT;
+        goto Exit;
+    }
+
+    test_run_context = (ebpf_program_test_run_context_t*)ebpf_allocate(sizeof(ebpf_program_test_run_context_t));
+    if (test_run_context == NULL) {
+        return_value = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    return_value = ebpf_signal_create(&signal);
+    if (return_value != EBPF_SUCCESS) {
+        return_value = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    test_run_context->program = program;
+    test_run_context->context = context;
+    test_run_context->options = options;
+    test_run_context->completion_event = signal;
+
+    // Queue the work item so that it can be executed on the target CPU and at the target dispatch level.
+    // The work item will signal the completion event when it is done.
+    return_value = ebpf_allocate_preemptible_work_item(&work_item, _ebpf_program_test_run_work_item, test_run_context);
+    if (return_value != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
+    // ebpf_queue_preemptible_work_item() will free both the work item and the context when it is done.
+    ebpf_queue_preemptible_work_item(work_item);
+    test_run_context = NULL;
+
+    (void)ebpf_signal_wait(signal, MAXUINT32);
+
+Exit:
+    program->context_destroy(
+        context, options->data_out, &options->data_size_out, options->context_out, &options->context_size_out);
+    ebpf_free(test_run_context);
+    ebpf_signal_destroy(signal);
+
+    return return_value;
 }

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -274,6 +274,35 @@ extern "C"
     ebpf_program_create_and_initialize(
         _In_ const ebpf_program_parameters_t* parameters, _Out_ ebpf_handle_t* program_handle);
 
+    typedef struct _ebpf_program_test_run_options
+    {
+        _Readable_bytes_(data_size_in) const uint8_t* data_in; ///< Input data to the program.
+        _Writable_bytes_(data_size_out) uint8_t* data_out;     ///< Output data from the program.
+        size_t data_size_in;                                   ///< Size of input data.
+        size_t data_size_out; ///< Maximum length of data_out on input and actual length of data_out on output.
+        _Readable_bytes_(context_size_in) const uint8_t* context_in; ///< Input context to the program.
+        _Writable_bytes_(context_size_out) uint8_t* context_out;     ///< Output context from the program.
+        size_t context_size_in;                                      ///< Size of input context.
+        size_t context_size_out; ///< Maximum length of context_out on input and actual length of context_out on output.
+        uint64_t return_value;   ///< Return value from the program.
+        size_t repeat_count;     ///< Number of times to repeat the program.
+        uint64_t duration;       ///< Duration in nanoseconds of the program execution.
+        uint32_t flags;          ///< Flags to control the test run.
+        uint32_t cpu;            ///< CPU to run the program on.
+        size_t batch_size;       ///< Number of times to repeat the program in a batch.
+    } ebpf_program_test_run_options_t;
+
+    /**
+     * @brief Run the program with the given input and output buffers and measure the duration.
+     *
+     * @param[in] program Program to run.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_INVALID_ARGUMENT Invalid argument.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this program.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_program_execute_test_run(_In_ ebpf_program_t* program, _Inout_ ebpf_program_test_run_options_t* options);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_protocol.h
+++ b/libs/execution_context/ebpf_protocol.h
@@ -41,6 +41,7 @@ typedef enum _ebpf_operation_id
     EBPF_OPERATION_RING_BUFFER_MAP_ASYNC_QUERY,
     EBPF_OPERATION_LOAD_NATIVE_MODULE,
     EBPF_OPERATION_LOAD_NATIVE_PROGRAMS,
+    EBPF_OPERATION_PROGRAM_TEST_RUN,
 } ebpf_operation_id_t;
 
 typedef enum _ebpf_code_type
@@ -429,3 +430,24 @@ typedef struct _ebpf_operation_load_native_programs_reply
     // Map handles followed by program handles.
     uint8_t data[1];
 } ebpf_operation_load_native_programs_reply_t;
+
+typedef struct _ebpf_operation_program_test_run_request
+{
+    struct _ebpf_operation_header header;
+    ebpf_handle_t program_handle;
+    size_t repeat_count;
+    uint32_t flags;
+    uint32_t cpu;
+    size_t batch_size;
+    uint16_t context_offset;
+    uint8_t data[1];
+
+} ebpf_operation_program_test_run_request_t;
+typedef struct _ebpf_operation_program_test_run_reply
+{
+    struct _ebpf_operation_header header;
+    uint64_t duration;
+    uint64_t return_value;
+    uint64_t context_offset;
+    uint8_t data[1];
+} ebpf_operation_program_test_run_reply_t;

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -370,6 +370,21 @@ extern "C"
         _Inout_ ebpf_lock_t* lock, _IRQL_restores_ ebpf_lock_state_t state);
 
     /**
+     * @brief Raise the IRQL to new_irql.
+     *
+     * @param[in] new_irql The new IRQL.
+     * @return The previous IRQL.
+     */
+    _IRQL_requires_max_(HIGH_LEVEL) _IRQL_raises_(new_irql) _IRQL_saves_ uint8_t ebpf_raise_irql(uint8_t new_irql);
+
+    /**
+     * @brief Lower the IRQL to old_irql.
+     *
+     * @param[in] old_irql The old IRQL.
+     */
+    _IRQL_requires_max_(HIGH_LEVEL) void ebpf_lower_irql(_In_ _Notliteral_ _IRQL_restores_ uint8_t old_irql);
+
+    /**
      * @brief Query the platform for the total number of CPUs.
      * @return The count of logical cores in the system.
      */
@@ -1174,6 +1189,54 @@ extern "C"
         _Out_writes_to_(input_length, *output_length) uint8_t* buffer,
         size_t input_length,
         _Out_ size_t* output_length);
+
+    typedef struct _ebpf_signal ebpf_signal_t;
+
+    /**
+     * @brief Create a signal object.
+     *
+     * @param[out] signal The signal object.
+     * @return EBPF_SUCCESS The signal object was created.
+     * @return EBPF_NO_MEMORY Unable to allocate memory for the signal object.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_signal_create(_Outptr_ ebpf_signal_t** signal);
+
+    /**
+     * @brief Destroy a signal object.
+     *
+     * @param[in] signal The signal object to destroy.
+     */
+    void
+    ebpf_signal_destroy(_In_opt_ _Frees_ptr_opt_ ebpf_signal_t* signal);
+
+    /**
+     * @brief Set the signal object.
+     *
+     * @param[in] signal The signal object to set.
+     */
+    void
+    ebpf_signal_set(_In_ ebpf_signal_t* signal);
+
+    /**
+     * @brief Reset the signal object.
+     *
+     * @param[in] signal The signal object to reset.
+     */
+    void
+    ebpf_signal_reset(_In_ ebpf_signal_t* signal);
+
+    /**
+     * @brief Wait for the signal object to be set.
+     *
+     * @param[in] signal The signal object to wait on.
+     * @param[in] timeout_ms Timeout in milliseconds.
+     * @return EBPF_SUCCESS The signal object was set.
+     * @return EBPF_OPERATION_ABORTED The wait was aborted.
+     * @return EBPF_TIMEOUT The wait timed out.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_signal_wait(_In_ ebpf_signal_t* signal, uint32_t timeout_ms);
 
 /**
  * @brief Append a value to a cryptographic hash object.

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -760,3 +760,67 @@ ebpf_platform_thread_id()
 {
     return (uint32_t)(uintptr_t)PsGetCurrentThreadId();
 }
+
+typedef struct _ebpf_signal
+{
+    KEVENT event;
+} ebpf_signal_t;
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_signal_create(_Outptr_ ebpf_signal_t** signal)
+{
+    *signal = (ebpf_signal_t*)ebpf_allocate(sizeof(ebpf_signal_t));
+    if (!*signal) {
+        return EBPF_NO_MEMORY;
+    }
+
+    KeInitializeEvent(&(*signal)->event, SynchronizationEvent, FALSE);
+
+    return EBPF_SUCCESS;
+}
+
+void
+ebpf_signal_destroy(_In_opt_ _Frees_ptr_opt_ ebpf_signal_t* signal)
+{
+    ebpf_free(signal);
+}
+
+void
+ebpf_signal_set(_In_ ebpf_signal_t* signal)
+{
+    KeSetEvent(&signal->event, 0, FALSE);
+}
+
+void
+ebpf_signal_reset(_In_ ebpf_signal_t* signal)
+{
+    KeResetEvent(&signal->event);
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_signal_wait(_In_ ebpf_signal_t* signal, uint32_t timeout_ms)
+{
+    LARGE_INTEGER timeout;
+    timeout.QuadPart = -10000 * (uint64_t)timeout_ms;
+
+    NTSTATUS status = KeWaitForSingleObject(&signal->event, Executive, KernelMode, FALSE, timeout_ms ? &timeout : NULL);
+    if (status == STATUS_SUCCESS) {
+        return EBPF_SUCCESS;
+    } else if (status == STATUS_TIMEOUT) {
+        return EBPF_TIMEOUT;
+    } else {
+        return EBPF_FAILED;
+    }
+}
+
+_IRQL_requires_max_(HIGH_LEVEL) _IRQL_raises_(new_irql) _IRQL_saves_ uint8_t ebpf_raise_irql(uint8_t new_irql)
+{
+    KIRQL old_irql;
+    KeRaiseIrql(new_irql, &old_irql);
+    return old_irql;
+}
+
+_IRQL_requires_max_(HIGH_LEVEL) void ebpf_lower_irql(_In_ _Notliteral_ _IRQL_restores_ uint8_t old_irql)
+{
+    KeLowerIrql(old_irql);
+}

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -317,6 +317,8 @@ _Success_(return == 0) static uint64_t _xdp_context_create(
 {
     uint64_t retval = 1;
     xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(malloc(sizeof(xdp_md_t)));
+    memset(xdp_context, 0, sizeof(xdp_md_t));
+
     *context = nullptr;
     if (xdp_context == nullptr) {
         goto Done;

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -307,6 +307,74 @@ typedef class _test_xdp_helper
     }
 } test_xdp_helper_t;
 
+// These are test xdp context creation functions.
+_Success_(return == 0) static uint64_t _xdp_context_create(
+    _In_reads_bytes_opt_(data_size_in) const uint8_t* data_in,
+    _In_ size_t data_size_in,
+    _In_reads_bytes_opt_(context_size_in) const uint8_t* context_in,
+    _In_ size_t context_size_in,
+    _Outptr_ void** context)
+{
+    uint64_t retval = 1;
+    xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(malloc(sizeof(xdp_md_t)));
+    *context = nullptr;
+    if (xdp_context == nullptr) {
+        goto Done;
+    }
+
+    if (context_in) {
+        if (context_size_in < sizeof(xdp_md_t)) {
+            goto Done;
+        }
+        xdp_md_t* provided_context = (xdp_md_t*)context_in;
+        xdp_context->ingress_ifindex = provided_context->ingress_ifindex;
+        xdp_context->data_meta = provided_context->data_meta;
+    }
+
+    xdp_context->data = (void*)data_in;
+    xdp_context->data_end = (void*)(data_in + data_size_in);
+
+    *context = xdp_context;
+    xdp_context = nullptr;
+    retval = 0;
+Done:
+    free(xdp_context);
+    return retval;
+}
+
+static void
+_xdp_context_destroy(
+    _In_opt_ void* context,
+    _Out_writes_bytes_to_(*data_size_out, *data_size_out) uint8_t* data_out,
+    _Inout_ size_t* data_size_out,
+    _Out_writes_bytes_to_(*data_size_out, *data_size_out) uint8_t* context_out,
+    _Inout_ size_t* context_size_out)
+{
+    if (!context) {
+        return;
+    }
+
+    xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(context);
+    uint8_t* data = reinterpret_cast<uint8_t*>(xdp_context->data);
+    uint8_t* data_end = reinterpret_cast<uint8_t*>(xdp_context->data_end);
+    size_t data_length = data_end - data;
+    if (data_length <= *data_size_out) {
+        memmove(data_out, data, data_length);
+        *data_size_out = data_length;
+    } else {
+        *data_size_out = 0;
+    }
+
+    if (context_out && *context_size_out >= sizeof(xdp_md_t)) {
+        xdp_md_t* provided_context = (xdp_md_t*)context_out;
+        provided_context->ingress_ifindex = xdp_context->ingress_ifindex;
+        provided_context->data_meta = xdp_context->data_meta;
+        *context_size_out = sizeof(xdp_md_t);
+    }
+
+    free(context);
+}
+
 #define TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION 0
 
 // program info provider data for various program types.
@@ -318,7 +386,11 @@ static ebpf_helper_function_addresses_t _test_ebpf_xdp_helper_function_address_t
     EBPF_COUNT_OF(_test_ebpf_xdp_helper_functions), (uint64_t*)_test_ebpf_xdp_helper_functions};
 
 static ebpf_program_data_t _ebpf_xdp_program_data = {
-    &_ebpf_xdp_program_info, &_test_ebpf_xdp_helper_function_address_table};
+    &_ebpf_xdp_program_info,
+    &_test_ebpf_xdp_helper_function_address_table,
+    nullptr,
+    _xdp_context_create,
+    _xdp_context_destroy};
 
 static ebpf_extension_data_t _ebpf_xdp_program_info_provider_data = {
     TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_xdp_program_data), &_ebpf_xdp_program_data};

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -316,10 +316,9 @@ _Success_(return == 0) static uint64_t _xdp_context_create(
     _Outptr_ void** context)
 {
     uint64_t retval = 1;
-    xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(malloc(sizeof(xdp_md_t)));
-    memset(xdp_context, 0, sizeof(xdp_md_t));
-
     *context = nullptr;
+
+    xdp_md_t* xdp_context = reinterpret_cast<xdp_md_t*>(malloc(sizeof(xdp_md_t)));
     if (xdp_context == nullptr) {
         goto Done;
     }
@@ -341,6 +340,7 @@ _Success_(return == 0) static uint64_t _xdp_context_create(
     retval = 0;
 Done:
     free(xdp_context);
+    xdp_context = nullptr;
     return retval;
 }
 

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -135,6 +135,21 @@ TEST_CASE("libbpf prog test run", "[libbpf][deprecated]")
     REQUIRE(bpf_prog_test_run_opts(program_fd, &opts) == 0);
     REQUIRE(opts.ctx_size_out == sizeof(xdp_md_t));
 
+    // With bpf syscall
+    bpf_attr attr = {};
+    attr.test.prog_fd = program_fd;
+    attr.test.data_in = reinterpret_cast<uint64_t>(packet.data());
+    attr.test.data_out = reinterpret_cast<uint64_t>(packet.data());
+    attr.test.data_size_in = static_cast<uint32_t>(packet.size());
+    attr.test.data_size_out = static_cast<uint32_t>(packet.size());
+    attr.test.ctx_in = reinterpret_cast<uint64_t>(&context_in);
+    attr.test.ctx_out = reinterpret_cast<uint64_t>(context_out.data());
+    attr.test.ctx_size_in = sizeof(context_in);
+    attr.test.ctx_size_out = static_cast<uint32_t>(context_out.size());
+    REQUIRE(bpf(BPF_PROG_TEST_RUN, &attr, sizeof(attr)) == 0);
+    REQUIRE(attr.test.ctx_size_out == sizeof(xdp_md_t));
+    REQUIRE(attr.test.duration > 0);
+
     bpf_object__close(object);
 }
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #715
Resolves: #1823 
Resolves: #1818

## Description

Add support for the bpf_prog_test_run_opts libbpf API. For this to be used, there needs to be a separate PR to add the required conversion functions to the various extension providers.

## Testing

CI/CD

## Documentation

No.
