### PR TITLE
Add unit tests for BIND, CGROUP_SOCK_ADDR, and SOCK_OPS

### DIFF
--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -154,7 +154,7 @@ typedef struct bpf_sock_addr
 /**
  * @brief Handle socket operation. Currently supports ingress/egress connection initialization.
  *
- * Program type: \ref EBPF_PROGRAM_TYPE_BIND
+ * Program type: \ref EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR
  *
  * Attach type(s):
  *  \ref EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -682,7 +682,7 @@ _net_ebpf_extension_sock_addr_get_connection_direction_from_hook_id(net_ebpf_ext
                : EBPF_HOOK_SOCK_ADDR_INGRESS;
 }
 
-wfp_ale_layer_fields_t wfp_connection_fields[] = {
+const wfp_ale_layer_fields_t wfp_connection_fields[] = {
     // EBPF_HOOK_ALE_AUTH_CONNECT_V4
     {FWPS_FIELD_ALE_AUTH_CONNECT_V4_IP_LOCAL_ADDRESS,
      FWPS_FIELD_ALE_AUTH_CONNECT_V4_IP_LOCAL_PORT,
@@ -755,7 +755,7 @@ _net_ebpf_extension_sock_addr_copy_wfp_connection_fields(
         net_ebpf_extension_get_hook_id_from_wfp_layer_id(incoming_fixed_values->layerId);
     net_ebpf_extension_sock_addr_connection_direction_t direction =
         _net_ebpf_extension_sock_addr_get_connection_direction_from_hook_id(hook_id);
-    wfp_ale_layer_fields_t* fields = &wfp_connection_fields[hook_id - EBPF_HOOK_ALE_AUTH_CONNECT_V4];
+    const wfp_ale_layer_fields_t* fields = &wfp_connection_fields[hook_id - EBPF_HOOK_ALE_AUTH_CONNECT_V4];
 
     uint16_t source_ip_address_field =
         (direction == EBPF_HOOK_SOCK_ADDR_EGRESS) ? fields->local_ip_address_field : fields->remote_ip_address_field;

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -112,16 +112,101 @@ _fwp_engine::test_bind_ipv4()
     return result.actionType;
 }
 
-void
+FWP_ACTION_TYPE
 _fwp_engine::test_cgroup_sock_addr()
 {
-    // TODO(issue #1869): implement sock_addr callout.
+    std::unique_lock l(lock);
+    const GUID* callout_key = get_callout_key_from_layer_guid(&FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4); // XXX
+    if (callout_key == nullptr) {
+        return FWP_ACTION_CALLOUT_UNKNOWN;
+    }
+    const FWPS_CALLOUT3* callout = get_callout_from_key(callout_key);
+    if (callout == nullptr) {
+        return FWP_ACTION_CALLOUT_UNKNOWN;
+    }
+    FWPS_CLASSIFY_OUT0 result = {};
+    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_MAX] = {};
+    const uint32_t test_local_ipv4_address = 0x01020304;
+    const uint16_t test_local_port = 1234;
+    const uint32_t test_remote_ipv4_address = 0x05060708;
+    const uint16_t test_remote_port = 5678;
+    const uint8_t test_protocol = IPPROTO_TCP;
+    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_ADDRESS].value.uint32 = test_local_ipv4_address;
+    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_PORT].value.uint16 = test_local_port;
+    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_REMOTE_ADDRESS].value.uint32 = test_remote_ipv4_address;
+    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_REMOTE_PORT].value.uint16 = test_remote_port;
+    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_PROTOCOL].value.uint8 = test_protocol;
+    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_COMPARTMENT_ID].value.uint32 = 0;
+    uint64_t test_interface_luid = 1;
+    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_INTERFACE].value.uint64 = &test_interface_luid;
+    FWP_BYTE_BLOB app_id = {};
+    app_id.data = (uint8_t*)"\\";
+    app_id.size = 2;
+    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_APP_ID].value.byteBlob = &app_id;
+
+    const uint16_t layer_id = FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4;
+    FWPS_INCOMING_VALUES incoming_fixed_values = {.layerId = layer_id, .incomingValue = incomingValue};
+    FWPS_INCOMING_METADATA_VALUES incoming_metadata_values = {};
+    const FWPM_FILTER* fwpm_filter = get_fwpm_filter_with_context();
+    if (!fwpm_filter) {
+        return FWP_ACTION_CALLOUT_UNKNOWN;
+    }
+    FWPS_FILTER fwps_filter = {.context = fwpm_filter->rawContext};
+
+    callout->classifyFn(
+        &incoming_fixed_values,
+        &incoming_metadata_values,
+        nullptr, // layer_data
+        nullptr, // classify_context,
+        &fwps_filter,
+        0, // flow_context,
+        &result);
+
+    return result.actionType;
 }
 
-void
+FWP_ACTION_TYPE
 _fwp_engine::test_sock_ops()
 {
-    // TODO(issue #1869): implement sock_ops callout.
+    std::unique_lock l(lock);
+    const GUID* callout_key = get_callout_key_from_layer_guid(&FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4); // XXX
+    if (callout_key == nullptr) {
+        return FWP_ACTION_CALLOUT_UNKNOWN;
+    }
+    const FWPS_CALLOUT3* callout = get_callout_from_key(callout_key);
+    if (callout == nullptr) {
+        return FWP_ACTION_CALLOUT_UNKNOWN;
+    }
+    FWPS_CLASSIFY_OUT0 result = {};
+    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_MAX] = {};
+    const uint16_t test_port = 1234;
+    const uint8_t test_protocol = IPPROTO_TCP;
+    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_PORT].value.uint16 = test_port;
+    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_ADDRESS].value.uint32 = INADDR_ANY;
+    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_PROTOCOL].value.uint8 = test_protocol;
+    FWP_BYTE_BLOB app_id = {};
+    app_id.data = (uint8_t*)"\\";
+    app_id.size = 2;
+    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_ALE_APP_ID].value.byteBlob = &app_id;
+
+    FWPS_INCOMING_VALUES incoming_fixed_values = {.incomingValue = incomingValue};
+    FWPS_INCOMING_METADATA_VALUES incoming_metadata_values = {};
+    const FWPM_FILTER* fwpm_filter = get_fwpm_filter_with_context();
+    if (!fwpm_filter) {
+        return FWP_ACTION_CALLOUT_UNKNOWN;
+    }
+    FWPS_FILTER fwps_filter = {.context = fwpm_filter->rawContext};
+
+    callout->classifyFn(
+        &incoming_fixed_values,
+        &incoming_metadata_values,
+        nullptr, // layer_data
+        nullptr, // classify_context,
+        &fwps_filter,
+        0, // flow_context,
+        &result);
+
+    return result.actionType;
 }
 
 typedef struct _fwp_injection_handle

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -70,14 +70,14 @@ _fwp_engine::classify_test_packet(_In_ const GUID* layer_guid, NET_IFINDEX if_in
     return result.actionType;
 }
 
-const uint32_t _test_destination_ipv4_address = 0x01020304;
+constexpr uint32_t _test_destination_ipv4_address = 0x01020304;
 static FWP_BYTE_ARRAY16 _test_destination_ipv6_address = {1, 2, 3, 4};
-const uint16_t _test_destination_port = 1234;
-const uint32_t _test_source_ipv4_address = 0x05060708;
+constexpr uint16_t _test_destination_port = 1234;
+constexpr uint32_t _test_source_ipv4_address = 0x05060708;
 static FWP_BYTE_ARRAY16 _test_source_ipv6_address = {5, 6, 7, 8};
-const uint16_t _test_source_port = 5678;
-const uint8_t _test_protocol = IPPROTO_TCP;
-const uint32_t _test_compartment_id = 1;
+constexpr uint16_t _test_source_port = 5678;
+constexpr uint8_t _test_protocol = IPPROTO_TCP;
+constexpr uint32_t _test_compartment_id = 1;
 static FWP_BYTE_BLOB _test_app_id = {.size = 2, .data = (uint8_t*)"\\"};
 static uint64_t _test_interface_luid = 1;
 

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -21,8 +21,8 @@ _fwp_engine::classify_test_packet(_In_ const GUID* layer_guid, NET_IFINDEX if_in
         return FWP_ACTION_CALLOUT_UNKNOWN;
     }
     FWPS_CLASSIFY_OUT0 result = {};
-    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_INBOUND_MAC_FRAME_NATIVE_MAX] = {};
-    FWPS_INCOMING_VALUES incoming_fixed_values = {.incomingValue = incomingValue};
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_INBOUND_MAC_FRAME_NATIVE_MAX] = {};
+    FWPS_INCOMING_VALUES incoming_fixed_values = {.incomingValue = incoming_value};
     incoming_fixed_values.incomingValue[FWPS_FIELD_INBOUND_MAC_FRAME_NATIVE_INTERFACE_INDEX].value.uint32 = if_index;
     FWPS_INCOMING_METADATA_VALUES incoming_metadata_values = {};
     const FWPM_FILTER* fwpm_filter = get_fwpm_filter_with_context();
@@ -69,6 +69,17 @@ _fwp_engine::classify_test_packet(_In_ const GUID* layer_guid, NET_IFINDEX if_in
     return result.actionType;
 }
 
+const uint32_t _test_local_ipv4_address = 0x01020304;
+const uint16_t _test_local_port = 1234;
+const uint32_t _test_remote_ipv4_address = 0x05060708;
+const uint16_t _test_remote_port = 5678;
+const uint8_t _test_protocol = IPPROTO_TCP;
+const uint32_t _test_compartment_id = 1;
+static FWP_BYTE_ARRAY16 _test_local_ipv6_address = {1, 2, 3, 4};
+static FWP_BYTE_ARRAY16 _test_remote_ipv6_address = {5, 6, 7, 8};
+static FWP_BYTE_BLOB _test_app_id = {.size = 2, .data = (uint8_t*)"\\"};
+static uint64_t _test_interface_luid = 1;
+
 FWP_ACTION_TYPE
 _fwp_engine::test_bind_ipv4()
 {
@@ -82,18 +93,13 @@ _fwp_engine::test_bind_ipv4()
         return FWP_ACTION_CALLOUT_UNKNOWN;
     }
     FWPS_CLASSIFY_OUT0 result = {};
-    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_MAX] = {};
-    const uint16_t test_port = 1234;
-    const uint8_t test_protocol = IPPROTO_TCP;
-    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_PORT].value.uint16 = test_port;
-    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_ADDRESS].value.uint32 = INADDR_ANY;
-    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_PROTOCOL].value.uint8 = test_protocol;
-    FWP_BYTE_BLOB app_id = {};
-    app_id.data = (uint8_t*)"\\";
-    app_id.size = 2;
-    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_ALE_APP_ID].value.byteBlob = &app_id;
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_PORT].value.uint16 = _test_local_port;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_ADDRESS].value.uint32 = _test_local_ipv4_address;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_PROTOCOL].value.uint8 = _test_protocol;
+    incoming_value[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_ALE_APP_ID].value.byteBlob = &_test_app_id;
 
-    FWPS_INCOMING_VALUES incoming_fixed_values = {.incomingValue = incomingValue};
+    FWPS_INCOMING_VALUES incoming_fixed_values = {.incomingValue = incoming_value};
     FWPS_INCOMING_METADATA_VALUES incoming_metadata_values = {};
     const FWPM_FILTER* fwpm_filter = get_fwpm_filter_with_context();
     if (!fwpm_filter) {
@@ -115,9 +121,9 @@ _fwp_engine::test_bind_ipv4()
 
 FWP_ACTION_TYPE
 _fwp_engine::test_cgroup_sock_addr(
-    uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incomingValue)
+    uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incoming_value)
 {
-    FWPS_INCOMING_VALUES incoming_fixed_values = {.layerId = layer_id, .incomingValue = incomingValue};
+    FWPS_INCOMING_VALUES incoming_fixed_values = {.layerId = layer_id, .incomingValue = incoming_value};
     FWPS_INCOMING_METADATA_VALUES incoming_metadata_values = {};
     const FWPM_FILTER* fwpm_filter = get_fwpm_filter_with_context();
     if (!fwpm_filter) {
@@ -160,26 +166,18 @@ _fwp_engine::test_cgroup_inet4_recv_accept()
 {
     std::unique_lock l(lock);
 
-    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_MAX] = {};
-    const uint32_t test_local_ipv4_address = 0x01020304;
-    const uint16_t test_local_port = 1234;
-    const uint32_t test_remote_ipv4_address = 0x05060708;
-    const uint16_t test_remote_port = 5678;
-    const uint8_t test_protocol = IPPROTO_TCP;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_ADDRESS].value.uint32 = test_local_ipv4_address;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_PORT].value.uint16 = test_local_port;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_REMOTE_ADDRESS].value.uint32 = test_remote_ipv4_address;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_REMOTE_PORT].value.uint16 = test_remote_port;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_PROTOCOL].value.uint8 = test_protocol;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_COMPARTMENT_ID].value.uint32 = 0;
-    uint64_t test_interface_luid = 1;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_INTERFACE].value.uint64 = &test_interface_luid;
-    FWP_BYTE_BLOB app_id = {};
-    app_id.data = (uint8_t*)"\\";
-    app_id.size = 2;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_APP_ID].value.byteBlob = &app_id;
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_ADDRESS].value.uint32 = _test_local_ipv4_address;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_PORT].value.uint16 = _test_local_port;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_REMOTE_ADDRESS].value.uint32 = _test_remote_ipv4_address;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_REMOTE_PORT].value.uint16 = _test_remote_port;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_PROTOCOL].value.uint8 = _test_protocol;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_COMPARTMENT_ID].value.uint32 = _test_compartment_id;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_IP_LOCAL_INTERFACE].value.uint64 = &_test_interface_luid;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_APP_ID].value.byteBlob = &_test_app_id;
 
-    return test_cgroup_sock_addr(FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4, incomingValue);
+    return test_cgroup_sock_addr(
+        FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4, incoming_value);
 }
 
 FWP_ACTION_TYPE
@@ -187,26 +185,18 @@ _fwp_engine::test_cgroup_inet6_recv_accept()
 {
     std::unique_lock l(lock);
 
-    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_MAX] = {};
-    FWP_BYTE_ARRAY16 test_local_ipv6_address = {1, 2, 3, 4};
-    const uint16_t test_local_port = 1234;
-    FWP_BYTE_ARRAY16 test_remote_ipv6_address = {5, 6, 7, 8};
-    const uint16_t test_remote_port = 5678;
-    const uint8_t test_protocol = IPPROTO_TCP;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_ADDRESS].value.byteArray16 = &test_local_ipv6_address;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_PORT].value.uint16 = test_local_port;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_REMOTE_ADDRESS].value.byteArray16 = &test_remote_ipv6_address;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_REMOTE_PORT].value.uint16 = test_remote_port;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_PROTOCOL].value.uint8 = test_protocol;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_COMPARTMENT_ID].value.uint32 = 0;
-    uint64_t test_interface_luid = 1;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_INTERFACE].value.uint64 = &test_interface_luid;
-    FWP_BYTE_BLOB app_id = {};
-    app_id.data = (uint8_t*)"\\";
-    app_id.size = 2;
-    incomingValue[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_APP_ID].value.byteBlob = &app_id;
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_ADDRESS].value.byteArray16 = &_test_local_ipv6_address;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_PORT].value.uint16 = _test_local_port;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_REMOTE_ADDRESS].value.byteArray16 = &_test_remote_ipv6_address;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_REMOTE_PORT].value.uint16 = _test_remote_port;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_PROTOCOL].value.uint8 = _test_protocol;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_COMPARTMENT_ID].value.uint32 = _test_compartment_id;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_INTERFACE].value.uint64 = &_test_interface_luid;
+    incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_APP_ID].value.byteBlob = &_test_app_id;
 
-    return test_cgroup_sock_addr(FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6, incomingValue);
+    return test_cgroup_sock_addr(
+        FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6, incoming_value);
 }
 
 FWP_ACTION_TYPE
@@ -214,24 +204,17 @@ _fwp_engine::test_cgroup_inet4_connect()
 {
     std::unique_lock l(lock);
 
-    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_MAX] = {};
-    const uint32_t test_remote_ipv4_address = 0x01020304;
-    const uint16_t test_remote_port = 1234;
-    const uint32_t test_local_ipv4_address = 0x05060708;
-    const uint16_t test_local_port = 5678;
-    const uint8_t test_protocol = IPPROTO_TCP;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_LOCAL_ADDRESS].value.uint32 = test_local_ipv4_address;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_LOCAL_PORT].value.uint16 = test_local_port;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_REMOTE_ADDRESS].value.uint32 = test_remote_ipv4_address;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_REMOTE_PORT].value.uint16 = test_remote_port;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_PROTOCOL].value.uint8 = test_protocol;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_COMPARTMENT_ID].value.uint32 = 0;
-    FWP_BYTE_BLOB app_id = {};
-    app_id.data = (uint8_t*)"\\";
-    app_id.size = 2;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_ALE_APP_ID].value.byteBlob = &app_id;
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_LOCAL_ADDRESS].value.uint32 = _test_local_ipv4_address;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_LOCAL_PORT].value.uint16 = _test_local_port;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_REMOTE_ADDRESS].value.uint32 = _test_remote_ipv4_address;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_REMOTE_PORT].value.uint16 = _test_remote_port;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_IP_PROTOCOL].value.uint8 = _test_protocol;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_COMPARTMENT_ID].value.uint32 = _test_compartment_id;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_ALE_APP_ID].value.byteBlob = &_test_app_id;
 
-    return test_cgroup_sock_addr(FWPS_LAYER_ALE_CONNECT_REDIRECT_V4, FWPM_LAYER_ALE_CONNECT_REDIRECT_V4, incomingValue);
+    return test_cgroup_sock_addr(
+        FWPS_LAYER_ALE_CONNECT_REDIRECT_V4, FWPM_LAYER_ALE_CONNECT_REDIRECT_V4, incoming_value);
 }
 
 FWP_ACTION_TYPE
@@ -239,31 +222,31 @@ _fwp_engine::test_cgroup_inet6_connect()
 {
     std::unique_lock l(lock);
 
-    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_MAX] = {};
-    FWP_BYTE_ARRAY16 test_remote_ipv6_address = {1, 2, 3, 4};
-    const uint16_t test_remote_port = 1234;
-    FWP_BYTE_ARRAY16 test_local_ipv6_address = {5, 6, 7, 8};
-    const uint16_t test_local_port = 5678;
-    const uint8_t test_protocol = IPPROTO_TCP;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_LOCAL_ADDRESS].value.byteArray16 = &test_local_ipv6_address;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_LOCAL_PORT].value.uint16 = test_local_port;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_REMOTE_ADDRESS].value.byteArray16 = &test_remote_ipv6_address;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_REMOTE_PORT].value.uint16 = test_remote_port;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_PROTOCOL].value.uint8 = test_protocol;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_COMPARTMENT_ID].value.uint32 = 0;
-    FWP_BYTE_BLOB app_id = {};
-    app_id.data = (uint8_t*)"\\";
-    app_id.size = 2;
-    incomingValue[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_ALE_APP_ID].value.byteBlob = &app_id;
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_LOCAL_ADDRESS].value.byteArray16 = &_test_local_ipv6_address;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_LOCAL_PORT].value.uint16 = _test_local_port;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_REMOTE_ADDRESS].value.byteArray16 = &_test_remote_ipv6_address;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_REMOTE_PORT].value.uint16 = _test_remote_port;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_IP_PROTOCOL].value.uint8 = _test_protocol;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_COMPARTMENT_ID].value.uint32 = _test_compartment_id;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_ALE_APP_ID].value.byteBlob = &_test_app_id;
 
-    return test_cgroup_sock_addr(FWPS_LAYER_ALE_CONNECT_REDIRECT_V6, FWPM_LAYER_ALE_CONNECT_REDIRECT_V6, incomingValue);
+    return test_cgroup_sock_addr(
+        FWPS_LAYER_ALE_CONNECT_REDIRECT_V6, FWPM_LAYER_ALE_CONNECT_REDIRECT_V6, incoming_value);
 }
 
 FWP_ACTION_TYPE
-_fwp_engine::test_sock_ops()
+_fwp_engine::test_sock_ops(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incoming_value)
 {
-    std::unique_lock l(lock);
-    const GUID* callout_key = get_callout_key_from_layer_guid(&FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4); // XXX
+    FWPS_INCOMING_VALUES incoming_fixed_values = {.layerId = layer_id, .incomingValue = incoming_value};
+    FWPS_INCOMING_METADATA_VALUES incoming_metadata_values = {};
+    const FWPM_FILTER* fwpm_filter = get_fwpm_filter_with_context();
+    if (!fwpm_filter) {
+        return FWP_ACTION_CALLOUT_UNKNOWN;
+    }
+    FWPS_FILTER fwps_filter = {.context = fwpm_filter->rawContext};
+
+    const GUID* callout_key = get_callout_key_from_layer_guid(&layer_guid);
     if (callout_key == nullptr) {
         return FWP_ACTION_CALLOUT_UNKNOWN;
     }
@@ -272,24 +255,6 @@ _fwp_engine::test_sock_ops()
         return FWP_ACTION_CALLOUT_UNKNOWN;
     }
     FWPS_CLASSIFY_OUT0 result = {};
-    FWPS_INCOMING_VALUE0 incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_MAX] = {};
-    const uint16_t test_port = 1234;
-    const uint8_t test_protocol = IPPROTO_TCP;
-    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_PORT].value.uint16 = test_port;
-    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_LOCAL_ADDRESS].value.uint32 = INADDR_ANY;
-    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_IP_PROTOCOL].value.uint8 = test_protocol;
-    FWP_BYTE_BLOB app_id = {};
-    app_id.data = (uint8_t*)"\\";
-    app_id.size = 2;
-    incomingValue[FWPS_FIELD_ALE_RESOURCE_ASSIGNMENT_V4_ALE_APP_ID].value.byteBlob = &app_id;
-
-    FWPS_INCOMING_VALUES incoming_fixed_values = {.incomingValue = incomingValue};
-    FWPS_INCOMING_METADATA_VALUES incoming_metadata_values = {};
-    const FWPM_FILTER* fwpm_filter = get_fwpm_filter_with_context();
-    if (!fwpm_filter) {
-        return FWP_ACTION_CALLOUT_UNKNOWN;
-    }
-    FWPS_FILTER fwps_filter = {.context = fwpm_filter->rawContext};
 
     callout->classifyFn(
         &incoming_fixed_values,
@@ -301,6 +266,43 @@ _fwp_engine::test_sock_ops()
         &result);
 
     return result.actionType;
+}
+
+FWP_ACTION_TYPE
+_fwp_engine::test_sock_ops_v4()
+{
+    std::unique_lock l(lock);
+
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_LOCAL_ADDRESS].value.uint32 = _test_local_ipv4_address;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_LOCAL_PORT].value.uint16 = _test_local_port;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_REMOTE_ADDRESS].value.uint32 = _test_remote_ipv4_address;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_REMOTE_PORT].value.uint16 = _test_remote_port;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_PROTOCOL].value.uint8 = _test_protocol;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_COMPARTMENT_ID].value.uint32 = _test_compartment_id;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_IP_LOCAL_INTERFACE].value.uint64 = &_test_interface_luid;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V4_ALE_APP_ID].value.byteBlob = &_test_app_id;
+
+    return test_sock_ops(FWPS_LAYER_ALE_FLOW_ESTABLISHED_V4, FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4, incoming_value);
+}
+
+FWP_ACTION_TYPE
+_fwp_engine::test_sock_ops_v6()
+{
+    std::unique_lock l(lock);
+
+    FWPS_INCOMING_VALUE0 incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_MAX] = {};
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_LOCAL_ADDRESS].value.byteArray16 = &_test_local_ipv6_address;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_LOCAL_PORT].value.uint16 = _test_local_port;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_REMOTE_ADDRESS].value.byteArray16 = &_test_remote_ipv6_address;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_REMOTE_PORT].value.uint16 = _test_remote_port;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_PROTOCOL].value.uint8 = _test_protocol;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_COMPARTMENT_ID].value.uint32 = _test_compartment_id;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_IP_LOCAL_INTERFACE].value.uint64 = &_test_interface_luid;
+    incoming_value[FWPS_FIELD_ALE_FLOW_ESTABLISHED_V6_ALE_APP_ID].value.byteBlob = &_test_app_id;
+
+    // TODO: can this work with test_sock_addr()?
+    return test_sock_ops(FWPS_LAYER_ALE_FLOW_ESTABLISHED_V6, FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6, incoming_value);
 }
 
 typedef struct _fwp_injection_handle
@@ -476,7 +478,9 @@ _IRQL_requires_max_(DISPATCH_LEVEL) NTSTATUS FwpsFlowAssociateContext0(
     UNREFERENCED_PARAMETER(layer_id);
     UNREFERENCED_PARAMETER(callout_id);
     UNREFERENCED_PARAMETER(flowContext);
-    return STATUS_NOT_IMPLEMENTED;
+
+    // TODO: what should we do here?
+    return STATUS_SUCCESS;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL) NTSTATUS FwpsAllocateNetBufferAndNetBufferList0(

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -77,8 +77,8 @@ typedef class _fwp_engine
     FWP_ACTION_TYPE
     classify_test_packet(_In_ const GUID* layer_guid, NET_IFINDEX if_index);
 
-    void
-    test_bind();
+    FWP_ACTION_TYPE
+    test_bind_ipv4();
 
     void
     test_cgroup_sock_addr();

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -111,16 +111,13 @@ typedef class _fwp_engine
     test_cgroup_sock_addr(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incomingValue);
 
     FWP_ACTION_TYPE
-    test_sock_ops(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incomingValue);
-
-    FWP_ACTION_TYPE
     test_callout(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incoming_value);
 
     _Ret_maybenull_ const FWPM_FILTER*
-    get_fwpm_filter_with_context()
+    get_fwpm_filter_with_context(_In_ const GUID& layer_guid)
     {
         for (auto& [first, filter] : fwpm_filters) {
-            if (filter.rawContext != 0) {
+            if (memcmp(&filter.layerKey, &layer_guid, sizeof(GUID)) == 0 && filter.rawContext != 0) {
                 return &filter;
             }
         }

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -93,7 +93,10 @@ typedef class _fwp_engine
     test_cgroup_inet6_connect();
 
     FWP_ACTION_TYPE
-    test_sock_ops();
+    test_sock_ops_v4();
+
+    FWP_ACTION_TYPE
+    test_sock_ops_v6();
 
     static _fwp_engine*
     get()
@@ -106,6 +109,9 @@ typedef class _fwp_engine
   private:
     FWP_ACTION_TYPE
     test_cgroup_sock_addr(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incomingValue);
+
+    FWP_ACTION_TYPE
+    test_sock_ops(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incomingValue);
 
     _Ret_maybenull_ const FWPM_FILTER*
     get_fwpm_filter_with_context()

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -81,7 +81,16 @@ typedef class _fwp_engine
     test_bind_ipv4();
 
     FWP_ACTION_TYPE
-    test_cgroup_sock_addr();
+    test_cgroup_inet4_recv_accept();
+
+    FWP_ACTION_TYPE
+    test_cgroup_inet6_recv_accept();
+
+    FWP_ACTION_TYPE
+    test_cgroup_inet4_connect();
+
+    FWP_ACTION_TYPE
+    test_cgroup_inet6_connect();
 
     FWP_ACTION_TYPE
     test_sock_ops();
@@ -95,6 +104,9 @@ typedef class _fwp_engine
     }
 
   private:
+    FWP_ACTION_TYPE
+    test_cgroup_sock_addr(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incomingValue);
+
     _Ret_maybenull_ const FWPM_FILTER*
     get_fwpm_filter_with_context()
     {

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -113,6 +113,9 @@ typedef class _fwp_engine
     FWP_ACTION_TYPE
     test_sock_ops(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incomingValue);
 
+    FWP_ACTION_TYPE
+    test_callout(uint16_t layer_id, _In_ const GUID& layer_guid, _In_ FWPS_INCOMING_VALUE0* incoming_value);
+
     _Ret_maybenull_ const FWPM_FILTER*
     get_fwpm_filter_with_context()
     {

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -80,10 +80,10 @@ typedef class _fwp_engine
     FWP_ACTION_TYPE
     test_bind_ipv4();
 
-    void
+    FWP_ACTION_TYPE
     test_cgroup_sock_addr();
 
-    void
+    FWP_ACTION_TYPE
     test_sock_ops();
 
     static _fwp_engine*

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -110,7 +110,10 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         (void)helper.test_bind_ipv4();
         break;
     case BPF_PROG_TYPE_CGROUP_SOCK_ADDR:
-        (void)helper.test_cgroup_sock_addr();
+        (void)helper.test_cgroup_inet4_recv_accept();
+        (void)helper.test_cgroup_inet6_recv_accept();
+        (void)helper.test_cgroup_inet4_connect();
+        (void)helper.test_cgroup_inet6_connect();
         break;
     case BPF_PROG_TYPE_SOCK_OPS:
         (void)helper.test_sock_ops();

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -79,9 +79,11 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
 
     NET_IFINDEX if_index = 0;
     ebpf_extension_data_t npi_specific_characteristics = {.size = sizeof(if_index), .data = &if_index};
-    netebpf_ext_helper_t helper(
-        &npi_specific_characteristics, (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_program);
     test_client_context_t client_context = {};
+    netebpf_ext_helper_t helper(
+        &npi_specific_characteristics,
+        (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_program,
+        &client_context.base);
 
     // Look up the context descriptor for the requested program type.
     std::vector<GUID> guids = helper.program_info_provider_guids();

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -107,7 +107,7 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         (void)helper.classify_test_packet(&FWPM_LAYER_INBOUND_MAC_FRAME_NATIVE, if_index);
         break;
     case BPF_PROG_TYPE_BIND:
-        helper.test_bind();
+        (void)helper.test_bind_ipv4();
         break;
     case BPF_PROG_TYPE_CGROUP_SOCK_ADDR:
         helper.test_cgroup_sock_addr();

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -110,10 +110,10 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         (void)helper.test_bind_ipv4();
         break;
     case BPF_PROG_TYPE_CGROUP_SOCK_ADDR:
-        helper.test_cgroup_sock_addr();
+        (void)helper.test_cgroup_sock_addr();
         break;
     case BPF_PROG_TYPE_SOCK_OPS:
-        helper.test_sock_ops();
+        (void)helper.test_sock_ops();
         break;
     }
 

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -19,7 +19,7 @@ typedef struct
 
 typedef struct _test_client_context
 {
-    void* provider_binding_context;
+    netebpfext_helper_base_client_context_t base;
     ebpf_context_descriptor_t* ctx_descriptor;
     netebpfext_fuzzer_metadata_t metadata;
 } test_client_context_t;
@@ -65,45 +65,6 @@ netebpfext_unit_invoke_program(
     return EBPF_SUCCESS;
 }
 
-// Netebpfext is ready for us to attach to it as if we were ebpfcore.
-NTSTATUS
-netebpf_fuzzer_attach_extension(
-    _In_ HANDLE nmr_binding_handle,
-    _Inout_ void* client_context,
-    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
-{
-    UNREFERENCED_PARAMETER(provider_registration_instance);
-    const void* provider_dispatch_table;
-    ebpf_extension_dispatch_table_t client_dispatch_table = {.size = 1};
-    client_dispatch_table.function[0] = (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_program;
-    auto test_client_context = (test_client_context_t*)client_context;
-
-    return NmrClientAttachProvider(
-        nmr_binding_handle,
-        test_client_context, // Client binding context.
-        &client_dispatch_table,
-        &test_client_context->provider_binding_context,
-        &provider_dispatch_table);
-}
-
-// Detach from netebpfext.
-NTSTATUS
-netebpf_fuzzer_detach_extension(_Inout_ void* client_binding_context)
-{
-    auto test_client_context = (test_client_context_t*)client_binding_context;
-    UNREFERENCED_PARAMETER(test_client_context);
-
-    // All callbacks we implement are done.
-    return STATUS_SUCCESS;
-}
-
-void
-netebpfext_fuzzer_cleanup_binding_context(_In_ const void* client_binding_context)
-{
-    auto test_client_context = (test_client_context_t*)client_binding_context;
-    UNREFERENCED_PARAMETER(test_client_context);
-}
-
 FUZZ_EXPORT int __cdecl LLVMFuzzerInitialize(int*, char***) { return 0; }
 
 FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
@@ -116,7 +77,10 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     // Read program type.
     bpf_prog_type_t prog_type = (bpf_prog_type_t)metadata->prog_type;
 
-    netebpf_ext_helper_t helper;
+    NET_IFINDEX if_index = 0;
+    ebpf_extension_data_t npi_specific_characteristics = {.size = sizeof(if_index), .data = &if_index};
+    netebpf_ext_helper_t helper(
+        &npi_specific_characteristics, (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_program);
     test_client_context_t client_context = {};
 
     // Look up the context descriptor for the requested program type.
@@ -137,33 +101,6 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         return 0;
     }
 
-    // Register with NMR as if we were ebpfcore.sys.
-    NPI_CLIENT_CHARACTERISTICS client_characteristics = {};
-    client_characteristics.ClientRegistrationInstance.NpiId = &EBPF_HOOK_EXTENSION_IID;
-    GUID module_guid = {/* dced0fd8-2922-436c-b3f0-e8609a3a2dc6 */
-                        0xdced0fd8,
-                        0x2922,
-                        0x436c,
-                        {0xb3, 0xf0, 0xe8, 0x60, 0x9a, 0x3a, 0x2d, 0xc6}};
-    NPI_MODULEID module_id = {.Length = sizeof(NPI_MODULEID), .Type = MIT_GUID, .Guid = module_guid};
-    client_characteristics.ClientRegistrationInstance.ModuleId = &module_id;
-    NET_IFINDEX if_index = 0;
-    ebpf_extension_data_t npi_specific_characteristics = {.size = sizeof(if_index), .data = &if_index};
-    client_characteristics.ClientRegistrationInstance.NpiSpecificCharacteristics = &npi_specific_characteristics;
-    client_characteristics.ClientAttachProvider = netebpf_fuzzer_attach_extension;
-    client_characteristics.ClientDetachProvider = netebpf_fuzzer_detach_extension;
-    client_characteristics.ClientCleanupBindingContext =
-        (NPI_CLIENT_CLEANUP_BINDING_CONTEXT_FN*)netebpfext_fuzzer_cleanup_binding_context;
-    HANDLE nmr_client_handle;
-    if (NmrRegisterClient(&client_characteristics, &client_context, &nmr_client_handle) != STATUS_SUCCESS) {
-        return 0;
-    }
-
-    // Verify we successfully attached to netebpfext.
-    if (client_context.provider_binding_context == nullptr) {
-        goto Done;
-    }
-
     client_context.metadata = *metadata;
     switch (prog_type) {
     case BPF_PROG_TYPE_XDP:
@@ -178,12 +115,6 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
     case BPF_PROG_TYPE_SOCK_OPS:
         helper.test_sock_ops();
         break;
-    }
-
-Done:
-    NTSTATUS status = NmrDeregisterClient(nmr_client_handle);
-    if (status == STATUS_PENDING) {
-        NmrWaitForClientDeregisterComplete(nmr_client_handle);
     }
 
     return 0; // Non-zero return values are reserved for future use.

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -116,7 +116,8 @@ FUZZ_EXPORT int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
         (void)helper.test_cgroup_inet6_connect();
         break;
     case BPF_PROG_TYPE_SOCK_OPS:
-        (void)helper.test_sock_ops();
+        (void)helper.test_sock_ops_v4();
+        (void)helper.test_sock_ops_v6();
         break;
     }
 

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -42,6 +42,7 @@ _netebpf_ext_helper::_netebpf_ext_helper(
 
     REQUIRE(NmrRegisterClient(&program_info_client, this, &nmr_program_info_client_handle) == STATUS_SUCCESS);
 
+    nmr_hook_client_handle = INVALID_HANDLE_VALUE;
     this->hook_invoke_function = dispatch_function;
     if (dispatch_function != nullptr) {
         hook_client.ClientRegistrationInstance.NpiSpecificCharacteristics = npi_specific_characteristics;

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -42,9 +42,9 @@ _netebpf_ext_helper::_netebpf_ext_helper(
 
     REQUIRE(NmrRegisterClient(&program_info_client, this, &nmr_program_info_client_handle) == STATUS_SUCCESS);
 
+    this->hook_invoke_function = dispatch_function;
     if (dispatch_function != nullptr) {
         hook_client.ClientRegistrationInstance.NpiSpecificCharacteristics = npi_specific_characteristics;
-        this->hook_invoke_function = dispatch_function;
         client_context->helper = this;
         REQUIRE(NmrRegisterClient(&hook_client, client_context, &nmr_hook_client_handle) == STATUS_SUCCESS);
     }

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -15,7 +15,10 @@ _get_program_context(_Outptr_ void** context)
 
 ebpf_extension_dispatch_table_t dispatch_table = {0, 1, {(_ebpf_extension_dispatch_function)_get_program_context}};
 
-_netebpf_ext_helper::_netebpf_ext_helper()
+_netebpf_ext_helper::_netebpf_ext_helper(
+    _In_opt_ const void* npi_specific_characteristics,
+    _In_opt_ _ebpf_extension_dispatch_function dispatch_function,
+    _In_opt_ netebpfext_helper_base_client_context_t* client_context)
 {
     NTSTATUS status;
     status = net_ebpf_ext_trace_initiate();
@@ -37,12 +40,32 @@ _netebpf_ext_helper::_netebpf_ext_helper()
 
     wfp_initialized = true;
 
-    REQUIRE(NmrRegisterClient(&client, this, &nmr_client_handle) == STATUS_SUCCESS);
+    REQUIRE(NmrRegisterClient(&program_info_client, this, &nmr_program_info_client_handle) == STATUS_SUCCESS);
+
+    if (dispatch_function != nullptr) {
+        hook_client.ClientRegistrationInstance.NpiSpecificCharacteristics = npi_specific_characteristics;
+        this->hook_invoke_function = dispatch_function;
+        client_context->helper = this;
+        REQUIRE(NmrRegisterClient(&hook_client, client_context, &nmr_hook_client_handle) == STATUS_SUCCESS);
+    }
 }
 
 _netebpf_ext_helper::~_netebpf_ext_helper()
 {
-    REQUIRE(NmrDeregisterClient(nmr_client_handle) == STATUS_SUCCESS);
+    if (nmr_program_info_client_handle != INVALID_HANDLE_VALUE) {
+        NTSTATUS status = NmrDeregisterClient(nmr_program_info_client_handle);
+        if (status == STATUS_PENDING) {
+            status = NmrWaitForClientDeregisterComplete(nmr_program_info_client_handle);
+        }
+        REQUIRE(status == STATUS_SUCCESS);
+    }
+    if (nmr_hook_client_handle != INVALID_HANDLE_VALUE) {
+        NTSTATUS status = NmrDeregisterClient(nmr_hook_client_handle);
+        if (status == STATUS_PENDING) {
+            status = NmrWaitForClientDeregisterComplete(nmr_hook_client_handle);
+        }
+        REQUIRE(status == STATUS_SUCCESS);
+    }
 
     if (wfp_initialized) {
         net_ebpf_extension_uninitialize_wfp_components();
@@ -119,6 +142,51 @@ _netebpf_ext_helper::_program_info_client_detach_provider(_Inout_ void* client_b
 
 void
 _netebpf_ext_helper::_program_info_client_cleanup_binding_context(_In_ _Post_invalid_ void* client_binding_context)
+{
+    UNREFERENCED_PARAMETER(client_binding_context);
+}
+
+NTSTATUS
+_netebpf_ext_helper::_hook_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _Inout_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
+{
+    UNREFERENCED_PARAMETER(provider_registration_instance);
+    const void* provider_dispatch_table;
+    ebpf_extension_dispatch_table_t client_dispatch_table = {.size = 1};
+    auto base_client_context = reinterpret_cast<netebpfext_helper_base_client_context_t*>(client_context);
+    if (base_client_context == nullptr) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    client_dispatch_table.function[0] = base_client_context->helper->hook_invoke_function;
+    auto provider_characteristics =
+        (const ebpf_extension_data_t*)provider_registration_instance->NpiSpecificCharacteristics;
+    auto provider_data = (const ebpf_attach_provider_data_t*)provider_characteristics->data;
+    if (base_client_context->desired_attach_type != BPF_ATTACH_TYPE_UNSPEC &&
+        provider_data->bpf_attach_type != base_client_context->desired_attach_type) {
+        return STATUS_ACCESS_DENIED;
+    }
+
+    return NmrClientAttachProvider(
+        nmr_binding_handle,
+        client_context, // Client binding context.
+        &client_dispatch_table,
+        &base_client_context->provider_binding_context,
+        &provider_dispatch_table);
+}
+
+NTSTATUS
+_netebpf_ext_helper::_hook_client_detach_provider(_Inout_ void* client_binding_context)
+{
+    UNREFERENCED_PARAMETER(client_binding_context);
+
+    // All callbacks we implement are done.
+    return STATUS_SUCCESS;
+}
+
+void
+_netebpf_ext_helper::_hook_client_cleanup_binding_context(_In_ void* client_binding_context)
 {
     UNREFERENCED_PARAMETER(client_binding_context);
 }

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -53,7 +53,16 @@ typedef class _netebpf_ext_helper
     test_bind_ipv4() { return _fwp_engine::get()->test_bind_ipv4(); }
 
     FWP_ACTION_TYPE
-    test_cgroup_sock_addr() { return _fwp_engine::get()->test_cgroup_sock_addr(); }
+    test_cgroup_inet4_recv_accept() { return _fwp_engine::get()->test_cgroup_inet4_recv_accept(); }
+
+    FWP_ACTION_TYPE
+    test_cgroup_inet6_recv_accept() { return _fwp_engine::get()->test_cgroup_inet6_recv_accept(); }
+
+    FWP_ACTION_TYPE
+    test_cgroup_inet4_connect() { return _fwp_engine::get()->test_cgroup_inet4_connect(); }
+
+    FWP_ACTION_TYPE
+    test_cgroup_inet6_connect() { return _fwp_engine::get()->test_cgroup_inet6_connect(); }
 
     FWP_ACTION_TYPE
     test_sock_ops() { return _fwp_engine::get()->test_sock_ops(); }

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -21,10 +21,20 @@
 #include "net_ebpf_ext.h"
 #include "fwp_um.h"
 
+typedef struct _netebpfext_helper_base_client_context
+{
+    class _netebpf_ext_helper* helper;
+    void* provider_binding_context;
+    bpf_attach_type_t desired_attach_type; // BPF_ATTACH_TYPE_UNSPEC for any allowed.
+} netebpfext_helper_base_client_context_t;
+
 typedef class _netebpf_ext_helper
 {
   public:
-    _netebpf_ext_helper();
+    _netebpf_ext_helper(
+        _In_opt_ const void* npi_specific_characteristics = nullptr,
+        _In_opt_ _ebpf_extension_dispatch_function dispatch_function = nullptr,
+        _In_opt_ netebpfext_helper_base_client_context_t* client_context = nullptr);
     ~_netebpf_ext_helper();
 
     std::vector<GUID>
@@ -103,7 +113,7 @@ typedef class _netebpf_ext_helper
         NPI_MODULEID_TYPE::MIT_GUID,
         {0x6be20b78, 0x9d94, 0x4e77, {0x9f, 0xbf, 0x85, 0x9f, 0xb1, 0x69, 0xb, 0x82}}};
 
-    NPI_CLIENT_CHARACTERISTICS client{
+    NPI_CLIENT_CHARACTERISTICS program_info_client{
         1,
         sizeof(NPI_PROVIDER_CHARACTERISTICS),
         _program_info_client_attach_provider,
@@ -119,6 +129,37 @@ typedef class _netebpf_ext_helper
         },
     };
 
-    HANDLE nmr_client_handle;
+    static NTSTATUS
+    _hook_client_attach_provider(
+        _In_ HANDLE nmr_binding_handle,
+        _Inout_ void* client_context,
+        _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance);
+
+    static NTSTATUS
+    _hook_client_detach_provider(_Inout_ void* client_binding_context);
+
+    static void
+    _hook_client_cleanup_binding_context(_In_ void* client_binding_context);
+
+    NPI_CLIENT_CHARACTERISTICS hook_client{
+        1,
+        sizeof(NPI_PROVIDER_CHARACTERISTICS),
+        _hook_client_attach_provider,
+        _hook_client_detach_provider,
+        _hook_client_cleanup_binding_context,
+        {
+            0,
+            sizeof(NPI_REGISTRATION_INSTANCE),
+            &EBPF_HOOK_EXTENSION_IID,
+            &module_id,
+            0,
+            nullptr,
+        },
+    };
+
+    _ebpf_extension_dispatch_function hook_invoke_function;
+
+    HANDLE nmr_program_info_client_handle;
+    HANDLE nmr_hook_client_handle;
 
 } netebpf_ext_helper_t;

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -65,7 +65,10 @@ typedef class _netebpf_ext_helper
     test_cgroup_inet6_connect() { return _fwp_engine::get()->test_cgroup_inet6_connect(); }
 
     FWP_ACTION_TYPE
-    test_sock_ops() { return _fwp_engine::get()->test_sock_ops(); }
+    test_sock_ops_v4() { return _fwp_engine::get()->test_sock_ops_v4(); }
+
+    FWP_ACTION_TYPE
+    test_sock_ops_v6() { return _fwp_engine::get()->test_sock_ops_v6(); }
 
   private:
     bool trace_initiated = false;

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -52,17 +52,11 @@ typedef class _netebpf_ext_helper
     FWP_ACTION_TYPE
     test_bind_ipv4() { return _fwp_engine::get()->test_bind_ipv4(); }
 
-    void
-    test_cgroup_sock_addr()
-    {
-        return _fwp_engine::get()->test_cgroup_sock_addr();
-    }
+    FWP_ACTION_TYPE
+    test_cgroup_sock_addr() { return _fwp_engine::get()->test_cgroup_sock_addr(); }
 
-    void
-    test_sock_ops()
-    {
-        return _fwp_engine::get()->test_sock_ops();
-    }
+    FWP_ACTION_TYPE
+    test_sock_ops() { return _fwp_engine::get()->test_sock_ops(); }
 
   private:
     bool trace_initiated = false;

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -49,11 +49,8 @@ typedef class _netebpf_ext_helper
         return _fwp_engine::get()->classify_test_packet(layer_guid, if_index);
     }
 
-    void
-    test_bind()
-    {
-        return _fwp_engine::get()->test_bind();
-    }
+    FWP_ACTION_TYPE
+    test_bind_ipv4() { return _fwp_engine::get()->test_bind_ipv4(); }
 
     void
     test_cgroup_sock_addr()

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -404,7 +404,7 @@ TEST_CASE("sock_addr_context", "[netebpfext]")
 typedef struct test_sock_ops_client_context_t
 {
     netebpfext_helper_base_client_context_t base;
-    uint32_t /*XXX*/ sock_ops_action;
+    uint32_t sock_ops_action;
 } test_sock_ops_client_context_t;
 
 _Must_inspect_result_ ebpf_result_t
@@ -427,9 +427,23 @@ TEST_CASE("sock_ops_invoke", "[netebpfext]")
         (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_sock_ops_program,
         (netebpfext_helper_base_client_context_t*)&client_context);
 
-    client_context.sock_ops_action = BIND_PERMIT; // XXX
-    FWP_ACTION_TYPE result = helper.test_sock_ops();
+    // Do some operations that return success.
+    client_context.sock_ops_action = 0;
+
+    FWP_ACTION_TYPE result = helper.test_sock_ops_v4();
     REQUIRE(result == FWP_ACTION_PERMIT);
+
+    result = helper.test_sock_ops_v6();
+    REQUIRE(result == FWP_ACTION_PERMIT);
+
+    // Do some operations that return failure.
+    client_context.sock_ops_action = -1;
+
+    result = helper.test_sock_ops_v4();
+    REQUIRE(result == FWP_ACTION_BLOCK);
+
+    result = helper.test_sock_ops_v6();
+    REQUIRE(result == FWP_ACTION_BLOCK);
 }
 
 TEST_CASE("sock_ops_context", "[netebpfext]")


### PR DESCRIPTION
## Description

* Move functionality common between netebpfext_unit.cpp and netebpfext_fuzzer.cpp into netebpf_ext_helper.cpp
* Add unit tests for BIND, CGROUP_SOCK_ADDR, and SOCK_OPS

Fixes #1869 

## Testing

This PR adds tests.

## Documentation

No impact.
