### PR TITLE
Prevent loading of incompatible native modules

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -42,6 +42,7 @@ jobs:
       build_artifact: Build-x64
       generate_release_package: true
       build_nuget: true
+      build_options: /p:ReleaseJIT='True'
 
   cmake:
     # Always run this job.

--- a/images/build-images.ps1
+++ b/images/build-images.ps1
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 # Download and copy release archive to local directory as ./ebpf-for-windows.msi before running this script.
- 
+
 param ([parameter(Mandatory=$false)][string] $TEMPDir = "c:\temp",
     [parameter(Mandatory=$true)][string] $Repository = "",
     [parameter(Mandatory=$true)][string] $Tag = "",

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -34,10 +34,17 @@ SPDX-License-Identifier: MIT
 				<ComponentGroupRef Id="eBPF_Runtime_Components" />
 				<ComponentGroupRef Id="eBPFCore_Driver" />
 				<ComponentGroupRef Id="NetEbpfExt_Driver" />
+				<?if $(var.IncludeJIT) = True ?>
 				<?if $(var.Configuration) = Debug ?>
 				<Feature Id="eBPF_Runtime_Components_JIT" Level="1" Title="JIT" Absent="allow">
 					<ComponentGroupRef Id="eBPF_Service" />
 				</Feature>
+				<?endif?>
+				<?if $(var.Configuration) = Release ?>
+				<Feature Id="eBPF_Runtime_Components_JIT" Level="11" Title="JIT" Absent="allow" >
+					<ComponentGroupRef Id="eBPF_Service" />
+				</Feature>
+				<?endif?>
 				<?endif?>
 			</Feature>
 			<Feature Id="eBPF_Development" Level="2" Title="Development components">
@@ -119,7 +126,7 @@ SPDX-License-Identifier: MIT
 		<Directory Id="TARGETDIR" Name="SourceDir">
 			<Directory Id="ProgramFiles64Folder">
 				<Directory Id="INSTALLFOLDER" Name="ebpf-for-windows">
-					<?if $(var.Configuration) = Debug ?>
+					<?if $(var.IncludeJIT) = True ?>
 					<Directory Id="dir_JIT" Name="JIT" />
 					<?endif?>
 					<Directory Id="dir_drivers" Name="drivers"/>
@@ -209,7 +216,7 @@ SPDX-License-Identifier: MIT
 		<CustomAction Id="eBPF_netsh_helper_uninstall_rollback" BinaryKey="WixCA" DllEntry="WixQuietExec64" Execute="deferred" Return="ignore" Impersonate="no"/>
 
 		<!--Install/Uninstall the eBPF Service -->
-		<?if $(var.Configuration) = Debug ?>
+		<?if $(var.IncludeJIT) = True ?>
 		<ComponentGroup Id="eBPF_Service" Directory="dir_JIT">
 			<Component Id="EBPFSVC.PDB" DiskId="1" Guid="{D1935DF0-2FC7-42F5-81E5-19AF88D6244B}">
 				<File Id="EBPFSVC.PDB" Name="EbpfSvc.pdb" Source="$(var.ebpfsvc.TargetDir)ebpfsvc.pdb" />

--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -17,13 +17,15 @@ SPDX-License-Identifier: MIT
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>Debug</DefineConstants>
+    <DefineConstants>Debug;IncludeJIT=True</DefineConstants>
+    <SuppressValidation>True</SuppressValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
     <OutputPath>$(SolutionDir)$(Platform)\$(Configuration)\</OutputPath>
     <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
-    <DefineConstants>
-    </DefineConstants>
+    <DefineConstants Condition=" '$(ReleaseJIT)' == 'True' ">IncludeJIT=True</DefineConstants>
+    <DefineConstants Condition=" '$(ReleaseJIT)' == 'False' OR '$(ReleaseJIT)' == '' ">IncludeJIT=False</DefineConstants>
+    <SuppressValidation>True</SuppressValidation>
   </PropertyGroup>
   <!-- In accordance to what defined in sample.vcxproj, the MSI build is disabled for the 'Analysis' CI/CD build, as it  does not generate the *.o artifacts. -->
   <ItemGroup Condition="'$(Analysis)'==''">

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -364,6 +364,18 @@ _ebpf_native_provider_attach_client_callback(
         goto Done;
     }
 
+    // If the metadata table changes in size, then require the regeneration of the native module.
+    if (table->size != sizeof(metadata_table_t)) {
+        result = EBPF_INVALID_ARGUMENT;
+        EBPF_LOG_MESSAGE_GUID(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_NATIVE,
+            "The metadata table size is wrong for client module. The version of bpf2c used to generate this module "
+            "may be too old.",
+            *client_module_id);
+        goto Done;
+    }
+
     bpf2c_version_t client_version = {0, 0, 0};
     table->version(&client_version);
     if (_ebpf_compare_versions(&client_version, &_ebpf_minimum_version) < 0) {

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1486,7 +1486,7 @@ _ebpf_helper_id_to_index_compare(const void* lhs, const void* rhs)
  * 2) During initialization, the program binds to the program information provider.
  * 3) During the attach callback, the program information is hashed and stored.
  * 4) The verifier then queries the program information from the ebpf_program_t object and uses it to verify the program
- * safety. 
+ * safety.
  * 5) If the program information provider is reattached, the program information is hashed and compared with the
  * hash stored in the program and the program is rejected if the hash does not match. This ensures that the program
  * information the verifier uses to verify the program safety is the same as the program information the program uses to

--- a/tests/bpf2c_tests/elf_bpf.cpp
+++ b/tests/bpf2c_tests/elf_bpf.cpp
@@ -128,6 +128,17 @@ run_test_elf(const std::string& elf_file, _test_mode test_mode, const std::optio
             auto actual_output = read_contents<std::istringstream>(
                 out, {transform_line_directives<'\\'>, transform_line_directives<'/'>});
 
+            // Find the first line that differs.
+            if (actual_output.size() != expected_output.size()) {
+                for (size_t i = 0; i < min(actual_output.size(), expected_output.size()); i++) {
+                    if (actual_output[i] != expected_output[i]) {
+                        std::cout << "First difference at line " << i << std::endl;
+                        std::cout << "Expected: " << expected_output[i] << std::endl;
+                        std::cout << "Actual: " << actual_output[i] << std::endl;
+                        break;
+                    }
+                }
+            }
             REQUIRE(actual_output.size() == expected_output.size());
             for (size_t i = 0; i < actual_output.size(); i++) {
                 REQUIRE(expected_output[i] == actual_output[i]);

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -190,4 +190,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bad_map_name_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bad_map_name_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bad_map_name_raw.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_raw.c
@@ -156,4 +156,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bad_map_name_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bad_map_name_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -323,4 +323,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bad_map_name_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bad_map_name_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -598,4 +598,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -564,4 +564,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -194,4 +194,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_ringbuf_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_raw.c
@@ -160,4 +160,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_ringbuf_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -327,4 +327,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_ringbuf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_ringbuf_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -731,4 +731,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -809,4 +809,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_tailcall_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -775,4 +775,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_tailcall_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -942,4 +942,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bindmonitor_tailcall_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bindmonitor_tailcall_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -190,4 +190,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bpf_call_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_call_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_call_raw.c
@@ -156,4 +156,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bpf_call_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -323,4 +323,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bpf_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bpf_call_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -121,4 +121,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bpf_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_raw.c
+++ b/tests/bpf2c_tests/expected/bpf_raw.c
@@ -87,4 +87,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bpf_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -254,4 +254,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t bpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t bpf_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -797,4 +797,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t cgroup_sock_addr2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -763,4 +763,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t cgroup_sock_addr2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -930,4 +930,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t cgroup_sock_addr2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t cgroup_sock_addr2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -690,4 +690,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t cgroup_sock_addr_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_raw.c
@@ -656,4 +656,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t cgroup_sock_addr_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -823,4 +823,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t cgroup_sock_addr_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t cgroup_sock_addr_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -500,4 +500,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t decap_permit_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
@@ -466,4 +466,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t decap_permit_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
@@ -633,4 +633,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t decap_permit_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t decap_permit_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -197,4 +197,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t divide_by_zero_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/divide_by_zero_raw.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_raw.c
@@ -163,4 +163,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t divide_by_zero_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -330,4 +330,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t divide_by_zero_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t divide_by_zero_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -332,4 +332,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t droppacket_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -298,4 +298,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t droppacket_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -465,4 +465,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t droppacket_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t droppacket_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/empty_dll.c
+++ b/tests/bpf2c_tests/expected/empty_dll.c
@@ -85,4 +85,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t empty_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/empty_raw.c
+++ b/tests/bpf2c_tests/expected/empty_raw.c
@@ -51,4 +51,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t empty_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/empty_sys.c
+++ b/tests/bpf2c_tests/expected/empty_sys.c
@@ -218,4 +218,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t empty_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t empty_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -1091,4 +1091,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t encap_reflect_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
@@ -1057,4 +1057,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t encap_reflect_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
@@ -1224,4 +1224,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t encap_reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t encap_reflect_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -4364,4 +4364,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_dll.c
@@ -234,4 +234,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_in_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_raw.c
@@ -200,4 +200,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_in_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_sys.c
@@ -367,4 +367,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_in_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_in_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
@@ -234,4 +234,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_in_map_v2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_raw.c
@@ -200,4 +200,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_in_map_v2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
@@ -367,4 +367,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_in_map_v2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_in_map_v2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -4330,4 +4330,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -291,4 +291,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_reuse_2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_2_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_raw.c
@@ -257,4 +257,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_reuse_2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -424,4 +424,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_reuse_2_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_reuse_2_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -291,4 +291,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_reuse_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_raw.c
+++ b/tests/bpf2c_tests/expected/map_reuse_raw.c
@@ -257,4 +257,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_reuse_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -424,4 +424,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_reuse_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_reuse_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -4497,4 +4497,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t map_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -237,4 +237,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t pidtgid_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -203,4 +203,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t pidtgid_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -370,4 +370,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t pidtgid_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t pidtgid_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -697,4 +697,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t printk_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -582,4 +582,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t printk_legacy_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_legacy_raw.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_raw.c
@@ -548,4 +548,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t printk_legacy_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -715,4 +715,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t printk_legacy_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t printk_legacy_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -663,4 +663,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t printk_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -830,4 +830,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t printk_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t printk_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -780,4 +780,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t reflect_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.c
@@ -746,4 +746,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t reflect_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.c
@@ -913,4 +913,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t reflect_packet_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t reflect_packet_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -900,4 +900,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t sockops_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -866,4 +866,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t sockops_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -1033,4 +1033,4 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t sockops_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t sockops_metadata_table = {sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -272,4 +272,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_bad_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_bad_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_raw.c
@@ -238,4 +238,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_bad_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -405,4 +405,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_bad_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_bad_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -267,4 +267,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -262,4 +262,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_map_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_raw.c
@@ -228,4 +228,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -395,4 +395,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_map_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -296,4 +296,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_multiple_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_raw.c
@@ -262,4 +262,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_multiple_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -429,4 +429,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_multiple_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_multiple_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_raw.c
+++ b/tests/bpf2c_tests/expected/tail_call_raw.c
@@ -233,4 +233,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -400,4 +400,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t tail_call_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t tail_call_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -580,4 +580,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t test_sample_ebpf_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_raw.c
@@ -546,4 +546,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t test_sample_ebpf_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -713,4 +713,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t test_sample_ebpf_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t test_sample_ebpf_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -346,4 +346,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t test_utility_helpers_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_raw.c
@@ -312,4 +312,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t test_utility_helpers_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -479,4 +479,5 @@ _get_version(_Out_ bpf2c_version_t* version)
     version->revision = 0;
 }
 
-metadata_table_t test_utility_helpers_metadata_table = {_get_programs, _get_maps, _get_hash, _get_version};
+metadata_table_t test_utility_helpers_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2725,3 +2725,121 @@ TEST_CASE("test_ebpf_object_set_execution_type", "[end_to_end]")
 
     bpf_object__close(jit_object);
 }
+
+static void
+extension_reload_test(ebpf_execution_type_t execution_type)
+{
+    _test_helper_end_to_end test_helper;
+    // Create a 0-byte UDP packet.
+    auto packet0 = prepare_udp_packet(0, ETHERNET_TYPE_IPV4);
+
+    // Test that we drop the packet and increment the map.
+    xdp_md_t ctx0{packet0.data(), packet0.data() + packet0.size(), 0, TEST_IFINDEX};
+
+    // Try loading without the extension loaded.
+    bpf_object* droppacket_object;
+    int program_fd = -1;
+    const char* error_message = nullptr;
+
+    // Should fail.
+    REQUIRE(
+        ebpf_program_load(
+            execution_type == EBPF_EXECUTION_NATIVE ? "droppacket_um.dll" : "droppacket.o",
+            BPF_PROG_TYPE_UNSPEC,
+            execution_type,
+            &droppacket_object,
+            &program_fd,
+            &error_message) != 0);
+
+    ebpf_free((void*)error_message);
+
+    // Load the program with the extension loaded.
+    {
+        single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
+
+        REQUIRE(
+            ebpf_program_load(
+                execution_type == EBPF_EXECUTION_NATIVE ? "droppacket_um.dll" : "droppacket.o",
+                BPF_PROG_TYPE_UNSPEC,
+                execution_type,
+                &droppacket_object,
+                &program_fd,
+                &error_message) == 0);
+
+        uint32_t if_index = TEST_IFINDEX;
+        bpf_link* link = nullptr;
+        // Attach only to the single interface being tested.
+        REQUIRE(hook.attach_link(program_fd, &if_index, sizeof(if_index), &link) == EBPF_SUCCESS);
+        bpf_link__disconnect(link);
+        bpf_link__destroy(link);
+
+        // Program should run.
+        int hook_result;
+        REQUIRE(hook.fire(&ctx0, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook_result == XDP_PASS);
+
+        // Unload the extension (xdp_program_info and hook will be destroyed).
+    }
+
+    // Reload the extension provider with unchanged data.
+    {
+        single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP);
+
+        // Program should re-attach to the hook.
+
+        // Program should run.
+        int hook_result;
+        REQUIRE(hook.fire(&ctx0, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook_result == XDP_PASS);
+    }
+
+    // Reload the extension provider with missing helper function.
+    {
+        ebpf_helper_function_addresses_t changed_helper_function_address_table =
+            _test_ebpf_xdp_helper_function_address_table;
+        ebpf_program_data_t changed_program_data = _ebpf_xdp_program_data;
+        changed_program_data.program_type_specific_helper_function_addresses = &changed_helper_function_address_table;
+        changed_helper_function_address_table.helper_function_count = 0;
+
+        ebpf_extension_data_t changed_provider_data = {
+            TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(changed_program_data), &changed_program_data};
+
+        single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP, &changed_provider_data);
+
+        // Program should re-attach to the hook.
+
+        // Program should not run.
+        int hook_result;
+        REQUIRE(hook.fire(&ctx0, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook_result != XDP_PASS);
+    }
+
+    // Reload the extension provider with changed helper function data.
+    {
+        ebpf_program_info_t changed_program_info = _ebpf_xdp_program_info;
+        ebpf_helper_function_prototype_t helper_function_prototypes[] = {
+            _xdp_ebpf_extension_helper_function_prototype[0]};
+        helper_function_prototypes[0].return_type = EBPF_RETURN_TYPE_PTR_TO_MAP_VALUE_OR_NULL;
+        changed_program_info.program_type_specific_helper_prototype = helper_function_prototypes;
+        ebpf_program_data_t changed_program_data = _ebpf_xdp_program_data;
+        changed_program_data.program_info = &changed_program_info;
+
+        ebpf_extension_data_t changed_provider_data = {
+            TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(changed_program_data), &changed_program_data};
+
+        single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        program_info_provider_t xdp_program_info(EBPF_PROGRAM_TYPE_XDP, &changed_provider_data);
+
+        // Program should re-attach to the hook.
+
+        // Program should not run.
+        int hook_result;
+        REQUIRE(hook.fire(&ctx0, &hook_result) == EBPF_SUCCESS);
+        REQUIRE(hook_result != XDP_PASS);
+    }
+}
+
+DECLARE_ALL_TEST_CASES("extension_reload_test", "[end_to_end]", extension_reload_test);

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -434,10 +434,12 @@ static ebpf_extension_data_t _test_ebpf_sample_extension_program_info_provider_d
 typedef class _program_info_provider
 {
   public:
-    _program_info_provider(ebpf_program_type_t program_type)
+    _program_info_provider(ebpf_program_type_t program_type, ebpf_extension_data_t* custom_provider_data = nullptr)
         : program_type(program_type), provider(nullptr), provider_data(nullptr)
     {
-        if (program_type == EBPF_PROGRAM_TYPE_XDP) {
+        if (custom_provider_data != nullptr) {
+            provider_data = custom_provider_data;
+        } else if (program_type == EBPF_PROGRAM_TYPE_XDP) {
             provider_data = &_ebpf_xdp_program_info_provider_data;
         } else if (program_type == EBPF_PROGRAM_TYPE_BIND) {
             provider_data = &_ebpf_bind_program_info_provider_data;

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -1115,8 +1115,14 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
                   << "}" << std::endl
                   << std::endl;
 
-    output_stream << "metadata_table_t " << (c_name.c_identifier() + "_metadata_table")
-                  << " = {_get_programs, _get_maps, _get_hash, _get_version};\n";
+    std::string meta_data_table = "metadata_table_t " + c_name.c_identifier() + "_metadata_table = {";
+    meta_data_table += "sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};\n";
+
+    if (meta_data_table.size() > LINE_BREAK_WIDTH) {
+        meta_data_table.insert(meta_data_table.find_first_of("{") + 1, "\n" INDENT);
+    }
+
+    output_stream << meta_data_table;
 }
 
 std::string

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -1118,7 +1118,7 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
     std::string meta_data_table = "metadata_table_t " + c_name.c_identifier() + "_metadata_table = {";
     meta_data_table += "sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version};\n";
 
-    if (meta_data_table.size() > LINE_BREAK_WIDTH) {
+    if ((meta_data_table.size() - 1) > LINE_BREAK_WIDTH) {
         meta_data_table.insert(meta_data_table.find_first_of("{") + 1, "\n" INDENT);
     }
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1964 

## Description

Add a size field to metadata_table_t to detect mismatch between bpf2c and eBPF for Windows runtime.

## Testing

CI/CD

## Documentation

No.
