### PR TITLE
Protect ebpf_link_detach_program with a ref-count

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -170,7 +170,7 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
     ebpf_lock_state_t state;
     ebpf_program_t* program = NULL;
 
-    ebpf_object_acquire_reference(link);
+    ebpf_object_acquire_reference((ebpf_core_object_t*)link);
 
     state = ebpf_lock_lock(&link->attach_lock);
     if (link->program != NULL && !link->detaching) {
@@ -194,7 +194,7 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
     link->client_data.data = NULL;
     link->client_data.size = 0;
 
-    ebpf_object_release_reference(link);
+    ebpf_object_release_reference((ebpf_core_object_t*)link);
 
     EBPF_RETURN_VOID();
 }

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -170,6 +170,8 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
     ebpf_lock_state_t state;
     ebpf_program_t* program = NULL;
 
+    ebpf_object_acquire_reference(link);
+
     state = ebpf_lock_lock(&link->attach_lock);
     if (link->program != NULL && !link->detaching) {
         program = link->program;
@@ -191,6 +193,9 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
     ebpf_free(link->client_data.data);
     link->client_data.data = NULL;
     link->client_data.size = 0;
+
+    ebpf_object_release_reference(link);
+
     EBPF_RETURN_VOID();
 }
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1983

## Description

ebpf_link_detach_program calls ebpf_program_detach_link which removes the program ref-count on the link object. If this is the last ref-count, then the link object is destroyed and this function accesses memory after it's been freed.

## Testing

CI/CD

## Documentation

No.
