### PR TITLE
Add JIT option for MSI Release bits and CI/CD.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -42,6 +42,7 @@ jobs:
       build_artifact: Build-x64
       generate_release_package: true
       build_nuget: true
+      build_options: /p:ReleaseJIT='True'
 
   cmake:
     # Always run this job.
@@ -49,7 +50,6 @@ jobs:
     uses: ./.github/workflows/reusable-cmake-build.yml
     with:
       build_artifact: Build-x64-cmake
-      build_options: /p:ReleaseJIT='True'
 
   # Perform the libfuzzer build.
   libfuzzer:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,6 +49,7 @@ jobs:
     uses: ./.github/workflows/reusable-cmake-build.yml
     with:
       build_artifact: Build-x64-cmake
+      build_options: /p:ReleaseJIT='True'
 
   # Perform the libfuzzer build.
   libfuzzer:

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -35,9 +35,16 @@ SPDX-License-Identifier: MIT
 				<ComponentGroupRef Id="eBPFCore_Driver" />
 				<ComponentGroupRef Id="NetEbpfExt_Driver" />
 				<?if $(var.IncludeJIT) = True ?>
+				<?if $(var.Configuration) = Debug ?>
 				<Feature Id="eBPF_Runtime_Components_JIT" Level="1" Title="JIT" Absent="allow">
 					<ComponentGroupRef Id="eBPF_Service" />
 				</Feature>
+				<?endif?>
+				<?if $(var.Configuration) = Release ?>
+				<Feature Id="eBPF_Runtime_Components_JIT" Level="11" Title="JIT" Absent="allow" >
+					<ComponentGroupRef Id="eBPF_Service" />
+				</Feature>
+				<?endif?>
 				<?endif?>
 			</Feature>
 			<Feature Id="eBPF_Development" Level="2" Title="Development components">

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -34,7 +34,7 @@ SPDX-License-Identifier: MIT
 				<ComponentGroupRef Id="eBPF_Runtime_Components" />
 				<ComponentGroupRef Id="eBPFCore_Driver" />
 				<ComponentGroupRef Id="NetEbpfExt_Driver" />
-				<?ifdef $(var.IncludeJIT)?>
+				<?if $(var.IncludeJIT) = True ?>
 				<Feature Id="eBPF_Runtime_Components_JIT" Level="1" Title="JIT" Absent="allow">
 					<ComponentGroupRef Id="eBPF_Service" />
 				</Feature>
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<Directory Id="ProgramFiles64Folder">
 				<Directory Id="INSTALLFOLDER" Name="ebpf-for-windows">
-					<?ifdef $(var.IncludeJIT)?>
+					<?if $(var.IncludeJIT) = True ?>
 					<Directory Id="dir_JIT" Name="JIT" />
 					<?endif?>
 					<Directory Id="dir_drivers" Name="drivers"/>
@@ -209,7 +209,7 @@ SPDX-License-Identifier: MIT
 		<CustomAction Id="eBPF_netsh_helper_uninstall_rollback" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no"/>
 
 		<!--Install/Uninstall the eBPF Service -->
-		<?ifdef $(var.IncludeJIT)?>
+		<?if $(var.IncludeJIT) = True ?>
 		<ComponentGroup Id="eBPF_Service" Directory="dir_JIT">
 			<Component Id="EBPFSVC.PDB" DiskId="1" Guid="{D1935DF0-2FC7-42F5-81E5-19AF88D6244B}">
 				<File Id="EBPFSVC.PDB" Name="EbpfSvc.pdb" Source="$(var.ebpfsvc.TargetDir)ebpfsvc.pdb" />

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -34,7 +34,7 @@ SPDX-License-Identifier: MIT
 				<ComponentGroupRef Id="eBPF_Runtime_Components" />
 				<ComponentGroupRef Id="eBPFCore_Driver" />
 				<ComponentGroupRef Id="NetEbpfExt_Driver" />
-				<?if $(var.Configuration) = Debug ?>
+				<?ifdef $(var.IncludeJIT)?>
 				<Feature Id="eBPF_Runtime_Components_JIT" Level="1" Title="JIT" Absent="allow">
 					<ComponentGroupRef Id="eBPF_Service" />
 				</Feature>
@@ -119,7 +119,7 @@ SPDX-License-Identifier: MIT
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<Directory Id="ProgramFiles64Folder">
 				<Directory Id="INSTALLFOLDER" Name="ebpf-for-windows">
-					<?if $(var.Configuration) = Debug ?>
+					<?ifdef $(var.IncludeJIT)?>
 					<Directory Id="dir_JIT" Name="JIT" />
 					<?endif?>
 					<Directory Id="dir_drivers" Name="drivers"/>
@@ -209,7 +209,7 @@ SPDX-License-Identifier: MIT
 		<CustomAction Id="eBPF_netsh_helper_uninstall_rollback" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no"/>
 
 		<!--Install/Uninstall the eBPF Service -->
-		<?if $(var.Configuration) = Debug ?>
+		<?ifdef $(var.IncludeJIT)?>
 		<ComponentGroup Id="eBPF_Service" Directory="dir_JIT">
 			<Component Id="EBPFSVC.PDB" DiskId="1" Guid="{D1935DF0-2FC7-42F5-81E5-19AF88D6244B}">
 				<File Id="EBPFSVC.PDB" Name="EbpfSvc.pdb" Source="$(var.ebpfsvc.TargetDir)ebpfsvc.pdb" />

--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -26,6 +26,7 @@ SPDX-License-Identifier: MIT
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants Condition=" '$(ReleaseJIT)' == 'False' OR '$(ReleaseJIT)' == '' ">IncludeJIT=False</DefineConstants>
+    <SuppressValidation>True</SuppressValidation>
   </PropertyGroup>
   <!-- In accordance to what defined in sample.vcxproj, the MSI build is disabled for the 'Analysis' CI/CD build, as it  does not generate the *.o artifacts. -->
   <ItemGroup Condition="'$(Analysis)'==''">

--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -14,15 +14,17 @@ SPDX-License-Identifier: MIT
     <OutputType>Package</OutputType>
     <InstallerPlatform>x64</InstallerPlatform>
   </PropertyGroup>
+  <PropertyGroup>
+    <DefineConstants>IncludeJIT=True</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug;IncludeJIT=True</DefineConstants>
+    <DefineConstants>Debug</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants Condition=" '$(ReleaseJIT)' == 'True' ">IncludeJIT=True</DefineConstants>
     <DefineConstants Condition=" '$(ReleaseJIT)' == 'False' OR '$(ReleaseJIT)' == '' ">IncludeJIT=False</DefineConstants>
   </PropertyGroup>
   <!-- In accordance to what defined in sample.vcxproj, the MSI build is disabled for the 'Analysis' CI/CD build, as it  does not generate the *.o artifacts. -->

--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -17,16 +17,13 @@ SPDX-License-Identifier: MIT
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug</DefineConstants>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(ReleaseJIT)' == 'Release|True' ">
-    <IncludeJIT/>
+    <DefineConstants>Debug;IncludeJIT=True</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>
-    </DefineConstants>
+    <DefineConstants Condition=" '$(ReleaseJIT)' == 'True' ">IncludeJIT=True</DefineConstants>
+    <DefineConstants Condition=" '$(ReleaseJIT)' == 'False' OR '$(ReleaseJIT)' == '' ">IncludeJIT=False</DefineConstants>
   </PropertyGroup>
   <!-- In accordance to what defined in sample.vcxproj, the MSI build is disabled for the 'Analysis' CI/CD build, as it  does not generate the *.o artifacts. -->
   <ItemGroup Condition="'$(Analysis)'==''">

--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -14,17 +14,16 @@ SPDX-License-Identifier: MIT
     <OutputType>Package</OutputType>
     <InstallerPlatform>x64</InstallerPlatform>
   </PropertyGroup>
-  <PropertyGroup>
-    <DefineConstants>IncludeJIT=True</DefineConstants>
-  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug</DefineConstants>
+    <DefineConstants>Debug;IncludeJIT=True</DefineConstants>
+    <SuppressValidation>True</SuppressValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants Condition=" '$(ReleaseJIT)' == 'True' ">IncludeJIT=True</DefineConstants>
     <DefineConstants Condition=" '$(ReleaseJIT)' == 'False' OR '$(ReleaseJIT)' == '' ">IncludeJIT=False</DefineConstants>
     <SuppressValidation>True</SuppressValidation>
   </PropertyGroup>

--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -19,6 +19,9 @@ SPDX-License-Identifier: MIT
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
     <DefineConstants>Debug</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(ReleaseJIT)' == 'Release|True' ">
+    <IncludeJIT/>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>


### PR DESCRIPTION
Closes #1985 

## Description

This PR adds the possibility of installing the JIT feature with the *Release* build of the eBPF for Windows installer.
The feature can be now triggered by adding `ReleaseJIT='True'` build option to *msbuild*. This switch has been set as default in the `cicd.yml` script, for "regular" build only.

New MSI behavior:

- The *Debug* build will continue to always have the JIT option enabled by design, and **selected** by default.
- The *Release* build will *optionally* (i.e. if built with `ReleaseJIT='True'`) have the JIT option enabled, but **deselected** by default.

## Testing

Manual testing on bare Nebula VM.

## Documentation

None.
