### PR TITLE
Remove license-check on 'corpus' directories

### DIFF
--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -11,7 +11,7 @@
 .*\.vsdx$
 
 # Directories with files that don't support embedding license info
-.*\corpus
+.*corpus
 
 # Generated files
 tools/netsh/resource.h

--- a/scripts/.check-license.ignore
+++ b/scripts/.check-license.ignore
@@ -10,6 +10,9 @@
 .*\.sln$
 .*\.vsdx$
 
+# Directories with files that don't support embedding license info
+.*\corpus
+
 # Generated files
 tools/netsh/resource.h
 


### PR DESCRIPTION
Closes #1862

`corpus` directories (containing binaries) must be excluded from license checks