### PR TITLE
Mark all ebpf_* api's as noexcept

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -42,7 +42,7 @@ extern "C"
         fd_t fd,
         _Out_ ebpf_execution_type_t* execution_type,
         _Outptr_result_z_ const char** file_name,
-        _Outptr_result_z_ const char** section_name);
+        _Outptr_result_z_ const char** section_name) EBPF_NO_EXCEPT;
 
     typedef struct _ebpf_stat
     {
@@ -78,14 +78,14 @@ extern "C"
         _In_z_ const char* file,
         bool verbose,
         _Outptr_result_maybenull_ ebpf_section_info_t** infos,
-        _Outptr_result_maybenull_z_ const char** error_message);
+        _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
 
     /**
      * @brief Free memory returned from \ref ebpf_enumerate_sections.
      * @param[in] data Memory to free.
      */
     void
-    ebpf_free_sections(_In_opt_ _Post_invalid_ ebpf_section_info_t* infos);
+    ebpf_free_sections(_In_opt_ _Post_invalid_ ebpf_section_info_t* infos) EBPF_NO_EXCEPT;
 
     /**
      * @brief Convert an eBPF program to human readable byte code.
@@ -100,7 +100,7 @@ extern "C"
         _In_z_ const char* file,
         _In_z_ const char* section,
         _Outptr_result_maybenull_z_ const char** disassembly,
-        _Outptr_result_maybenull_z_ const char** error_message);
+        _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT;
 
     typedef struct
     {
@@ -131,7 +131,7 @@ extern "C"
         bool verbose,
         _Outptr_result_maybenull_z_ const char** report,
         _Outptr_result_maybenull_z_ const char** error_message,
-        _Out_opt_ ebpf_api_verifier_stats_t* stats);
+        _Out_opt_ ebpf_api_verifier_stats_t* stats) EBPF_NO_EXCEPT;
 
     /**
      * @brief Verify that the program is safe to execute.
@@ -157,14 +157,14 @@ extern "C"
         bool verbose,
         _Outptr_result_maybenull_z_ const char** report,
         _Outptr_result_maybenull_z_ const char** error_message,
-        _Out_opt_ ebpf_api_verifier_stats_t* stats);
+        _Out_opt_ ebpf_api_verifier_stats_t* stats) EBPF_NO_EXCEPT;
 
     /**
      * @brief Free memory for a string returned from an eBPF API.
      * @param[in] string Memory to free.
      */
     void
-    ebpf_free_string(_In_opt_ _Post_invalid_ const char* string);
+    ebpf_free_string(_In_opt_ _Post_invalid_ const char* string) EBPF_NO_EXCEPT;
 
     /**
      * @brief Dissociate a name with an object handle.
@@ -172,7 +172,7 @@ extern "C"
      * @param[in] name_length Length in bytes of the name.
      */
     uint32_t
-    ebpf_api_unpin_object(const uint8_t* name, uint32_t name_length);
+    ebpf_api_unpin_object(const uint8_t* name, uint32_t name_length) EBPF_NO_EXCEPT;
 
     /**
      * @brief Unpin the object from the specified path.
@@ -181,7 +181,7 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_object_unpin(_In_z_ const char* path);
+    ebpf_object_unpin(_In_z_ const char* path) EBPF_NO_EXCEPT;
 
     /**
      * @brief Detach the eBPF program from the link.
@@ -192,7 +192,7 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT The link handle is invalid.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_api_unlink_program(ebpf_handle_t link_handle);
+    ebpf_api_unlink_program(ebpf_handle_t link_handle) EBPF_NO_EXCEPT;
 
     /**
      * @brief Close an eBPF handle.
@@ -202,7 +202,7 @@ extern "C"
      * @retval EBPF_INVALID_OBJECT Handle is not valid.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_api_close_handle(ebpf_handle_t handle);
+    ebpf_api_close_handle(ebpf_handle_t handle) EBPF_NO_EXCEPT;
 
     /**
      * @brief Returns an array of \ref ebpf_map_info_t for all pinned maps.
@@ -210,13 +210,14 @@ extern "C"
      * @param[out] map_count Number of pinned maps.
      * @param[out] map_info Array of ebpf_map_info_t for pinned maps.
      *
-     * @retval EBPF_SUCCESS The API suceeded.
+     * @retval EBPF_SUCCESS The API succeeded.
      * @retval EBPF_NO_MEMORY Out of memory.
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_api_get_pinned_map_info(
-        _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info);
+        _Out_ uint16_t* map_count,
+        _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info) EBPF_NO_EXCEPT;
 
     /**
      * @brief Helper Function to free array of \ref ebpf_map_info_t allocated by
@@ -227,7 +228,8 @@ extern "C"
      */
     void
     ebpf_api_map_info_free(
-        uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info);
+        uint16_t map_count,
+        _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info) EBPF_NO_EXCEPT;
 
     /**
      * @brief Get the execution type for an eBPF object file.
@@ -237,7 +239,7 @@ extern "C"
      * @returns Execution type.
      */
     ebpf_execution_type_t
-    ebpf_object_get_execution_type(_In_ const struct bpf_object* object);
+    ebpf_object_get_execution_type(_In_ const struct bpf_object* object) EBPF_NO_EXCEPT;
 
     /**
      * @brief Set the execution type for an eBPF object file.
@@ -249,7 +251,8 @@ extern "C"
      * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_object_set_execution_type(_Inout_ struct bpf_object* object, ebpf_execution_type_t execution_type);
+    ebpf_object_set_execution_type(_Inout_ struct bpf_object* object, ebpf_execution_type_t execution_type)
+        EBPF_NO_EXCEPT;
 
     /**
      * @brief Attach an eBPF program.
@@ -273,7 +276,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
         size_t attach_params_size,
-        _Outptr_ struct bpf_link** link);
+        _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Attach an eBPF program by program file descriptor.
@@ -297,7 +300,7 @@ extern "C"
         _In_opt_ const ebpf_attach_type_t* attach_type,
         _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
         size_t attach_parameters_size,
-        _Outptr_ struct bpf_link** link);
+        _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Detach an eBPF program from an attach point represented by
@@ -309,7 +312,7 @@ extern "C"
      * @retval EBPF_INVALID_OBJECT Invalid object was passed.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_link_detach(_Inout_ struct bpf_link* link);
+    ebpf_link_detach(_Inout_ struct bpf_link* link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Detach an eBPF program.
@@ -342,7 +345,7 @@ extern "C"
      * @sa bpf_link_detach
      */
     void
-    ebpf_link_close(_Frees_ptr_ struct bpf_link* link);
+    ebpf_link_close(_Frees_ptr_ struct bpf_link* link) EBPF_NO_EXCEPT;
 
     /**
      * @brief Close a file descriptor. Also close the underlying handle.
@@ -352,7 +355,7 @@ extern "C"
      * @retval EBPF_INVALID_FD Invalid fd was provided.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_close_fd(fd_t fd);
+    ebpf_close_fd(fd_t fd) EBPF_NO_EXCEPT;
 
     /**
      * @brief Get eBPF program type and expected attach type by name.
@@ -368,7 +371,7 @@ extern "C"
     ebpf_get_program_type_by_name(
         _In_z_ const char* name,
         _Out_ ebpf_program_type_t* program_type,
-        _Out_ ebpf_attach_type_t* expected_attach_type);
+        _Out_ ebpf_attach_type_t* expected_attach_type) EBPF_NO_EXCEPT;
 
     /**
      * @brief Get the name of a given program type.
@@ -378,7 +381,7 @@ extern "C"
      * @returns Name of the program type, or NULL if not found.
      */
     _Ret_maybenull_z_ const char*
-    ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type);
+    ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type) EBPF_NO_EXCEPT;
 
     /**
      * @brief Get the name of a given attach type.
@@ -388,7 +391,7 @@ extern "C"
      * @returns Name of the attach type, or NULL if not found.
      */
     _Ret_maybenull_z_ const char*
-    ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type);
+    ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type) EBPF_NO_EXCEPT;
 
     /**
      * @brief Gets the next pinned program after a given path.
@@ -401,7 +404,7 @@ extern "C"
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_get_next_pinned_program_path(
-        _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path);
+        _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) EBPF_NO_EXCEPT;
 
     typedef struct _ebpf_program_info ebpf_program_info_t;
 
@@ -415,7 +418,7 @@ extern "C"
      * @retval EBPF_OBJECT_NOT_FOUND No program information was found.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info);
+    ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info) EBPF_NO_EXCEPT;
 
     typedef struct _ebpf_test_run_options
     {
@@ -444,7 +447,7 @@ extern "C"
      * @retval EBPF_INVALID_OBJECT Invalid object was passed.
      */
     _Must_inspect_result_ ebpf_result_t
-    ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options);
+    ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options) EBPF_NO_EXCEPT;
 
 #ifdef __cplusplus
 }

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -448,7 +448,7 @@ ebpf_api_elf_disassemble_section(
     _In_z_ const char* file,
     _In_z_ const char* section,
     _Outptr_result_maybenull_z_ const char** disassembly,
-    _Outptr_result_maybenull_z_ const char** error_message)
+    _Outptr_result_maybenull_z_ const char** error_message) noexcept
 {
     ebpf_verifier_options_t verifier_options = ebpf_verifier_default_options;
     const ebpf_platform_t* platform = &g_ebpf_platform_windows;
@@ -612,7 +612,7 @@ _Success_(return == 0) uint32_t ebpf_api_elf_verify_section_from_file(
     bool verbose,
     _Outptr_result_maybenull_z_ const char** report,
     _Outptr_result_maybenull_z_ const char** error_message,
-    _Out_opt_ ebpf_api_verifier_stats_t* stats)
+    _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept
 {
     *error_message = nullptr;
     *report = nullptr;
@@ -632,7 +632,7 @@ _Success_(return == 0) uint32_t ebpf_api_elf_verify_section_from_memory(
     bool verbose,
     _Outptr_result_maybenull_z_ const char** report,
     _Outptr_result_maybenull_z_ const char** error_message,
-    _Out_opt_ ebpf_api_verifier_stats_t* stats)
+    _Out_opt_ ebpf_api_verifier_stats_t* stats) noexcept
 {
     return _verify_section_from_string(
         std::string(data, data_length), "memory", section, program_type, verbose, report, error_message, stats);

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -757,7 +757,7 @@ Exit:
 }
 
 void
-ebpf_free_string(_In_opt_ _Post_invalid_ const char* error_message)
+ebpf_free_string(_In_opt_ _Post_invalid_ const char* error_message) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_free(const_cast<char*>(error_message));
@@ -795,7 +795,7 @@ ebpf_object_pin(fd_t fd, _In_z_ const char* path) noexcept
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_object_unpin(_In_z_ const char* path)
+ebpf_object_unpin(_In_z_ const char* path) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(path);
@@ -923,7 +923,7 @@ ebpf_program_query_info(
     fd_t fd,
     _Out_ ebpf_execution_type_t* execution_type,
     _Outptr_result_z_ const char** file_name,
-    _Outptr_result_z_ const char** section_name)
+    _Outptr_result_z_ const char** section_name) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result;
@@ -1097,7 +1097,7 @@ ebpf_program_attach(
     _In_opt_ const ebpf_attach_type_t* attach_type,
     _In_reads_bytes_opt_(attach_params_size) void* attach_parameters,
     size_t attach_params_size,
-    _Outptr_ struct bpf_link** link)
+    _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result = EBPF_SUCCESS;
@@ -1134,7 +1134,7 @@ ebpf_program_attach_by_fd(
     _In_opt_ const ebpf_attach_type_t* attach_type,
     _In_reads_bytes_opt_(attach_parameters_size) void* attach_parameters,
     size_t attach_parameters_size,
-    _Outptr_ struct bpf_link** link)
+    _Outptr_ struct bpf_link** link) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(attach_parameters || !attach_parameters_size);
@@ -1161,7 +1161,7 @@ ebpf_program_attach_by_fd(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_api_unlink_program(ebpf_handle_t link_handle)
+ebpf_api_unlink_program(ebpf_handle_t link_handle) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_operation_unlink_program_request_t request = {0};
@@ -1173,7 +1173,7 @@ ebpf_api_unlink_program(ebpf_handle_t link_handle)
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_link_detach(_Inout_ struct bpf_link* link)
+ebpf_link_detach(_Inout_ struct bpf_link* link) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(link);
@@ -1223,7 +1223,7 @@ Exit:
 }
 
 void
-ebpf_link_close(_Frees_ptr_ struct bpf_link* link)
+ebpf_link_close(_Frees_ptr_ struct bpf_link* link) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(link);
@@ -1232,7 +1232,7 @@ ebpf_link_close(_Frees_ptr_ struct bpf_link* link)
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_api_close_handle(ebpf_handle_t handle)
+ebpf_api_close_handle(ebpf_handle_t handle) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_operation_close_handle_request_t request = {
@@ -1243,7 +1243,7 @@ ebpf_api_close_handle(ebpf_handle_t handle)
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_api_get_pinned_map_info(
-    _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info)
+    _Out_ uint16_t* map_count, _Outptr_result_buffer_maybenull_(*map_count) ebpf_map_info_t** map_info) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t result = EBPF_SUCCESS;
@@ -1339,7 +1339,8 @@ Exit:
 
 void
 ebpf_api_map_info_free(
-    const uint16_t map_count, _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info)
+    const uint16_t map_count,
+    _In_opt_count_(map_count) _Post_ptr_invalid_ const ebpf_map_info_t* map_info) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_map_info_array_free(map_count, const_cast<ebpf_map_info_t*>(map_info));
@@ -1846,7 +1847,7 @@ _ebpf_free_section_info(_In_ _Frees_ptr_ ebpf_section_info_t* info) noexcept
 }
 
 void
-ebpf_free_sections(_In_opt_ _Post_invalid_ ebpf_section_info_t* infos)
+ebpf_free_sections(_In_opt_ _Post_invalid_ ebpf_section_info_t* infos) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     while (infos != nullptr) {
@@ -2206,7 +2207,7 @@ ebpf_enumerate_sections(
     _In_z_ const char* file,
     bool verbose,
     _Outptr_result_maybenull_ ebpf_section_info_t** infos,
-    _Outptr_result_maybenull_z_ const char** error_message)
+    _Outptr_result_maybenull_z_ const char** error_message) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     std::string file_name_string(file);
@@ -2274,7 +2275,7 @@ _ebpf_is_map_in_map(_In_ const ebpf_map_t* map) noexcept
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_object_set_execution_type(_Inout_ struct bpf_object* object, ebpf_execution_type_t execution_type)
+ebpf_object_set_execution_type(_Inout_ struct bpf_object* object, ebpf_execution_type_t execution_type) EBPF_NO_EXCEPT
 {
     if (Platform::_is_native_program(object->file_name)) {
         if (execution_type == EBPF_EXECUTION_INTERPRET || execution_type == EBPF_EXECUTION_JIT) {
@@ -2296,7 +2297,7 @@ ebpf_object_set_execution_type(_Inout_ struct bpf_object* object, ebpf_execution
 }
 
 ebpf_execution_type_t
-ebpf_object_get_execution_type(_In_ const struct bpf_object* object)
+ebpf_object_get_execution_type(_In_ const struct bpf_object* object) EBPF_NO_EXCEPT
 {
     return object->execution_type;
 }
@@ -3289,7 +3290,7 @@ ebpf_get_link_fd_by_id(ebpf_id_t id, _Out_ int* fd) noexcept
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_get_next_pinned_program_path(
-    _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path)
+    _In_z_ const char* start_path, _Out_writes_z_(EBPF_MAX_PIN_PATH_LENGTH) char* next_path) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(start_path);
@@ -3388,7 +3389,9 @@ ebpf_object_get_info_by_fd(
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_get_program_type_by_name(
-    _In_z_ const char* name, _Out_ ebpf_program_type_t* program_type, _Out_ ebpf_attach_type_t* expected_attach_type)
+    _In_z_ const char* name,
+    _Out_ ebpf_program_type_t* program_type,
+    _Out_ ebpf_attach_type_t* expected_attach_type) EBPF_NO_EXCEPT
 {
     ebpf_result_t result = EBPF_SUCCESS;
     EBPF_LOG_ENTRY();
@@ -3402,7 +3405,7 @@ ebpf_get_program_type_by_name(
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info)
+ebpf_get_program_info_from_verifier(_Outptr_ const ebpf_program_info_t** program_info) EBPF_NO_EXCEPT
 {
     ebpf_result_t result = EBPF_SUCCESS;
     EBPF_LOG_ENTRY();
@@ -3423,7 +3426,7 @@ ebpf_get_ebpf_program_type(bpf_prog_type_t bpf_program_type) noexcept
 }
 
 _Ret_maybenull_z_ const char*
-ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type)
+ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(program_type);
@@ -3437,7 +3440,7 @@ ebpf_get_program_type_name(_In_ const ebpf_program_type_t* program_type)
 }
 
 _Ret_maybenull_z_ const char*
-ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type)
+ebpf_get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
     ebpf_assert(attach_type);
@@ -3730,7 +3733,7 @@ ebpf_ring_buffer_map_unsubscribe(_In_ _Post_invalid_ ring_buffer_subscription_t*
 }
 
 _Must_inspect_result_ ebpf_result_t
-ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options)
+ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options) EBPF_NO_EXCEPT
 {
     EBPF_LOG_ENTRY();
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1618

## Description

The ebpf layer APIs need to all be marked as noexcept to prevent propagating exceptions to callers that don't support C++ exceptions. All exceptions should be terminated and handled, but if they aren't this code should terminate the process and log an error.

## Testing

CI/CD + low memory testing.

## Documentation

No.
