### PR TITLE
move misplaced assert in memory leak detection stack dump code to the right location.

### DIFF
--- a/libs/platform/user/ebpf_leak_detector.cpp
+++ b/libs/platform/user/ebpf_leak_detector.cpp
@@ -36,7 +36,6 @@ void
 _ebpf_leak_detector::dump_leaks()
 {
     std::unique_lock<std::mutex> lock(_mutex);
-    ebpf_assert(_allocations.empty());
     for (auto& allocation : _allocations) {
         std::vector<uintptr_t> stack = _stack_hashes[allocation.second.stack_hash];
         std::cout << "Leak of " << allocation.second.size << " bytes at " << allocation.second.address << std::endl;
@@ -55,6 +54,9 @@ _ebpf_leak_detector::dump_leaks()
         }
         std::cout << std::endl;
     }
+
+    // assert to make sure that a leaking test throws an exception thereby failing the test.
+    ebpf_assert(_allocations.empty());
 
     _allocations.clear();
     _stack_hashes.clear();


### PR DESCRIPTION
## Description

Move an assert in ```_ebpf_leak_detector::dump_leaks()``` that terminates the application before the leak stack trace can be printed.  This assert should fire _after_ the stack trace has been printed to ensure that leaking test is marked as 'failed'.

## Testing

1. Locally modify an existing test to force a memory leak. (Comment out the ```hook.detach_link(link);``` and
 ```hook.close_link(link);``` calls in ```end_to_end.cpp:bindmonitor_test()``` to trigger a memory leak) and rebuild the ```unit_tests.exe``` application.
2. set the ```EBPF_MEMORY_LEAK_DETECTION``` to ```true``` and run ```unit_tests bindmonitor-native```.

Output before fix:

```
D:\wrk\ebpf-for-windows\x64\Debug [mem-leak-assert]
PS > ./unit_tests bindmonitor-native
Filters: "bindmonitor-native"
Randomness seeded to: 3603025526
Assertion failed: _allocations.empty(), file D:\wrk\ebpf-for-windows\libs\platform\user\ebpf_leak_detector.cpp, line 39


D:\wrk\ebpf-for-windows\x64\Debug [mem-leak-assert]
PS >
```
Output after fix:

```
D:\wrk\ebpf-for-windows\x64\Debug [mem-leak-assert]
PS > ./unit_tests bindmonitor-native
Filters: "bindmonitor-native"
Randomness seeded to: 1692944704
Leak of 24 bytes at 2844019342128
    ebpf_allocate + 224 (D:\wrk\ebpf-for-windows\libs\platform\user\ebpf_platform_user.cpp:389)
    _link_ebpf_program + 370 (D:\wrk\ebpf-for-windows\libs\api\ebpf_api.cpp:997)
    ebpf_program_attach_by_fd + 1364 (D:\wrk\ebpf-for-windows\libs\api\ebpf_api.cpp:1159)
    _hook_helper::attach_link + 61 (D:\wrk\ebpf-for-windows\tests\end_to_end\helpers.h:82)
    bindmonitor_test + 2237 (D:\wrk\ebpf-for-windows\tests\end_to_end\end_to_end.cpp:613)
    CATCH2_INTERNAL_TEST_15 + 16 (D:\wrk\ebpf-for-windows\tests\end_to_end\end_to_end.cpp:905)
    Catch::TestInvokerAsFunction::invoke + 18 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\internal\catch_test_case_registry_impl.cpp:150)
    Catch::TestCaseHandle::invoke + 33 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\catch_test_case_info.hpp:116)
    Catch::RunContext::invokeActiveTestCase + 71 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\internal\catch_run_context.cpp:513)
    Catch::RunContext::runCurrentTest + 592 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\internal\catch_run_context.cpp:478)
    Catch::RunContext::runTest + 700 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\internal\catch_run_context.cpp:239)
    Catch::`anonymous namespace'::TestGroup::execute + 243 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\catch_session.cpp:110)
    Catch::Session::runInternal + 1033 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\catch_session.cpp:335)
    Catch::Session::run + 80 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\catch_session.cpp:263)
    Catch::Session::run<char> + 82 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\catch_session.hpp:41)
    main + 97 (D:\wrk\ebpf-for-windows\external\Catch2\src\catch2\internal\catch_main.cpp:36)
    invoke_main + 57 (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:79)
    __scrt_common_main_seh + 302 (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
    __scrt_common_main + 14 (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:331)
    mainCRTStartup + 14 (D:\a\_work\1\s\src\vctools\crt\vcstartup\src\startup\exe_main.cpp:17)
    BaseThreadInitThunk + 29
    RtlUserThreadStart + 40

Assertion failed: _allocations.empty(), file D:\wrk\ebpf-for-windows\libs\platform\user\ebpf_leak_detector.cpp, line 59

D:\wrk\ebpf-for-windows\x64\Debug [mem-leak-assert]
PS >
```

## Documentation

No documentation changes needed.

Fixes: #1958 

