### PR TITLE
Use MSI package to build docker image

### DIFF
--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -101,12 +101,8 @@ command prompt:
 The following instructions will build an ebpf-for-windows image and deploy a daemonset referencing the image. This is the easiest way
 to install eBPF on all Windows nodes in a Kubernetes cluster.
 
-1. Deploy the binaries to `C:\Temp` on the machine (Windows Host) where you built the binaries.
-   Start an admin Powershell on the Windows Host and run:
+1. Download the `.msi` file from the [latest release on GitHub](https://github.com/microsoft/ebpf-for-windows/releases) and copy it over to [images](../images) directory.
 
-    ```ps
-    .\x64\debug\deploy-ebpf
-    ```
 
 2. Build ebpf-for-windows image.
 
@@ -118,13 +114,6 @@ Start an admin Powershell on the Windows Host and run the following command and 
         ````
 
     * To **build the image on a Linux machine** (e.g. Ubuntu), make sure docker is installed (see [install docker on Ubuntu](https://docs.docker.com/engine/install/ubuntu/)), and do the following:
-
-      - Run the following Powershell command on the Windows Host to create zip files containing the binaries.
-          ```ps
-          Compress-Archive -Update -Path C:\temp -DestinationPath ebpf-for-windows-c-temp.zip
-          ```
-
-      - Copy `images\*` and `ebpf-for-windows-c-temp.zip` from the Windows Host to a directory on the Linux machine (e.g. `$HOME/ebpf-for-windows-image`).
 
       - Run the following command and provide parameters for `repository`, `tag` and `OSVersion`:
           ```bash

--- a/images/Dockerfile.install
+++ b/images/Dockerfile.install
@@ -3,7 +3,7 @@
 
 # Base image for Windows nanoserver 1809.
 # The files in this image are copied to $env:CONTAINER_SANDBOX_MOUNT_POINT on the host.
-FROM mcr.microsoft.com/windows/nanoserver@sha256:b4248836dea118c48481b821d9fbb40daf7e207b48f5e6edc9da6837050b0f65
+FROM mcr.microsoft.com/windows/nanoserver@sha256:18161f2add9622768033bacf4f069d6d618a734aa9587c6d213fc15d99bcb057
 
 ENV PATH="C:\Program Files\PowerShell;C:\utils;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0;"
 

--- a/images/Dockerfile.install
+++ b/images/Dockerfile.install
@@ -7,9 +7,9 @@ FROM mcr.microsoft.com/windows/nanoserver@sha256:b4248836dea118c48481b821d9fbb40
 
 ENV PATH="C:\Program Files\PowerShell;C:\utils;C:\Windows\system32;C:\Windows;C:\Windows\System32\WindowsPowerShell\v1.0;"
 
-ARG RELEASE_ZIP=ebpf-for-windows-c-temp.zip
+ARG RELEASE_MSI=ebpf-for-windows.msi
 
-COPY ${RELEASE_ZIP} /ebpf-for-windows-c-temp.zip
+COPY ${RELEASE_MSI} /ebpf-for-windows.msi
 COPY install-ebpf-for-windows.ps1 /
 
 ENTRYPOINT ["powershell"]

--- a/images/build-images.ps1
+++ b/images/build-images.ps1
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 
+# Download and copy release archive to local directory as ./ebpf-for-windows.msi before running this script.
+ 
 param ([parameter(Mandatory=$false)][string] $TEMPDir = "c:\temp",
     [parameter(Mandatory=$true)][string] $Repository = "",
     [parameter(Mandatory=$true)][string] $Tag = "",
@@ -13,7 +15,5 @@ if ($svc -EQ $null) {
 if ($svc.Status -NE 'Running') {
     throw "Docker service is not running."
 }
-
-Compress-Archive -Update -Path $TEMPDir -DestinationPath ebpf-for-windows-c-temp.zip
 
 docker build -t $Repository/ebpfwin-install:$Tag  -f .\Dockerfile.install --build-arg WINDOWS_VERSION=$OSVersion .

--- a/images/build-images.sh
+++ b/images/build-images.sh
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 
-# Copy release archive to local directory as ebpf-for-windows-c-temp.zip before running this script.
+# Download and copy release archive to local directory as ./ebpf-for-windows.msi before running this script.
 
 repository=${repository:-"your repository"}
 tag=${tag:-"your tag"}

--- a/images/install-ebpf-for-windows.ps1
+++ b/images/install-ebpf-for-windows.ps1
@@ -9,19 +9,8 @@ if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
     throw "Install script is NOT running in a HostProcess container."
 }
 
-# Unzip release archive to c:\temp.
-$EbpfWindowsZip = "ebpf-for-windows-c-temp.zip"
-if (!(Test-Path $EbpfWindowsZip))
-{
-    throw "$EbpfWindowsZip not found..."
-}
-Write-Host "Unzip ebpf-for-windows release..."
-Expand-Archive -Force $EbpfWindowsZip c:\
-
-# Run install-ebpf.bat
-cd c:\temp
 Write-Host "Install ebpf-for-windows ..."
-.\install-ebpf.bat
+.\ebpf-for-windows.msi /quiet
 
 # Make sure netsh ebpf works.
 Write-Host "ebpf-for-windows installation completed. Show program..."

--- a/images/install-ebpf-for-windows.ps1
+++ b/images/install-ebpf-for-windows.ps1
@@ -9,8 +9,17 @@ if ($env:CONTAINER_SANDBOX_MOUNT_POINT) {
     throw "Install script is NOT running in a HostProcess container."
 }
 
-Write-Host "Install ebpf-for-windows ..."
-.\ebpf-for-windows.msi /quiet
+Write-Host "Installing VC Redistributable. This will take a while ..."
+invoke-webrequest https://aka.ms/vs/17/release/vc_redist.x64.exe -OutFile vc_redist.x64.exe
+.\vc_redist.x64.exe
+Write-Host "Installation of VC Redistributable completed."
+
+Start-Sleep -Seconds 10
+
+Write-Host "Installing ebpf-for-windows ..."
+.\ebpf-for-windows.msi /quiet /L*V ".\ebpf-for-windows.install.log"
+
+Start-Sleep -Seconds 10
 
 # Make sure netsh ebpf works.
 Write-Host "ebpf-for-windows installation completed. Show program..."


### PR DESCRIPTION
## Description

This PR fixes https://github.com/microsoft/ebpf-for-windows/issues/1448.

`ebpf-for-windows` has now been released as an MSI package. This PR updated image build scripts to use MSI package and replace the old `install-ebpf.bat` script.

## Testing

I've tested locally. However, we should set up CI pipelines for each release to test
- Image can be built and pushed to a public repository. 
- Install on Windows nodes in a Kubernetes cluster by applying the manifest and verify everything works.

## Documentation

Doc updated.
