### PR TITLE
Cache verifier based on commit id and options

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -68,6 +68,23 @@ jobs:
     - name: Add MSBuild to PATH
       uses: microsoft/setup-msbuild@34cfbaee7f672c76950673338facd8a73f637506
 
+    - name: Setup choco cache folder
+      # Set the choco cache to a local folder so that it can be cached.
+      id: choco-cache
+      run: |
+        mkdir ${{github.workspace}}\choco_cache
+        choco config set --name cacheLocation --value ${{github.workspace}}\choco_cache
+
+    - name: Cache choco packages
+      # Add cache entry for any choco packages that are installed.
+      # The cache key is based on the hash of this file so if any choco packages are added or removed, the cache will be invalidated.
+      uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+      env:
+        cache-name: cache-choco-packages
+      with:
+        path: ${{github.workspace}}\choco_cache
+        key: ${{ hashFiles('.github/workflows/reusable-build.yml') }}
+
     - name: Install tools
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: |
@@ -87,12 +104,13 @@ jobs:
       run: nuget restore ${{env.SOLUTION_FILE_PATH}}
 
     - name: Cache verifier project
+      # The hash is based on the HEAD of the ebpf-verifier submodule, the Directory.Build.props file, and the build variant.
       uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
       env:
         cache-name: cache-verifier-project
       with:
         path: external/ebpf-verifier/build
-        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('.git/modules/external/ebpf-verifier/HEAD') }}-${{ env.LD_FLAGS }}-${{ env.CXX_FLAGS }}
+        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('.git/modules/external/ebpf-verifier/HEAD') }}-${{ hashFiles('external/Directory.Build.props')}}
 
     - name: Create verifier project
       working-directory: ${{env.GITHUB_WORKSPACE}}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -86,6 +86,14 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: nuget restore ${{env.SOLUTION_FILE_PATH}}
 
+    - name: Cache verifier project
+      uses: actions/cache@4723a57e26efda3a62cbde1812113b730952852d
+      env:
+        cache-name: cache-verifier-project
+      with:
+        path: external/ebpf-verifier/build
+        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('.git/modules/external/ebpf-verifier/HEAD') }}-${{ env.LD_FLAGS }}-${{ env.CXX_FLAGS }}
+
     - name: Create verifier project
       working-directory: ${{env.GITHUB_WORKSPACE}}
       env:


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Only rebuild ebpf-verifer if the commit id has changed.

## Testing

CI/CD

## Documentation

No.

Resolves: #1925