### PR TITLE
Resolve circular references using uni-directional weak references

### DIFF
--- a/libs/platform/ebpf_hash_table.c
+++ b/libs/platform/ebpf_hash_table.c
@@ -660,11 +660,12 @@ ebpf_hash_table_find(_In_ const ebpf_hash_table_t* hash_table, _In_ const uint8_
     size_t index;
     ebpf_hash_bucket_header_t* bucket;
 
-    if (!hash_table || !key) {
+    if (!hash_table || !key || !value) {
         retval = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
 
+    *value = NULL;
     hash = _ebpf_hash_table_compute_hash(hash_table, key);
     bucket = hash_table->buckets[hash % hash_table->bucket_count].header;
     if (!bucket) {

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -411,44 +411,69 @@ void
 _test_nested_maps(bpf_map_type type)
 {
     // Create first inner map.
-    fd_t inner1 = bpf_map_create(BPF_MAP_TYPE_ARRAY, nullptr, sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
-    REQUIRE(inner1 > 0);
+    fd_t inner_map_fd1 =
+        bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map1", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(inner_map_fd1 > 0);
 
     // Create outer map.
-    bpf_map_create_opts opts = {.inner_map_fd = (uint32_t)inner1};
+    bpf_map_create_opts opts = {.inner_map_fd = (uint32_t)inner_map_fd1};
     fd_t outer_map_fd = bpf_map_create(type, "outer_map", sizeof(uint32_t), sizeof(fd_t), 10, &opts);
-
     REQUIRE(outer_map_fd > 0);
 
     // Create second inner map.
-    fd_t inner2 = bpf_map_create(BPF_MAP_TYPE_ARRAY, nullptr, sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
-    REQUIRE(inner2 > 0);
+    fd_t inner_map_fd2 =
+        bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map2", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(inner_map_fd2 > 0);
 
     // Insert both inner maps in outer map.
     uint32_t key = 1;
-    uint32_t result = bpf_map_update_elem(outer_map_fd, &key, &inner1, 0);
+    uint32_t result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd1, 0);
     REQUIRE(result == ERROR_SUCCESS);
 
     key = 2;
-    result = bpf_map_update_elem(outer_map_fd, &key, &inner1, 0);
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
     REQUIRE(result == ERROR_SUCCESS);
 
-    // Remove the inner maps from outer map.
+    // Add inner map (1) multiple times.
+    key = 3;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd1, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 4;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd1, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    // Add inner map (2) multiple times.
+    key = 5;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 6;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 7;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    // Remove some inner maps from outer map.
     key = 1;
     result = bpf_map_delete_elem(outer_map_fd, &key);
     REQUIRE(result == ERROR_SUCCESS);
+
     key = 2;
     result = bpf_map_delete_elem(outer_map_fd, &key);
     REQUIRE(result == ERROR_SUCCESS);
 
-    _close(inner1);
-    _close(inner2);
+    // Leave the other instances of 'map inserts' as-is, the post-app-termination clean-up should take care of these.
+
+    _close(inner_map_fd1);
+    _close(inner_map_fd2);
     _close(outer_map_fd);
 }
 
-TEST_CASE("array_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
-
-TEST_CASE("hash_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }
+TEST_CASE("array_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
+TEST_CASE("hash_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }
 
 TEST_CASE("tailcall_load_test", "[tailcall_load_test]")
 {
@@ -712,4 +737,96 @@ TEST_CASE("nomap_load_test", "[native_tests]")
         "printk.sys", BPF_PROG_TYPE_BIND, "func", EBPF_EXECUTION_NATIVE, nullptr, 0, hook);
     auto object = _helper.get_object();
     REQUIRE(object != nullptr);
+}
+
+// This test tests resource reclamation and clean-up after a premature/abnormal user mode application exit.
+TEST_CASE("close_unload_test", "[native_tests][native_close_cleanup_tests]")
+{
+    struct bpf_object* object = nullptr;
+    hook_helper_t hook(EBPF_ATTACH_TYPE_BIND);
+    program_load_attach_helper_t _helper(
+        "bindmonitor_tailcall.sys", BPF_PROG_TYPE_BIND, "BindMonitor", EBPF_EXECUTION_NATIVE, nullptr, 0, hook);
+    object = _helper.get_object();
+
+    // Setup tail calls.
+    struct bpf_program* callee0 = bpf_object__find_program_by_name(object, "BindMonitor_Callee0");
+    REQUIRE(callee0 != nullptr);
+    fd_t callee0_fd = bpf_program__fd(callee0);
+    REQUIRE(callee0_fd > 0);
+
+    struct bpf_program* callee1 = bpf_object__find_program_by_name(object, "BindMonitor_Callee1");
+    REQUIRE(callee1 != nullptr);
+    fd_t callee1_fd = bpf_program__fd(callee1);
+    REQUIRE(callee1_fd > 0);
+
+    fd_t prog_map_fd = bpf_object__find_map_fd_by_name(object, "prog_array_map");
+    REQUIRE(prog_map_fd > 0);
+
+    uint32_t index = 0;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee0_fd, 0) == 0);
+
+    index = 1;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    // Now insert the same program for multiple keys in the same map.
+    index = 2;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    index = 4;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    index = 7;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    bindmonitor_test(object);
+
+    // The block of commented code after this comment is for documentation purposes only.
+    //
+    // A well-behaved user mode application _should_ call these calls to correctly free the allocated objects. In case
+    // of careless applications that do not do so (or even well behaved applications, when they crash or terminate for
+    // some reason before getting to this point), the 'premature application close' event handling _should_ take care
+    // of reclaiming and free'ing such objects. All unit tests belonging to the '[native_close_cleanup_tests]'
+    // unit-test class simulate this behavior by _not_ calling the clean-up api calls.
+    //
+    // For native tests (meant for execution on the kernel mode ebpf-for-windows driver), this event will be handled
+    // by the ebpf-core kernel mode driver on test application termination.
+    //
+    // The success/failure of the [native_close_cleanup_tests] tests can only be (indirectly) checked by attempting to
+    // stop the ebpf-core driver after executing this class of tests.  If the clean-up by the ebpf-core driver is not
+    // successful, it cannot be stopped/unloaded.  This step is performed automatically by the CI/CD test pass runs and
+    // will need to be perfomed as an explicit manual step after a manually initiated test-run.
+    //
+    // On a final note, each test in the [native_close_cleanup_tests] set _must_ load a .sys driver (if it needs one)
+    // that either has not been loaded yet, or was loaded but has since been unloaded (before start of the test). Given
+    // that we deliberately skip the clean-up API calls, the drivers stay loaded at the end of the individual test. An
+    // attempt to (re)load the same driver again (by the next test) will fail (as it should), but leads to spurious
+    // test failures (by way of an assert due to an error returned by bpf_object__load() in the
+    // program_load_attach_helper_t constructor).
+
+    /*
+        --- DO NOT REMOVE OR UN-COMMENT ---
+
+    auto cleanup = [prog_map_fd, &index]() {
+        index = 0;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+        index = 1;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+        index = 2;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+        index = 4;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+        index = 7;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+    };
+
+    // Clean up tail calls.
+    cleanup();
+
+    // Free the program as well.
+    bpf_object__close(object);
+    */
 }

--- a/tests/api_test/api_test.vcxproj
+++ b/tests/api_test/api_test.vcxproj
@@ -58,6 +58,8 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)libs\execution_context;$(SolutionDir)libs\Platform;$(SolutionDir)libs\Platform\user;$(SolutionDir)libs\thunk;$(SolutionDir)\netebpfext;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\bpftool;$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\api_common;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -77,7 +77,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         2,                       // Maximum number of entries allowed in the map.
+         8,                       // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -43,7 +43,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         2,                       // Maximum number of entries allowed in the map.
+         8,                       // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -210,7 +210,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         2,                       // Maximum number of entries allowed in the map.
+         8,                       // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.

--- a/tests/sample/bindmonitor_tailcall.c
+++ b/tests/sample/bindmonitor_tailcall.c
@@ -40,7 +40,7 @@ struct bpf_map_def limits_map = {
 
 SEC("maps")
 struct bpf_map_def prog_array_map = {
-    .type = BPF_MAP_TYPE_PROG_ARRAY, .key_size = sizeof(uint32_t), .value_size = sizeof(uint32_t), .max_entries = 2};
+    .type = BPF_MAP_TYPE_PROG_ARRAY, .key_size = sizeof(uint32_t), .value_size = sizeof(uint32_t), .max_entries = 8};
 
 SEC("maps")
 // Dummy map. Should not be populated by UM.

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1504,20 +1504,21 @@ _ebpf_test_map_in_map(ebpf_map_type_t type)
     _test_helper_end_to_end test_helper;
 
     // Create an inner map that we'll use both as a template and as an actual entry.
-    int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_ARRAY, nullptr, sizeof(__u32), sizeof(__u32), 1, nullptr);
+    int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map", sizeof(__u32), sizeof(__u32), 1, nullptr);
     REQUIRE(inner_map_fd > 0);
 
     // Verify that we cannot simply create an outer map without a template.
-    REQUIRE(bpf_map_create(type, nullptr, sizeof(__u32), sizeof(__u32), 2, nullptr) < 0);
+    REQUIRE(bpf_map_create(type, "array_map_of_maps", sizeof(__u32), sizeof(__u32), 2, nullptr) < 0);
     REQUIRE(errno == EBADF);
 
+    // Verify that we cannot create an outer map with an invalid fd for the inner map.
     bpf_map_create_opts opts = {.inner_map_fd = (uint32_t)ebpf_fd_invalid};
-    REQUIRE(bpf_map_create(type, nullptr, sizeof(__u32), sizeof(fd_t), 2, &opts) < 0);
+    REQUIRE(bpf_map_create(type, "array_map_of_maps", sizeof(__u32), sizeof(fd_t), 2, &opts) < 0);
     REQUIRE(errno == EBADF);
 
     // Verify we can create an outer map with a template.
     opts.inner_map_fd = inner_map_fd;
-    int outer_map_fd = bpf_map_create(type, nullptr, sizeof(__u32), sizeof(fd_t), 2, &opts);
+    int outer_map_fd = bpf_map_create(type, "array_map_of_maps", sizeof(__u32), sizeof(fd_t), 2, &opts);
     REQUIRE(outer_map_fd > 0);
 
     // Verify we can insert the inner map into the outer map.
@@ -2650,3 +2651,49 @@ TEST_CASE("libbpf_num_possible_cpus", "[libbpf]")
     int cpu_count = libbpf_num_possible_cpus();
     REQUIRE(cpu_count > 0);
 }
+
+void
+_test_nested_maps(bpf_map_type map_type)
+{
+    _test_helper_end_to_end test_helper;
+
+    // First, create an inner map.
+    fd_t inner_map_fd1 =
+        bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map1", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(inner_map_fd1 > 0);
+
+    // Create outer map with the inner map handle in options.
+    bpf_map_create_opts opts = {.inner_map_fd = (uint32_t)inner_map_fd1};
+    fd_t outer_map_fd = bpf_map_create(map_type, "outer_map", sizeof(uint32_t), sizeof(fd_t), 10, &opts);
+    REQUIRE(outer_map_fd > 0);
+
+    // Create second inner map.
+    fd_t inner_map_fd2 =
+        bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map2", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(inner_map_fd2 > 0);
+
+    // Insert both inner maps in outer map.
+    uint32_t key = 1;
+    uint32_t result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd1, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 2;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    // Remove the inner maps from outer map.
+    key = 1;
+    result = bpf_map_delete_elem(outer_map_fd, &key);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 2;
+    result = bpf_map_delete_elem(outer_map_fd, &key);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    Platform::_close(inner_map_fd2);
+    Platform::_close(inner_map_fd1);
+    Platform::_close(outer_map_fd);
+}
+
+TEST_CASE("array_map_of_maps", "[libbpf]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
+TEST_CASE("hash_map_of_maps", "[libbpf]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }

--- a/tests/unit/test.vcxproj
+++ b/tests/unit/test.vcxproj
@@ -58,6 +58,8 @@
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <AdditionalIncludeDirectories>$(SolutionDir)libs\api_common;$(SolutionDir)include;$(SolutionDir)libs\api;$(SolutionDir)libs\ebpfnetsh;$(SolutionDir)tests\libs\util;$(SolutionDir)tests\libs\common;$(OutDir);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)libs\service;$(SolutionDir)rpc_interface;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\user;$(SolutionDir)libs\execution_context;$(SolutionDir)tests\end_to_end;$(SolutionDir)tests\sample;$(SolutionDir)tests\sample\ext\inc;$(SolutionDir)\tests\xdp;$(SolutionDir)tools\export_program_info;$(SolutionDir)libs\thunk;$(SolutionDir)libs\thunk\mock;$(SolutionDir)\netebpfext;$(SolutionDir)external\catch2\src;$(SolutionDir)external\catch2\build\generated-includes;$(SolutionDir)external\bpftool;$(SolutionDir)include\user;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard_C>stdc17</LanguageStandard_C>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
## Description

The current 'map <--> contained-objects' relationship uses strong circular references maintained between object-maps (map-of-maps, hash-map-of-maps) and objects (programs and maps).

While this design works for well-behaved user mode applications, it breaks down if the user mode applications do not perform explicit clean-up via the provided clean-up APIs, leading to leaked resources by the way of programs and maps orphaned in memory. This typically happens with user programs that either exit prematurely, do not call the clean-up API calls or crash before they can do so. 

This PR proposes a new design solution where the references from the maps to the contained objects are replaced by 'weak-references'.

## Testing

User mode:

_NOTE: I'm currently investigating a transient new kernel-mode test failure that reproduces in very specific conditions in a seemingly unrelated area (program load).  Will update this PR once I've figured that out._

Ensure that the ```unit_tests.exe``` test suite passes successfully.

Kernel Mode:

1. Ensure that the ```api_test.exe``` test suite passes successfully.
2. The ```epbfcore.sys``` driver can be unloaded and re-loaded successfully after a test pass run.

Testing Notes:
1. Some edge cases were not covered by the existing tests, so new tests (user and kernel-mode) were added.
2. I'm seeing some inconsistencies in API behavior across different map types. My plan is to verify API functionality on linux for these scenarios and create new issues where required.


## Documentation

The design is documented in a design note .md.  The document is currently available review under this [PR](https://github.com/microsoft/ebpf-for-windows/pull/1961)

Fixes: #1509 #1510
