### PR TITLE
Enable global new/delete

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -74,6 +74,16 @@ jobs:
       ld_flags: '"clang_rt.fuzzer_MD-x86_64.lib" "libsancov.lib"'
       build_options: /p:Fuzzer='True' /t:tests\libfuzzer\execution_context_fuzzer /t:tests\libfuzzer\bpf2c_fuzzer /t:tests\libfuzzer\verifier_fuzzer /t:tests\libfuzzer\core_helper_fuzzer /t:tests\libfuzzer\netebpfext_fuzzer
 
+  # Perform the low memory build with iterator debugging disabled
+  no_iterator_debug_build:
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      build_artifact: Build-x64-no-iterator-debug
+      build_options: /p:ReleaseJIT='True'
+      cxx_flags: /D_ITERATOR_DEBUG_LEVEL=0
+
   # Run the unit tests in GitHub.
   unit_tests:
     # Always run this job.
@@ -92,13 +102,13 @@ jobs:
 
   unit_tests_leak_detection:
     # Always run this job.
-    needs: regular
+    needs: no_iterator_debug_build
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests_with_leak_detection
       test_command: .\unit_tests.exe -d yes
-      build_artifact: Build-x64
+      build_artifact: Build-x64-no-iterator-debug
       environment: windows-2022
       code_coverage: true
       gather_dumps: true
@@ -353,12 +363,12 @@ jobs:
 
   # Run the low memory simulator in GitHub.
   low_memory:
-    needs: regular
+    needs: no_iterator_debug_build
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: low_memory
       test_command: .\unit_tests.exe
-      build_artifact: Build-x64
+      build_artifact: Build-x64-no-iterator-debug
       environment: windows-2022
       code_coverage: true
       gather_dumps: true
@@ -378,13 +388,13 @@ jobs:
   # Run the complete low memory simulator in GitHub.
   # Runs on a schedule as this takes a long time to run.
   low_memory_full:
-    needs: regular
+    needs: no_iterator_debug_build
     if: github.event_name == 'schedule'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: low_memory_full
       test_command: .\unit_tests.exe
-      build_artifact: Build-x64
+      build_artifact: Build-x64-no-iterator-debug
       environment: windows-2019
       code_coverage: false
       gather_dumps: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -81,7 +81,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       build_artifact: Build-x64-no-iterator-debug
-      build_options: /p:ReleaseJIT='True'
+      build_options: /p:ReleaseJIT='True' /t:tests\unit_tests
       cxx_flags: /D_ITERATOR_DEBUG_LEVEL=0
 
   # Run the unit tests in GitHub.

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -51,8 +51,8 @@ jobs:
       BUILD_CONFIGURATION: ${{matrix.configurations}}
       BUILD_PLATFORM: x64
       BUILD_OPTIONS: ${{inputs.build_options}}
-      CXX_FLAGS: ${{inputs.cxx_flags}}
-      LD_FLAGS: ${{inputs.ld_flags}}
+      CXXFLAGS: ${{inputs.cxx_flags}}
+      LDFLAGS: ${{inputs.ld_flags}}
 
     steps:
     - id: skip_check
@@ -128,27 +128,18 @@ jobs:
     - name: Create verifier project
       if: steps.skip_check.outputs.should_skip != 'true'
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      env:
-        CXXFLAGS: /ZH:SHA_256 ${{env.CXX_FLAGS}}
-        LDFLAGS: ${{env.LD_FLAGS}}
       run: |
         cmake -G "Visual Studio 17 2022" -S external\ebpf-verifier -B external\ebpf-verifier\build
 
     - name: Create catch2 project
       if: steps.skip_check.outputs.should_skip != 'true'
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      env:
-        CXXFLAGS: /ZH:SHA_256 ${{env.CXX_FLAGS}}
-        LDFLAGS: ${{env.LD_FLAGS}}
       run: |
         cmake -G "Visual Studio 17 2022" -S external\catch2 -B external\catch2\build -DBUILD_TESTING=OFF
 
     - name: Create ubpf project
       if: steps.skip_check.outputs.should_skip != 'true'
       working-directory: ${{env.GITHUB_WORKSPACE}}
-      env:
-        CXXFLAGS: /ZH:SHA_256 ${{env.CXX_FLAGS}}
-        LDFLAGS: ${{env.LD_FLAGS}}
       run: |
         cmake -G "Visual Studio 17 2022" -S external\ubpf -B external\ubpf\build
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,6 @@
     <Link>
       <CETCompat>true</CETCompat>
       <AdditionalLibraryDirectories>$(VC_LibraryPath_VC_x64_Desktop);%(Link.AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
-      <AdditionalOptions>$(LDFLAGS) %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(DisableJIT)'=='Release|True'">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -40,12 +40,13 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions) $(CXXFLAGS)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <CETCompat>true</CETCompat>
       <AdditionalLibraryDirectories>$(VC_LibraryPath_VC_x64_Desktop);%(Link.AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalOptions>$(LDFLAGS) %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(DisableJIT)'=='Release|True'">

--- a/docs/SelfHostedRunnerSetup.md
+++ b/docs/SelfHostedRunnerSetup.md
@@ -29,7 +29,7 @@ This document discusses the steps to set up such a self-hosted actions-runner th
    2) `New-StoredCredential -Target `**`TEST_VM`**` -Username <VM Administrator> -Password <VM Administrator account password> -Persist LocalMachine`
    3) `New-StoredCredential -Target `**`TEST_VM_STANDARD`**` -Username <VM Standard User Name> -Password <VM Standard User account password> -Persist LocalMachine`
 
-10) Modify the environment of the VM as needed. Create new checkpoints using **Hyper-V**. Rename the new checkpoint as `baseline`, and remove the old baseline. 
+10) Modify the environment of the VM as needed. Create new checkpoints using **Hyper-V**. Rename the new checkpoint as `baseline`, and remove the old baseline.
 11) Set up Windows Error Reporting [Local Dump Collection](https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps) on the VMs with the following commands.
     ```New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -ErrorAction SilentlyContinue```
     ```New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpType" -Value 2 -PropertyType DWord -ErrorAction SilentlyContinue```

--- a/ebpf-for-windows.sln
+++ b/ebpf-for-windows.sln
@@ -179,6 +179,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "installer", "installer", "{8CA48236-9B24-4841-B3E2-496C31ABBB23}"
 EndProject
 Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "ebpf-for-windows", "installer\ebpf-for-windows.wixproj", "{FE9B26CD-E885-4881-90D7-A096131C5C4A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{07DC6181-84A2-4A14-A806-5E9AF6C929C2} = {07DC6181-84A2-4A14-A806-5E9AF6C929C2}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1496,7 +1496,7 @@ _Requires_lock_not_held_(_ebpf_state_mutex) static void _clean_up_ebpf_objects()
         _delete_ebpf_object(object);
     }
 
-// Intentional use of scope to limit lifetime of lock.
+    // Intentional use of scope to limit lifetime of lock.
     {
         std::unique_lock lock(_ebpf_state_mutex);
         ebpf_assert(_ebpf_programs->size() == 0);

--- a/libs/ebpfnetsh/programs.cpp
+++ b/libs/ebpfnetsh/programs.cpp
@@ -79,7 +79,7 @@ struct _program_unloader
     ~_program_unloader() { bpf_object__close(object); }
 };
 
-// The following function uses windows specific input type to match 
+// The following function uses windows specific input type to match
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_add_program(
@@ -311,7 +311,7 @@ _find_object_with_program(ebpf_id_t id)
     return _ebpf_netsh_objects->end();
 }
 
-// The following function uses windows specific type to match 
+// The following function uses windows specific type to match
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_delete_program(
@@ -441,7 +441,7 @@ _ebpf_program_detach_by_id(ebpf_id_t program_id)
     return ERROR_NOT_FOUND;
 }
 
-// The following function uses windows specific type as an input to match 
+// The following function uses windows specific type as an input to match
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_set_program(
@@ -553,7 +553,7 @@ handle_ebpf_set_program(
     return ERROR_OKAY;
 }
 
-// The following function uses windows specific type as an input to match 
+// The following function uses windows specific type as an input to match
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_show_programs(

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -243,7 +243,6 @@ TEST_CASE("hash_table_stress_test", "[platform]")
             for (auto& key : keys)
                 run_in_epoch([&]() { (void)ebpf_hash_table_delete(table, reinterpret_cast<const uint8_t*>(&key)); });
         }
-        ebpf_enable_memory_tests = false;
     };
 
     std::vector<std::jthread> threads;

--- a/libs/platform/user/ebpf_low_memory_test.cpp
+++ b/libs/platform/user/ebpf_low_memory_test.cpp
@@ -30,31 +30,6 @@
 
 #define EBPF_MODULE_SIZE_IN_BYTES (10 * 1024 * 1024)
 
-/**
- * @brief Thread local storage to track recursing from the low memory callback.
- */
-static thread_local int _ebpf_low_memory_test_recursion = 0;
-
-/**
- * @brief Class to automatically increment and decrement the recursion count.
- */
-class ebpf_low_memory_test_recursion_guard
-{
-  public:
-    ebpf_low_memory_test_recursion_guard() { _ebpf_low_memory_test_recursion++; }
-    ~ebpf_low_memory_test_recursion_guard() { _ebpf_low_memory_test_recursion--; }
-    /**
-     * @brief Return true if the current thread is recursing from the low memory callback.
-     * @retval true
-     * @retval false
-     */
-    bool
-    is_recursing()
-    {
-        return (_ebpf_low_memory_test_recursion > 1);
-    }
-};
-
 _ebpf_low_memory_test::_ebpf_low_memory_test(size_t stack_depth = EBPF_ALLOCATION_STACK_CAPTURE_FRAME_COUNT_FOR_HASH)
     : _stack_depth(stack_depth)
 {
@@ -78,11 +53,6 @@ _ebpf_low_memory_test::fail_stack_allocation()
 bool
 _ebpf_low_memory_test::is_new_stack()
 {
-    // Prevent infinite recursion during allocation.
-    ebpf_low_memory_test_recursion_guard recursion_guard;
-    if (recursion_guard.is_recursing()) {
-        return false;
-    }
     std::vector<uintptr_t> stack(EBPF_ALLOCATION_STACK_CAPTURE_FRAME_COUNT);
     std::vector<uintptr_t> canonical_stack(_stack_depth);
 

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -3,6 +3,7 @@
 
 #include "ebpf_leak_detector.h"
 #include "ebpf_low_memory_test.h"
+#include "ebpf_recursion_guard.h"
 #include "ebpf_symbol_decoder.h"
 #include "ebpf_utilities.h"
 
@@ -18,12 +19,6 @@
 #include <stdint.h>
 #include <string>
 #include <vector>
-
-#include "ebpf_leak_detector.h"
-#include "ebpf_low_memory_test.h"
-#include "ebpf_recursion_guard.h"
-#include "ebpf_symbol_decoder.h"
-#include "ebpf_utilities.h"
 
 // Global variables used to override behavior for testing.
 // Permit the test to simulate both Hyper-V Code Integrity.

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -380,7 +380,6 @@ ebpf_platform_terminate()
     }
     ebpf_enable_memory_tests = false;
 
-    _clean_up_thread_pool();
     _ebpf_emulated_dpcs.resize(0);
 }
 

--- a/libs/platform/user/ebpf_recursion_guard.h
+++ b/libs/platform/user/ebpf_recursion_guard.h
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+/**
+ * @brief Thread local storage to track recursing from the low memory callback.
+ */
+inline static thread_local int _ebpf_recursion_guard_count = 0;
+
+/**
+ * @brief Class to automatically increment and decrement the recursion count.
+ */
+typedef class _ebpf_recursion_guard
+{
+  public:
+    _ebpf_recursion_guard() { _ebpf_recursion_guard_count++; }
+    ~_ebpf_recursion_guard() { _ebpf_recursion_guard_count--; }
+
+    /**
+     * @brief Return true if the current thread is recursing from the low memory callback.
+     * @retval true
+     * @retval false
+     */
+    bool
+    is_recursing()
+    {
+        return (_ebpf_recursion_guard_count > 1);
+    }
+} ebpf_recursion_guard_t;

--- a/libs/platform/user/kernel_um.cpp
+++ b/libs/platform/user/kernel_um.cpp
@@ -39,6 +39,12 @@ typedef class _rundown_ref_table
         return *_instance;
     }
 
+    static void
+    reset()
+    {
+        _instance->_rundown_ref_counts.clear();
+    }
+
     /**
      * @brief Initialize the rundown ref table entry for the given context.
      *
@@ -166,6 +172,12 @@ typedef class _rundown_ref_table
     std::map<uint64_t, std::tuple<bool, uint64_t>> _rundown_ref_counts;
     std::condition_variable _rundown_ref_cv;
 } rundown_ref_table_t;
+
+void
+kernel_um_reset_rundown_table()
+{
+    rundown_ref_table_t::reset();
+}
 
 /**
  * @brief The singleton instance of the rundown ref table. Created during static initialization and destroyed during

--- a/libs/platform/user/kernel_um.h
+++ b/libs/platform/user/kernel_um.h
@@ -487,7 +487,7 @@ extern "C"
     VOID
     RtlMapGenericMask(_Inout_ PACCESS_MASK AccessMask, _In_ const GENERIC_MAPPING* GenericMapping);
 
-    unsigned long 
+    unsigned long
     RtlLengthSid(_In_ PSID Sid);
 
     NTSTATUS

--- a/libs/platform/user/platform_user.vcxproj
+++ b/libs/platform/user/platform_user.vcxproj
@@ -49,6 +49,7 @@
     <ClInclude Include="..\ebpf_state.h" />
     <ClInclude Include="ebpf_leak_detector.h" />
     <ClInclude Include="ebpf_low_memory_test.h" />
+    <ClInclude Include="ebpf_recursion_guard.h" />
     <ClInclude Include="ebpf_rundown.h" />
     <ClInclude Include="ebpf_symbol_decoder.h" />
     <ClInclude Include="framework.h" />

--- a/libs/platform/user/platform_user.vcxproj.filters
+++ b/libs/platform/user/platform_user.vcxproj.filters
@@ -144,5 +144,8 @@
     <ClInclude Include="ebpf_rundown.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="ebpf_recursion_guard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -65,6 +65,9 @@ typedef class _emulate_dpc
 
 } emulate_dpc_t;
 
+void
+clear_ebpf_provider_data();
+
 typedef class _hook_helper
 {
   public:
@@ -114,6 +117,7 @@ typedef class _single_instance_hook : public _hook_helper
     {
         detach();
         ebpf_provider_unload(provider);
+        clear_ebpf_provider_data();
     }
 
     uint32_t

--- a/tests/libs/common/passed_test_log.h
+++ b/tests/libs/common/passed_test_log.h
@@ -10,6 +10,8 @@
 #include <fstream>
 #include <iostream>
 
+extern thread_local bool ebpf_enable_memory_tests;
+
 /**
  * @brief A Catch2 reporter that logs the name of each test that passes.
  * This is used to generate a list of tests that passed in the last run in a
@@ -25,6 +27,7 @@ class _passed_test_log : public Catch::EventListenerBase
     void
     testCaseEnded(Catch::TestCaseStats const& testCaseStats) override
     {
+        assert(!ebpf_enable_memory_tests);
         if (!passed_tests) {
             char process_name[MAX_PATH];
             GetModuleFileNameA(nullptr, process_name, MAX_PATH);

--- a/tests/performance/performance_measure.h
+++ b/tests/performance/performance_measure.h
@@ -57,9 +57,9 @@ template <typename T> class _performance_measure
     run_test(size_t multiplier = 1)
     {
         int32_t ready_count = 0;
-        std::vector<std::thread> threads;
+        std::vector<std::jthread> threads;
         for (uint32_t i = 0; i < cpu_count; i++) {
-            threads.emplace_back(std::thread([i, this, &ready_count] {
+            threads.emplace_back(std::jthread([i, this, &ready_count] {
                 uint32_t local_cpu_id = i;
                 uintptr_t thread_mask = local_cpu_id;
                 thread_mask = static_cast<uintptr_t>(1) << thread_mask;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -36,6 +36,7 @@
     TEST_CASE(CONCAT(_name, "-native"), _group) { _function(EBPF_EXECUTION_NATIVE); }
 
 const int nonexistent_fd = 12345678;
+extern thread_local bool ebpf_enable_memory_tests;
 
 TEST_CASE("libbpf load program", "[libbpf][deprecated]")
 {
@@ -2715,6 +2716,7 @@ TEST_CASE("libbpf_load_stress", "[libbpf]")
     for (size_t i = 0; i < static_cast<size_t>(ebpf_get_cpu_count()) * 4; i++) {
         // Initialize thread object with lambda plus stop token
         threads.emplace_back([i](std::stop_token stop_token) {
+            ebpf_enable_memory_tests = true;
             while (!stop_token.stop_requested()) {
                 struct bpf_object* object = bpf_object__open("droppacket_um.dll");
                 if (!object) {

--- a/tests/unit/wer_report_test_wrapper.cpp
+++ b/tests/unit/wer_report_test_wrapper.cpp
@@ -41,7 +41,7 @@ AddVectoredExceptionHandler_test(_In_ unsigned long first, _In_ PVECTORED_EXCEPT
 
 unsigned long SetThreadStackGuarantee_test_stack_size_in_bytes = 0;
 
-// Use BOOL to pass "SetThreadStackGuarantee" 
+// Use BOOL to pass "SetThreadStackGuarantee"
 // defined in windows "processthreadapi.h" file
 BOOL
 SetThreadStackGuarantee_test(_Inout_ unsigned long* stack_size_in_bytes)

--- a/tools/dnsflood/dns_flood.cpp
+++ b/tools/dnsflood/dns_flood.cpp
@@ -63,10 +63,10 @@ main(int argc, const char** argv)
     unsigned long bytes_sent;
 
     volatile long packet_sent = 0;
-    std::vector<std::thread> threads(4);
+    std::vector<std::jthread> threads(4);
 
     for (auto& t : threads) {
-        t = std::thread([&] {
+        t = std::jthread([&] {
             for (;;) {
                 if (WSASend(
                         socket,

--- a/tools/export_program_info/export_program_info.vcxproj
+++ b/tools/export_program_info/export_program_info.vcxproj
@@ -64,7 +64,7 @@
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(FuzzerLibs);mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
@@ -89,7 +89,7 @@ $(OutputPath)export_program_info.exe</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalDependencies>mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(FuzzerLibs);mincore.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1968

## Description

Add a global new/delete operator to allow instrumentation all allocation paths in C++ code.

## Testing

CI/CD

## Documentation

No.
