### PR TITLE
Shave 8+ minutes off the overall build time

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -208,7 +208,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: bpf2c_fuzzer
-      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
       build_artifact: Build-x64-fuzzer
       environment: windows-2022
       code_coverage: false
@@ -235,7 +235,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: verifier_fuzzer
-      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
       build_artifact: Build-x64-fuzzer
       environment: windows-2022
       code_coverage: false

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -203,12 +203,23 @@ jobs:
 
   bpf2c_fuzzer:
     needs: libfuzzer
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: bpf2c_fuzzer
       test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64-fuzzer
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+
+  bpf2c_fuzzer_scheduled:
+    needs: libfuzzer
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: bpf2c_fuzzer
+      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
       build_artifact: Build-x64-fuzzer
       environment: windows-2022
       code_coverage: false
@@ -231,7 +242,7 @@ jobs:
   verifier_fuzzer:
     needs: libfuzzer
     # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: verifier_fuzzer
@@ -240,6 +251,20 @@ jobs:
       environment: windows-2022
       code_coverage: false
       gather_dumps: true
+
+  verifier_fuzzer_scheduled:
+    needs: libfuzzer
+    # Always run this job.
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: verifier_fuzzer
+      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64-fuzzer
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+
 
   core_helper_fuzzer:
     needs: libfuzzer


### PR DESCRIPTION
Currently bpf2c_fuzzer and verifier_fuzzer complete last, 8 or so minutes after the next long pole (using https://github.com/microsoft/ebpf-for-windows/actions/runs/3952621659 as a recent example):

* bpf2c_fuzzer: 41 mins
* verifier_fuzzer: 41 mins
* stress: 33 mins
* sanitize_unit_tests: 32 mins
* driver: 31 mins
* fuzzing: 31 mins
* bpf2c: 30 mins

Breakdown within the bpf2c fuzzer and verifier fuzzer runs:
* 23-24 mins to build with fuzzing
* 2 mins to download the build artifact
* 15 mins to run the actual fuzzer using random inputs

Fuzz tests should not be the long pole on a per-PR basis, so drop the fuzz time from 15 mins to 5 mins per run so they are not the bottleneck.

Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Testing

This PR just changes the test duration.

## Documentation

No impact.
