### PR TITLE
Update verifier to latest

### DIFF
--- a/docs/isa-support.rst
+++ b/docs/isa-support.rst
@@ -69,28 +69,28 @@ opcode  src   imm   description                                          PREVAIL
 0x5d    any   0x00  if dst != src goto +offset                              Y      Y      Y    jne-reg
 0x5e    any   0x00  if (uint32_t)dst != (uint32_t)src goto +offset          Y      Y      Y    jne32-reg
 0x5f    any   0x00  dst &= src                                              Y      Y      Y    alu64-bit
-0x61    any   0x00  dst = \*(uint32_t \*)(src + offset)                    ???     Y      Y    ldxw
+0x61    any   0x00  dst = \*(uint32_t \*)(src + offset)                     Y      Y      Y    ldxw
 0x62    0x0   any   \*(uint32_t \*)(dst + offset) = imm                     Y      Y      Y    stw
 0x63    any   0x00  \*(uint32_t \*)(dst + offset) = src                     Y      Y      Y    stxw
 0x64    0x0   any   dst = (uint32_t)(dst << imm)                            Y      Y      Y    alu-bit
 0x65    0x0   any   if dst s> imm goto +offset                              Y      Y      Y    jsgt-imm
 0x66    0x0   any   if (int32_t)dst s> (int32_t)imm goto +offset            Y      Y      Y    jsgt32-imm
 0x67    0x0   any   dst <<= imm                                             Y      Y      Y    alu64-bit
-0x69    any   0x00  dst = \*(uint16_t \*)(src + offset)                    ???     Y      Y    ldxh
+0x69    any   0x00  dst = \*(uint16_t \*)(src + offset)                     Y      Y      Y    ldxh
 0x6a    0x0   any   \*(uint16_t \*)(dst + offset) = imm                     Y      Y      Y    sth
 0x6b    any   0x00  \*(uint16_t \*)(dst + offset) = src                     Y      Y      Y    stxh
 0x6c    any   0x00  dst = (uint32_t)(dst << src)                            Y      Y      Y    alu-bit
 0x6d    any   0x00  if dst s> src goto +offset                              Y      Y      Y    jsgt-reg
 0x6e    any   0x00  if (int32_t)dst s> (int32_t)src goto +offset            Y      Y      Y    jsgt32-reg
 0x6f    any   0x00  dst <<= src                                             Y      Y      Y    lsh-reg
-0x71    any   0x00  dst = \*(uint8_t \*)(src + offset)                     ???     Y      Y    ldxb
+0x71    any   0x00  dst = \*(uint8_t \*)(src + offset)                      Y      Y      Y    ldxb
 0x72    0x0   any   \*(uint8_t \*)(dst + offset) = imm                      Y      Y      Y    stb
 0x73    any   0x00  \*(uint8_t \*)(dst + offset) = src                      Y      Y      Y    stxb
 0x74    0x0   any   dst = (uint32_t)(dst >> imm)                            Y      Y      Y    rsh32
 0x75    0x0   any   if dst s>= imm goto +offset                             Y      Y      Y    jsge-imm
 0x76    0x0   any   if (int32_t)dst s>= (int32_t)imm goto +offset           Y      Y      Y    jsge32-imm
 0x77    0x0   any   dst >>= imm                                             Y      Y      Y    alu64-bit
-0x79    any   0x00  dst = \*(uint64_t \*)(src + offset)                    ???     Y      Y    ldxdw
+0x79    any   0x00  dst = \*(uint64_t \*)(src + offset)                     Y      Y      Y    ldxdw
 0x7a    0x0   any   \*(uint64_t \*)(dst + offset) = imm                     Y      Y      Y    stdw
 0x7b    any   0x00  \*(uint64_t \*)(dst + offset) = src                     Y      Y      Y    stxdw
 0x7c    any   0x00  dst = (uint32_t)(dst >> src)                            Y      Y      Y    alu-bit

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: MIT
 
 add_subdirectory("ebpf-verifier" EXCLUDE_FROM_ALL)
-add_subdirectory("Catch2" EXCLUDE_FROM_ALL)
 add_subdirectory("ubpf" EXCLUDE_FROM_ALL)
 
 # Special target that we can link to external dependencies
@@ -15,14 +14,6 @@ target_compile_options("ebpf_for_windows_external_settings" INTERFACE
 target_compile_definitions("ebpf_for_windows_external_settings" INTERFACE
   "_CRT_SECURE_NO_WARNINGS"
   "_SILENCE_ALL_CXX17_DEPRECATION_WARNINGS"
-)
-
-#
-# Catch2
-#
-
-target_link_libraries("Catch2" PRIVATE
-  "ebpf_for_windows_external_settings"
 )
 
 #

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1486,7 +1486,7 @@ _ebpf_helper_id_to_index_compare(const void* lhs, const void* rhs)
  * 2) During initialization, the program binds to the program information provider.
  * 3) During the attach callback, the program information is hashed and stored.
  * 4) The verifier then queries the program information from the ebpf_program_t object and uses it to verify the program
- * safety. 
+ * safety.
  * 5) If the program information provider is reattached, the program information is hashed and compared with the
  * hash stored in the program and the program is rejected if the hash does not match. This ensures that the program
  * information the verifier uses to verify the program safety is the same as the program information the program uses to
@@ -1504,7 +1504,7 @@ _ebpf_program_initialize_or_verify_program_info_hash(_Inout_ ebpf_program_t* pro
     ebpf_result_t result;
     ebpf_cryptographic_hash_t* cryptographic_hash = NULL;
     ebpf_helper_id_to_index_t* helper_id_to_index = NULL;
-    const ebpf_program_info_t* program_info = NULL;
+    ebpf_program_info_t* program_info = NULL;
 
     result = ebpf_program_get_program_info(program, &program_info);
     if (result != EBPF_SUCCESS) {

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -116,48 +116,46 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
 {
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     // Prologue
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r0 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r1 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r2 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r3 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r4 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r5 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r6 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r7 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r8 = 0;
-#line 100 "sample/bindmonitor.c"
-    register uint64_t r9 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r10 = 0;
 
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r1 = (uintptr_t)context;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r8 src=r0 offset=0 imm=0
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r8 offset=-84 imm=0
-#line 102 "sample/bindmonitor.c"
+#line 298 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=19
 #line 52 "sample/bindmonitor.c"
@@ -241,32 +239,32 @@ BindMonitor(void* context)
 #line 58 "sample/bindmonitor.c"
     r2 += IMMEDIATE(-84);
     // EBPF_OP_LDDW pc=23 dst=r1 src=r0 offset=0 imm=0
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[4].address
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
          (r1, r2, r3, r4, r5);
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r7 = r0;
-    // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=82 imm=0
-#line 108 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=519 imm=0
+#line 304 "sample/bindmonitor.c"
     if (r7 == IMMEDIATE(0))
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
         goto label_9;
         // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=80 imm=0
-#line 108 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=517 imm=0
+#line 304 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
         goto label_9;
         // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 64 "sample/bindmonitor.c"
@@ -322,64 +320,87 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 69 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
 #line 70 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 70 "sample/bindmonitor.c"
-        goto label_1;
-        // EBPF_OP_JA pc=48 dst=r0 src=r0 offset=33 imm=0
-#line 70 "sample/bindmonitor.c"
-    goto label_3;
+        goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_MOV64_IMM pc=48 dst=r8 src=r0 offset=0 imm=0
+#line 70 "sample/bindmonitor.c"
+    r8 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=49 dst=r0 src=r0 offset=497 imm=0
+#line 309 "sample/bindmonitor.c"
+    if (r0 == IMMEDIATE(0))
+#line 309 "sample/bindmonitor.c"
+        goto label_9;
+label_2:
+    // EBPF_OP_LDXW pc=50 dst=r1 src=r6 offset=44 imm=0
+#line 313 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=51 dst=r1 src=r0 offset=488 imm=0
+#line 313 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(0))
+#line 313 "sample/bindmonitor.c"
+        goto label_7;
+        // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
+#line 313 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(2))
+#line 313 "sample/bindmonitor.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
+#line 329 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_JA pc=54 dst=r0 src=r0 offset=473 imm=0
+#line 329 "sample/bindmonitor.c"
+    goto label_5;
+label_3:
+    // EBPF_OP_LDXW pc=55 dst=r1 src=r6 offset=44 imm=0
 #line 73 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JNE_IMM pc=50 dst=r1 src=r0 offset=58 imm=0
+    // EBPF_OP_JNE_IMM pc=56 dst=r1 src=r0 offset=489 imm=0
 #line 73 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
 #line 73 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=56 imm=0
+    // EBPF_OP_JEQ_IMM pc=58 dst=r1 src=r0 offset=487 imm=0
 #line 76 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
 #line 76 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
 #line 76 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JEQ_IMM pc=54 dst=r1 src=r0 offset=54 imm=0
+    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=485 imm=0
 #line 76 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
 #line 76 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r8 = r10;
-    // EBPF_OP_ADD64_IMM pc=56 dst=r8 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=62 dst=r8 src=r0 offset=0 imm=-8
 #line 76 "sample/bindmonitor.c"
     r8 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=57 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=63 dst=r3 src=r10 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r3 src=r0 offset=0 imm=-80
+    // EBPF_OP_ADD64_IMM pc=64 dst=r3 src=r0 offset=0 imm=-80
 #line 76 "sample/bindmonitor.c"
     r3 += IMMEDIATE(-80);
-    // EBPF_OP_MOV64_IMM pc=59 dst=r9 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=65 dst=r1 src=r0 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=62 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=67 dst=r2 src=r8 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r2 = r8;
-    // EBPF_OP_MOV64_IMM pc=63 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=68 dst=r4 src=r0 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=2
 #line 79 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[3].address
 #line 79 "sample/bindmonitor.c"
@@ -388,13 +409,13 @@ label_1:
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 79 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_LDDW pc=65 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 80 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=67 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=72 dst=r2 src=r8 offset=0 imm=0
 #line 80 "sample/bindmonitor.c"
     r2 = r8;
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[4].address
 #line 80 "sample/bindmonitor.c"
@@ -403,163 +424,1577 @@ label_1:
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 80 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=69 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
 #line 81 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 81 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=70 dst=r1 src=r0 offset=0 imm=0
-#line 81 "sample/bindmonitor.c"
-    r1 = r0;
-    // EBPF_OP_ADD64_IMM pc=71 dst=r1 src=r0 offset=0 imm=4
-#line 81 "sample/bindmonitor.c"
-    r1 += IMMEDIATE(4);
-label_2:
-    // EBPF_OP_LDXDW pc=72 dst=r2 src=r6 offset=0 imm=0
-#line 85 "sample/bindmonitor.c"
-    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_ADD64_REG pc=73 dst=r2 src=r9 offset=0 imm=0
-#line 85 "sample/bindmonitor.c"
-    r2 += r9;
-    // EBPF_OP_LDXDW pc=74 dst=r3 src=r6 offset=8 imm=0
-#line 85 "sample/bindmonitor.c"
-    r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JGE_REG pc=75 dst=r2 src=r3 offset=6 imm=0
-#line 85 "sample/bindmonitor.c"
-    if (r2 >= r3)
-#line 85 "sample/bindmonitor.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=76 dst=r3 src=r1 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=77 dst=r3 src=r9 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r3 += r9;
-    // EBPF_OP_LDXB pc=78 dst=r2 src=r2 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXB pc=79 dst=r3 src=r2 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    *(uint8_t*)(uintptr_t)(r3 + OFFSET(0)) = (uint8_t)r2;
-    // EBPF_OP_ADD64_IMM pc=80 dst=r9 src=r0 offset=0 imm=1
-#line 84 "sample/bindmonitor.c"
-    r9 += IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=81 dst=r9 src=r0 offset=-10 imm=64
-#line 84 "sample/bindmonitor.c"
-    if (r9 != IMMEDIATE(64))
-#line 84 "sample/bindmonitor.c"
+        // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=76 dst=r2 src=r6 offset=8 imm=0
+#line 93 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=77 dst=r2 src=r1 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=78 dst=r3 src=r0 offset=0 imm=1
+#line 93 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_JSGT_REG pc=79 dst=r3 src=r2 offset=-32 imm=0
+#line 93 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 93 "sample/bindmonitor.c"
+        goto label_1;
+        // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
+#line 94 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_STXB pc=81 dst=r0 src=r1 offset=4 imm=0
+#line 94 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(4)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=82 dst=r1 src=r6 offset=0 imm=0
+#line 96 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=83 dst=r2 src=r6 offset=8 imm=0
+#line 96 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=84 dst=r2 src=r1 offset=0 imm=0
+#line 96 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=85 dst=r3 src=r0 offset=0 imm=2
+#line 96 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_JSGT_REG pc=86 dst=r3 src=r2 offset=-37 imm=0
+#line 96 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 96 "sample/bindmonitor.c"
         goto label_2;
-label_3:
-    // EBPF_OP_LDXW pc=82 dst=r1 src=r6 offset=44 imm=0
+        // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
+#line 97 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
+    // EBPF_OP_STXB pc=88 dst=r0 src=r1 offset=5 imm=0
+#line 97 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(5)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=89 dst=r1 src=r6 offset=0 imm=0
+#line 99 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=90 dst=r2 src=r6 offset=8 imm=0
+#line 99 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=91 dst=r2 src=r1 offset=0 imm=0
+#line 99 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=92 dst=r3 src=r0 offset=0 imm=3
+#line 99 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_JSGT_REG pc=93 dst=r3 src=r2 offset=-44 imm=0
+#line 99 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 99 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
+#line 100 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
+    // EBPF_OP_STXB pc=95 dst=r0 src=r1 offset=6 imm=0
+#line 100 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(6)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=96 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=97 dst=r2 src=r6 offset=8 imm=0
+#line 102 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=98 dst=r2 src=r1 offset=0 imm=0
+#line 102 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=99 dst=r3 src=r0 offset=0 imm=4
+#line 102 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_JSGT_REG pc=100 dst=r3 src=r2 offset=-51 imm=0
+#line 102 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 102 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
+#line 103 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
+    // EBPF_OP_STXB pc=102 dst=r0 src=r1 offset=7 imm=0
+#line 103 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(7)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=103 dst=r1 src=r6 offset=0 imm=0
+#line 105 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=104 dst=r2 src=r6 offset=8 imm=0
+#line 105 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=105 dst=r2 src=r1 offset=0 imm=0
+#line 105 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=106 dst=r3 src=r0 offset=0 imm=5
+#line 105 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_JSGT_REG pc=107 dst=r3 src=r2 offset=-58 imm=0
+#line 105 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 105 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
+#line 106 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_STXB pc=109 dst=r0 src=r1 offset=8 imm=0
+#line 106 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(8)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=110 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=111 dst=r2 src=r6 offset=8 imm=0
+#line 108 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=112 dst=r2 src=r1 offset=0 imm=0
+#line 108 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=113 dst=r3 src=r0 offset=0 imm=6
+#line 108 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_JSGT_REG pc=114 dst=r3 src=r2 offset=-65 imm=0
+#line 108 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 108 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
+#line 109 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
+    // EBPF_OP_STXB pc=116 dst=r0 src=r1 offset=9 imm=0
+#line 109 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(9)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=117 dst=r1 src=r6 offset=0 imm=0
+#line 111 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=118 dst=r2 src=r6 offset=8 imm=0
+#line 111 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=119 dst=r2 src=r1 offset=0 imm=0
+#line 111 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=120 dst=r3 src=r0 offset=0 imm=7
+#line 111 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_JSGT_REG pc=121 dst=r3 src=r2 offset=-72 imm=0
+#line 111 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 111 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
+#line 112 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
+    // EBPF_OP_STXB pc=123 dst=r0 src=r1 offset=10 imm=0
+#line 112 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(10)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=124 dst=r1 src=r6 offset=0 imm=0
+#line 114 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=125 dst=r2 src=r6 offset=8 imm=0
+#line 114 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=126 dst=r2 src=r1 offset=0 imm=0
+#line 114 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=127 dst=r3 src=r0 offset=0 imm=8
+#line 114 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_JSGT_REG pc=128 dst=r3 src=r2 offset=-79 imm=0
+#line 114 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 114 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
+#line 115 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
+    // EBPF_OP_STXB pc=130 dst=r0 src=r1 offset=11 imm=0
+#line 115 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(11)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=131 dst=r1 src=r6 offset=0 imm=0
 #line 117 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=83 dst=r1 src=r0 offset=3 imm=0
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=132 dst=r2 src=r6 offset=8 imm=0
 #line 117 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=133 dst=r2 src=r1 offset=0 imm=0
 #line 117 "sample/bindmonitor.c"
-        goto label_4;
-        // EBPF_OP_JEQ_IMM pc=84 dst=r1 src=r0 offset=9 imm=2
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=134 dst=r3 src=r0 offset=0 imm=9
 #line 117 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(2))
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_JSGT_REG pc=135 dst=r3 src=r2 offset=-86 imm=0
 #line 117 "sample/bindmonitor.c"
-        goto label_5;
-        // EBPF_OP_LDXW pc=85 dst=r1 src=r0 offset=0 imm=0
+    if ((int64_t)r3 > (int64_t)r2)
+#line 117 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
+#line 118 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXB pc=137 dst=r0 src=r1 offset=12 imm=0
+#line 118 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(12)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=138 dst=r1 src=r6 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=139 dst=r2 src=r6 offset=8 imm=0
+#line 120 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=140 dst=r2 src=r1 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=141 dst=r3 src=r0 offset=0 imm=10
+#line 120 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_JSGT_REG pc=142 dst=r3 src=r2 offset=-93 imm=0
+#line 120 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 120 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
+#line 121 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_STXB pc=144 dst=r0 src=r1 offset=13 imm=0
+#line 121 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(13)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=145 dst=r1 src=r6 offset=0 imm=0
+#line 123 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=146 dst=r2 src=r6 offset=8 imm=0
+#line 123 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=147 dst=r2 src=r1 offset=0 imm=0
+#line 123 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=148 dst=r3 src=r0 offset=0 imm=11
+#line 123 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_JSGT_REG pc=149 dst=r3 src=r2 offset=-100 imm=0
+#line 123 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 123 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
+#line 124 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_STXB pc=151 dst=r0 src=r1 offset=14 imm=0
+#line 124 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(14)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=152 dst=r1 src=r6 offset=0 imm=0
+#line 126 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=153 dst=r2 src=r6 offset=8 imm=0
+#line 126 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=154 dst=r2 src=r1 offset=0 imm=0
+#line 126 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=155 dst=r3 src=r0 offset=0 imm=12
+#line 126 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_JSGT_REG pc=156 dst=r3 src=r2 offset=-107 imm=0
+#line 126 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 126 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
+#line 127 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_STXB pc=158 dst=r0 src=r1 offset=15 imm=0
+#line 127 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(15)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=159 dst=r1 src=r6 offset=0 imm=0
+#line 129 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=160 dst=r2 src=r6 offset=8 imm=0
+#line 129 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
+#line 129 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=162 dst=r3 src=r0 offset=0 imm=13
+#line 129 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_JSGT_REG pc=163 dst=r3 src=r2 offset=-114 imm=0
+#line 129 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 129 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
+#line 130 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_STXB pc=165 dst=r0 src=r1 offset=16 imm=0
+#line 130 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(16)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=166 dst=r1 src=r6 offset=0 imm=0
+#line 132 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=167 dst=r2 src=r6 offset=8 imm=0
+#line 132 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=168 dst=r2 src=r1 offset=0 imm=0
+#line 132 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=169 dst=r3 src=r0 offset=0 imm=14
+#line 132 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_JSGT_REG pc=170 dst=r3 src=r2 offset=-121 imm=0
+#line 132 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 132 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
 #line 133 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JA pc=86 dst=r0 src=r0 offset=11 imm=0
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_STXB pc=172 dst=r0 src=r1 offset=17 imm=0
 #line 133 "sample/bindmonitor.c"
-    goto label_6;
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(17)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=173 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=174 dst=r2 src=r6 offset=8 imm=0
+#line 135 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=175 dst=r2 src=r1 offset=0 imm=0
+#line 135 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=176 dst=r3 src=r0 offset=0 imm=15
+#line 135 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_JSGT_REG pc=177 dst=r3 src=r2 offset=-128 imm=0
+#line 135 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 135 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
+#line 136 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_STXB pc=179 dst=r0 src=r1 offset=18 imm=0
+#line 136 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(18)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=180 dst=r1 src=r6 offset=0 imm=0
+#line 138 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=181 dst=r2 src=r6 offset=8 imm=0
+#line 138 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=182 dst=r2 src=r1 offset=0 imm=0
+#line 138 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=183 dst=r3 src=r0 offset=0 imm=16
+#line 138 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_JSGT_REG pc=184 dst=r3 src=r2 offset=-135 imm=0
+#line 138 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 138 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
+#line 139 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_STXB pc=186 dst=r0 src=r1 offset=19 imm=0
+#line 139 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(19)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=187 dst=r1 src=r6 offset=0 imm=0
+#line 141 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=188 dst=r2 src=r6 offset=8 imm=0
+#line 141 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=189 dst=r2 src=r1 offset=0 imm=0
+#line 141 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=190 dst=r3 src=r0 offset=0 imm=17
+#line 141 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_JSGT_REG pc=191 dst=r3 src=r2 offset=-142 imm=0
+#line 141 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 141 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
+#line 142 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_STXB pc=193 dst=r0 src=r1 offset=20 imm=0
+#line 142 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(20)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=194 dst=r1 src=r6 offset=0 imm=0
+#line 144 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=195 dst=r2 src=r6 offset=8 imm=0
+#line 144 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=196 dst=r2 src=r1 offset=0 imm=0
+#line 144 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=197 dst=r3 src=r0 offset=0 imm=18
+#line 144 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_JSGT_REG pc=198 dst=r3 src=r2 offset=-149 imm=0
+#line 144 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 144 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
+#line 145 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_STXB pc=200 dst=r0 src=r1 offset=21 imm=0
+#line 145 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(21)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=201 dst=r1 src=r6 offset=0 imm=0
+#line 147 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=202 dst=r2 src=r6 offset=8 imm=0
+#line 147 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=203 dst=r2 src=r1 offset=0 imm=0
+#line 147 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=204 dst=r3 src=r0 offset=0 imm=19
+#line 147 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_JSGT_REG pc=205 dst=r3 src=r2 offset=-156 imm=0
+#line 147 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 147 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
+#line 148 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_STXB pc=207 dst=r0 src=r1 offset=22 imm=0
+#line 148 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(22)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=208 dst=r1 src=r6 offset=0 imm=0
+#line 150 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=209 dst=r2 src=r6 offset=8 imm=0
+#line 150 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=210 dst=r2 src=r1 offset=0 imm=0
+#line 150 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=211 dst=r3 src=r0 offset=0 imm=20
+#line 150 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_JSGT_REG pc=212 dst=r3 src=r2 offset=-163 imm=0
+#line 150 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 150 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
+#line 151 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_STXB pc=214 dst=r0 src=r1 offset=23 imm=0
+#line 151 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(23)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=215 dst=r1 src=r6 offset=0 imm=0
+#line 153 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=216 dst=r2 src=r6 offset=8 imm=0
+#line 153 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=217 dst=r2 src=r1 offset=0 imm=0
+#line 153 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=21
+#line 153 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_JSGT_REG pc=219 dst=r3 src=r2 offset=-170 imm=0
+#line 153 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 153 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
+#line 154 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_STXB pc=221 dst=r0 src=r1 offset=24 imm=0
+#line 154 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(24)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=222 dst=r1 src=r6 offset=0 imm=0
+#line 156 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=223 dst=r2 src=r6 offset=8 imm=0
+#line 156 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=224 dst=r2 src=r1 offset=0 imm=0
+#line 156 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=225 dst=r3 src=r0 offset=0 imm=22
+#line 156 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_JSGT_REG pc=226 dst=r3 src=r2 offset=-177 imm=0
+#line 156 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 156 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
+#line 157 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_STXB pc=228 dst=r0 src=r1 offset=25 imm=0
+#line 157 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(25)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=229 dst=r1 src=r6 offset=0 imm=0
+#line 159 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=230 dst=r2 src=r6 offset=8 imm=0
+#line 159 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=231 dst=r2 src=r1 offset=0 imm=0
+#line 159 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=232 dst=r3 src=r0 offset=0 imm=23
+#line 159 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_JSGT_REG pc=233 dst=r3 src=r2 offset=-184 imm=0
+#line 159 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 159 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
+#line 160 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_STXB pc=235 dst=r0 src=r1 offset=26 imm=0
+#line 160 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(26)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=236 dst=r1 src=r6 offset=0 imm=0
+#line 162 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=237 dst=r2 src=r6 offset=8 imm=0
+#line 162 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=238 dst=r2 src=r1 offset=0 imm=0
+#line 162 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=239 dst=r3 src=r0 offset=0 imm=24
+#line 162 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_JSGT_REG pc=240 dst=r3 src=r2 offset=-191 imm=0
+#line 162 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 162 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
+#line 163 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_STXB pc=242 dst=r0 src=r1 offset=27 imm=0
+#line 163 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(27)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=243 dst=r1 src=r6 offset=0 imm=0
+#line 165 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=244 dst=r2 src=r6 offset=8 imm=0
+#line 165 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=245 dst=r2 src=r1 offset=0 imm=0
+#line 165 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=246 dst=r3 src=r0 offset=0 imm=25
+#line 165 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_JSGT_REG pc=247 dst=r3 src=r2 offset=-198 imm=0
+#line 165 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 165 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
+#line 166 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXB pc=249 dst=r0 src=r1 offset=28 imm=0
+#line 166 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(28)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=250 dst=r1 src=r6 offset=0 imm=0
+#line 168 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=251 dst=r2 src=r6 offset=8 imm=0
+#line 168 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=252 dst=r2 src=r1 offset=0 imm=0
+#line 168 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=253 dst=r3 src=r0 offset=0 imm=26
+#line 168 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_JSGT_REG pc=254 dst=r3 src=r2 offset=-205 imm=0
+#line 168 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 168 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
+#line 169 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
+    // EBPF_OP_STXB pc=256 dst=r0 src=r1 offset=29 imm=0
+#line 169 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(29)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=257 dst=r1 src=r6 offset=0 imm=0
+#line 171 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=258 dst=r2 src=r6 offset=8 imm=0
+#line 171 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=259 dst=r2 src=r1 offset=0 imm=0
+#line 171 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=260 dst=r3 src=r0 offset=0 imm=27
+#line 171 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_JSGT_REG pc=261 dst=r3 src=r2 offset=-212 imm=0
+#line 171 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 171 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
+#line 172 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
+    // EBPF_OP_STXB pc=263 dst=r0 src=r1 offset=30 imm=0
+#line 172 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(30)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=264 dst=r1 src=r6 offset=0 imm=0
+#line 174 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=265 dst=r2 src=r6 offset=8 imm=0
+#line 174 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=266 dst=r2 src=r1 offset=0 imm=0
+#line 174 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=267 dst=r3 src=r0 offset=0 imm=28
+#line 174 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_JSGT_REG pc=268 dst=r3 src=r2 offset=-219 imm=0
+#line 174 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 174 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
+#line 175 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
+    // EBPF_OP_STXB pc=270 dst=r0 src=r1 offset=31 imm=0
+#line 175 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(31)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=271 dst=r1 src=r6 offset=0 imm=0
+#line 177 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=272 dst=r2 src=r6 offset=8 imm=0
+#line 177 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=273 dst=r2 src=r1 offset=0 imm=0
+#line 177 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=274 dst=r3 src=r0 offset=0 imm=29
+#line 177 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_JSGT_REG pc=275 dst=r3 src=r2 offset=-226 imm=0
+#line 177 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 177 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
+#line 178 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXB pc=277 dst=r0 src=r1 offset=32 imm=0
+#line 178 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(32)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=278 dst=r1 src=r6 offset=0 imm=0
+#line 180 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=279 dst=r2 src=r6 offset=8 imm=0
+#line 180 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=280 dst=r2 src=r1 offset=0 imm=0
+#line 180 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=281 dst=r3 src=r0 offset=0 imm=30
+#line 180 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_JSGT_REG pc=282 dst=r3 src=r2 offset=-233 imm=0
+#line 180 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 180 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
+#line 181 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_STXB pc=284 dst=r0 src=r1 offset=33 imm=0
+#line 181 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(33)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=285 dst=r1 src=r6 offset=0 imm=0
+#line 183 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=286 dst=r2 src=r6 offset=8 imm=0
+#line 183 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=287 dst=r2 src=r1 offset=0 imm=0
+#line 183 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=288 dst=r3 src=r0 offset=0 imm=31
+#line 183 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(31);
+    // EBPF_OP_JSGT_REG pc=289 dst=r3 src=r2 offset=-240 imm=0
+#line 183 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 183 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
+#line 184 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_STXB pc=291 dst=r0 src=r1 offset=34 imm=0
+#line 184 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(34)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=292 dst=r1 src=r6 offset=0 imm=0
+#line 186 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=293 dst=r2 src=r6 offset=8 imm=0
+#line 186 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=294 dst=r2 src=r1 offset=0 imm=0
+#line 186 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=295 dst=r3 src=r0 offset=0 imm=32
+#line 186 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=296 dst=r3 src=r2 offset=-247 imm=0
+#line 186 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 186 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
+#line 187 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_STXB pc=298 dst=r0 src=r1 offset=35 imm=0
+#line 187 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(35)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=299 dst=r1 src=r6 offset=0 imm=0
+#line 189 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=300 dst=r2 src=r6 offset=8 imm=0
+#line 189 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=301 dst=r2 src=r1 offset=0 imm=0
+#line 189 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=302 dst=r3 src=r0 offset=0 imm=33
+#line 189 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(33);
+    // EBPF_OP_JSGT_REG pc=303 dst=r3 src=r2 offset=-254 imm=0
+#line 189 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 189 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
+#line 190 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_STXB pc=305 dst=r0 src=r1 offset=36 imm=0
+#line 190 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(36)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=306 dst=r1 src=r6 offset=0 imm=0
+#line 192 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=307 dst=r2 src=r6 offset=8 imm=0
+#line 192 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=308 dst=r2 src=r1 offset=0 imm=0
+#line 192 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=309 dst=r3 src=r0 offset=0 imm=34
+#line 192 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(34);
+    // EBPF_OP_JSGT_REG pc=310 dst=r3 src=r2 offset=-261 imm=0
+#line 192 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 192 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
+#line 193 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_STXB pc=312 dst=r0 src=r1 offset=37 imm=0
+#line 193 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(37)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=313 dst=r1 src=r6 offset=0 imm=0
+#line 195 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=314 dst=r2 src=r6 offset=8 imm=0
+#line 195 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=315 dst=r2 src=r1 offset=0 imm=0
+#line 195 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=316 dst=r3 src=r0 offset=0 imm=35
+#line 195 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(35);
+    // EBPF_OP_JSGT_REG pc=317 dst=r3 src=r2 offset=-268 imm=0
+#line 195 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 195 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
+#line 196 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_STXB pc=319 dst=r0 src=r1 offset=38 imm=0
+#line 196 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(38)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=320 dst=r1 src=r6 offset=0 imm=0
+#line 198 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=321 dst=r2 src=r6 offset=8 imm=0
+#line 198 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=322 dst=r2 src=r1 offset=0 imm=0
+#line 198 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=323 dst=r3 src=r0 offset=0 imm=36
+#line 198 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(36);
+    // EBPF_OP_JSGT_REG pc=324 dst=r3 src=r2 offset=-275 imm=0
+#line 198 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 198 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
+#line 199 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_STXB pc=326 dst=r0 src=r1 offset=39 imm=0
+#line 199 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(39)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=327 dst=r1 src=r6 offset=0 imm=0
+#line 201 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=328 dst=r2 src=r6 offset=8 imm=0
+#line 201 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=329 dst=r2 src=r1 offset=0 imm=0
+#line 201 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=330 dst=r3 src=r0 offset=0 imm=37
+#line 201 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(37);
+    // EBPF_OP_JSGT_REG pc=331 dst=r3 src=r2 offset=-282 imm=0
+#line 201 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 201 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
+#line 202 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_STXB pc=333 dst=r0 src=r1 offset=40 imm=0
+#line 202 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(40)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=334 dst=r1 src=r6 offset=0 imm=0
+#line 204 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=335 dst=r2 src=r6 offset=8 imm=0
+#line 204 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=336 dst=r2 src=r1 offset=0 imm=0
+#line 204 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=337 dst=r3 src=r0 offset=0 imm=38
+#line 204 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(38);
+    // EBPF_OP_JSGT_REG pc=338 dst=r3 src=r2 offset=-289 imm=0
+#line 204 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 204 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
+#line 205 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_STXB pc=340 dst=r0 src=r1 offset=41 imm=0
+#line 205 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(41)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=341 dst=r1 src=r6 offset=0 imm=0
+#line 207 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=342 dst=r2 src=r6 offset=8 imm=0
+#line 207 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=343 dst=r2 src=r1 offset=0 imm=0
+#line 207 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=344 dst=r3 src=r0 offset=0 imm=39
+#line 207 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(39);
+    // EBPF_OP_JSGT_REG pc=345 dst=r3 src=r2 offset=-296 imm=0
+#line 207 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 207 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
+#line 208 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_STXB pc=347 dst=r0 src=r1 offset=42 imm=0
+#line 208 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(42)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=348 dst=r1 src=r6 offset=0 imm=0
+#line 210 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=349 dst=r2 src=r6 offset=8 imm=0
+#line 210 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=350 dst=r2 src=r1 offset=0 imm=0
+#line 210 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=351 dst=r3 src=r0 offset=0 imm=40
+#line 210 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(40);
+    // EBPF_OP_JSGT_REG pc=352 dst=r3 src=r2 offset=-303 imm=0
+#line 210 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 210 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
+#line 211 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_STXB pc=354 dst=r0 src=r1 offset=43 imm=0
+#line 211 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(43)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=355 dst=r1 src=r6 offset=0 imm=0
+#line 213 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=356 dst=r2 src=r6 offset=8 imm=0
+#line 213 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=357 dst=r2 src=r1 offset=0 imm=0
+#line 213 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=358 dst=r3 src=r0 offset=0 imm=41
+#line 213 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(41);
+    // EBPF_OP_JSGT_REG pc=359 dst=r3 src=r2 offset=-310 imm=0
+#line 213 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 213 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
+#line 214 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_STXB pc=361 dst=r0 src=r1 offset=44 imm=0
+#line 214 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(44)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=362 dst=r1 src=r6 offset=0 imm=0
+#line 216 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=363 dst=r2 src=r6 offset=8 imm=0
+#line 216 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=364 dst=r2 src=r1 offset=0 imm=0
+#line 216 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=365 dst=r3 src=r0 offset=0 imm=42
+#line 216 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(42);
+    // EBPF_OP_JSGT_REG pc=366 dst=r3 src=r2 offset=-317 imm=0
+#line 216 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 216 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
+#line 217 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_STXB pc=368 dst=r0 src=r1 offset=45 imm=0
+#line 217 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(45)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=369 dst=r1 src=r6 offset=0 imm=0
+#line 219 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=370 dst=r2 src=r6 offset=8 imm=0
+#line 219 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=371 dst=r2 src=r1 offset=0 imm=0
+#line 219 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=372 dst=r3 src=r0 offset=0 imm=43
+#line 219 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(43);
+    // EBPF_OP_JSGT_REG pc=373 dst=r3 src=r2 offset=-324 imm=0
+#line 219 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 219 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
+#line 220 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_STXB pc=375 dst=r0 src=r1 offset=46 imm=0
+#line 220 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(46)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=376 dst=r1 src=r6 offset=0 imm=0
+#line 222 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=377 dst=r2 src=r6 offset=8 imm=0
+#line 222 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=378 dst=r2 src=r1 offset=0 imm=0
+#line 222 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=379 dst=r3 src=r0 offset=0 imm=44
+#line 222 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(44);
+    // EBPF_OP_JSGT_REG pc=380 dst=r3 src=r2 offset=-331 imm=0
+#line 222 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 222 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
+#line 223 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_STXB pc=382 dst=r0 src=r1 offset=47 imm=0
+#line 223 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(47)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=383 dst=r1 src=r6 offset=0 imm=0
+#line 225 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=384 dst=r2 src=r6 offset=8 imm=0
+#line 225 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=385 dst=r2 src=r1 offset=0 imm=0
+#line 225 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=386 dst=r3 src=r0 offset=0 imm=45
+#line 225 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(45);
+    // EBPF_OP_JSGT_REG pc=387 dst=r3 src=r2 offset=-338 imm=0
+#line 225 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 225 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
+#line 226 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXB pc=389 dst=r0 src=r1 offset=48 imm=0
+#line 226 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(48)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=390 dst=r1 src=r6 offset=0 imm=0
+#line 228 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=391 dst=r2 src=r6 offset=8 imm=0
+#line 228 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=392 dst=r2 src=r1 offset=0 imm=0
+#line 228 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=393 dst=r3 src=r0 offset=0 imm=46
+#line 228 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(46);
+    // EBPF_OP_JSGT_REG pc=394 dst=r3 src=r2 offset=-345 imm=0
+#line 228 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 228 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
+#line 229 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
+    // EBPF_OP_STXB pc=396 dst=r0 src=r1 offset=49 imm=0
+#line 229 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(49)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=397 dst=r1 src=r6 offset=0 imm=0
+#line 231 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=398 dst=r2 src=r6 offset=8 imm=0
+#line 231 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=399 dst=r2 src=r1 offset=0 imm=0
+#line 231 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=400 dst=r3 src=r0 offset=0 imm=47
+#line 231 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(47);
+    // EBPF_OP_JSGT_REG pc=401 dst=r3 src=r2 offset=-352 imm=0
+#line 231 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 231 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
+#line 232 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
+    // EBPF_OP_STXB pc=403 dst=r0 src=r1 offset=50 imm=0
+#line 232 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(50)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=404 dst=r1 src=r6 offset=0 imm=0
+#line 234 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=405 dst=r2 src=r6 offset=8 imm=0
+#line 234 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=406 dst=r2 src=r1 offset=0 imm=0
+#line 234 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=407 dst=r3 src=r0 offset=0 imm=48
+#line 234 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(48);
+    // EBPF_OP_JSGT_REG pc=408 dst=r3 src=r2 offset=-359 imm=0
+#line 234 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 234 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
+#line 235 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
+    // EBPF_OP_STXB pc=410 dst=r0 src=r1 offset=51 imm=0
+#line 235 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(51)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=411 dst=r1 src=r6 offset=0 imm=0
+#line 237 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=412 dst=r2 src=r6 offset=8 imm=0
+#line 237 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=413 dst=r2 src=r1 offset=0 imm=0
+#line 237 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=414 dst=r3 src=r0 offset=0 imm=49
+#line 237 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(49);
+    // EBPF_OP_JSGT_REG pc=415 dst=r3 src=r2 offset=-366 imm=0
+#line 237 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 237 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
+#line 238 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXB pc=417 dst=r0 src=r1 offset=52 imm=0
+#line 238 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(52)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=418 dst=r1 src=r6 offset=0 imm=0
+#line 240 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=419 dst=r2 src=r6 offset=8 imm=0
+#line 240 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=420 dst=r2 src=r1 offset=0 imm=0
+#line 240 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=421 dst=r3 src=r0 offset=0 imm=50
+#line 240 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(50);
+    // EBPF_OP_JSGT_REG pc=422 dst=r3 src=r2 offset=-373 imm=0
+#line 240 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 240 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
+#line 241 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
+    // EBPF_OP_STXB pc=424 dst=r0 src=r1 offset=53 imm=0
+#line 241 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(53)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=425 dst=r1 src=r6 offset=0 imm=0
+#line 243 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=426 dst=r2 src=r6 offset=8 imm=0
+#line 243 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=427 dst=r2 src=r1 offset=0 imm=0
+#line 243 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=428 dst=r3 src=r0 offset=0 imm=51
+#line 243 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(51);
+    // EBPF_OP_JSGT_REG pc=429 dst=r3 src=r2 offset=-380 imm=0
+#line 243 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 243 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
+#line 244 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
+    // EBPF_OP_STXB pc=431 dst=r0 src=r1 offset=54 imm=0
+#line 244 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(54)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=432 dst=r1 src=r6 offset=0 imm=0
+#line 246 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=433 dst=r2 src=r6 offset=8 imm=0
+#line 246 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=434 dst=r2 src=r1 offset=0 imm=0
+#line 246 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=435 dst=r3 src=r0 offset=0 imm=52
+#line 246 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(52);
+    // EBPF_OP_JSGT_REG pc=436 dst=r3 src=r2 offset=-387 imm=0
+#line 246 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 246 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
+#line 247 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
+    // EBPF_OP_STXB pc=438 dst=r0 src=r1 offset=55 imm=0
+#line 247 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(55)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=439 dst=r1 src=r6 offset=0 imm=0
+#line 249 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=440 dst=r2 src=r6 offset=8 imm=0
+#line 249 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=441 dst=r2 src=r1 offset=0 imm=0
+#line 249 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=442 dst=r3 src=r0 offset=0 imm=53
+#line 249 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(53);
+    // EBPF_OP_JSGT_REG pc=443 dst=r3 src=r2 offset=-394 imm=0
+#line 249 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 249 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
+#line 250 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
+    // EBPF_OP_STXB pc=445 dst=r0 src=r1 offset=56 imm=0
+#line 250 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(56)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=446 dst=r1 src=r6 offset=0 imm=0
+#line 252 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=447 dst=r2 src=r6 offset=8 imm=0
+#line 252 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=448 dst=r2 src=r1 offset=0 imm=0
+#line 252 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=449 dst=r3 src=r0 offset=0 imm=54
+#line 252 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(54);
+    // EBPF_OP_JSGT_REG pc=450 dst=r3 src=r2 offset=-401 imm=0
+#line 252 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 252 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
+#line 253 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
+    // EBPF_OP_STXB pc=452 dst=r0 src=r1 offset=57 imm=0
+#line 253 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(57)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=453 dst=r1 src=r6 offset=0 imm=0
+#line 255 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=454 dst=r2 src=r6 offset=8 imm=0
+#line 255 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=455 dst=r2 src=r1 offset=0 imm=0
+#line 255 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=456 dst=r3 src=r0 offset=0 imm=55
+#line 255 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(55);
+    // EBPF_OP_JSGT_REG pc=457 dst=r3 src=r2 offset=-408 imm=0
+#line 255 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 255 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
+#line 256 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
+    // EBPF_OP_STXB pc=459 dst=r0 src=r1 offset=58 imm=0
+#line 256 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(58)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=460 dst=r1 src=r6 offset=0 imm=0
+#line 258 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=461 dst=r2 src=r6 offset=8 imm=0
+#line 258 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=462 dst=r2 src=r1 offset=0 imm=0
+#line 258 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=463 dst=r3 src=r0 offset=0 imm=56
+#line 258 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(56);
+    // EBPF_OP_JSGT_REG pc=464 dst=r3 src=r2 offset=-415 imm=0
+#line 258 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 258 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
+#line 259 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
+    // EBPF_OP_STXB pc=466 dst=r0 src=r1 offset=59 imm=0
+#line 259 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(59)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=467 dst=r1 src=r6 offset=0 imm=0
+#line 261 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=468 dst=r2 src=r6 offset=8 imm=0
+#line 261 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=469 dst=r2 src=r1 offset=0 imm=0
+#line 261 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=470 dst=r3 src=r0 offset=0 imm=57
+#line 261 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(57);
+    // EBPF_OP_JSGT_REG pc=471 dst=r3 src=r2 offset=-422 imm=0
+#line 261 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 261 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
+#line 262 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=473 dst=r0 src=r1 offset=60 imm=0
+#line 262 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(60)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=474 dst=r1 src=r6 offset=0 imm=0
+#line 264 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=475 dst=r2 src=r6 offset=8 imm=0
+#line 264 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=476 dst=r2 src=r1 offset=0 imm=0
+#line 264 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=477 dst=r3 src=r0 offset=0 imm=58
+#line 264 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(58);
+    // EBPF_OP_JSGT_REG pc=478 dst=r3 src=r2 offset=-429 imm=0
+#line 264 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 264 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
+#line 265 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
+    // EBPF_OP_STXB pc=480 dst=r0 src=r1 offset=61 imm=0
+#line 265 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(61)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=481 dst=r1 src=r6 offset=0 imm=0
+#line 267 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=482 dst=r2 src=r6 offset=8 imm=0
+#line 267 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=483 dst=r2 src=r1 offset=0 imm=0
+#line 267 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=484 dst=r3 src=r0 offset=0 imm=59
+#line 267 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(59);
+    // EBPF_OP_JSGT_REG pc=485 dst=r3 src=r2 offset=-436 imm=0
+#line 267 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 267 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
+#line 268 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
+    // EBPF_OP_STXB pc=487 dst=r0 src=r1 offset=62 imm=0
+#line 268 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(62)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=488 dst=r1 src=r6 offset=0 imm=0
+#line 270 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=489 dst=r2 src=r6 offset=8 imm=0
+#line 270 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=490 dst=r2 src=r1 offset=0 imm=0
+#line 270 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=491 dst=r3 src=r0 offset=0 imm=60
+#line 270 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(60);
+    // EBPF_OP_JSGT_REG pc=492 dst=r3 src=r2 offset=-443 imm=0
+#line 270 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 270 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
+#line 271 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
+    // EBPF_OP_STXB pc=494 dst=r0 src=r1 offset=63 imm=0
+#line 271 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(63)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=495 dst=r1 src=r6 offset=0 imm=0
+#line 273 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=496 dst=r2 src=r6 offset=8 imm=0
+#line 273 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=497 dst=r2 src=r1 offset=0 imm=0
+#line 273 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=498 dst=r3 src=r0 offset=0 imm=61
+#line 273 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(61);
+    // EBPF_OP_JSGT_REG pc=499 dst=r3 src=r2 offset=-450 imm=0
+#line 273 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 273 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
+#line 274 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
+    // EBPF_OP_STXB pc=501 dst=r0 src=r1 offset=64 imm=0
+#line 274 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(64)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=502 dst=r1 src=r6 offset=0 imm=0
+#line 276 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=503 dst=r2 src=r6 offset=8 imm=0
+#line 276 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=504 dst=r2 src=r1 offset=0 imm=0
+#line 276 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=505 dst=r3 src=r0 offset=0 imm=62
+#line 276 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(62);
+    // EBPF_OP_JSGT_REG pc=506 dst=r3 src=r2 offset=-457 imm=0
+#line 276 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 276 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
+#line 277 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
+    // EBPF_OP_STXB pc=508 dst=r0 src=r1 offset=65 imm=0
+#line 277 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(65)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=509 dst=r1 src=r6 offset=0 imm=0
+#line 279 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=510 dst=r2 src=r6 offset=8 imm=0
+#line 279 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=511 dst=r2 src=r1 offset=0 imm=0
+#line 279 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=512 dst=r3 src=r0 offset=0 imm=63
+#line 279 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(63);
+    // EBPF_OP_JSGT_REG pc=513 dst=r3 src=r2 offset=-464 imm=0
+#line 279 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 279 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
+#line 280 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
+    // EBPF_OP_STXB pc=515 dst=r0 src=r1 offset=66 imm=0
+#line 280 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(66)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=516 dst=r1 src=r6 offset=0 imm=0
+#line 282 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=517 dst=r2 src=r6 offset=8 imm=0
+#line 282 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=518 dst=r2 src=r1 offset=0 imm=0
+#line 282 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=519 dst=r3 src=r0 offset=0 imm=64
+#line 282 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_JSGT_REG pc=520 dst=r3 src=r2 offset=-471 imm=0
+#line 282 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 282 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
+#line 283 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
+    // EBPF_OP_STXB pc=522 dst=r0 src=r1 offset=67 imm=0
+#line 283 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(67)) = (uint8_t)r1;
+    // EBPF_OP_JA pc=523 dst=r0 src=r0 offset=-474 imm=0
+#line 283 "sample/bindmonitor.c"
+    goto label_2;
 label_4:
-    // EBPF_OP_MOV64_IMM pc=87 dst=r8 src=r0 offset=0 imm=1
-#line 133 "sample/bindmonitor.c"
-    r8 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=88 dst=r1 src=r0 offset=0 imm=0
-#line 119 "sample/bindmonitor.c"
+    // EBPF_OP_LDXW pc=524 dst=r1 src=r0 offset=0 imm=0
+#line 322 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_LDXW pc=89 dst=r2 src=r7 offset=0 imm=0
-#line 119 "sample/bindmonitor.c"
-    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JGE_REG pc=90 dst=r1 src=r2 offset=19 imm=0
-#line 119 "sample/bindmonitor.c"
-    if (r1 >= r2)
-#line 119 "sample/bindmonitor.c"
-        goto label_9;
-        // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=1
-#line 123 "sample/bindmonitor.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=92 dst=r0 src=r1 offset=0 imm=0
-#line 123 "sample/bindmonitor.c"
-    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_JA pc=93 dst=r0 src=r0 offset=15 imm=0
-#line 123 "sample/bindmonitor.c"
-    goto label_8;
-label_5:
-    // EBPF_OP_LDXW pc=94 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=95 dst=r1 src=r0 offset=6 imm=0
-#line 126 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=525 dst=r1 src=r0 offset=6 imm=0
+#line 322 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
-#line 126 "sample/bindmonitor.c"
-        goto label_7;
-        // EBPF_OP_ADD64_IMM pc=96 dst=r1 src=r0 offset=0 imm=-1
-#line 127 "sample/bindmonitor.c"
+#line 322 "sample/bindmonitor.c"
+        goto label_6;
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
+#line 323 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
-    // EBPF_OP_STXW pc=97 dst=r0 src=r1 offset=0 imm=0
-#line 127 "sample/bindmonitor.c"
+    // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
+#line 323 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-label_6:
-    // EBPF_OP_MOV64_IMM pc=98 dst=r8 src=r0 offset=0 imm=0
-#line 127 "sample/bindmonitor.c"
+label_5:
+    // EBPF_OP_MOV64_IMM pc=528 dst=r8 src=r0 offset=0 imm=0
+#line 323 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
-    // EBPF_OP_LSH64_IMM pc=99 dst=r1 src=r0 offset=0 imm=32
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_LSH64_IMM pc=529 dst=r1 src=r0 offset=0 imm=32
+#line 329 "sample/bindmonitor.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=100 dst=r1 src=r0 offset=0 imm=32
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_RSH64_IMM pc=530 dst=r1 src=r0 offset=0 imm=32
+#line 329 "sample/bindmonitor.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=101 dst=r1 src=r0 offset=8 imm=0
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_JNE_IMM pc=531 dst=r1 src=r0 offset=15 imm=0
+#line 329 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
-#line 133 "sample/bindmonitor.c"
+#line 329 "sample/bindmonitor.c"
         goto label_9;
-label_7:
-    // EBPF_OP_LDXDW pc=102 dst=r1 src=r6 offset=16 imm=0
-#line 134 "sample/bindmonitor.c"
+label_6:
+    // EBPF_OP_LDXDW pc=532 dst=r1 src=r6 offset=16 imm=0
+#line 330 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
-    // EBPF_OP_STXDW pc=103 dst=r10 src=r1 offset=-80 imm=0
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_STXDW pc=533 dst=r10 src=r1 offset=-80 imm=0
+#line 330 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=104 dst=r2 src=r10 offset=0 imm=0
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_REG pc=534 dst=r2 src=r10 offset=0 imm=0
+#line 330 "sample/bindmonitor.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=105 dst=r2 src=r0 offset=0 imm=-80
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_ADD64_IMM pc=535 dst=r2 src=r0 offset=0 imm=-80
+#line 330 "sample/bindmonitor.c"
     r2 += IMMEDIATE(-80);
-    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_LDDW pc=536 dst=r1 src=r0 offset=0 imm=0
+#line 331 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=108 dst=r0 src=r0 offset=0 imm=3
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_CALL pc=538 dst=r0 src=r0 offset=0 imm=3
+#line 331 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[5].address
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
          (r1, r2, r3, r4, r5);
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
     if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
         return 0;
+        // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
+#line 331 "sample/bindmonitor.c"
+    goto label_8;
+label_7:
+    // EBPF_OP_MOV64_IMM pc=540 dst=r8 src=r0 offset=0 imm=1
+#line 331 "sample/bindmonitor.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=541 dst=r1 src=r0 offset=0 imm=0
+#line 315 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_LDXW pc=542 dst=r2 src=r7 offset=0 imm=0
+#line 315 "sample/bindmonitor.c"
+    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_JGE_REG pc=543 dst=r1 src=r2 offset=3 imm=0
+#line 315 "sample/bindmonitor.c"
+    if (r1 >= r2)
+#line 315 "sample/bindmonitor.c"
+        goto label_9;
+        // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
+#line 319 "sample/bindmonitor.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=545 dst=r0 src=r1 offset=0 imm=0
+#line 319 "sample/bindmonitor.c"
+    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
 label_8:
-    // EBPF_OP_MOV64_IMM pc=109 dst=r8 src=r0 offset=0 imm=0
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_IMM pc=546 dst=r8 src=r0 offset=0 imm=0
+#line 319 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
 label_9:
-    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r8 offset=0 imm=0
-#line 139 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_REG pc=547 dst=r0 src=r8 offset=0 imm=0
+#line 335 "sample/bindmonitor.c"
     r0 = r8;
-    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
-#line 139 "sample/bindmonitor.c"
+    // EBPF_OP_EXIT pc=548 dst=r0 src=r0 offset=0 imm=0
+#line 335 "sample/bindmonitor.c"
     return r0;
-#line 139 "sample/bindmonitor.c"
+#line 335 "sample/bindmonitor.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -576,7 +2011,7 @@ static program_entry_t _programs[] = {
         3,
         BindMonitor_helpers,
         6,
-        112,
+        549,
         &BindMonitor_program_type_guid,
         &BindMonitor_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -82,48 +82,46 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
 {
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     // Prologue
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r0 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r1 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r2 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r3 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r4 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r5 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r6 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r7 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r8 = 0;
-#line 100 "sample/bindmonitor.c"
-    register uint64_t r9 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r10 = 0;
 
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r1 = (uintptr_t)context;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r8 src=r0 offset=0 imm=0
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r8 offset=-84 imm=0
-#line 102 "sample/bindmonitor.c"
+#line 298 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=19
 #line 52 "sample/bindmonitor.c"
@@ -207,32 +205,32 @@ BindMonitor(void* context)
 #line 58 "sample/bindmonitor.c"
     r2 += IMMEDIATE(-84);
     // EBPF_OP_LDDW pc=23 dst=r1 src=r0 offset=0 imm=0
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[4].address
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
          (r1, r2, r3, r4, r5);
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r7 = r0;
-    // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=82 imm=0
-#line 108 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=519 imm=0
+#line 304 "sample/bindmonitor.c"
     if (r7 == IMMEDIATE(0))
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
         goto label_9;
         // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=80 imm=0
-#line 108 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=517 imm=0
+#line 304 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
         goto label_9;
         // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 64 "sample/bindmonitor.c"
@@ -288,64 +286,87 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 69 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
 #line 70 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 70 "sample/bindmonitor.c"
-        goto label_1;
-        // EBPF_OP_JA pc=48 dst=r0 src=r0 offset=33 imm=0
-#line 70 "sample/bindmonitor.c"
-    goto label_3;
+        goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_MOV64_IMM pc=48 dst=r8 src=r0 offset=0 imm=0
+#line 70 "sample/bindmonitor.c"
+    r8 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=49 dst=r0 src=r0 offset=497 imm=0
+#line 309 "sample/bindmonitor.c"
+    if (r0 == IMMEDIATE(0))
+#line 309 "sample/bindmonitor.c"
+        goto label_9;
+label_2:
+    // EBPF_OP_LDXW pc=50 dst=r1 src=r6 offset=44 imm=0
+#line 313 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=51 dst=r1 src=r0 offset=488 imm=0
+#line 313 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(0))
+#line 313 "sample/bindmonitor.c"
+        goto label_7;
+        // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
+#line 313 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(2))
+#line 313 "sample/bindmonitor.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
+#line 329 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_JA pc=54 dst=r0 src=r0 offset=473 imm=0
+#line 329 "sample/bindmonitor.c"
+    goto label_5;
+label_3:
+    // EBPF_OP_LDXW pc=55 dst=r1 src=r6 offset=44 imm=0
 #line 73 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JNE_IMM pc=50 dst=r1 src=r0 offset=58 imm=0
+    // EBPF_OP_JNE_IMM pc=56 dst=r1 src=r0 offset=489 imm=0
 #line 73 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
 #line 73 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=56 imm=0
+    // EBPF_OP_JEQ_IMM pc=58 dst=r1 src=r0 offset=487 imm=0
 #line 76 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
 #line 76 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
 #line 76 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JEQ_IMM pc=54 dst=r1 src=r0 offset=54 imm=0
+    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=485 imm=0
 #line 76 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
 #line 76 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r8 = r10;
-    // EBPF_OP_ADD64_IMM pc=56 dst=r8 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=62 dst=r8 src=r0 offset=0 imm=-8
 #line 76 "sample/bindmonitor.c"
     r8 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=57 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=63 dst=r3 src=r10 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r3 src=r0 offset=0 imm=-80
+    // EBPF_OP_ADD64_IMM pc=64 dst=r3 src=r0 offset=0 imm=-80
 #line 76 "sample/bindmonitor.c"
     r3 += IMMEDIATE(-80);
-    // EBPF_OP_MOV64_IMM pc=59 dst=r9 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=65 dst=r1 src=r0 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=62 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=67 dst=r2 src=r8 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r2 = r8;
-    // EBPF_OP_MOV64_IMM pc=63 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=68 dst=r4 src=r0 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=2
 #line 79 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[3].address
 #line 79 "sample/bindmonitor.c"
@@ -354,13 +375,13 @@ label_1:
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 79 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_LDDW pc=65 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 80 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=67 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=72 dst=r2 src=r8 offset=0 imm=0
 #line 80 "sample/bindmonitor.c"
     r2 = r8;
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[4].address
 #line 80 "sample/bindmonitor.c"
@@ -369,163 +390,1577 @@ label_1:
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 80 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=69 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
 #line 81 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 81 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=70 dst=r1 src=r0 offset=0 imm=0
-#line 81 "sample/bindmonitor.c"
-    r1 = r0;
-    // EBPF_OP_ADD64_IMM pc=71 dst=r1 src=r0 offset=0 imm=4
-#line 81 "sample/bindmonitor.c"
-    r1 += IMMEDIATE(4);
-label_2:
-    // EBPF_OP_LDXDW pc=72 dst=r2 src=r6 offset=0 imm=0
-#line 85 "sample/bindmonitor.c"
-    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_ADD64_REG pc=73 dst=r2 src=r9 offset=0 imm=0
-#line 85 "sample/bindmonitor.c"
-    r2 += r9;
-    // EBPF_OP_LDXDW pc=74 dst=r3 src=r6 offset=8 imm=0
-#line 85 "sample/bindmonitor.c"
-    r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JGE_REG pc=75 dst=r2 src=r3 offset=6 imm=0
-#line 85 "sample/bindmonitor.c"
-    if (r2 >= r3)
-#line 85 "sample/bindmonitor.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=76 dst=r3 src=r1 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=77 dst=r3 src=r9 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r3 += r9;
-    // EBPF_OP_LDXB pc=78 dst=r2 src=r2 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXB pc=79 dst=r3 src=r2 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    *(uint8_t*)(uintptr_t)(r3 + OFFSET(0)) = (uint8_t)r2;
-    // EBPF_OP_ADD64_IMM pc=80 dst=r9 src=r0 offset=0 imm=1
-#line 84 "sample/bindmonitor.c"
-    r9 += IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=81 dst=r9 src=r0 offset=-10 imm=64
-#line 84 "sample/bindmonitor.c"
-    if (r9 != IMMEDIATE(64))
-#line 84 "sample/bindmonitor.c"
+        // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=76 dst=r2 src=r6 offset=8 imm=0
+#line 93 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=77 dst=r2 src=r1 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=78 dst=r3 src=r0 offset=0 imm=1
+#line 93 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_JSGT_REG pc=79 dst=r3 src=r2 offset=-32 imm=0
+#line 93 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 93 "sample/bindmonitor.c"
+        goto label_1;
+        // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
+#line 94 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_STXB pc=81 dst=r0 src=r1 offset=4 imm=0
+#line 94 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(4)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=82 dst=r1 src=r6 offset=0 imm=0
+#line 96 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=83 dst=r2 src=r6 offset=8 imm=0
+#line 96 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=84 dst=r2 src=r1 offset=0 imm=0
+#line 96 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=85 dst=r3 src=r0 offset=0 imm=2
+#line 96 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_JSGT_REG pc=86 dst=r3 src=r2 offset=-37 imm=0
+#line 96 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 96 "sample/bindmonitor.c"
         goto label_2;
-label_3:
-    // EBPF_OP_LDXW pc=82 dst=r1 src=r6 offset=44 imm=0
+        // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
+#line 97 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
+    // EBPF_OP_STXB pc=88 dst=r0 src=r1 offset=5 imm=0
+#line 97 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(5)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=89 dst=r1 src=r6 offset=0 imm=0
+#line 99 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=90 dst=r2 src=r6 offset=8 imm=0
+#line 99 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=91 dst=r2 src=r1 offset=0 imm=0
+#line 99 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=92 dst=r3 src=r0 offset=0 imm=3
+#line 99 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_JSGT_REG pc=93 dst=r3 src=r2 offset=-44 imm=0
+#line 99 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 99 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
+#line 100 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
+    // EBPF_OP_STXB pc=95 dst=r0 src=r1 offset=6 imm=0
+#line 100 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(6)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=96 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=97 dst=r2 src=r6 offset=8 imm=0
+#line 102 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=98 dst=r2 src=r1 offset=0 imm=0
+#line 102 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=99 dst=r3 src=r0 offset=0 imm=4
+#line 102 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_JSGT_REG pc=100 dst=r3 src=r2 offset=-51 imm=0
+#line 102 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 102 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
+#line 103 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
+    // EBPF_OP_STXB pc=102 dst=r0 src=r1 offset=7 imm=0
+#line 103 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(7)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=103 dst=r1 src=r6 offset=0 imm=0
+#line 105 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=104 dst=r2 src=r6 offset=8 imm=0
+#line 105 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=105 dst=r2 src=r1 offset=0 imm=0
+#line 105 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=106 dst=r3 src=r0 offset=0 imm=5
+#line 105 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_JSGT_REG pc=107 dst=r3 src=r2 offset=-58 imm=0
+#line 105 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 105 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
+#line 106 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_STXB pc=109 dst=r0 src=r1 offset=8 imm=0
+#line 106 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(8)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=110 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=111 dst=r2 src=r6 offset=8 imm=0
+#line 108 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=112 dst=r2 src=r1 offset=0 imm=0
+#line 108 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=113 dst=r3 src=r0 offset=0 imm=6
+#line 108 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_JSGT_REG pc=114 dst=r3 src=r2 offset=-65 imm=0
+#line 108 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 108 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
+#line 109 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
+    // EBPF_OP_STXB pc=116 dst=r0 src=r1 offset=9 imm=0
+#line 109 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(9)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=117 dst=r1 src=r6 offset=0 imm=0
+#line 111 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=118 dst=r2 src=r6 offset=8 imm=0
+#line 111 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=119 dst=r2 src=r1 offset=0 imm=0
+#line 111 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=120 dst=r3 src=r0 offset=0 imm=7
+#line 111 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_JSGT_REG pc=121 dst=r3 src=r2 offset=-72 imm=0
+#line 111 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 111 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
+#line 112 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
+    // EBPF_OP_STXB pc=123 dst=r0 src=r1 offset=10 imm=0
+#line 112 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(10)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=124 dst=r1 src=r6 offset=0 imm=0
+#line 114 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=125 dst=r2 src=r6 offset=8 imm=0
+#line 114 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=126 dst=r2 src=r1 offset=0 imm=0
+#line 114 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=127 dst=r3 src=r0 offset=0 imm=8
+#line 114 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_JSGT_REG pc=128 dst=r3 src=r2 offset=-79 imm=0
+#line 114 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 114 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
+#line 115 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
+    // EBPF_OP_STXB pc=130 dst=r0 src=r1 offset=11 imm=0
+#line 115 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(11)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=131 dst=r1 src=r6 offset=0 imm=0
 #line 117 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=83 dst=r1 src=r0 offset=3 imm=0
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=132 dst=r2 src=r6 offset=8 imm=0
 #line 117 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=133 dst=r2 src=r1 offset=0 imm=0
 #line 117 "sample/bindmonitor.c"
-        goto label_4;
-        // EBPF_OP_JEQ_IMM pc=84 dst=r1 src=r0 offset=9 imm=2
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=134 dst=r3 src=r0 offset=0 imm=9
 #line 117 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(2))
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_JSGT_REG pc=135 dst=r3 src=r2 offset=-86 imm=0
 #line 117 "sample/bindmonitor.c"
-        goto label_5;
-        // EBPF_OP_LDXW pc=85 dst=r1 src=r0 offset=0 imm=0
+    if ((int64_t)r3 > (int64_t)r2)
+#line 117 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
+#line 118 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXB pc=137 dst=r0 src=r1 offset=12 imm=0
+#line 118 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(12)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=138 dst=r1 src=r6 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=139 dst=r2 src=r6 offset=8 imm=0
+#line 120 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=140 dst=r2 src=r1 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=141 dst=r3 src=r0 offset=0 imm=10
+#line 120 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_JSGT_REG pc=142 dst=r3 src=r2 offset=-93 imm=0
+#line 120 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 120 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
+#line 121 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_STXB pc=144 dst=r0 src=r1 offset=13 imm=0
+#line 121 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(13)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=145 dst=r1 src=r6 offset=0 imm=0
+#line 123 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=146 dst=r2 src=r6 offset=8 imm=0
+#line 123 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=147 dst=r2 src=r1 offset=0 imm=0
+#line 123 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=148 dst=r3 src=r0 offset=0 imm=11
+#line 123 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_JSGT_REG pc=149 dst=r3 src=r2 offset=-100 imm=0
+#line 123 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 123 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
+#line 124 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_STXB pc=151 dst=r0 src=r1 offset=14 imm=0
+#line 124 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(14)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=152 dst=r1 src=r6 offset=0 imm=0
+#line 126 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=153 dst=r2 src=r6 offset=8 imm=0
+#line 126 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=154 dst=r2 src=r1 offset=0 imm=0
+#line 126 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=155 dst=r3 src=r0 offset=0 imm=12
+#line 126 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_JSGT_REG pc=156 dst=r3 src=r2 offset=-107 imm=0
+#line 126 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 126 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
+#line 127 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_STXB pc=158 dst=r0 src=r1 offset=15 imm=0
+#line 127 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(15)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=159 dst=r1 src=r6 offset=0 imm=0
+#line 129 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=160 dst=r2 src=r6 offset=8 imm=0
+#line 129 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
+#line 129 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=162 dst=r3 src=r0 offset=0 imm=13
+#line 129 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_JSGT_REG pc=163 dst=r3 src=r2 offset=-114 imm=0
+#line 129 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 129 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
+#line 130 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_STXB pc=165 dst=r0 src=r1 offset=16 imm=0
+#line 130 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(16)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=166 dst=r1 src=r6 offset=0 imm=0
+#line 132 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=167 dst=r2 src=r6 offset=8 imm=0
+#line 132 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=168 dst=r2 src=r1 offset=0 imm=0
+#line 132 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=169 dst=r3 src=r0 offset=0 imm=14
+#line 132 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_JSGT_REG pc=170 dst=r3 src=r2 offset=-121 imm=0
+#line 132 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 132 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
 #line 133 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JA pc=86 dst=r0 src=r0 offset=11 imm=0
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_STXB pc=172 dst=r0 src=r1 offset=17 imm=0
 #line 133 "sample/bindmonitor.c"
-    goto label_6;
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(17)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=173 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=174 dst=r2 src=r6 offset=8 imm=0
+#line 135 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=175 dst=r2 src=r1 offset=0 imm=0
+#line 135 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=176 dst=r3 src=r0 offset=0 imm=15
+#line 135 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_JSGT_REG pc=177 dst=r3 src=r2 offset=-128 imm=0
+#line 135 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 135 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
+#line 136 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_STXB pc=179 dst=r0 src=r1 offset=18 imm=0
+#line 136 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(18)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=180 dst=r1 src=r6 offset=0 imm=0
+#line 138 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=181 dst=r2 src=r6 offset=8 imm=0
+#line 138 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=182 dst=r2 src=r1 offset=0 imm=0
+#line 138 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=183 dst=r3 src=r0 offset=0 imm=16
+#line 138 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_JSGT_REG pc=184 dst=r3 src=r2 offset=-135 imm=0
+#line 138 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 138 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
+#line 139 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_STXB pc=186 dst=r0 src=r1 offset=19 imm=0
+#line 139 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(19)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=187 dst=r1 src=r6 offset=0 imm=0
+#line 141 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=188 dst=r2 src=r6 offset=8 imm=0
+#line 141 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=189 dst=r2 src=r1 offset=0 imm=0
+#line 141 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=190 dst=r3 src=r0 offset=0 imm=17
+#line 141 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_JSGT_REG pc=191 dst=r3 src=r2 offset=-142 imm=0
+#line 141 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 141 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
+#line 142 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_STXB pc=193 dst=r0 src=r1 offset=20 imm=0
+#line 142 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(20)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=194 dst=r1 src=r6 offset=0 imm=0
+#line 144 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=195 dst=r2 src=r6 offset=8 imm=0
+#line 144 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=196 dst=r2 src=r1 offset=0 imm=0
+#line 144 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=197 dst=r3 src=r0 offset=0 imm=18
+#line 144 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_JSGT_REG pc=198 dst=r3 src=r2 offset=-149 imm=0
+#line 144 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 144 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
+#line 145 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_STXB pc=200 dst=r0 src=r1 offset=21 imm=0
+#line 145 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(21)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=201 dst=r1 src=r6 offset=0 imm=0
+#line 147 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=202 dst=r2 src=r6 offset=8 imm=0
+#line 147 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=203 dst=r2 src=r1 offset=0 imm=0
+#line 147 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=204 dst=r3 src=r0 offset=0 imm=19
+#line 147 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_JSGT_REG pc=205 dst=r3 src=r2 offset=-156 imm=0
+#line 147 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 147 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
+#line 148 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_STXB pc=207 dst=r0 src=r1 offset=22 imm=0
+#line 148 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(22)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=208 dst=r1 src=r6 offset=0 imm=0
+#line 150 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=209 dst=r2 src=r6 offset=8 imm=0
+#line 150 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=210 dst=r2 src=r1 offset=0 imm=0
+#line 150 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=211 dst=r3 src=r0 offset=0 imm=20
+#line 150 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_JSGT_REG pc=212 dst=r3 src=r2 offset=-163 imm=0
+#line 150 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 150 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
+#line 151 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_STXB pc=214 dst=r0 src=r1 offset=23 imm=0
+#line 151 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(23)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=215 dst=r1 src=r6 offset=0 imm=0
+#line 153 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=216 dst=r2 src=r6 offset=8 imm=0
+#line 153 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=217 dst=r2 src=r1 offset=0 imm=0
+#line 153 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=21
+#line 153 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_JSGT_REG pc=219 dst=r3 src=r2 offset=-170 imm=0
+#line 153 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 153 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
+#line 154 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_STXB pc=221 dst=r0 src=r1 offset=24 imm=0
+#line 154 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(24)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=222 dst=r1 src=r6 offset=0 imm=0
+#line 156 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=223 dst=r2 src=r6 offset=8 imm=0
+#line 156 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=224 dst=r2 src=r1 offset=0 imm=0
+#line 156 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=225 dst=r3 src=r0 offset=0 imm=22
+#line 156 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_JSGT_REG pc=226 dst=r3 src=r2 offset=-177 imm=0
+#line 156 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 156 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
+#line 157 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_STXB pc=228 dst=r0 src=r1 offset=25 imm=0
+#line 157 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(25)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=229 dst=r1 src=r6 offset=0 imm=0
+#line 159 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=230 dst=r2 src=r6 offset=8 imm=0
+#line 159 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=231 dst=r2 src=r1 offset=0 imm=0
+#line 159 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=232 dst=r3 src=r0 offset=0 imm=23
+#line 159 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_JSGT_REG pc=233 dst=r3 src=r2 offset=-184 imm=0
+#line 159 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 159 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
+#line 160 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_STXB pc=235 dst=r0 src=r1 offset=26 imm=0
+#line 160 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(26)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=236 dst=r1 src=r6 offset=0 imm=0
+#line 162 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=237 dst=r2 src=r6 offset=8 imm=0
+#line 162 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=238 dst=r2 src=r1 offset=0 imm=0
+#line 162 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=239 dst=r3 src=r0 offset=0 imm=24
+#line 162 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_JSGT_REG pc=240 dst=r3 src=r2 offset=-191 imm=0
+#line 162 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 162 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
+#line 163 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_STXB pc=242 dst=r0 src=r1 offset=27 imm=0
+#line 163 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(27)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=243 dst=r1 src=r6 offset=0 imm=0
+#line 165 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=244 dst=r2 src=r6 offset=8 imm=0
+#line 165 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=245 dst=r2 src=r1 offset=0 imm=0
+#line 165 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=246 dst=r3 src=r0 offset=0 imm=25
+#line 165 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_JSGT_REG pc=247 dst=r3 src=r2 offset=-198 imm=0
+#line 165 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 165 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
+#line 166 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXB pc=249 dst=r0 src=r1 offset=28 imm=0
+#line 166 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(28)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=250 dst=r1 src=r6 offset=0 imm=0
+#line 168 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=251 dst=r2 src=r6 offset=8 imm=0
+#line 168 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=252 dst=r2 src=r1 offset=0 imm=0
+#line 168 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=253 dst=r3 src=r0 offset=0 imm=26
+#line 168 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_JSGT_REG pc=254 dst=r3 src=r2 offset=-205 imm=0
+#line 168 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 168 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
+#line 169 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
+    // EBPF_OP_STXB pc=256 dst=r0 src=r1 offset=29 imm=0
+#line 169 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(29)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=257 dst=r1 src=r6 offset=0 imm=0
+#line 171 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=258 dst=r2 src=r6 offset=8 imm=0
+#line 171 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=259 dst=r2 src=r1 offset=0 imm=0
+#line 171 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=260 dst=r3 src=r0 offset=0 imm=27
+#line 171 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_JSGT_REG pc=261 dst=r3 src=r2 offset=-212 imm=0
+#line 171 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 171 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
+#line 172 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
+    // EBPF_OP_STXB pc=263 dst=r0 src=r1 offset=30 imm=0
+#line 172 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(30)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=264 dst=r1 src=r6 offset=0 imm=0
+#line 174 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=265 dst=r2 src=r6 offset=8 imm=0
+#line 174 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=266 dst=r2 src=r1 offset=0 imm=0
+#line 174 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=267 dst=r3 src=r0 offset=0 imm=28
+#line 174 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_JSGT_REG pc=268 dst=r3 src=r2 offset=-219 imm=0
+#line 174 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 174 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
+#line 175 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
+    // EBPF_OP_STXB pc=270 dst=r0 src=r1 offset=31 imm=0
+#line 175 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(31)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=271 dst=r1 src=r6 offset=0 imm=0
+#line 177 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=272 dst=r2 src=r6 offset=8 imm=0
+#line 177 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=273 dst=r2 src=r1 offset=0 imm=0
+#line 177 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=274 dst=r3 src=r0 offset=0 imm=29
+#line 177 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_JSGT_REG pc=275 dst=r3 src=r2 offset=-226 imm=0
+#line 177 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 177 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
+#line 178 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXB pc=277 dst=r0 src=r1 offset=32 imm=0
+#line 178 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(32)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=278 dst=r1 src=r6 offset=0 imm=0
+#line 180 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=279 dst=r2 src=r6 offset=8 imm=0
+#line 180 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=280 dst=r2 src=r1 offset=0 imm=0
+#line 180 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=281 dst=r3 src=r0 offset=0 imm=30
+#line 180 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_JSGT_REG pc=282 dst=r3 src=r2 offset=-233 imm=0
+#line 180 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 180 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
+#line 181 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_STXB pc=284 dst=r0 src=r1 offset=33 imm=0
+#line 181 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(33)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=285 dst=r1 src=r6 offset=0 imm=0
+#line 183 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=286 dst=r2 src=r6 offset=8 imm=0
+#line 183 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=287 dst=r2 src=r1 offset=0 imm=0
+#line 183 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=288 dst=r3 src=r0 offset=0 imm=31
+#line 183 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(31);
+    // EBPF_OP_JSGT_REG pc=289 dst=r3 src=r2 offset=-240 imm=0
+#line 183 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 183 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
+#line 184 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_STXB pc=291 dst=r0 src=r1 offset=34 imm=0
+#line 184 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(34)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=292 dst=r1 src=r6 offset=0 imm=0
+#line 186 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=293 dst=r2 src=r6 offset=8 imm=0
+#line 186 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=294 dst=r2 src=r1 offset=0 imm=0
+#line 186 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=295 dst=r3 src=r0 offset=0 imm=32
+#line 186 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=296 dst=r3 src=r2 offset=-247 imm=0
+#line 186 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 186 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
+#line 187 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_STXB pc=298 dst=r0 src=r1 offset=35 imm=0
+#line 187 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(35)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=299 dst=r1 src=r6 offset=0 imm=0
+#line 189 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=300 dst=r2 src=r6 offset=8 imm=0
+#line 189 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=301 dst=r2 src=r1 offset=0 imm=0
+#line 189 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=302 dst=r3 src=r0 offset=0 imm=33
+#line 189 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(33);
+    // EBPF_OP_JSGT_REG pc=303 dst=r3 src=r2 offset=-254 imm=0
+#line 189 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 189 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
+#line 190 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_STXB pc=305 dst=r0 src=r1 offset=36 imm=0
+#line 190 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(36)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=306 dst=r1 src=r6 offset=0 imm=0
+#line 192 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=307 dst=r2 src=r6 offset=8 imm=0
+#line 192 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=308 dst=r2 src=r1 offset=0 imm=0
+#line 192 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=309 dst=r3 src=r0 offset=0 imm=34
+#line 192 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(34);
+    // EBPF_OP_JSGT_REG pc=310 dst=r3 src=r2 offset=-261 imm=0
+#line 192 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 192 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
+#line 193 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_STXB pc=312 dst=r0 src=r1 offset=37 imm=0
+#line 193 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(37)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=313 dst=r1 src=r6 offset=0 imm=0
+#line 195 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=314 dst=r2 src=r6 offset=8 imm=0
+#line 195 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=315 dst=r2 src=r1 offset=0 imm=0
+#line 195 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=316 dst=r3 src=r0 offset=0 imm=35
+#line 195 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(35);
+    // EBPF_OP_JSGT_REG pc=317 dst=r3 src=r2 offset=-268 imm=0
+#line 195 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 195 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
+#line 196 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_STXB pc=319 dst=r0 src=r1 offset=38 imm=0
+#line 196 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(38)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=320 dst=r1 src=r6 offset=0 imm=0
+#line 198 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=321 dst=r2 src=r6 offset=8 imm=0
+#line 198 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=322 dst=r2 src=r1 offset=0 imm=0
+#line 198 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=323 dst=r3 src=r0 offset=0 imm=36
+#line 198 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(36);
+    // EBPF_OP_JSGT_REG pc=324 dst=r3 src=r2 offset=-275 imm=0
+#line 198 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 198 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
+#line 199 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_STXB pc=326 dst=r0 src=r1 offset=39 imm=0
+#line 199 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(39)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=327 dst=r1 src=r6 offset=0 imm=0
+#line 201 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=328 dst=r2 src=r6 offset=8 imm=0
+#line 201 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=329 dst=r2 src=r1 offset=0 imm=0
+#line 201 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=330 dst=r3 src=r0 offset=0 imm=37
+#line 201 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(37);
+    // EBPF_OP_JSGT_REG pc=331 dst=r3 src=r2 offset=-282 imm=0
+#line 201 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 201 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
+#line 202 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_STXB pc=333 dst=r0 src=r1 offset=40 imm=0
+#line 202 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(40)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=334 dst=r1 src=r6 offset=0 imm=0
+#line 204 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=335 dst=r2 src=r6 offset=8 imm=0
+#line 204 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=336 dst=r2 src=r1 offset=0 imm=0
+#line 204 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=337 dst=r3 src=r0 offset=0 imm=38
+#line 204 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(38);
+    // EBPF_OP_JSGT_REG pc=338 dst=r3 src=r2 offset=-289 imm=0
+#line 204 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 204 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
+#line 205 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_STXB pc=340 dst=r0 src=r1 offset=41 imm=0
+#line 205 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(41)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=341 dst=r1 src=r6 offset=0 imm=0
+#line 207 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=342 dst=r2 src=r6 offset=8 imm=0
+#line 207 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=343 dst=r2 src=r1 offset=0 imm=0
+#line 207 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=344 dst=r3 src=r0 offset=0 imm=39
+#line 207 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(39);
+    // EBPF_OP_JSGT_REG pc=345 dst=r3 src=r2 offset=-296 imm=0
+#line 207 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 207 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
+#line 208 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_STXB pc=347 dst=r0 src=r1 offset=42 imm=0
+#line 208 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(42)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=348 dst=r1 src=r6 offset=0 imm=0
+#line 210 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=349 dst=r2 src=r6 offset=8 imm=0
+#line 210 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=350 dst=r2 src=r1 offset=0 imm=0
+#line 210 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=351 dst=r3 src=r0 offset=0 imm=40
+#line 210 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(40);
+    // EBPF_OP_JSGT_REG pc=352 dst=r3 src=r2 offset=-303 imm=0
+#line 210 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 210 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
+#line 211 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_STXB pc=354 dst=r0 src=r1 offset=43 imm=0
+#line 211 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(43)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=355 dst=r1 src=r6 offset=0 imm=0
+#line 213 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=356 dst=r2 src=r6 offset=8 imm=0
+#line 213 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=357 dst=r2 src=r1 offset=0 imm=0
+#line 213 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=358 dst=r3 src=r0 offset=0 imm=41
+#line 213 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(41);
+    // EBPF_OP_JSGT_REG pc=359 dst=r3 src=r2 offset=-310 imm=0
+#line 213 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 213 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
+#line 214 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_STXB pc=361 dst=r0 src=r1 offset=44 imm=0
+#line 214 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(44)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=362 dst=r1 src=r6 offset=0 imm=0
+#line 216 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=363 dst=r2 src=r6 offset=8 imm=0
+#line 216 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=364 dst=r2 src=r1 offset=0 imm=0
+#line 216 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=365 dst=r3 src=r0 offset=0 imm=42
+#line 216 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(42);
+    // EBPF_OP_JSGT_REG pc=366 dst=r3 src=r2 offset=-317 imm=0
+#line 216 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 216 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
+#line 217 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_STXB pc=368 dst=r0 src=r1 offset=45 imm=0
+#line 217 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(45)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=369 dst=r1 src=r6 offset=0 imm=0
+#line 219 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=370 dst=r2 src=r6 offset=8 imm=0
+#line 219 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=371 dst=r2 src=r1 offset=0 imm=0
+#line 219 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=372 dst=r3 src=r0 offset=0 imm=43
+#line 219 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(43);
+    // EBPF_OP_JSGT_REG pc=373 dst=r3 src=r2 offset=-324 imm=0
+#line 219 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 219 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
+#line 220 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_STXB pc=375 dst=r0 src=r1 offset=46 imm=0
+#line 220 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(46)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=376 dst=r1 src=r6 offset=0 imm=0
+#line 222 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=377 dst=r2 src=r6 offset=8 imm=0
+#line 222 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=378 dst=r2 src=r1 offset=0 imm=0
+#line 222 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=379 dst=r3 src=r0 offset=0 imm=44
+#line 222 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(44);
+    // EBPF_OP_JSGT_REG pc=380 dst=r3 src=r2 offset=-331 imm=0
+#line 222 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 222 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
+#line 223 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_STXB pc=382 dst=r0 src=r1 offset=47 imm=0
+#line 223 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(47)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=383 dst=r1 src=r6 offset=0 imm=0
+#line 225 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=384 dst=r2 src=r6 offset=8 imm=0
+#line 225 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=385 dst=r2 src=r1 offset=0 imm=0
+#line 225 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=386 dst=r3 src=r0 offset=0 imm=45
+#line 225 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(45);
+    // EBPF_OP_JSGT_REG pc=387 dst=r3 src=r2 offset=-338 imm=0
+#line 225 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 225 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
+#line 226 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXB pc=389 dst=r0 src=r1 offset=48 imm=0
+#line 226 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(48)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=390 dst=r1 src=r6 offset=0 imm=0
+#line 228 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=391 dst=r2 src=r6 offset=8 imm=0
+#line 228 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=392 dst=r2 src=r1 offset=0 imm=0
+#line 228 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=393 dst=r3 src=r0 offset=0 imm=46
+#line 228 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(46);
+    // EBPF_OP_JSGT_REG pc=394 dst=r3 src=r2 offset=-345 imm=0
+#line 228 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 228 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
+#line 229 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
+    // EBPF_OP_STXB pc=396 dst=r0 src=r1 offset=49 imm=0
+#line 229 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(49)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=397 dst=r1 src=r6 offset=0 imm=0
+#line 231 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=398 dst=r2 src=r6 offset=8 imm=0
+#line 231 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=399 dst=r2 src=r1 offset=0 imm=0
+#line 231 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=400 dst=r3 src=r0 offset=0 imm=47
+#line 231 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(47);
+    // EBPF_OP_JSGT_REG pc=401 dst=r3 src=r2 offset=-352 imm=0
+#line 231 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 231 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
+#line 232 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
+    // EBPF_OP_STXB pc=403 dst=r0 src=r1 offset=50 imm=0
+#line 232 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(50)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=404 dst=r1 src=r6 offset=0 imm=0
+#line 234 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=405 dst=r2 src=r6 offset=8 imm=0
+#line 234 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=406 dst=r2 src=r1 offset=0 imm=0
+#line 234 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=407 dst=r3 src=r0 offset=0 imm=48
+#line 234 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(48);
+    // EBPF_OP_JSGT_REG pc=408 dst=r3 src=r2 offset=-359 imm=0
+#line 234 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 234 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
+#line 235 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
+    // EBPF_OP_STXB pc=410 dst=r0 src=r1 offset=51 imm=0
+#line 235 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(51)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=411 dst=r1 src=r6 offset=0 imm=0
+#line 237 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=412 dst=r2 src=r6 offset=8 imm=0
+#line 237 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=413 dst=r2 src=r1 offset=0 imm=0
+#line 237 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=414 dst=r3 src=r0 offset=0 imm=49
+#line 237 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(49);
+    // EBPF_OP_JSGT_REG pc=415 dst=r3 src=r2 offset=-366 imm=0
+#line 237 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 237 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
+#line 238 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXB pc=417 dst=r0 src=r1 offset=52 imm=0
+#line 238 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(52)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=418 dst=r1 src=r6 offset=0 imm=0
+#line 240 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=419 dst=r2 src=r6 offset=8 imm=0
+#line 240 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=420 dst=r2 src=r1 offset=0 imm=0
+#line 240 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=421 dst=r3 src=r0 offset=0 imm=50
+#line 240 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(50);
+    // EBPF_OP_JSGT_REG pc=422 dst=r3 src=r2 offset=-373 imm=0
+#line 240 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 240 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
+#line 241 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
+    // EBPF_OP_STXB pc=424 dst=r0 src=r1 offset=53 imm=0
+#line 241 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(53)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=425 dst=r1 src=r6 offset=0 imm=0
+#line 243 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=426 dst=r2 src=r6 offset=8 imm=0
+#line 243 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=427 dst=r2 src=r1 offset=0 imm=0
+#line 243 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=428 dst=r3 src=r0 offset=0 imm=51
+#line 243 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(51);
+    // EBPF_OP_JSGT_REG pc=429 dst=r3 src=r2 offset=-380 imm=0
+#line 243 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 243 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
+#line 244 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
+    // EBPF_OP_STXB pc=431 dst=r0 src=r1 offset=54 imm=0
+#line 244 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(54)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=432 dst=r1 src=r6 offset=0 imm=0
+#line 246 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=433 dst=r2 src=r6 offset=8 imm=0
+#line 246 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=434 dst=r2 src=r1 offset=0 imm=0
+#line 246 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=435 dst=r3 src=r0 offset=0 imm=52
+#line 246 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(52);
+    // EBPF_OP_JSGT_REG pc=436 dst=r3 src=r2 offset=-387 imm=0
+#line 246 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 246 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
+#line 247 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
+    // EBPF_OP_STXB pc=438 dst=r0 src=r1 offset=55 imm=0
+#line 247 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(55)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=439 dst=r1 src=r6 offset=0 imm=0
+#line 249 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=440 dst=r2 src=r6 offset=8 imm=0
+#line 249 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=441 dst=r2 src=r1 offset=0 imm=0
+#line 249 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=442 dst=r3 src=r0 offset=0 imm=53
+#line 249 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(53);
+    // EBPF_OP_JSGT_REG pc=443 dst=r3 src=r2 offset=-394 imm=0
+#line 249 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 249 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
+#line 250 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
+    // EBPF_OP_STXB pc=445 dst=r0 src=r1 offset=56 imm=0
+#line 250 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(56)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=446 dst=r1 src=r6 offset=0 imm=0
+#line 252 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=447 dst=r2 src=r6 offset=8 imm=0
+#line 252 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=448 dst=r2 src=r1 offset=0 imm=0
+#line 252 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=449 dst=r3 src=r0 offset=0 imm=54
+#line 252 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(54);
+    // EBPF_OP_JSGT_REG pc=450 dst=r3 src=r2 offset=-401 imm=0
+#line 252 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 252 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
+#line 253 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
+    // EBPF_OP_STXB pc=452 dst=r0 src=r1 offset=57 imm=0
+#line 253 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(57)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=453 dst=r1 src=r6 offset=0 imm=0
+#line 255 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=454 dst=r2 src=r6 offset=8 imm=0
+#line 255 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=455 dst=r2 src=r1 offset=0 imm=0
+#line 255 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=456 dst=r3 src=r0 offset=0 imm=55
+#line 255 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(55);
+    // EBPF_OP_JSGT_REG pc=457 dst=r3 src=r2 offset=-408 imm=0
+#line 255 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 255 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
+#line 256 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
+    // EBPF_OP_STXB pc=459 dst=r0 src=r1 offset=58 imm=0
+#line 256 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(58)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=460 dst=r1 src=r6 offset=0 imm=0
+#line 258 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=461 dst=r2 src=r6 offset=8 imm=0
+#line 258 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=462 dst=r2 src=r1 offset=0 imm=0
+#line 258 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=463 dst=r3 src=r0 offset=0 imm=56
+#line 258 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(56);
+    // EBPF_OP_JSGT_REG pc=464 dst=r3 src=r2 offset=-415 imm=0
+#line 258 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 258 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
+#line 259 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
+    // EBPF_OP_STXB pc=466 dst=r0 src=r1 offset=59 imm=0
+#line 259 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(59)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=467 dst=r1 src=r6 offset=0 imm=0
+#line 261 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=468 dst=r2 src=r6 offset=8 imm=0
+#line 261 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=469 dst=r2 src=r1 offset=0 imm=0
+#line 261 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=470 dst=r3 src=r0 offset=0 imm=57
+#line 261 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(57);
+    // EBPF_OP_JSGT_REG pc=471 dst=r3 src=r2 offset=-422 imm=0
+#line 261 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 261 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
+#line 262 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=473 dst=r0 src=r1 offset=60 imm=0
+#line 262 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(60)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=474 dst=r1 src=r6 offset=0 imm=0
+#line 264 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=475 dst=r2 src=r6 offset=8 imm=0
+#line 264 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=476 dst=r2 src=r1 offset=0 imm=0
+#line 264 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=477 dst=r3 src=r0 offset=0 imm=58
+#line 264 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(58);
+    // EBPF_OP_JSGT_REG pc=478 dst=r3 src=r2 offset=-429 imm=0
+#line 264 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 264 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
+#line 265 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
+    // EBPF_OP_STXB pc=480 dst=r0 src=r1 offset=61 imm=0
+#line 265 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(61)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=481 dst=r1 src=r6 offset=0 imm=0
+#line 267 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=482 dst=r2 src=r6 offset=8 imm=0
+#line 267 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=483 dst=r2 src=r1 offset=0 imm=0
+#line 267 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=484 dst=r3 src=r0 offset=0 imm=59
+#line 267 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(59);
+    // EBPF_OP_JSGT_REG pc=485 dst=r3 src=r2 offset=-436 imm=0
+#line 267 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 267 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
+#line 268 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
+    // EBPF_OP_STXB pc=487 dst=r0 src=r1 offset=62 imm=0
+#line 268 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(62)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=488 dst=r1 src=r6 offset=0 imm=0
+#line 270 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=489 dst=r2 src=r6 offset=8 imm=0
+#line 270 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=490 dst=r2 src=r1 offset=0 imm=0
+#line 270 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=491 dst=r3 src=r0 offset=0 imm=60
+#line 270 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(60);
+    // EBPF_OP_JSGT_REG pc=492 dst=r3 src=r2 offset=-443 imm=0
+#line 270 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 270 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
+#line 271 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
+    // EBPF_OP_STXB pc=494 dst=r0 src=r1 offset=63 imm=0
+#line 271 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(63)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=495 dst=r1 src=r6 offset=0 imm=0
+#line 273 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=496 dst=r2 src=r6 offset=8 imm=0
+#line 273 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=497 dst=r2 src=r1 offset=0 imm=0
+#line 273 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=498 dst=r3 src=r0 offset=0 imm=61
+#line 273 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(61);
+    // EBPF_OP_JSGT_REG pc=499 dst=r3 src=r2 offset=-450 imm=0
+#line 273 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 273 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
+#line 274 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
+    // EBPF_OP_STXB pc=501 dst=r0 src=r1 offset=64 imm=0
+#line 274 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(64)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=502 dst=r1 src=r6 offset=0 imm=0
+#line 276 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=503 dst=r2 src=r6 offset=8 imm=0
+#line 276 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=504 dst=r2 src=r1 offset=0 imm=0
+#line 276 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=505 dst=r3 src=r0 offset=0 imm=62
+#line 276 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(62);
+    // EBPF_OP_JSGT_REG pc=506 dst=r3 src=r2 offset=-457 imm=0
+#line 276 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 276 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
+#line 277 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
+    // EBPF_OP_STXB pc=508 dst=r0 src=r1 offset=65 imm=0
+#line 277 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(65)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=509 dst=r1 src=r6 offset=0 imm=0
+#line 279 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=510 dst=r2 src=r6 offset=8 imm=0
+#line 279 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=511 dst=r2 src=r1 offset=0 imm=0
+#line 279 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=512 dst=r3 src=r0 offset=0 imm=63
+#line 279 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(63);
+    // EBPF_OP_JSGT_REG pc=513 dst=r3 src=r2 offset=-464 imm=0
+#line 279 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 279 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
+#line 280 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
+    // EBPF_OP_STXB pc=515 dst=r0 src=r1 offset=66 imm=0
+#line 280 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(66)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=516 dst=r1 src=r6 offset=0 imm=0
+#line 282 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=517 dst=r2 src=r6 offset=8 imm=0
+#line 282 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=518 dst=r2 src=r1 offset=0 imm=0
+#line 282 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=519 dst=r3 src=r0 offset=0 imm=64
+#line 282 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_JSGT_REG pc=520 dst=r3 src=r2 offset=-471 imm=0
+#line 282 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 282 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
+#line 283 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
+    // EBPF_OP_STXB pc=522 dst=r0 src=r1 offset=67 imm=0
+#line 283 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(67)) = (uint8_t)r1;
+    // EBPF_OP_JA pc=523 dst=r0 src=r0 offset=-474 imm=0
+#line 283 "sample/bindmonitor.c"
+    goto label_2;
 label_4:
-    // EBPF_OP_MOV64_IMM pc=87 dst=r8 src=r0 offset=0 imm=1
-#line 133 "sample/bindmonitor.c"
-    r8 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=88 dst=r1 src=r0 offset=0 imm=0
-#line 119 "sample/bindmonitor.c"
+    // EBPF_OP_LDXW pc=524 dst=r1 src=r0 offset=0 imm=0
+#line 322 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_LDXW pc=89 dst=r2 src=r7 offset=0 imm=0
-#line 119 "sample/bindmonitor.c"
-    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JGE_REG pc=90 dst=r1 src=r2 offset=19 imm=0
-#line 119 "sample/bindmonitor.c"
-    if (r1 >= r2)
-#line 119 "sample/bindmonitor.c"
-        goto label_9;
-        // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=1
-#line 123 "sample/bindmonitor.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=92 dst=r0 src=r1 offset=0 imm=0
-#line 123 "sample/bindmonitor.c"
-    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_JA pc=93 dst=r0 src=r0 offset=15 imm=0
-#line 123 "sample/bindmonitor.c"
-    goto label_8;
-label_5:
-    // EBPF_OP_LDXW pc=94 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=95 dst=r1 src=r0 offset=6 imm=0
-#line 126 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=525 dst=r1 src=r0 offset=6 imm=0
+#line 322 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
-#line 126 "sample/bindmonitor.c"
-        goto label_7;
-        // EBPF_OP_ADD64_IMM pc=96 dst=r1 src=r0 offset=0 imm=-1
-#line 127 "sample/bindmonitor.c"
+#line 322 "sample/bindmonitor.c"
+        goto label_6;
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
+#line 323 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
-    // EBPF_OP_STXW pc=97 dst=r0 src=r1 offset=0 imm=0
-#line 127 "sample/bindmonitor.c"
+    // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
+#line 323 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-label_6:
-    // EBPF_OP_MOV64_IMM pc=98 dst=r8 src=r0 offset=0 imm=0
-#line 127 "sample/bindmonitor.c"
+label_5:
+    // EBPF_OP_MOV64_IMM pc=528 dst=r8 src=r0 offset=0 imm=0
+#line 323 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
-    // EBPF_OP_LSH64_IMM pc=99 dst=r1 src=r0 offset=0 imm=32
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_LSH64_IMM pc=529 dst=r1 src=r0 offset=0 imm=32
+#line 329 "sample/bindmonitor.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=100 dst=r1 src=r0 offset=0 imm=32
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_RSH64_IMM pc=530 dst=r1 src=r0 offset=0 imm=32
+#line 329 "sample/bindmonitor.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=101 dst=r1 src=r0 offset=8 imm=0
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_JNE_IMM pc=531 dst=r1 src=r0 offset=15 imm=0
+#line 329 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
-#line 133 "sample/bindmonitor.c"
+#line 329 "sample/bindmonitor.c"
         goto label_9;
-label_7:
-    // EBPF_OP_LDXDW pc=102 dst=r1 src=r6 offset=16 imm=0
-#line 134 "sample/bindmonitor.c"
+label_6:
+    // EBPF_OP_LDXDW pc=532 dst=r1 src=r6 offset=16 imm=0
+#line 330 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
-    // EBPF_OP_STXDW pc=103 dst=r10 src=r1 offset=-80 imm=0
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_STXDW pc=533 dst=r10 src=r1 offset=-80 imm=0
+#line 330 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=104 dst=r2 src=r10 offset=0 imm=0
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_REG pc=534 dst=r2 src=r10 offset=0 imm=0
+#line 330 "sample/bindmonitor.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=105 dst=r2 src=r0 offset=0 imm=-80
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_ADD64_IMM pc=535 dst=r2 src=r0 offset=0 imm=-80
+#line 330 "sample/bindmonitor.c"
     r2 += IMMEDIATE(-80);
-    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_LDDW pc=536 dst=r1 src=r0 offset=0 imm=0
+#line 331 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=108 dst=r0 src=r0 offset=0 imm=3
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_CALL pc=538 dst=r0 src=r0 offset=0 imm=3
+#line 331 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[5].address
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
          (r1, r2, r3, r4, r5);
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
     if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
         return 0;
+        // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
+#line 331 "sample/bindmonitor.c"
+    goto label_8;
+label_7:
+    // EBPF_OP_MOV64_IMM pc=540 dst=r8 src=r0 offset=0 imm=1
+#line 331 "sample/bindmonitor.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=541 dst=r1 src=r0 offset=0 imm=0
+#line 315 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_LDXW pc=542 dst=r2 src=r7 offset=0 imm=0
+#line 315 "sample/bindmonitor.c"
+    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_JGE_REG pc=543 dst=r1 src=r2 offset=3 imm=0
+#line 315 "sample/bindmonitor.c"
+    if (r1 >= r2)
+#line 315 "sample/bindmonitor.c"
+        goto label_9;
+        // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
+#line 319 "sample/bindmonitor.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=545 dst=r0 src=r1 offset=0 imm=0
+#line 319 "sample/bindmonitor.c"
+    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
 label_8:
-    // EBPF_OP_MOV64_IMM pc=109 dst=r8 src=r0 offset=0 imm=0
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_IMM pc=546 dst=r8 src=r0 offset=0 imm=0
+#line 319 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
 label_9:
-    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r8 offset=0 imm=0
-#line 139 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_REG pc=547 dst=r0 src=r8 offset=0 imm=0
+#line 335 "sample/bindmonitor.c"
     r0 = r8;
-    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
-#line 139 "sample/bindmonitor.c"
+    // EBPF_OP_EXIT pc=548 dst=r0 src=r0 offset=0 imm=0
+#line 335 "sample/bindmonitor.c"
     return r0;
-#line 139 "sample/bindmonitor.c"
+#line 335 "sample/bindmonitor.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -542,7 +1977,7 @@ static program_entry_t _programs[] = {
         3,
         BindMonitor_helpers,
         6,
-        112,
+        549,
         &BindMonitor_program_type_guid,
         &BindMonitor_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -249,48 +249,46 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
 {
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     // Prologue
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r0 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r1 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r2 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r3 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r4 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r5 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r6 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r7 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r8 = 0;
-#line 100 "sample/bindmonitor.c"
-    register uint64_t r9 = 0;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     register uint64_t r10 = 0;
 
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r1 = (uintptr_t)context;
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r8 src=r0 offset=0 imm=0
-#line 100 "sample/bindmonitor.c"
+#line 296 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r8 offset=-84 imm=0
-#line 102 "sample/bindmonitor.c"
+#line 298 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_CALL pc=3 dst=r0 src=r0 offset=0 imm=19
 #line 52 "sample/bindmonitor.c"
@@ -374,32 +372,32 @@ BindMonitor(void* context)
 #line 58 "sample/bindmonitor.c"
     r2 += IMMEDIATE(-84);
     // EBPF_OP_LDDW pc=23 dst=r1 src=r0 offset=0 imm=0
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r1 = POINTER(_maps[2].address);
     // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=1
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[4].address
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
          (r1, r2, r3, r4, r5);
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
-#line 107 "sample/bindmonitor.c"
+#line 303 "sample/bindmonitor.c"
     r7 = r0;
-    // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=82 imm=0
-#line 108 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=519 imm=0
+#line 304 "sample/bindmonitor.c"
     if (r7 == IMMEDIATE(0))
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
         goto label_9;
         // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=80 imm=0
-#line 108 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=517 imm=0
+#line 304 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
-#line 108 "sample/bindmonitor.c"
+#line 304 "sample/bindmonitor.c"
         goto label_9;
         // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 64 "sample/bindmonitor.c"
@@ -455,64 +453,87 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 69 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
 #line 70 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 70 "sample/bindmonitor.c"
-        goto label_1;
-        // EBPF_OP_JA pc=48 dst=r0 src=r0 offset=33 imm=0
-#line 70 "sample/bindmonitor.c"
-    goto label_3;
+        goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=49 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_MOV64_IMM pc=48 dst=r8 src=r0 offset=0 imm=0
+#line 70 "sample/bindmonitor.c"
+    r8 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=49 dst=r0 src=r0 offset=497 imm=0
+#line 309 "sample/bindmonitor.c"
+    if (r0 == IMMEDIATE(0))
+#line 309 "sample/bindmonitor.c"
+        goto label_9;
+label_2:
+    // EBPF_OP_LDXW pc=50 dst=r1 src=r6 offset=44 imm=0
+#line 313 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=51 dst=r1 src=r0 offset=488 imm=0
+#line 313 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(0))
+#line 313 "sample/bindmonitor.c"
+        goto label_7;
+        // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
+#line 313 "sample/bindmonitor.c"
+    if (r1 == IMMEDIATE(2))
+#line 313 "sample/bindmonitor.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
+#line 329 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_JA pc=54 dst=r0 src=r0 offset=473 imm=0
+#line 329 "sample/bindmonitor.c"
+    goto label_5;
+label_3:
+    // EBPF_OP_LDXW pc=55 dst=r1 src=r6 offset=44 imm=0
 #line 73 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JNE_IMM pc=50 dst=r1 src=r0 offset=58 imm=0
+    // EBPF_OP_JNE_IMM pc=56 dst=r1 src=r0 offset=489 imm=0
 #line 73 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
 #line 73 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=51 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=56 imm=0
+    // EBPF_OP_JEQ_IMM pc=58 dst=r1 src=r0 offset=487 imm=0
 #line 76 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
 #line 76 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=53 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
 #line 76 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JEQ_IMM pc=54 dst=r1 src=r0 offset=54 imm=0
+    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=485 imm=0
 #line 76 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
 #line 76 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=55 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r8 = r10;
-    // EBPF_OP_ADD64_IMM pc=56 dst=r8 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=62 dst=r8 src=r0 offset=0 imm=-8
 #line 76 "sample/bindmonitor.c"
     r8 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=57 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=63 dst=r3 src=r10 offset=0 imm=0
 #line 76 "sample/bindmonitor.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r3 src=r0 offset=0 imm=-80
+    // EBPF_OP_ADD64_IMM pc=64 dst=r3 src=r0 offset=0 imm=-80
 #line 76 "sample/bindmonitor.c"
     r3 += IMMEDIATE(-80);
-    // EBPF_OP_MOV64_IMM pc=59 dst=r9 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=65 dst=r1 src=r0 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=62 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=67 dst=r2 src=r8 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r2 = r8;
-    // EBPF_OP_MOV64_IMM pc=63 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=68 dst=r4 src=r0 offset=0 imm=0
 #line 79 "sample/bindmonitor.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=2
 #line 79 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[3].address
 #line 79 "sample/bindmonitor.c"
@@ -521,13 +542,13 @@ label_1:
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 79 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_LDDW pc=65 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 80 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=67 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=72 dst=r2 src=r8 offset=0 imm=0
 #line 80 "sample/bindmonitor.c"
     r2 = r8;
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=1
 #line 80 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[4].address
 #line 80 "sample/bindmonitor.c"
@@ -536,163 +557,1577 @@ label_1:
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 80 "sample/bindmonitor.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=69 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
 #line 81 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 81 "sample/bindmonitor.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=70 dst=r1 src=r0 offset=0 imm=0
-#line 81 "sample/bindmonitor.c"
-    r1 = r0;
-    // EBPF_OP_ADD64_IMM pc=71 dst=r1 src=r0 offset=0 imm=4
-#line 81 "sample/bindmonitor.c"
-    r1 += IMMEDIATE(4);
-label_2:
-    // EBPF_OP_LDXDW pc=72 dst=r2 src=r6 offset=0 imm=0
-#line 85 "sample/bindmonitor.c"
-    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_ADD64_REG pc=73 dst=r2 src=r9 offset=0 imm=0
-#line 85 "sample/bindmonitor.c"
-    r2 += r9;
-    // EBPF_OP_LDXDW pc=74 dst=r3 src=r6 offset=8 imm=0
-#line 85 "sample/bindmonitor.c"
-    r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JGE_REG pc=75 dst=r2 src=r3 offset=6 imm=0
-#line 85 "sample/bindmonitor.c"
-    if (r2 >= r3)
-#line 85 "sample/bindmonitor.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=76 dst=r3 src=r1 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=77 dst=r3 src=r9 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r3 += r9;
-    // EBPF_OP_LDXB pc=78 dst=r2 src=r2 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXB pc=79 dst=r3 src=r2 offset=0 imm=0
-#line 88 "sample/bindmonitor.c"
-    *(uint8_t*)(uintptr_t)(r3 + OFFSET(0)) = (uint8_t)r2;
-    // EBPF_OP_ADD64_IMM pc=80 dst=r9 src=r0 offset=0 imm=1
-#line 84 "sample/bindmonitor.c"
-    r9 += IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=81 dst=r9 src=r0 offset=-10 imm=64
-#line 84 "sample/bindmonitor.c"
-    if (r9 != IMMEDIATE(64))
-#line 84 "sample/bindmonitor.c"
+        // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=76 dst=r2 src=r6 offset=8 imm=0
+#line 93 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=77 dst=r2 src=r1 offset=0 imm=0
+#line 93 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=78 dst=r3 src=r0 offset=0 imm=1
+#line 93 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_JSGT_REG pc=79 dst=r3 src=r2 offset=-32 imm=0
+#line 93 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 93 "sample/bindmonitor.c"
+        goto label_1;
+        // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
+#line 94 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_STXB pc=81 dst=r0 src=r1 offset=4 imm=0
+#line 94 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(4)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=82 dst=r1 src=r6 offset=0 imm=0
+#line 96 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=83 dst=r2 src=r6 offset=8 imm=0
+#line 96 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=84 dst=r2 src=r1 offset=0 imm=0
+#line 96 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=85 dst=r3 src=r0 offset=0 imm=2
+#line 96 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_JSGT_REG pc=86 dst=r3 src=r2 offset=-37 imm=0
+#line 96 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 96 "sample/bindmonitor.c"
         goto label_2;
-label_3:
-    // EBPF_OP_LDXW pc=82 dst=r1 src=r6 offset=44 imm=0
+        // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
+#line 97 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
+    // EBPF_OP_STXB pc=88 dst=r0 src=r1 offset=5 imm=0
+#line 97 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(5)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=89 dst=r1 src=r6 offset=0 imm=0
+#line 99 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=90 dst=r2 src=r6 offset=8 imm=0
+#line 99 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=91 dst=r2 src=r1 offset=0 imm=0
+#line 99 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=92 dst=r3 src=r0 offset=0 imm=3
+#line 99 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_JSGT_REG pc=93 dst=r3 src=r2 offset=-44 imm=0
+#line 99 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 99 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
+#line 100 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
+    // EBPF_OP_STXB pc=95 dst=r0 src=r1 offset=6 imm=0
+#line 100 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(6)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=96 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=97 dst=r2 src=r6 offset=8 imm=0
+#line 102 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=98 dst=r2 src=r1 offset=0 imm=0
+#line 102 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=99 dst=r3 src=r0 offset=0 imm=4
+#line 102 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_JSGT_REG pc=100 dst=r3 src=r2 offset=-51 imm=0
+#line 102 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 102 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
+#line 103 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
+    // EBPF_OP_STXB pc=102 dst=r0 src=r1 offset=7 imm=0
+#line 103 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(7)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=103 dst=r1 src=r6 offset=0 imm=0
+#line 105 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=104 dst=r2 src=r6 offset=8 imm=0
+#line 105 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=105 dst=r2 src=r1 offset=0 imm=0
+#line 105 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=106 dst=r3 src=r0 offset=0 imm=5
+#line 105 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_JSGT_REG pc=107 dst=r3 src=r2 offset=-58 imm=0
+#line 105 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 105 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
+#line 106 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_STXB pc=109 dst=r0 src=r1 offset=8 imm=0
+#line 106 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(8)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=110 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=111 dst=r2 src=r6 offset=8 imm=0
+#line 108 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=112 dst=r2 src=r1 offset=0 imm=0
+#line 108 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=113 dst=r3 src=r0 offset=0 imm=6
+#line 108 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_JSGT_REG pc=114 dst=r3 src=r2 offset=-65 imm=0
+#line 108 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 108 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
+#line 109 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
+    // EBPF_OP_STXB pc=116 dst=r0 src=r1 offset=9 imm=0
+#line 109 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(9)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=117 dst=r1 src=r6 offset=0 imm=0
+#line 111 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=118 dst=r2 src=r6 offset=8 imm=0
+#line 111 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=119 dst=r2 src=r1 offset=0 imm=0
+#line 111 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=120 dst=r3 src=r0 offset=0 imm=7
+#line 111 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_JSGT_REG pc=121 dst=r3 src=r2 offset=-72 imm=0
+#line 111 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 111 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
+#line 112 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
+    // EBPF_OP_STXB pc=123 dst=r0 src=r1 offset=10 imm=0
+#line 112 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(10)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=124 dst=r1 src=r6 offset=0 imm=0
+#line 114 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=125 dst=r2 src=r6 offset=8 imm=0
+#line 114 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=126 dst=r2 src=r1 offset=0 imm=0
+#line 114 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=127 dst=r3 src=r0 offset=0 imm=8
+#line 114 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_JSGT_REG pc=128 dst=r3 src=r2 offset=-79 imm=0
+#line 114 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 114 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
+#line 115 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
+    // EBPF_OP_STXB pc=130 dst=r0 src=r1 offset=11 imm=0
+#line 115 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(11)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=131 dst=r1 src=r6 offset=0 imm=0
 #line 117 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=83 dst=r1 src=r0 offset=3 imm=0
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=132 dst=r2 src=r6 offset=8 imm=0
 #line 117 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(0))
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=133 dst=r2 src=r1 offset=0 imm=0
 #line 117 "sample/bindmonitor.c"
-        goto label_4;
-        // EBPF_OP_JEQ_IMM pc=84 dst=r1 src=r0 offset=9 imm=2
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=134 dst=r3 src=r0 offset=0 imm=9
 #line 117 "sample/bindmonitor.c"
-    if (r1 == IMMEDIATE(2))
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_JSGT_REG pc=135 dst=r3 src=r2 offset=-86 imm=0
 #line 117 "sample/bindmonitor.c"
-        goto label_5;
-        // EBPF_OP_LDXW pc=85 dst=r1 src=r0 offset=0 imm=0
+    if ((int64_t)r3 > (int64_t)r2)
+#line 117 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
+#line 118 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXB pc=137 dst=r0 src=r1 offset=12 imm=0
+#line 118 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(12)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=138 dst=r1 src=r6 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=139 dst=r2 src=r6 offset=8 imm=0
+#line 120 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=140 dst=r2 src=r1 offset=0 imm=0
+#line 120 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=141 dst=r3 src=r0 offset=0 imm=10
+#line 120 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_JSGT_REG pc=142 dst=r3 src=r2 offset=-93 imm=0
+#line 120 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 120 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
+#line 121 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_STXB pc=144 dst=r0 src=r1 offset=13 imm=0
+#line 121 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(13)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=145 dst=r1 src=r6 offset=0 imm=0
+#line 123 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=146 dst=r2 src=r6 offset=8 imm=0
+#line 123 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=147 dst=r2 src=r1 offset=0 imm=0
+#line 123 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=148 dst=r3 src=r0 offset=0 imm=11
+#line 123 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_JSGT_REG pc=149 dst=r3 src=r2 offset=-100 imm=0
+#line 123 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 123 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
+#line 124 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_STXB pc=151 dst=r0 src=r1 offset=14 imm=0
+#line 124 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(14)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=152 dst=r1 src=r6 offset=0 imm=0
+#line 126 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=153 dst=r2 src=r6 offset=8 imm=0
+#line 126 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=154 dst=r2 src=r1 offset=0 imm=0
+#line 126 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=155 dst=r3 src=r0 offset=0 imm=12
+#line 126 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_JSGT_REG pc=156 dst=r3 src=r2 offset=-107 imm=0
+#line 126 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 126 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
+#line 127 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_STXB pc=158 dst=r0 src=r1 offset=15 imm=0
+#line 127 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(15)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=159 dst=r1 src=r6 offset=0 imm=0
+#line 129 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=160 dst=r2 src=r6 offset=8 imm=0
+#line 129 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=161 dst=r2 src=r1 offset=0 imm=0
+#line 129 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=162 dst=r3 src=r0 offset=0 imm=13
+#line 129 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_JSGT_REG pc=163 dst=r3 src=r2 offset=-114 imm=0
+#line 129 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 129 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
+#line 130 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_STXB pc=165 dst=r0 src=r1 offset=16 imm=0
+#line 130 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(16)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=166 dst=r1 src=r6 offset=0 imm=0
+#line 132 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=167 dst=r2 src=r6 offset=8 imm=0
+#line 132 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=168 dst=r2 src=r1 offset=0 imm=0
+#line 132 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=169 dst=r3 src=r0 offset=0 imm=14
+#line 132 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_JSGT_REG pc=170 dst=r3 src=r2 offset=-121 imm=0
+#line 132 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 132 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
 #line 133 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JA pc=86 dst=r0 src=r0 offset=11 imm=0
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_STXB pc=172 dst=r0 src=r1 offset=17 imm=0
 #line 133 "sample/bindmonitor.c"
-    goto label_6;
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(17)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=173 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=174 dst=r2 src=r6 offset=8 imm=0
+#line 135 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=175 dst=r2 src=r1 offset=0 imm=0
+#line 135 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=176 dst=r3 src=r0 offset=0 imm=15
+#line 135 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_JSGT_REG pc=177 dst=r3 src=r2 offset=-128 imm=0
+#line 135 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 135 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
+#line 136 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_STXB pc=179 dst=r0 src=r1 offset=18 imm=0
+#line 136 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(18)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=180 dst=r1 src=r6 offset=0 imm=0
+#line 138 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=181 dst=r2 src=r6 offset=8 imm=0
+#line 138 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=182 dst=r2 src=r1 offset=0 imm=0
+#line 138 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=183 dst=r3 src=r0 offset=0 imm=16
+#line 138 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_JSGT_REG pc=184 dst=r3 src=r2 offset=-135 imm=0
+#line 138 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 138 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
+#line 139 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_STXB pc=186 dst=r0 src=r1 offset=19 imm=0
+#line 139 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(19)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=187 dst=r1 src=r6 offset=0 imm=0
+#line 141 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=188 dst=r2 src=r6 offset=8 imm=0
+#line 141 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=189 dst=r2 src=r1 offset=0 imm=0
+#line 141 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=190 dst=r3 src=r0 offset=0 imm=17
+#line 141 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_JSGT_REG pc=191 dst=r3 src=r2 offset=-142 imm=0
+#line 141 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 141 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
+#line 142 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_STXB pc=193 dst=r0 src=r1 offset=20 imm=0
+#line 142 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(20)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=194 dst=r1 src=r6 offset=0 imm=0
+#line 144 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=195 dst=r2 src=r6 offset=8 imm=0
+#line 144 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=196 dst=r2 src=r1 offset=0 imm=0
+#line 144 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=197 dst=r3 src=r0 offset=0 imm=18
+#line 144 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_JSGT_REG pc=198 dst=r3 src=r2 offset=-149 imm=0
+#line 144 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 144 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
+#line 145 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_STXB pc=200 dst=r0 src=r1 offset=21 imm=0
+#line 145 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(21)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=201 dst=r1 src=r6 offset=0 imm=0
+#line 147 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=202 dst=r2 src=r6 offset=8 imm=0
+#line 147 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=203 dst=r2 src=r1 offset=0 imm=0
+#line 147 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=204 dst=r3 src=r0 offset=0 imm=19
+#line 147 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_JSGT_REG pc=205 dst=r3 src=r2 offset=-156 imm=0
+#line 147 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 147 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
+#line 148 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_STXB pc=207 dst=r0 src=r1 offset=22 imm=0
+#line 148 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(22)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=208 dst=r1 src=r6 offset=0 imm=0
+#line 150 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=209 dst=r2 src=r6 offset=8 imm=0
+#line 150 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=210 dst=r2 src=r1 offset=0 imm=0
+#line 150 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=211 dst=r3 src=r0 offset=0 imm=20
+#line 150 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_JSGT_REG pc=212 dst=r3 src=r2 offset=-163 imm=0
+#line 150 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 150 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
+#line 151 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_STXB pc=214 dst=r0 src=r1 offset=23 imm=0
+#line 151 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(23)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=215 dst=r1 src=r6 offset=0 imm=0
+#line 153 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=216 dst=r2 src=r6 offset=8 imm=0
+#line 153 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=217 dst=r2 src=r1 offset=0 imm=0
+#line 153 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=218 dst=r3 src=r0 offset=0 imm=21
+#line 153 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_JSGT_REG pc=219 dst=r3 src=r2 offset=-170 imm=0
+#line 153 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 153 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
+#line 154 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_STXB pc=221 dst=r0 src=r1 offset=24 imm=0
+#line 154 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(24)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=222 dst=r1 src=r6 offset=0 imm=0
+#line 156 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=223 dst=r2 src=r6 offset=8 imm=0
+#line 156 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=224 dst=r2 src=r1 offset=0 imm=0
+#line 156 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=225 dst=r3 src=r0 offset=0 imm=22
+#line 156 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_JSGT_REG pc=226 dst=r3 src=r2 offset=-177 imm=0
+#line 156 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 156 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
+#line 157 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_STXB pc=228 dst=r0 src=r1 offset=25 imm=0
+#line 157 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(25)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=229 dst=r1 src=r6 offset=0 imm=0
+#line 159 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=230 dst=r2 src=r6 offset=8 imm=0
+#line 159 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=231 dst=r2 src=r1 offset=0 imm=0
+#line 159 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=232 dst=r3 src=r0 offset=0 imm=23
+#line 159 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_JSGT_REG pc=233 dst=r3 src=r2 offset=-184 imm=0
+#line 159 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 159 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
+#line 160 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_STXB pc=235 dst=r0 src=r1 offset=26 imm=0
+#line 160 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(26)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=236 dst=r1 src=r6 offset=0 imm=0
+#line 162 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=237 dst=r2 src=r6 offset=8 imm=0
+#line 162 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=238 dst=r2 src=r1 offset=0 imm=0
+#line 162 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=239 dst=r3 src=r0 offset=0 imm=24
+#line 162 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_JSGT_REG pc=240 dst=r3 src=r2 offset=-191 imm=0
+#line 162 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 162 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
+#line 163 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_STXB pc=242 dst=r0 src=r1 offset=27 imm=0
+#line 163 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(27)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=243 dst=r1 src=r6 offset=0 imm=0
+#line 165 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=244 dst=r2 src=r6 offset=8 imm=0
+#line 165 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=245 dst=r2 src=r1 offset=0 imm=0
+#line 165 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=246 dst=r3 src=r0 offset=0 imm=25
+#line 165 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_JSGT_REG pc=247 dst=r3 src=r2 offset=-198 imm=0
+#line 165 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 165 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
+#line 166 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXB pc=249 dst=r0 src=r1 offset=28 imm=0
+#line 166 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(28)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=250 dst=r1 src=r6 offset=0 imm=0
+#line 168 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=251 dst=r2 src=r6 offset=8 imm=0
+#line 168 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=252 dst=r2 src=r1 offset=0 imm=0
+#line 168 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=253 dst=r3 src=r0 offset=0 imm=26
+#line 168 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_JSGT_REG pc=254 dst=r3 src=r2 offset=-205 imm=0
+#line 168 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 168 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
+#line 169 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
+    // EBPF_OP_STXB pc=256 dst=r0 src=r1 offset=29 imm=0
+#line 169 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(29)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=257 dst=r1 src=r6 offset=0 imm=0
+#line 171 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=258 dst=r2 src=r6 offset=8 imm=0
+#line 171 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=259 dst=r2 src=r1 offset=0 imm=0
+#line 171 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=260 dst=r3 src=r0 offset=0 imm=27
+#line 171 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_JSGT_REG pc=261 dst=r3 src=r2 offset=-212 imm=0
+#line 171 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 171 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
+#line 172 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
+    // EBPF_OP_STXB pc=263 dst=r0 src=r1 offset=30 imm=0
+#line 172 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(30)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=264 dst=r1 src=r6 offset=0 imm=0
+#line 174 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=265 dst=r2 src=r6 offset=8 imm=0
+#line 174 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=266 dst=r2 src=r1 offset=0 imm=0
+#line 174 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=267 dst=r3 src=r0 offset=0 imm=28
+#line 174 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_JSGT_REG pc=268 dst=r3 src=r2 offset=-219 imm=0
+#line 174 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 174 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
+#line 175 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
+    // EBPF_OP_STXB pc=270 dst=r0 src=r1 offset=31 imm=0
+#line 175 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(31)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=271 dst=r1 src=r6 offset=0 imm=0
+#line 177 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=272 dst=r2 src=r6 offset=8 imm=0
+#line 177 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=273 dst=r2 src=r1 offset=0 imm=0
+#line 177 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=274 dst=r3 src=r0 offset=0 imm=29
+#line 177 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_JSGT_REG pc=275 dst=r3 src=r2 offset=-226 imm=0
+#line 177 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 177 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
+#line 178 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXB pc=277 dst=r0 src=r1 offset=32 imm=0
+#line 178 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(32)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=278 dst=r1 src=r6 offset=0 imm=0
+#line 180 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=279 dst=r2 src=r6 offset=8 imm=0
+#line 180 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=280 dst=r2 src=r1 offset=0 imm=0
+#line 180 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=281 dst=r3 src=r0 offset=0 imm=30
+#line 180 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_JSGT_REG pc=282 dst=r3 src=r2 offset=-233 imm=0
+#line 180 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 180 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
+#line 181 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_STXB pc=284 dst=r0 src=r1 offset=33 imm=0
+#line 181 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(33)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=285 dst=r1 src=r6 offset=0 imm=0
+#line 183 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=286 dst=r2 src=r6 offset=8 imm=0
+#line 183 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=287 dst=r2 src=r1 offset=0 imm=0
+#line 183 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=288 dst=r3 src=r0 offset=0 imm=31
+#line 183 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(31);
+    // EBPF_OP_JSGT_REG pc=289 dst=r3 src=r2 offset=-240 imm=0
+#line 183 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 183 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
+#line 184 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_STXB pc=291 dst=r0 src=r1 offset=34 imm=0
+#line 184 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(34)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=292 dst=r1 src=r6 offset=0 imm=0
+#line 186 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=293 dst=r2 src=r6 offset=8 imm=0
+#line 186 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=294 dst=r2 src=r1 offset=0 imm=0
+#line 186 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=295 dst=r3 src=r0 offset=0 imm=32
+#line 186 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=296 dst=r3 src=r2 offset=-247 imm=0
+#line 186 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 186 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
+#line 187 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_STXB pc=298 dst=r0 src=r1 offset=35 imm=0
+#line 187 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(35)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=299 dst=r1 src=r6 offset=0 imm=0
+#line 189 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=300 dst=r2 src=r6 offset=8 imm=0
+#line 189 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=301 dst=r2 src=r1 offset=0 imm=0
+#line 189 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=302 dst=r3 src=r0 offset=0 imm=33
+#line 189 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(33);
+    // EBPF_OP_JSGT_REG pc=303 dst=r3 src=r2 offset=-254 imm=0
+#line 189 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 189 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
+#line 190 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_STXB pc=305 dst=r0 src=r1 offset=36 imm=0
+#line 190 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(36)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=306 dst=r1 src=r6 offset=0 imm=0
+#line 192 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=307 dst=r2 src=r6 offset=8 imm=0
+#line 192 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=308 dst=r2 src=r1 offset=0 imm=0
+#line 192 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=309 dst=r3 src=r0 offset=0 imm=34
+#line 192 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(34);
+    // EBPF_OP_JSGT_REG pc=310 dst=r3 src=r2 offset=-261 imm=0
+#line 192 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 192 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
+#line 193 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_STXB pc=312 dst=r0 src=r1 offset=37 imm=0
+#line 193 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(37)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=313 dst=r1 src=r6 offset=0 imm=0
+#line 195 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=314 dst=r2 src=r6 offset=8 imm=0
+#line 195 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=315 dst=r2 src=r1 offset=0 imm=0
+#line 195 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=316 dst=r3 src=r0 offset=0 imm=35
+#line 195 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(35);
+    // EBPF_OP_JSGT_REG pc=317 dst=r3 src=r2 offset=-268 imm=0
+#line 195 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 195 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
+#line 196 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_STXB pc=319 dst=r0 src=r1 offset=38 imm=0
+#line 196 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(38)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=320 dst=r1 src=r6 offset=0 imm=0
+#line 198 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=321 dst=r2 src=r6 offset=8 imm=0
+#line 198 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=322 dst=r2 src=r1 offset=0 imm=0
+#line 198 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=323 dst=r3 src=r0 offset=0 imm=36
+#line 198 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(36);
+    // EBPF_OP_JSGT_REG pc=324 dst=r3 src=r2 offset=-275 imm=0
+#line 198 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 198 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
+#line 199 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_STXB pc=326 dst=r0 src=r1 offset=39 imm=0
+#line 199 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(39)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=327 dst=r1 src=r6 offset=0 imm=0
+#line 201 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=328 dst=r2 src=r6 offset=8 imm=0
+#line 201 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=329 dst=r2 src=r1 offset=0 imm=0
+#line 201 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=330 dst=r3 src=r0 offset=0 imm=37
+#line 201 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(37);
+    // EBPF_OP_JSGT_REG pc=331 dst=r3 src=r2 offset=-282 imm=0
+#line 201 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 201 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
+#line 202 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_STXB pc=333 dst=r0 src=r1 offset=40 imm=0
+#line 202 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(40)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=334 dst=r1 src=r6 offset=0 imm=0
+#line 204 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=335 dst=r2 src=r6 offset=8 imm=0
+#line 204 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=336 dst=r2 src=r1 offset=0 imm=0
+#line 204 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=337 dst=r3 src=r0 offset=0 imm=38
+#line 204 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(38);
+    // EBPF_OP_JSGT_REG pc=338 dst=r3 src=r2 offset=-289 imm=0
+#line 204 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 204 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
+#line 205 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_STXB pc=340 dst=r0 src=r1 offset=41 imm=0
+#line 205 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(41)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=341 dst=r1 src=r6 offset=0 imm=0
+#line 207 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=342 dst=r2 src=r6 offset=8 imm=0
+#line 207 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=343 dst=r2 src=r1 offset=0 imm=0
+#line 207 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=344 dst=r3 src=r0 offset=0 imm=39
+#line 207 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(39);
+    // EBPF_OP_JSGT_REG pc=345 dst=r3 src=r2 offset=-296 imm=0
+#line 207 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 207 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
+#line 208 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_STXB pc=347 dst=r0 src=r1 offset=42 imm=0
+#line 208 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(42)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=348 dst=r1 src=r6 offset=0 imm=0
+#line 210 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=349 dst=r2 src=r6 offset=8 imm=0
+#line 210 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=350 dst=r2 src=r1 offset=0 imm=0
+#line 210 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=351 dst=r3 src=r0 offset=0 imm=40
+#line 210 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(40);
+    // EBPF_OP_JSGT_REG pc=352 dst=r3 src=r2 offset=-303 imm=0
+#line 210 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 210 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
+#line 211 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_STXB pc=354 dst=r0 src=r1 offset=43 imm=0
+#line 211 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(43)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=355 dst=r1 src=r6 offset=0 imm=0
+#line 213 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=356 dst=r2 src=r6 offset=8 imm=0
+#line 213 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=357 dst=r2 src=r1 offset=0 imm=0
+#line 213 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=358 dst=r3 src=r0 offset=0 imm=41
+#line 213 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(41);
+    // EBPF_OP_JSGT_REG pc=359 dst=r3 src=r2 offset=-310 imm=0
+#line 213 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 213 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
+#line 214 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_STXB pc=361 dst=r0 src=r1 offset=44 imm=0
+#line 214 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(44)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=362 dst=r1 src=r6 offset=0 imm=0
+#line 216 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=363 dst=r2 src=r6 offset=8 imm=0
+#line 216 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=364 dst=r2 src=r1 offset=0 imm=0
+#line 216 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=365 dst=r3 src=r0 offset=0 imm=42
+#line 216 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(42);
+    // EBPF_OP_JSGT_REG pc=366 dst=r3 src=r2 offset=-317 imm=0
+#line 216 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 216 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
+#line 217 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_STXB pc=368 dst=r0 src=r1 offset=45 imm=0
+#line 217 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(45)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=369 dst=r1 src=r6 offset=0 imm=0
+#line 219 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=370 dst=r2 src=r6 offset=8 imm=0
+#line 219 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=371 dst=r2 src=r1 offset=0 imm=0
+#line 219 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=372 dst=r3 src=r0 offset=0 imm=43
+#line 219 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(43);
+    // EBPF_OP_JSGT_REG pc=373 dst=r3 src=r2 offset=-324 imm=0
+#line 219 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 219 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
+#line 220 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_STXB pc=375 dst=r0 src=r1 offset=46 imm=0
+#line 220 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(46)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=376 dst=r1 src=r6 offset=0 imm=0
+#line 222 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=377 dst=r2 src=r6 offset=8 imm=0
+#line 222 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=378 dst=r2 src=r1 offset=0 imm=0
+#line 222 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=379 dst=r3 src=r0 offset=0 imm=44
+#line 222 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(44);
+    // EBPF_OP_JSGT_REG pc=380 dst=r3 src=r2 offset=-331 imm=0
+#line 222 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 222 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
+#line 223 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_STXB pc=382 dst=r0 src=r1 offset=47 imm=0
+#line 223 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(47)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=383 dst=r1 src=r6 offset=0 imm=0
+#line 225 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=384 dst=r2 src=r6 offset=8 imm=0
+#line 225 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=385 dst=r2 src=r1 offset=0 imm=0
+#line 225 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=386 dst=r3 src=r0 offset=0 imm=45
+#line 225 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(45);
+    // EBPF_OP_JSGT_REG pc=387 dst=r3 src=r2 offset=-338 imm=0
+#line 225 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 225 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
+#line 226 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXB pc=389 dst=r0 src=r1 offset=48 imm=0
+#line 226 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(48)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=390 dst=r1 src=r6 offset=0 imm=0
+#line 228 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=391 dst=r2 src=r6 offset=8 imm=0
+#line 228 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=392 dst=r2 src=r1 offset=0 imm=0
+#line 228 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=393 dst=r3 src=r0 offset=0 imm=46
+#line 228 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(46);
+    // EBPF_OP_JSGT_REG pc=394 dst=r3 src=r2 offset=-345 imm=0
+#line 228 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 228 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
+#line 229 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
+    // EBPF_OP_STXB pc=396 dst=r0 src=r1 offset=49 imm=0
+#line 229 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(49)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=397 dst=r1 src=r6 offset=0 imm=0
+#line 231 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=398 dst=r2 src=r6 offset=8 imm=0
+#line 231 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=399 dst=r2 src=r1 offset=0 imm=0
+#line 231 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=400 dst=r3 src=r0 offset=0 imm=47
+#line 231 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(47);
+    // EBPF_OP_JSGT_REG pc=401 dst=r3 src=r2 offset=-352 imm=0
+#line 231 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 231 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
+#line 232 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
+    // EBPF_OP_STXB pc=403 dst=r0 src=r1 offset=50 imm=0
+#line 232 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(50)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=404 dst=r1 src=r6 offset=0 imm=0
+#line 234 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=405 dst=r2 src=r6 offset=8 imm=0
+#line 234 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=406 dst=r2 src=r1 offset=0 imm=0
+#line 234 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=407 dst=r3 src=r0 offset=0 imm=48
+#line 234 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(48);
+    // EBPF_OP_JSGT_REG pc=408 dst=r3 src=r2 offset=-359 imm=0
+#line 234 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 234 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
+#line 235 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
+    // EBPF_OP_STXB pc=410 dst=r0 src=r1 offset=51 imm=0
+#line 235 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(51)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=411 dst=r1 src=r6 offset=0 imm=0
+#line 237 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=412 dst=r2 src=r6 offset=8 imm=0
+#line 237 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=413 dst=r2 src=r1 offset=0 imm=0
+#line 237 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=414 dst=r3 src=r0 offset=0 imm=49
+#line 237 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(49);
+    // EBPF_OP_JSGT_REG pc=415 dst=r3 src=r2 offset=-366 imm=0
+#line 237 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 237 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
+#line 238 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXB pc=417 dst=r0 src=r1 offset=52 imm=0
+#line 238 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(52)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=418 dst=r1 src=r6 offset=0 imm=0
+#line 240 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=419 dst=r2 src=r6 offset=8 imm=0
+#line 240 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=420 dst=r2 src=r1 offset=0 imm=0
+#line 240 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=421 dst=r3 src=r0 offset=0 imm=50
+#line 240 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(50);
+    // EBPF_OP_JSGT_REG pc=422 dst=r3 src=r2 offset=-373 imm=0
+#line 240 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 240 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
+#line 241 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
+    // EBPF_OP_STXB pc=424 dst=r0 src=r1 offset=53 imm=0
+#line 241 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(53)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=425 dst=r1 src=r6 offset=0 imm=0
+#line 243 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=426 dst=r2 src=r6 offset=8 imm=0
+#line 243 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=427 dst=r2 src=r1 offset=0 imm=0
+#line 243 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=428 dst=r3 src=r0 offset=0 imm=51
+#line 243 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(51);
+    // EBPF_OP_JSGT_REG pc=429 dst=r3 src=r2 offset=-380 imm=0
+#line 243 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 243 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
+#line 244 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
+    // EBPF_OP_STXB pc=431 dst=r0 src=r1 offset=54 imm=0
+#line 244 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(54)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=432 dst=r1 src=r6 offset=0 imm=0
+#line 246 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=433 dst=r2 src=r6 offset=8 imm=0
+#line 246 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=434 dst=r2 src=r1 offset=0 imm=0
+#line 246 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=435 dst=r3 src=r0 offset=0 imm=52
+#line 246 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(52);
+    // EBPF_OP_JSGT_REG pc=436 dst=r3 src=r2 offset=-387 imm=0
+#line 246 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 246 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
+#line 247 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
+    // EBPF_OP_STXB pc=438 dst=r0 src=r1 offset=55 imm=0
+#line 247 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(55)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=439 dst=r1 src=r6 offset=0 imm=0
+#line 249 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=440 dst=r2 src=r6 offset=8 imm=0
+#line 249 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=441 dst=r2 src=r1 offset=0 imm=0
+#line 249 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=442 dst=r3 src=r0 offset=0 imm=53
+#line 249 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(53);
+    // EBPF_OP_JSGT_REG pc=443 dst=r3 src=r2 offset=-394 imm=0
+#line 249 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 249 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
+#line 250 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
+    // EBPF_OP_STXB pc=445 dst=r0 src=r1 offset=56 imm=0
+#line 250 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(56)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=446 dst=r1 src=r6 offset=0 imm=0
+#line 252 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=447 dst=r2 src=r6 offset=8 imm=0
+#line 252 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=448 dst=r2 src=r1 offset=0 imm=0
+#line 252 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=449 dst=r3 src=r0 offset=0 imm=54
+#line 252 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(54);
+    // EBPF_OP_JSGT_REG pc=450 dst=r3 src=r2 offset=-401 imm=0
+#line 252 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 252 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
+#line 253 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
+    // EBPF_OP_STXB pc=452 dst=r0 src=r1 offset=57 imm=0
+#line 253 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(57)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=453 dst=r1 src=r6 offset=0 imm=0
+#line 255 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=454 dst=r2 src=r6 offset=8 imm=0
+#line 255 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=455 dst=r2 src=r1 offset=0 imm=0
+#line 255 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=456 dst=r3 src=r0 offset=0 imm=55
+#line 255 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(55);
+    // EBPF_OP_JSGT_REG pc=457 dst=r3 src=r2 offset=-408 imm=0
+#line 255 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 255 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
+#line 256 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
+    // EBPF_OP_STXB pc=459 dst=r0 src=r1 offset=58 imm=0
+#line 256 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(58)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=460 dst=r1 src=r6 offset=0 imm=0
+#line 258 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=461 dst=r2 src=r6 offset=8 imm=0
+#line 258 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=462 dst=r2 src=r1 offset=0 imm=0
+#line 258 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=463 dst=r3 src=r0 offset=0 imm=56
+#line 258 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(56);
+    // EBPF_OP_JSGT_REG pc=464 dst=r3 src=r2 offset=-415 imm=0
+#line 258 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 258 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
+#line 259 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
+    // EBPF_OP_STXB pc=466 dst=r0 src=r1 offset=59 imm=0
+#line 259 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(59)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=467 dst=r1 src=r6 offset=0 imm=0
+#line 261 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=468 dst=r2 src=r6 offset=8 imm=0
+#line 261 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=469 dst=r2 src=r1 offset=0 imm=0
+#line 261 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=470 dst=r3 src=r0 offset=0 imm=57
+#line 261 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(57);
+    // EBPF_OP_JSGT_REG pc=471 dst=r3 src=r2 offset=-422 imm=0
+#line 261 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 261 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
+#line 262 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=473 dst=r0 src=r1 offset=60 imm=0
+#line 262 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(60)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=474 dst=r1 src=r6 offset=0 imm=0
+#line 264 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=475 dst=r2 src=r6 offset=8 imm=0
+#line 264 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=476 dst=r2 src=r1 offset=0 imm=0
+#line 264 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=477 dst=r3 src=r0 offset=0 imm=58
+#line 264 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(58);
+    // EBPF_OP_JSGT_REG pc=478 dst=r3 src=r2 offset=-429 imm=0
+#line 264 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 264 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
+#line 265 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
+    // EBPF_OP_STXB pc=480 dst=r0 src=r1 offset=61 imm=0
+#line 265 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(61)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=481 dst=r1 src=r6 offset=0 imm=0
+#line 267 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=482 dst=r2 src=r6 offset=8 imm=0
+#line 267 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=483 dst=r2 src=r1 offset=0 imm=0
+#line 267 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=484 dst=r3 src=r0 offset=0 imm=59
+#line 267 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(59);
+    // EBPF_OP_JSGT_REG pc=485 dst=r3 src=r2 offset=-436 imm=0
+#line 267 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 267 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
+#line 268 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
+    // EBPF_OP_STXB pc=487 dst=r0 src=r1 offset=62 imm=0
+#line 268 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(62)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=488 dst=r1 src=r6 offset=0 imm=0
+#line 270 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=489 dst=r2 src=r6 offset=8 imm=0
+#line 270 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=490 dst=r2 src=r1 offset=0 imm=0
+#line 270 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=491 dst=r3 src=r0 offset=0 imm=60
+#line 270 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(60);
+    // EBPF_OP_JSGT_REG pc=492 dst=r3 src=r2 offset=-443 imm=0
+#line 270 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 270 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
+#line 271 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
+    // EBPF_OP_STXB pc=494 dst=r0 src=r1 offset=63 imm=0
+#line 271 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(63)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=495 dst=r1 src=r6 offset=0 imm=0
+#line 273 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=496 dst=r2 src=r6 offset=8 imm=0
+#line 273 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=497 dst=r2 src=r1 offset=0 imm=0
+#line 273 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=498 dst=r3 src=r0 offset=0 imm=61
+#line 273 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(61);
+    // EBPF_OP_JSGT_REG pc=499 dst=r3 src=r2 offset=-450 imm=0
+#line 273 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 273 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
+#line 274 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
+    // EBPF_OP_STXB pc=501 dst=r0 src=r1 offset=64 imm=0
+#line 274 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(64)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=502 dst=r1 src=r6 offset=0 imm=0
+#line 276 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=503 dst=r2 src=r6 offset=8 imm=0
+#line 276 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=504 dst=r2 src=r1 offset=0 imm=0
+#line 276 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=505 dst=r3 src=r0 offset=0 imm=62
+#line 276 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(62);
+    // EBPF_OP_JSGT_REG pc=506 dst=r3 src=r2 offset=-457 imm=0
+#line 276 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 276 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
+#line 277 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
+    // EBPF_OP_STXB pc=508 dst=r0 src=r1 offset=65 imm=0
+#line 277 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(65)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=509 dst=r1 src=r6 offset=0 imm=0
+#line 279 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=510 dst=r2 src=r6 offset=8 imm=0
+#line 279 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=511 dst=r2 src=r1 offset=0 imm=0
+#line 279 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=512 dst=r3 src=r0 offset=0 imm=63
+#line 279 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(63);
+    // EBPF_OP_JSGT_REG pc=513 dst=r3 src=r2 offset=-464 imm=0
+#line 279 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 279 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
+#line 280 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
+    // EBPF_OP_STXB pc=515 dst=r0 src=r1 offset=66 imm=0
+#line 280 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(66)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=516 dst=r1 src=r6 offset=0 imm=0
+#line 282 "sample/bindmonitor.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=517 dst=r2 src=r6 offset=8 imm=0
+#line 282 "sample/bindmonitor.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=518 dst=r2 src=r1 offset=0 imm=0
+#line 282 "sample/bindmonitor.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=519 dst=r3 src=r0 offset=0 imm=64
+#line 282 "sample/bindmonitor.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_JSGT_REG pc=520 dst=r3 src=r2 offset=-471 imm=0
+#line 282 "sample/bindmonitor.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 282 "sample/bindmonitor.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
+#line 283 "sample/bindmonitor.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
+    // EBPF_OP_STXB pc=522 dst=r0 src=r1 offset=67 imm=0
+#line 283 "sample/bindmonitor.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(67)) = (uint8_t)r1;
+    // EBPF_OP_JA pc=523 dst=r0 src=r0 offset=-474 imm=0
+#line 283 "sample/bindmonitor.c"
+    goto label_2;
 label_4:
-    // EBPF_OP_MOV64_IMM pc=87 dst=r8 src=r0 offset=0 imm=1
-#line 133 "sample/bindmonitor.c"
-    r8 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=88 dst=r1 src=r0 offset=0 imm=0
-#line 119 "sample/bindmonitor.c"
+    // EBPF_OP_LDXW pc=524 dst=r1 src=r0 offset=0 imm=0
+#line 322 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_LDXW pc=89 dst=r2 src=r7 offset=0 imm=0
-#line 119 "sample/bindmonitor.c"
-    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JGE_REG pc=90 dst=r1 src=r2 offset=19 imm=0
-#line 119 "sample/bindmonitor.c"
-    if (r1 >= r2)
-#line 119 "sample/bindmonitor.c"
-        goto label_9;
-        // EBPF_OP_ADD64_IMM pc=91 dst=r1 src=r0 offset=0 imm=1
-#line 123 "sample/bindmonitor.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=92 dst=r0 src=r1 offset=0 imm=0
-#line 123 "sample/bindmonitor.c"
-    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_JA pc=93 dst=r0 src=r0 offset=15 imm=0
-#line 123 "sample/bindmonitor.c"
-    goto label_8;
-label_5:
-    // EBPF_OP_LDXW pc=94 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/bindmonitor.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=95 dst=r1 src=r0 offset=6 imm=0
-#line 126 "sample/bindmonitor.c"
+    // EBPF_OP_JEQ_IMM pc=525 dst=r1 src=r0 offset=6 imm=0
+#line 322 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(0))
-#line 126 "sample/bindmonitor.c"
-        goto label_7;
-        // EBPF_OP_ADD64_IMM pc=96 dst=r1 src=r0 offset=0 imm=-1
-#line 127 "sample/bindmonitor.c"
+#line 322 "sample/bindmonitor.c"
+        goto label_6;
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
+#line 323 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
-    // EBPF_OP_STXW pc=97 dst=r0 src=r1 offset=0 imm=0
-#line 127 "sample/bindmonitor.c"
+    // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
+#line 323 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-label_6:
-    // EBPF_OP_MOV64_IMM pc=98 dst=r8 src=r0 offset=0 imm=0
-#line 127 "sample/bindmonitor.c"
+label_5:
+    // EBPF_OP_MOV64_IMM pc=528 dst=r8 src=r0 offset=0 imm=0
+#line 323 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
-    // EBPF_OP_LSH64_IMM pc=99 dst=r1 src=r0 offset=0 imm=32
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_LSH64_IMM pc=529 dst=r1 src=r0 offset=0 imm=32
+#line 329 "sample/bindmonitor.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=100 dst=r1 src=r0 offset=0 imm=32
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_RSH64_IMM pc=530 dst=r1 src=r0 offset=0 imm=32
+#line 329 "sample/bindmonitor.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=101 dst=r1 src=r0 offset=8 imm=0
-#line 133 "sample/bindmonitor.c"
+    // EBPF_OP_JNE_IMM pc=531 dst=r1 src=r0 offset=15 imm=0
+#line 329 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
-#line 133 "sample/bindmonitor.c"
+#line 329 "sample/bindmonitor.c"
         goto label_9;
-label_7:
-    // EBPF_OP_LDXDW pc=102 dst=r1 src=r6 offset=16 imm=0
-#line 134 "sample/bindmonitor.c"
+label_6:
+    // EBPF_OP_LDXDW pc=532 dst=r1 src=r6 offset=16 imm=0
+#line 330 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
-    // EBPF_OP_STXDW pc=103 dst=r10 src=r1 offset=-80 imm=0
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_STXDW pc=533 dst=r10 src=r1 offset=-80 imm=0
+#line 330 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=104 dst=r2 src=r10 offset=0 imm=0
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_REG pc=534 dst=r2 src=r10 offset=0 imm=0
+#line 330 "sample/bindmonitor.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=105 dst=r2 src=r0 offset=0 imm=-80
-#line 134 "sample/bindmonitor.c"
+    // EBPF_OP_ADD64_IMM pc=535 dst=r2 src=r0 offset=0 imm=-80
+#line 330 "sample/bindmonitor.c"
     r2 += IMMEDIATE(-80);
-    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_LDDW pc=536 dst=r1 src=r0 offset=0 imm=0
+#line 331 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=108 dst=r0 src=r0 offset=0 imm=3
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_CALL pc=538 dst=r0 src=r0 offset=0 imm=3
+#line 331 "sample/bindmonitor.c"
     r0 = BindMonitor_helpers[5].address
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
          (r1, r2, r3, r4, r5);
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
     if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
-#line 135 "sample/bindmonitor.c"
+#line 331 "sample/bindmonitor.c"
         return 0;
+        // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
+#line 331 "sample/bindmonitor.c"
+    goto label_8;
+label_7:
+    // EBPF_OP_MOV64_IMM pc=540 dst=r8 src=r0 offset=0 imm=1
+#line 331 "sample/bindmonitor.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=541 dst=r1 src=r0 offset=0 imm=0
+#line 315 "sample/bindmonitor.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_LDXW pc=542 dst=r2 src=r7 offset=0 imm=0
+#line 315 "sample/bindmonitor.c"
+    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_JGE_REG pc=543 dst=r1 src=r2 offset=3 imm=0
+#line 315 "sample/bindmonitor.c"
+    if (r1 >= r2)
+#line 315 "sample/bindmonitor.c"
+        goto label_9;
+        // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
+#line 319 "sample/bindmonitor.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=545 dst=r0 src=r1 offset=0 imm=0
+#line 319 "sample/bindmonitor.c"
+    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
 label_8:
-    // EBPF_OP_MOV64_IMM pc=109 dst=r8 src=r0 offset=0 imm=0
-#line 135 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_IMM pc=546 dst=r8 src=r0 offset=0 imm=0
+#line 319 "sample/bindmonitor.c"
     r8 = IMMEDIATE(0);
 label_9:
-    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r8 offset=0 imm=0
-#line 139 "sample/bindmonitor.c"
+    // EBPF_OP_MOV64_REG pc=547 dst=r0 src=r8 offset=0 imm=0
+#line 335 "sample/bindmonitor.c"
     r0 = r8;
-    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
-#line 139 "sample/bindmonitor.c"
+    // EBPF_OP_EXIT pc=548 dst=r0 src=r0 offset=0 imm=0
+#line 335 "sample/bindmonitor.c"
     return r0;
-#line 139 "sample/bindmonitor.c"
+#line 335 "sample/bindmonitor.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -709,7 +2144,7 @@ static program_entry_t _programs[] = {
         3,
         BindMonitor_helpers,
         6,
-        112,
+        549,
         &BindMonitor_program_type_guid,
         &BindMonitor_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -159,92 +159,92 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
 {
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-4 imm=0
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-4
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_helpers[0].address
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
-#line 119 "sample/bindmonitor_tailcall.c"
+#line 315 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
-#line 119 "sample/bindmonitor_tailcall.c"
+#line 315 "sample/bindmonitor_tailcall.c"
         goto label_1;
         // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r2 = POINTER(_maps[2].address);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_helpers[1].address
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=15 dst=r0 src=r0 offset=0 imm=0
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -266,92 +266,92 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
 {
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-4 imm=0
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-4
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[0].address
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
-#line 135 "sample/bindmonitor_tailcall.c"
+#line 331 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
-#line 135 "sample/bindmonitor_tailcall.c"
+#line 331 "sample/bindmonitor_tailcall.c"
         goto label_1;
         // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r2 = POINTER(_maps[2].address);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=1
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[1].address
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=15 dst=r0 src=r0 offset=0 imm=0
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -374,82 +374,80 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
 {
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r7 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r8 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
-    register uint64_t r9 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r8 src=r0 offset=0 imm=0
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r8 offset=-84 imm=0
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-84
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-84);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r7 = r0;
-    // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=519 imm=0
+#line 347 "sample/bindmonitor_tailcall.c"
     if (r7 == IMMEDIATE(0))
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
         goto label_9;
         // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=517 imm=0
+#line 347 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
         goto label_9;
         // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
@@ -505,64 +503,87 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
-        goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
-#line 84 "sample/bindmonitor_tailcall.c"
-    goto label_3;
+        goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_MOV64_IMM pc=30 dst=r8 src=r0 offset=0 imm=0
+#line 84 "sample/bindmonitor_tailcall.c"
+    r8 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=31 dst=r0 src=r0 offset=497 imm=0
+#line 352 "sample/bindmonitor_tailcall.c"
+    if (r0 == IMMEDIATE(0))
+#line 352 "sample/bindmonitor_tailcall.c"
+        goto label_9;
+label_2:
+    // EBPF_OP_LDXW pc=32 dst=r1 src=r6 offset=44 imm=0
+#line 356 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=33 dst=r1 src=r0 offset=488 imm=0
+#line 356 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(0))
+#line 356 "sample/bindmonitor_tailcall.c"
+        goto label_7;
+        // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
+#line 356 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(2))
+#line 356 "sample/bindmonitor_tailcall.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_JA pc=36 dst=r0 src=r0 offset=473 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
+    goto label_5;
+label_3:
+    // EBPF_OP_LDXW pc=37 dst=r1 src=r6 offset=44 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
+    // EBPF_OP_JNE_IMM pc=38 dst=r1 src=r0 offset=489 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
+    // EBPF_OP_JEQ_IMM pc=40 dst=r1 src=r0 offset=487 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
+    // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=485 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=44 dst=r8 src=r0 offset=0 imm=-8
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=39 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=45 dst=r3 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=40 dst=r3 src=r0 offset=0 imm=-80
+    // EBPF_OP_ADD64_IMM pc=46 dst=r3 src=r0 offset=0 imm=-80
 #line 90 "sample/bindmonitor_tailcall.c"
     r3 += IMMEDIATE(-80);
-    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
-#line 90 "sample/bindmonitor_tailcall.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_LDDW pc=42 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=44 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r2 = r8;
-    // EBPF_OP_MOV64_IMM pc=45 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=50 dst=r4 src=r0 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=51 dst=r0 src=r0 offset=0 imm=2
 #line 93 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[1].address
 #line 93 "sample/bindmonitor_tailcall.c"
@@ -571,13 +592,13 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 93 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=54 dst=r2 src=r8 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r2 = r8;
-    // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=1
 #line 94 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
 #line 94 "sample/bindmonitor_tailcall.c"
@@ -586,163 +607,1577 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 94 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 95 "sample/bindmonitor_tailcall.c"
-    r1 = r0;
-    // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 95 "sample/bindmonitor_tailcall.c"
-    r1 += IMMEDIATE(4);
-label_2:
-    // EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_ADD64_REG pc=55 dst=r2 src=r9 offset=0 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r2 += r9;
-    // EBPF_OP_LDXDW pc=56 dst=r3 src=r6 offset=8 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    if (r2 >= r3)
-#line 99 "sample/bindmonitor_tailcall.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r3 += r9;
-    // EBPF_OP_LDXB pc=60 dst=r2 src=r2 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXB pc=61 dst=r3 src=r2 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    *(uint8_t*)(uintptr_t)(r3 + OFFSET(0)) = (uint8_t)r2;
-    // EBPF_OP_ADD64_IMM pc=62 dst=r9 src=r0 offset=0 imm=1
-#line 98 "sample/bindmonitor_tailcall.c"
-    r9 += IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
-#line 98 "sample/bindmonitor_tailcall.c"
-    if (r9 != IMMEDIATE(64))
-#line 98 "sample/bindmonitor_tailcall.c"
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=58 dst=r2 src=r6 offset=8 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=59 dst=r2 src=r1 offset=0 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=60 dst=r3 src=r0 offset=0 imm=1
+#line 107 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_JSGT_REG pc=61 dst=r3 src=r2 offset=-32 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 107 "sample/bindmonitor_tailcall.c"
+        goto label_1;
+        // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
+#line 108 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_STXB pc=63 dst=r0 src=r1 offset=4 imm=0
+#line 108 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(4)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=64 dst=r1 src=r6 offset=0 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=65 dst=r2 src=r6 offset=8 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=66 dst=r2 src=r1 offset=0 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=2
+#line 110 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_JSGT_REG pc=68 dst=r3 src=r2 offset=-37 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 110 "sample/bindmonitor_tailcall.c"
         goto label_2;
-label_3:
-    // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
-#line 160 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
-#line 160 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
-#line 160 "sample/bindmonitor_tailcall.c"
-        goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
-#line 160 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(2))
-#line 160 "sample/bindmonitor_tailcall.c"
-        goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
+#line 111 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
+    // EBPF_OP_STXB pc=70 dst=r0 src=r1 offset=5 imm=0
+#line 111 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(5)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=72 dst=r2 src=r6 offset=8 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=73 dst=r2 src=r1 offset=0 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=74 dst=r3 src=r0 offset=0 imm=3
+#line 113 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_JSGT_REG pc=75 dst=r3 src=r2 offset=-44 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 113 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
+#line 114 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
+    // EBPF_OP_STXB pc=77 dst=r0 src=r1 offset=6 imm=0
+#line 114 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(6)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=78 dst=r1 src=r6 offset=0 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=79 dst=r2 src=r6 offset=8 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=80 dst=r2 src=r1 offset=0 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=81 dst=r3 src=r0 offset=0 imm=4
+#line 116 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_JSGT_REG pc=82 dst=r3 src=r2 offset=-51 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 116 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
+#line 117 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
+    // EBPF_OP_STXB pc=84 dst=r0 src=r1 offset=7 imm=0
+#line 117 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(7)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=85 dst=r1 src=r6 offset=0 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=86 dst=r2 src=r6 offset=8 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=87 dst=r2 src=r1 offset=0 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=88 dst=r3 src=r0 offset=0 imm=5
+#line 119 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_JSGT_REG pc=89 dst=r3 src=r2 offset=-58 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 119 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
+#line 120 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_STXB pc=91 dst=r0 src=r1 offset=8 imm=0
+#line 120 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(8)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=92 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=93 dst=r2 src=r6 offset=8 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=94 dst=r2 src=r1 offset=0 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=95 dst=r3 src=r0 offset=0 imm=6
+#line 122 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_JSGT_REG pc=96 dst=r3 src=r2 offset=-65 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 122 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
+    // EBPF_OP_STXB pc=98 dst=r0 src=r1 offset=9 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(9)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=99 dst=r1 src=r6 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=100 dst=r2 src=r6 offset=8 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=101 dst=r2 src=r1 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=102 dst=r3 src=r0 offset=0 imm=7
+#line 125 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_JSGT_REG pc=103 dst=r3 src=r2 offset=-72 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 125 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
+#line 126 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
+    // EBPF_OP_STXB pc=105 dst=r0 src=r1 offset=10 imm=0
+#line 126 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(10)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=106 dst=r1 src=r6 offset=0 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=107 dst=r2 src=r6 offset=8 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=108 dst=r2 src=r1 offset=0 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=109 dst=r3 src=r0 offset=0 imm=8
+#line 128 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_JSGT_REG pc=110 dst=r3 src=r2 offset=-79 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 128 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
+#line 129 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
+    // EBPF_OP_STXB pc=112 dst=r0 src=r1 offset=11 imm=0
+#line 129 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(11)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=113 dst=r1 src=r6 offset=0 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=114 dst=r2 src=r6 offset=8 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=115 dst=r2 src=r1 offset=0 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=116 dst=r3 src=r0 offset=0 imm=9
+#line 131 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_JSGT_REG pc=117 dst=r3 src=r2 offset=-86 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 131 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
+#line 132 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXB pc=119 dst=r0 src=r1 offset=12 imm=0
+#line 132 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(12)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=120 dst=r1 src=r6 offset=0 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=121 dst=r2 src=r6 offset=8 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=122 dst=r2 src=r1 offset=0 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=123 dst=r3 src=r0 offset=0 imm=10
+#line 134 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_JSGT_REG pc=124 dst=r3 src=r2 offset=-93 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 134 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
+#line 135 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_STXB pc=126 dst=r0 src=r1 offset=13 imm=0
+#line 135 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(13)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=127 dst=r1 src=r6 offset=0 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=128 dst=r2 src=r6 offset=8 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=129 dst=r2 src=r1 offset=0 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=130 dst=r3 src=r0 offset=0 imm=11
+#line 137 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_JSGT_REG pc=131 dst=r3 src=r2 offset=-100 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 137 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
+#line 138 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_STXB pc=133 dst=r0 src=r1 offset=14 imm=0
+#line 138 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(14)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=134 dst=r1 src=r6 offset=0 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=135 dst=r2 src=r6 offset=8 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=136 dst=r2 src=r1 offset=0 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=137 dst=r3 src=r0 offset=0 imm=12
+#line 140 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_JSGT_REG pc=138 dst=r3 src=r2 offset=-107 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 140 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_STXB pc=140 dst=r0 src=r1 offset=15 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(15)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=141 dst=r1 src=r6 offset=0 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=142 dst=r2 src=r6 offset=8 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=143 dst=r2 src=r1 offset=0 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=144 dst=r3 src=r0 offset=0 imm=13
+#line 143 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_JSGT_REG pc=145 dst=r3 src=r2 offset=-114 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 143 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
+#line 144 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_STXB pc=147 dst=r0 src=r1 offset=16 imm=0
+#line 144 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(16)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=148 dst=r1 src=r6 offset=0 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=149 dst=r2 src=r6 offset=8 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=150 dst=r2 src=r1 offset=0 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=151 dst=r3 src=r0 offset=0 imm=14
+#line 146 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_JSGT_REG pc=152 dst=r3 src=r2 offset=-121 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 146 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
+#line 147 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_STXB pc=154 dst=r0 src=r1 offset=17 imm=0
+#line 147 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(17)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=155 dst=r1 src=r6 offset=0 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=156 dst=r2 src=r6 offset=8 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=157 dst=r2 src=r1 offset=0 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=158 dst=r3 src=r0 offset=0 imm=15
+#line 149 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_JSGT_REG pc=159 dst=r3 src=r2 offset=-128 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 149 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
+#line 150 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_STXB pc=161 dst=r0 src=r1 offset=18 imm=0
+#line 150 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(18)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=162 dst=r1 src=r6 offset=0 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=163 dst=r2 src=r6 offset=8 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=164 dst=r2 src=r1 offset=0 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=165 dst=r3 src=r0 offset=0 imm=16
+#line 152 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_JSGT_REG pc=166 dst=r3 src=r2 offset=-135 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 152 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
+#line 153 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_STXB pc=168 dst=r0 src=r1 offset=19 imm=0
+#line 153 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(19)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=169 dst=r1 src=r6 offset=0 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=170 dst=r2 src=r6 offset=8 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=171 dst=r2 src=r1 offset=0 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=172 dst=r3 src=r0 offset=0 imm=17
+#line 155 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_JSGT_REG pc=173 dst=r3 src=r2 offset=-142 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 155 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_STXB pc=175 dst=r0 src=r1 offset=20 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(20)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=176 dst=r1 src=r6 offset=0 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=177 dst=r2 src=r6 offset=8 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=178 dst=r2 src=r1 offset=0 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=179 dst=r3 src=r0 offset=0 imm=18
+#line 158 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_JSGT_REG pc=180 dst=r3 src=r2 offset=-149 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 158 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
+#line 159 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_STXB pc=182 dst=r0 src=r1 offset=21 imm=0
+#line 159 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(21)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=183 dst=r1 src=r6 offset=0 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=184 dst=r2 src=r6 offset=8 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=185 dst=r2 src=r1 offset=0 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=186 dst=r3 src=r0 offset=0 imm=19
+#line 161 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_JSGT_REG pc=187 dst=r3 src=r2 offset=-156 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 161 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
+#line 162 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_STXB pc=189 dst=r0 src=r1 offset=22 imm=0
+#line 162 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(22)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=190 dst=r1 src=r6 offset=0 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=191 dst=r2 src=r6 offset=8 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=192 dst=r2 src=r1 offset=0 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=193 dst=r3 src=r0 offset=0 imm=20
+#line 164 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_JSGT_REG pc=194 dst=r3 src=r2 offset=-163 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 164 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
+#line 165 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_STXB pc=196 dst=r0 src=r1 offset=23 imm=0
+#line 165 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(23)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=197 dst=r1 src=r6 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=198 dst=r2 src=r6 offset=8 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=199 dst=r2 src=r1 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=200 dst=r3 src=r0 offset=0 imm=21
+#line 167 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_JSGT_REG pc=201 dst=r3 src=r2 offset=-170 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 167 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
+#line 168 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_STXB pc=203 dst=r0 src=r1 offset=24 imm=0
+#line 168 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(24)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=204 dst=r1 src=r6 offset=0 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=205 dst=r2 src=r6 offset=8 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=206 dst=r2 src=r1 offset=0 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=207 dst=r3 src=r0 offset=0 imm=22
+#line 170 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_JSGT_REG pc=208 dst=r3 src=r2 offset=-177 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 170 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
+#line 171 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_STXB pc=210 dst=r0 src=r1 offset=25 imm=0
+#line 171 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(25)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=211 dst=r1 src=r6 offset=0 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=212 dst=r2 src=r6 offset=8 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=213 dst=r2 src=r1 offset=0 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=214 dst=r3 src=r0 offset=0 imm=23
+#line 173 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_JSGT_REG pc=215 dst=r3 src=r2 offset=-184 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 173 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
+#line 174 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_STXB pc=217 dst=r0 src=r1 offset=26 imm=0
+#line 174 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(26)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=218 dst=r1 src=r6 offset=0 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=219 dst=r2 src=r6 offset=8 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    goto label_6;
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=220 dst=r2 src=r1 offset=0 imm=0
+#line 176 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=221 dst=r3 src=r0 offset=0 imm=24
+#line 176 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_JSGT_REG pc=222 dst=r3 src=r2 offset=-191 imm=0
+#line 176 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 176 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
+#line 177 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_STXB pc=224 dst=r0 src=r1 offset=27 imm=0
+#line 177 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(27)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=225 dst=r1 src=r6 offset=0 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=226 dst=r2 src=r6 offset=8 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=227 dst=r2 src=r1 offset=0 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=228 dst=r3 src=r0 offset=0 imm=25
+#line 179 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_JSGT_REG pc=229 dst=r3 src=r2 offset=-198 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 179 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
+#line 180 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXB pc=231 dst=r0 src=r1 offset=28 imm=0
+#line 180 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(28)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=232 dst=r1 src=r6 offset=0 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=233 dst=r2 src=r6 offset=8 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=234 dst=r2 src=r1 offset=0 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=235 dst=r3 src=r0 offset=0 imm=26
+#line 182 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_JSGT_REG pc=236 dst=r3 src=r2 offset=-205 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 182 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
+#line 183 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
+    // EBPF_OP_STXB pc=238 dst=r0 src=r1 offset=29 imm=0
+#line 183 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(29)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=239 dst=r1 src=r6 offset=0 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=240 dst=r2 src=r6 offset=8 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=241 dst=r2 src=r1 offset=0 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=242 dst=r3 src=r0 offset=0 imm=27
+#line 185 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_JSGT_REG pc=243 dst=r3 src=r2 offset=-212 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 185 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
+#line 186 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
+    // EBPF_OP_STXB pc=245 dst=r0 src=r1 offset=30 imm=0
+#line 186 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(30)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=246 dst=r1 src=r6 offset=0 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=247 dst=r2 src=r6 offset=8 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=248 dst=r2 src=r1 offset=0 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=249 dst=r3 src=r0 offset=0 imm=28
+#line 188 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_JSGT_REG pc=250 dst=r3 src=r2 offset=-219 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 188 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
+#line 189 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
+    // EBPF_OP_STXB pc=252 dst=r0 src=r1 offset=31 imm=0
+#line 189 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(31)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=253 dst=r1 src=r6 offset=0 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=254 dst=r2 src=r6 offset=8 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=255 dst=r2 src=r1 offset=0 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=256 dst=r3 src=r0 offset=0 imm=29
+#line 191 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_JSGT_REG pc=257 dst=r3 src=r2 offset=-226 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 191 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
+#line 192 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXB pc=259 dst=r0 src=r1 offset=32 imm=0
+#line 192 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(32)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=260 dst=r1 src=r6 offset=0 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=261 dst=r2 src=r6 offset=8 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=262 dst=r2 src=r1 offset=0 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=263 dst=r3 src=r0 offset=0 imm=30
+#line 194 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_JSGT_REG pc=264 dst=r3 src=r2 offset=-233 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 194 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
+#line 195 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_STXB pc=266 dst=r0 src=r1 offset=33 imm=0
+#line 195 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(33)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=267 dst=r1 src=r6 offset=0 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=268 dst=r2 src=r6 offset=8 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=269 dst=r2 src=r1 offset=0 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=270 dst=r3 src=r0 offset=0 imm=31
+#line 197 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(31);
+    // EBPF_OP_JSGT_REG pc=271 dst=r3 src=r2 offset=-240 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 197 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
+#line 198 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_STXB pc=273 dst=r0 src=r1 offset=34 imm=0
+#line 198 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(34)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=274 dst=r1 src=r6 offset=0 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=275 dst=r2 src=r6 offset=8 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=276 dst=r2 src=r1 offset=0 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=277 dst=r3 src=r0 offset=0 imm=32
+#line 200 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=278 dst=r3 src=r2 offset=-247 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 200 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
+#line 201 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_STXB pc=280 dst=r0 src=r1 offset=35 imm=0
+#line 201 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(35)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=281 dst=r1 src=r6 offset=0 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=282 dst=r2 src=r6 offset=8 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=283 dst=r2 src=r1 offset=0 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=284 dst=r3 src=r0 offset=0 imm=33
+#line 203 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(33);
+    // EBPF_OP_JSGT_REG pc=285 dst=r3 src=r2 offset=-254 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 203 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
+#line 204 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_STXB pc=287 dst=r0 src=r1 offset=36 imm=0
+#line 204 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(36)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=288 dst=r1 src=r6 offset=0 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=289 dst=r2 src=r6 offset=8 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=290 dst=r2 src=r1 offset=0 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=291 dst=r3 src=r0 offset=0 imm=34
+#line 206 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(34);
+    // EBPF_OP_JSGT_REG pc=292 dst=r3 src=r2 offset=-261 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 206 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
+#line 207 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_STXB pc=294 dst=r0 src=r1 offset=37 imm=0
+#line 207 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(37)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=295 dst=r1 src=r6 offset=0 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=296 dst=r2 src=r6 offset=8 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=297 dst=r2 src=r1 offset=0 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=298 dst=r3 src=r0 offset=0 imm=35
+#line 209 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(35);
+    // EBPF_OP_JSGT_REG pc=299 dst=r3 src=r2 offset=-268 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 209 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
+#line 210 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_STXB pc=301 dst=r0 src=r1 offset=38 imm=0
+#line 210 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(38)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=302 dst=r1 src=r6 offset=0 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=303 dst=r2 src=r6 offset=8 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=304 dst=r2 src=r1 offset=0 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=305 dst=r3 src=r0 offset=0 imm=36
+#line 212 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(36);
+    // EBPF_OP_JSGT_REG pc=306 dst=r3 src=r2 offset=-275 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 212 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
+#line 213 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_STXB pc=308 dst=r0 src=r1 offset=39 imm=0
+#line 213 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(39)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=309 dst=r1 src=r6 offset=0 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=310 dst=r2 src=r6 offset=8 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=311 dst=r2 src=r1 offset=0 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=312 dst=r3 src=r0 offset=0 imm=37
+#line 215 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(37);
+    // EBPF_OP_JSGT_REG pc=313 dst=r3 src=r2 offset=-282 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 215 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
+#line 216 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_STXB pc=315 dst=r0 src=r1 offset=40 imm=0
+#line 216 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(40)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=316 dst=r1 src=r6 offset=0 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=317 dst=r2 src=r6 offset=8 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=318 dst=r2 src=r1 offset=0 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=319 dst=r3 src=r0 offset=0 imm=38
+#line 218 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(38);
+    // EBPF_OP_JSGT_REG pc=320 dst=r3 src=r2 offset=-289 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 218 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
+#line 219 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_STXB pc=322 dst=r0 src=r1 offset=41 imm=0
+#line 219 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(41)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=323 dst=r1 src=r6 offset=0 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=324 dst=r2 src=r6 offset=8 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=325 dst=r2 src=r1 offset=0 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=326 dst=r3 src=r0 offset=0 imm=39
+#line 221 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(39);
+    // EBPF_OP_JSGT_REG pc=327 dst=r3 src=r2 offset=-296 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 221 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
+#line 222 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_STXB pc=329 dst=r0 src=r1 offset=42 imm=0
+#line 222 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(42)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=330 dst=r1 src=r6 offset=0 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=331 dst=r2 src=r6 offset=8 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=332 dst=r2 src=r1 offset=0 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=333 dst=r3 src=r0 offset=0 imm=40
+#line 224 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(40);
+    // EBPF_OP_JSGT_REG pc=334 dst=r3 src=r2 offset=-303 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 224 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
+#line 225 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_STXB pc=336 dst=r0 src=r1 offset=43 imm=0
+#line 225 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(43)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=337 dst=r1 src=r6 offset=0 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=338 dst=r2 src=r6 offset=8 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=339 dst=r2 src=r1 offset=0 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=340 dst=r3 src=r0 offset=0 imm=41
+#line 227 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(41);
+    // EBPF_OP_JSGT_REG pc=341 dst=r3 src=r2 offset=-310 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 227 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
+#line 228 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_STXB pc=343 dst=r0 src=r1 offset=44 imm=0
+#line 228 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(44)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=344 dst=r1 src=r6 offset=0 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=345 dst=r2 src=r6 offset=8 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=346 dst=r2 src=r1 offset=0 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=347 dst=r3 src=r0 offset=0 imm=42
+#line 230 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(42);
+    // EBPF_OP_JSGT_REG pc=348 dst=r3 src=r2 offset=-317 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 230 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
+#line 231 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_STXB pc=350 dst=r0 src=r1 offset=45 imm=0
+#line 231 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(45)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=351 dst=r1 src=r6 offset=0 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=352 dst=r2 src=r6 offset=8 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=353 dst=r2 src=r1 offset=0 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=354 dst=r3 src=r0 offset=0 imm=43
+#line 233 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(43);
+    // EBPF_OP_JSGT_REG pc=355 dst=r3 src=r2 offset=-324 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 233 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
+#line 234 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_STXB pc=357 dst=r0 src=r1 offset=46 imm=0
+#line 234 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(46)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=358 dst=r1 src=r6 offset=0 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=359 dst=r2 src=r6 offset=8 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=360 dst=r2 src=r1 offset=0 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=361 dst=r3 src=r0 offset=0 imm=44
+#line 236 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(44);
+    // EBPF_OP_JSGT_REG pc=362 dst=r3 src=r2 offset=-331 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 236 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
+#line 237 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_STXB pc=364 dst=r0 src=r1 offset=47 imm=0
+#line 237 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(47)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=365 dst=r1 src=r6 offset=0 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=366 dst=r2 src=r6 offset=8 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=367 dst=r2 src=r1 offset=0 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=368 dst=r3 src=r0 offset=0 imm=45
+#line 239 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(45);
+    // EBPF_OP_JSGT_REG pc=369 dst=r3 src=r2 offset=-338 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 239 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
+#line 240 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXB pc=371 dst=r0 src=r1 offset=48 imm=0
+#line 240 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(48)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=372 dst=r1 src=r6 offset=0 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=373 dst=r2 src=r6 offset=8 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=374 dst=r2 src=r1 offset=0 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=375 dst=r3 src=r0 offset=0 imm=46
+#line 242 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(46);
+    // EBPF_OP_JSGT_REG pc=376 dst=r3 src=r2 offset=-345 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 242 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
+#line 243 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
+    // EBPF_OP_STXB pc=378 dst=r0 src=r1 offset=49 imm=0
+#line 243 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(49)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=379 dst=r1 src=r6 offset=0 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=380 dst=r2 src=r6 offset=8 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=381 dst=r2 src=r1 offset=0 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=382 dst=r3 src=r0 offset=0 imm=47
+#line 245 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(47);
+    // EBPF_OP_JSGT_REG pc=383 dst=r3 src=r2 offset=-352 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 245 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
+#line 246 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
+    // EBPF_OP_STXB pc=385 dst=r0 src=r1 offset=50 imm=0
+#line 246 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(50)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=386 dst=r1 src=r6 offset=0 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=387 dst=r2 src=r6 offset=8 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=388 dst=r2 src=r1 offset=0 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=389 dst=r3 src=r0 offset=0 imm=48
+#line 248 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(48);
+    // EBPF_OP_JSGT_REG pc=390 dst=r3 src=r2 offset=-359 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 248 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
+#line 249 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
+    // EBPF_OP_STXB pc=392 dst=r0 src=r1 offset=51 imm=0
+#line 249 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(51)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=393 dst=r1 src=r6 offset=0 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=394 dst=r2 src=r6 offset=8 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=395 dst=r2 src=r1 offset=0 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=396 dst=r3 src=r0 offset=0 imm=49
+#line 251 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(49);
+    // EBPF_OP_JSGT_REG pc=397 dst=r3 src=r2 offset=-366 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 251 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
+#line 252 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXB pc=399 dst=r0 src=r1 offset=52 imm=0
+#line 252 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(52)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=400 dst=r1 src=r6 offset=0 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=401 dst=r2 src=r6 offset=8 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=402 dst=r2 src=r1 offset=0 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=403 dst=r3 src=r0 offset=0 imm=50
+#line 254 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(50);
+    // EBPF_OP_JSGT_REG pc=404 dst=r3 src=r2 offset=-373 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 254 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
+#line 255 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
+    // EBPF_OP_STXB pc=406 dst=r0 src=r1 offset=53 imm=0
+#line 255 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(53)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=407 dst=r1 src=r6 offset=0 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=408 dst=r2 src=r6 offset=8 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=409 dst=r2 src=r1 offset=0 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=410 dst=r3 src=r0 offset=0 imm=51
+#line 257 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(51);
+    // EBPF_OP_JSGT_REG pc=411 dst=r3 src=r2 offset=-380 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 257 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
+#line 258 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
+    // EBPF_OP_STXB pc=413 dst=r0 src=r1 offset=54 imm=0
+#line 258 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(54)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=414 dst=r1 src=r6 offset=0 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=415 dst=r2 src=r6 offset=8 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=416 dst=r2 src=r1 offset=0 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=417 dst=r3 src=r0 offset=0 imm=52
+#line 260 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(52);
+    // EBPF_OP_JSGT_REG pc=418 dst=r3 src=r2 offset=-387 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 260 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
+#line 261 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
+    // EBPF_OP_STXB pc=420 dst=r0 src=r1 offset=55 imm=0
+#line 261 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(55)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=421 dst=r1 src=r6 offset=0 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=422 dst=r2 src=r6 offset=8 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=423 dst=r2 src=r1 offset=0 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=424 dst=r3 src=r0 offset=0 imm=53
+#line 263 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(53);
+    // EBPF_OP_JSGT_REG pc=425 dst=r3 src=r2 offset=-394 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 263 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
+#line 264 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
+    // EBPF_OP_STXB pc=427 dst=r0 src=r1 offset=56 imm=0
+#line 264 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(56)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=428 dst=r1 src=r6 offset=0 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=429 dst=r2 src=r6 offset=8 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=430 dst=r2 src=r1 offset=0 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=431 dst=r3 src=r0 offset=0 imm=54
+#line 266 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(54);
+    // EBPF_OP_JSGT_REG pc=432 dst=r3 src=r2 offset=-401 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 266 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
+#line 267 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
+    // EBPF_OP_STXB pc=434 dst=r0 src=r1 offset=57 imm=0
+#line 267 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(57)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=435 dst=r1 src=r6 offset=0 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=436 dst=r2 src=r6 offset=8 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=437 dst=r2 src=r1 offset=0 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=438 dst=r3 src=r0 offset=0 imm=55
+#line 269 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(55);
+    // EBPF_OP_JSGT_REG pc=439 dst=r3 src=r2 offset=-408 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 269 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
+#line 270 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
+    // EBPF_OP_STXB pc=441 dst=r0 src=r1 offset=58 imm=0
+#line 270 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(58)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=442 dst=r1 src=r6 offset=0 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=443 dst=r2 src=r6 offset=8 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=444 dst=r2 src=r1 offset=0 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=445 dst=r3 src=r0 offset=0 imm=56
+#line 272 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(56);
+    // EBPF_OP_JSGT_REG pc=446 dst=r3 src=r2 offset=-415 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 272 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
+#line 273 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
+    // EBPF_OP_STXB pc=448 dst=r0 src=r1 offset=59 imm=0
+#line 273 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(59)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=449 dst=r1 src=r6 offset=0 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=450 dst=r2 src=r6 offset=8 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=451 dst=r2 src=r1 offset=0 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=452 dst=r3 src=r0 offset=0 imm=57
+#line 275 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(57);
+    // EBPF_OP_JSGT_REG pc=453 dst=r3 src=r2 offset=-422 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 275 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
+#line 276 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=455 dst=r0 src=r1 offset=60 imm=0
+#line 276 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(60)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=456 dst=r1 src=r6 offset=0 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=457 dst=r2 src=r6 offset=8 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=458 dst=r2 src=r1 offset=0 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=459 dst=r3 src=r0 offset=0 imm=58
+#line 278 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(58);
+    // EBPF_OP_JSGT_REG pc=460 dst=r3 src=r2 offset=-429 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 278 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
+#line 279 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
+    // EBPF_OP_STXB pc=462 dst=r0 src=r1 offset=61 imm=0
+#line 279 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(61)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=463 dst=r1 src=r6 offset=0 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=464 dst=r2 src=r6 offset=8 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=465 dst=r2 src=r1 offset=0 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=466 dst=r3 src=r0 offset=0 imm=59
+#line 281 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(59);
+    // EBPF_OP_JSGT_REG pc=467 dst=r3 src=r2 offset=-436 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 281 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
+#line 282 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
+    // EBPF_OP_STXB pc=469 dst=r0 src=r1 offset=62 imm=0
+#line 282 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(62)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=470 dst=r1 src=r6 offset=0 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=471 dst=r2 src=r6 offset=8 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=472 dst=r2 src=r1 offset=0 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=473 dst=r3 src=r0 offset=0 imm=60
+#line 284 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(60);
+    // EBPF_OP_JSGT_REG pc=474 dst=r3 src=r2 offset=-443 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 284 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
+#line 285 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
+    // EBPF_OP_STXB pc=476 dst=r0 src=r1 offset=63 imm=0
+#line 285 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(63)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=477 dst=r1 src=r6 offset=0 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=478 dst=r2 src=r6 offset=8 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=479 dst=r2 src=r1 offset=0 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=480 dst=r3 src=r0 offset=0 imm=61
+#line 287 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(61);
+    // EBPF_OP_JSGT_REG pc=481 dst=r3 src=r2 offset=-450 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 287 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
+#line 288 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
+    // EBPF_OP_STXB pc=483 dst=r0 src=r1 offset=64 imm=0
+#line 288 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(64)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=484 dst=r1 src=r6 offset=0 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=485 dst=r2 src=r6 offset=8 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=486 dst=r2 src=r1 offset=0 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=487 dst=r3 src=r0 offset=0 imm=62
+#line 290 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(62);
+    // EBPF_OP_JSGT_REG pc=488 dst=r3 src=r2 offset=-457 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 290 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
+#line 291 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
+    // EBPF_OP_STXB pc=490 dst=r0 src=r1 offset=65 imm=0
+#line 291 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(65)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=491 dst=r1 src=r6 offset=0 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=492 dst=r2 src=r6 offset=8 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=493 dst=r2 src=r1 offset=0 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=494 dst=r3 src=r0 offset=0 imm=63
+#line 293 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(63);
+    // EBPF_OP_JSGT_REG pc=495 dst=r3 src=r2 offset=-464 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 293 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
+#line 294 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
+    // EBPF_OP_STXB pc=497 dst=r0 src=r1 offset=66 imm=0
+#line 294 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(66)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=498 dst=r1 src=r6 offset=0 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=499 dst=r2 src=r6 offset=8 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=500 dst=r2 src=r1 offset=0 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=501 dst=r3 src=r0 offset=0 imm=64
+#line 296 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_JSGT_REG pc=502 dst=r3 src=r2 offset=-471 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 296 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
+    // EBPF_OP_STXB pc=504 dst=r0 src=r1 offset=67 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(67)) = (uint8_t)r1;
+    // EBPF_OP_JA pc=505 dst=r0 src=r0 offset=-474 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    goto label_2;
 label_4:
-    // EBPF_OP_MOV64_IMM pc=69 dst=r8 src=r0 offset=0 imm=1
-#line 176 "sample/bindmonitor_tailcall.c"
-    r8 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=70 dst=r1 src=r0 offset=0 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LDXW pc=506 dst=r1 src=r0 offset=0 imm=0
+#line 365 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_LDXW pc=71 dst=r2 src=r7 offset=0 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
-    if (r1 >= r2)
-#line 162 "sample/bindmonitor_tailcall.c"
-        goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
-#line 166 "sample/bindmonitor_tailcall.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
-#line 166 "sample/bindmonitor_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=15 imm=0
-#line 166 "sample/bindmonitor_tailcall.c"
-    goto label_8;
-label_5:
-    // EBPF_OP_LDXW pc=76 dst=r1 src=r0 offset=0 imm=0
-#line 169 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
-#line 169 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=507 dst=r1 src=r0 offset=6 imm=0
+#line 365 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
-#line 169 "sample/bindmonitor_tailcall.c"
-        goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
-#line 170 "sample/bindmonitor_tailcall.c"
+#line 365 "sample/bindmonitor_tailcall.c"
+        goto label_6;
+        // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
+#line 366 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
-    // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
-#line 170 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_STXW pc=509 dst=r0 src=r1 offset=0 imm=0
+#line 366 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-label_6:
-    // EBPF_OP_MOV64_IMM pc=80 dst=r8 src=r0 offset=0 imm=0
-#line 170 "sample/bindmonitor_tailcall.c"
+label_5:
+    // EBPF_OP_MOV64_IMM pc=510 dst=r8 src=r0 offset=0 imm=0
+#line 366 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
-    // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
+#line 372 "sample/bindmonitor_tailcall.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_RSH64_IMM pc=512 dst=r1 src=r0 offset=0 imm=32
+#line 372 "sample/bindmonitor_tailcall.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JNE_IMM pc=513 dst=r1 src=r0 offset=15 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
-#line 176 "sample/bindmonitor_tailcall.c"
+#line 372 "sample/bindmonitor_tailcall.c"
         goto label_9;
-label_7:
-    // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+label_6:
+    // EBPF_OP_LDXDW pc=514 dst=r1 src=r6 offset=16 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
-    // EBPF_OP_STXDW pc=85 dst=r10 src=r1 offset=-80 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_STXDW pc=515 dst=r10 src=r1 offset=-80 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=86 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=516 dst=r2 src=r10 offset=0 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=87 dst=r2 src=r0 offset=0 imm=-80
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_ADD64_IMM pc=517 dst=r2 src=r0 offset=0 imm=-80
+#line 373 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-80);
-    // EBPF_OP_LDDW pc=88 dst=r1 src=r0 offset=0 imm=0
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LDDW pc=518 dst=r1 src=r0 offset=0 imm=0
+#line 374 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_CALL pc=520 dst=r0 src=r0 offset=0 imm=3
+#line 374 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[2].address
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
         return 0;
+        // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
+#line 374 "sample/bindmonitor_tailcall.c"
+    goto label_8;
+label_7:
+    // EBPF_OP_MOV64_IMM pc=522 dst=r8 src=r0 offset=0 imm=1
+#line 374 "sample/bindmonitor_tailcall.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=523 dst=r1 src=r0 offset=0 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_LDXW pc=524 dst=r2 src=r7 offset=0 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_JGE_REG pc=525 dst=r1 src=r2 offset=3 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    if (r1 >= r2)
+#line 358 "sample/bindmonitor_tailcall.c"
+        goto label_9;
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
+#line 362 "sample/bindmonitor_tailcall.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
+#line 362 "sample/bindmonitor_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
 label_8:
-    // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=528 dst=r8 src=r0 offset=0 imm=0
+#line 362 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
 label_9:
-    // EBPF_OP_MOV64_REG pc=92 dst=r0 src=r8 offset=0 imm=0
-#line 182 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=529 dst=r0 src=r8 offset=0 imm=0
+#line 378 "sample/bindmonitor_tailcall.c"
     r0 = r8;
-    // EBPF_OP_EXIT pc=93 dst=r0 src=r0 offset=0 imm=0
-#line 182 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_EXIT pc=530 dst=r0 src=r0 offset=0 imm=0
+#line 378 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 182 "sample/bindmonitor_tailcall.c"
+#line 378 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -787,7 +2222,7 @@ static program_entry_t _programs[] = {
         2,
         BindMonitor_Callee1_helpers,
         3,
-        94,
+        531,
         &BindMonitor_Callee1_program_type_guid,
         &BindMonitor_Callee1_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -125,92 +125,92 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
 {
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-4 imm=0
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-4
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_helpers[0].address
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
-#line 119 "sample/bindmonitor_tailcall.c"
+#line 315 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
-#line 119 "sample/bindmonitor_tailcall.c"
+#line 315 "sample/bindmonitor_tailcall.c"
         goto label_1;
         // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r2 = POINTER(_maps[2].address);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_helpers[1].address
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=15 dst=r0 src=r0 offset=0 imm=0
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -232,92 +232,92 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
 {
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-4 imm=0
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-4
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[0].address
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
-#line 135 "sample/bindmonitor_tailcall.c"
+#line 331 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
-#line 135 "sample/bindmonitor_tailcall.c"
+#line 331 "sample/bindmonitor_tailcall.c"
         goto label_1;
         // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r2 = POINTER(_maps[2].address);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=1
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[1].address
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=15 dst=r0 src=r0 offset=0 imm=0
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -340,82 +340,80 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
 {
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r7 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r8 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
-    register uint64_t r9 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r8 src=r0 offset=0 imm=0
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r8 offset=-84 imm=0
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-84
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-84);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r7 = r0;
-    // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=519 imm=0
+#line 347 "sample/bindmonitor_tailcall.c"
     if (r7 == IMMEDIATE(0))
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
         goto label_9;
         // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=517 imm=0
+#line 347 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
         goto label_9;
         // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
@@ -471,64 +469,87 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
-        goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
-#line 84 "sample/bindmonitor_tailcall.c"
-    goto label_3;
+        goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_MOV64_IMM pc=30 dst=r8 src=r0 offset=0 imm=0
+#line 84 "sample/bindmonitor_tailcall.c"
+    r8 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=31 dst=r0 src=r0 offset=497 imm=0
+#line 352 "sample/bindmonitor_tailcall.c"
+    if (r0 == IMMEDIATE(0))
+#line 352 "sample/bindmonitor_tailcall.c"
+        goto label_9;
+label_2:
+    // EBPF_OP_LDXW pc=32 dst=r1 src=r6 offset=44 imm=0
+#line 356 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=33 dst=r1 src=r0 offset=488 imm=0
+#line 356 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(0))
+#line 356 "sample/bindmonitor_tailcall.c"
+        goto label_7;
+        // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
+#line 356 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(2))
+#line 356 "sample/bindmonitor_tailcall.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_JA pc=36 dst=r0 src=r0 offset=473 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
+    goto label_5;
+label_3:
+    // EBPF_OP_LDXW pc=37 dst=r1 src=r6 offset=44 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
+    // EBPF_OP_JNE_IMM pc=38 dst=r1 src=r0 offset=489 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
+    // EBPF_OP_JEQ_IMM pc=40 dst=r1 src=r0 offset=487 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
+    // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=485 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=44 dst=r8 src=r0 offset=0 imm=-8
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=39 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=45 dst=r3 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=40 dst=r3 src=r0 offset=0 imm=-80
+    // EBPF_OP_ADD64_IMM pc=46 dst=r3 src=r0 offset=0 imm=-80
 #line 90 "sample/bindmonitor_tailcall.c"
     r3 += IMMEDIATE(-80);
-    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
-#line 90 "sample/bindmonitor_tailcall.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_LDDW pc=42 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=44 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r2 = r8;
-    // EBPF_OP_MOV64_IMM pc=45 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=50 dst=r4 src=r0 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=51 dst=r0 src=r0 offset=0 imm=2
 #line 93 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[1].address
 #line 93 "sample/bindmonitor_tailcall.c"
@@ -537,13 +558,13 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 93 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=54 dst=r2 src=r8 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r2 = r8;
-    // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=1
 #line 94 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
 #line 94 "sample/bindmonitor_tailcall.c"
@@ -552,163 +573,1577 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 94 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 95 "sample/bindmonitor_tailcall.c"
-    r1 = r0;
-    // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 95 "sample/bindmonitor_tailcall.c"
-    r1 += IMMEDIATE(4);
-label_2:
-    // EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_ADD64_REG pc=55 dst=r2 src=r9 offset=0 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r2 += r9;
-    // EBPF_OP_LDXDW pc=56 dst=r3 src=r6 offset=8 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    if (r2 >= r3)
-#line 99 "sample/bindmonitor_tailcall.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r3 += r9;
-    // EBPF_OP_LDXB pc=60 dst=r2 src=r2 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXB pc=61 dst=r3 src=r2 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    *(uint8_t*)(uintptr_t)(r3 + OFFSET(0)) = (uint8_t)r2;
-    // EBPF_OP_ADD64_IMM pc=62 dst=r9 src=r0 offset=0 imm=1
-#line 98 "sample/bindmonitor_tailcall.c"
-    r9 += IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
-#line 98 "sample/bindmonitor_tailcall.c"
-    if (r9 != IMMEDIATE(64))
-#line 98 "sample/bindmonitor_tailcall.c"
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=58 dst=r2 src=r6 offset=8 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=59 dst=r2 src=r1 offset=0 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=60 dst=r3 src=r0 offset=0 imm=1
+#line 107 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_JSGT_REG pc=61 dst=r3 src=r2 offset=-32 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 107 "sample/bindmonitor_tailcall.c"
+        goto label_1;
+        // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
+#line 108 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_STXB pc=63 dst=r0 src=r1 offset=4 imm=0
+#line 108 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(4)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=64 dst=r1 src=r6 offset=0 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=65 dst=r2 src=r6 offset=8 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=66 dst=r2 src=r1 offset=0 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=2
+#line 110 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_JSGT_REG pc=68 dst=r3 src=r2 offset=-37 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 110 "sample/bindmonitor_tailcall.c"
         goto label_2;
-label_3:
-    // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
-#line 160 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
-#line 160 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
-#line 160 "sample/bindmonitor_tailcall.c"
-        goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
-#line 160 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(2))
-#line 160 "sample/bindmonitor_tailcall.c"
-        goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
+#line 111 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
+    // EBPF_OP_STXB pc=70 dst=r0 src=r1 offset=5 imm=0
+#line 111 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(5)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=72 dst=r2 src=r6 offset=8 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=73 dst=r2 src=r1 offset=0 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=74 dst=r3 src=r0 offset=0 imm=3
+#line 113 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_JSGT_REG pc=75 dst=r3 src=r2 offset=-44 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 113 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
+#line 114 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
+    // EBPF_OP_STXB pc=77 dst=r0 src=r1 offset=6 imm=0
+#line 114 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(6)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=78 dst=r1 src=r6 offset=0 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=79 dst=r2 src=r6 offset=8 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=80 dst=r2 src=r1 offset=0 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=81 dst=r3 src=r0 offset=0 imm=4
+#line 116 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_JSGT_REG pc=82 dst=r3 src=r2 offset=-51 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 116 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
+#line 117 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
+    // EBPF_OP_STXB pc=84 dst=r0 src=r1 offset=7 imm=0
+#line 117 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(7)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=85 dst=r1 src=r6 offset=0 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=86 dst=r2 src=r6 offset=8 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=87 dst=r2 src=r1 offset=0 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=88 dst=r3 src=r0 offset=0 imm=5
+#line 119 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_JSGT_REG pc=89 dst=r3 src=r2 offset=-58 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 119 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
+#line 120 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_STXB pc=91 dst=r0 src=r1 offset=8 imm=0
+#line 120 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(8)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=92 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=93 dst=r2 src=r6 offset=8 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=94 dst=r2 src=r1 offset=0 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=95 dst=r3 src=r0 offset=0 imm=6
+#line 122 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_JSGT_REG pc=96 dst=r3 src=r2 offset=-65 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 122 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
+    // EBPF_OP_STXB pc=98 dst=r0 src=r1 offset=9 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(9)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=99 dst=r1 src=r6 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=100 dst=r2 src=r6 offset=8 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=101 dst=r2 src=r1 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=102 dst=r3 src=r0 offset=0 imm=7
+#line 125 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_JSGT_REG pc=103 dst=r3 src=r2 offset=-72 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 125 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
+#line 126 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
+    // EBPF_OP_STXB pc=105 dst=r0 src=r1 offset=10 imm=0
+#line 126 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(10)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=106 dst=r1 src=r6 offset=0 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=107 dst=r2 src=r6 offset=8 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=108 dst=r2 src=r1 offset=0 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=109 dst=r3 src=r0 offset=0 imm=8
+#line 128 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_JSGT_REG pc=110 dst=r3 src=r2 offset=-79 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 128 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
+#line 129 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
+    // EBPF_OP_STXB pc=112 dst=r0 src=r1 offset=11 imm=0
+#line 129 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(11)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=113 dst=r1 src=r6 offset=0 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=114 dst=r2 src=r6 offset=8 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=115 dst=r2 src=r1 offset=0 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=116 dst=r3 src=r0 offset=0 imm=9
+#line 131 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_JSGT_REG pc=117 dst=r3 src=r2 offset=-86 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 131 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
+#line 132 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXB pc=119 dst=r0 src=r1 offset=12 imm=0
+#line 132 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(12)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=120 dst=r1 src=r6 offset=0 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=121 dst=r2 src=r6 offset=8 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=122 dst=r2 src=r1 offset=0 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=123 dst=r3 src=r0 offset=0 imm=10
+#line 134 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_JSGT_REG pc=124 dst=r3 src=r2 offset=-93 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 134 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
+#line 135 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_STXB pc=126 dst=r0 src=r1 offset=13 imm=0
+#line 135 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(13)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=127 dst=r1 src=r6 offset=0 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=128 dst=r2 src=r6 offset=8 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=129 dst=r2 src=r1 offset=0 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=130 dst=r3 src=r0 offset=0 imm=11
+#line 137 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_JSGT_REG pc=131 dst=r3 src=r2 offset=-100 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 137 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
+#line 138 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_STXB pc=133 dst=r0 src=r1 offset=14 imm=0
+#line 138 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(14)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=134 dst=r1 src=r6 offset=0 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=135 dst=r2 src=r6 offset=8 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=136 dst=r2 src=r1 offset=0 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=137 dst=r3 src=r0 offset=0 imm=12
+#line 140 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_JSGT_REG pc=138 dst=r3 src=r2 offset=-107 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 140 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_STXB pc=140 dst=r0 src=r1 offset=15 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(15)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=141 dst=r1 src=r6 offset=0 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=142 dst=r2 src=r6 offset=8 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=143 dst=r2 src=r1 offset=0 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=144 dst=r3 src=r0 offset=0 imm=13
+#line 143 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_JSGT_REG pc=145 dst=r3 src=r2 offset=-114 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 143 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
+#line 144 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_STXB pc=147 dst=r0 src=r1 offset=16 imm=0
+#line 144 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(16)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=148 dst=r1 src=r6 offset=0 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=149 dst=r2 src=r6 offset=8 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=150 dst=r2 src=r1 offset=0 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=151 dst=r3 src=r0 offset=0 imm=14
+#line 146 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_JSGT_REG pc=152 dst=r3 src=r2 offset=-121 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 146 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
+#line 147 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_STXB pc=154 dst=r0 src=r1 offset=17 imm=0
+#line 147 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(17)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=155 dst=r1 src=r6 offset=0 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=156 dst=r2 src=r6 offset=8 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=157 dst=r2 src=r1 offset=0 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=158 dst=r3 src=r0 offset=0 imm=15
+#line 149 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_JSGT_REG pc=159 dst=r3 src=r2 offset=-128 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 149 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
+#line 150 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_STXB pc=161 dst=r0 src=r1 offset=18 imm=0
+#line 150 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(18)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=162 dst=r1 src=r6 offset=0 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=163 dst=r2 src=r6 offset=8 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=164 dst=r2 src=r1 offset=0 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=165 dst=r3 src=r0 offset=0 imm=16
+#line 152 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_JSGT_REG pc=166 dst=r3 src=r2 offset=-135 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 152 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
+#line 153 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_STXB pc=168 dst=r0 src=r1 offset=19 imm=0
+#line 153 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(19)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=169 dst=r1 src=r6 offset=0 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=170 dst=r2 src=r6 offset=8 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=171 dst=r2 src=r1 offset=0 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=172 dst=r3 src=r0 offset=0 imm=17
+#line 155 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_JSGT_REG pc=173 dst=r3 src=r2 offset=-142 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 155 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_STXB pc=175 dst=r0 src=r1 offset=20 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(20)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=176 dst=r1 src=r6 offset=0 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=177 dst=r2 src=r6 offset=8 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=178 dst=r2 src=r1 offset=0 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=179 dst=r3 src=r0 offset=0 imm=18
+#line 158 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_JSGT_REG pc=180 dst=r3 src=r2 offset=-149 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 158 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
+#line 159 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_STXB pc=182 dst=r0 src=r1 offset=21 imm=0
+#line 159 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(21)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=183 dst=r1 src=r6 offset=0 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=184 dst=r2 src=r6 offset=8 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=185 dst=r2 src=r1 offset=0 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=186 dst=r3 src=r0 offset=0 imm=19
+#line 161 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_JSGT_REG pc=187 dst=r3 src=r2 offset=-156 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 161 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
+#line 162 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_STXB pc=189 dst=r0 src=r1 offset=22 imm=0
+#line 162 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(22)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=190 dst=r1 src=r6 offset=0 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=191 dst=r2 src=r6 offset=8 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=192 dst=r2 src=r1 offset=0 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=193 dst=r3 src=r0 offset=0 imm=20
+#line 164 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_JSGT_REG pc=194 dst=r3 src=r2 offset=-163 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 164 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
+#line 165 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_STXB pc=196 dst=r0 src=r1 offset=23 imm=0
+#line 165 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(23)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=197 dst=r1 src=r6 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=198 dst=r2 src=r6 offset=8 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=199 dst=r2 src=r1 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=200 dst=r3 src=r0 offset=0 imm=21
+#line 167 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_JSGT_REG pc=201 dst=r3 src=r2 offset=-170 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 167 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
+#line 168 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_STXB pc=203 dst=r0 src=r1 offset=24 imm=0
+#line 168 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(24)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=204 dst=r1 src=r6 offset=0 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=205 dst=r2 src=r6 offset=8 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=206 dst=r2 src=r1 offset=0 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=207 dst=r3 src=r0 offset=0 imm=22
+#line 170 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_JSGT_REG pc=208 dst=r3 src=r2 offset=-177 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 170 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
+#line 171 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_STXB pc=210 dst=r0 src=r1 offset=25 imm=0
+#line 171 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(25)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=211 dst=r1 src=r6 offset=0 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=212 dst=r2 src=r6 offset=8 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=213 dst=r2 src=r1 offset=0 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=214 dst=r3 src=r0 offset=0 imm=23
+#line 173 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_JSGT_REG pc=215 dst=r3 src=r2 offset=-184 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 173 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
+#line 174 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_STXB pc=217 dst=r0 src=r1 offset=26 imm=0
+#line 174 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(26)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=218 dst=r1 src=r6 offset=0 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=219 dst=r2 src=r6 offset=8 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    goto label_6;
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=220 dst=r2 src=r1 offset=0 imm=0
+#line 176 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=221 dst=r3 src=r0 offset=0 imm=24
+#line 176 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_JSGT_REG pc=222 dst=r3 src=r2 offset=-191 imm=0
+#line 176 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 176 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
+#line 177 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_STXB pc=224 dst=r0 src=r1 offset=27 imm=0
+#line 177 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(27)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=225 dst=r1 src=r6 offset=0 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=226 dst=r2 src=r6 offset=8 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=227 dst=r2 src=r1 offset=0 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=228 dst=r3 src=r0 offset=0 imm=25
+#line 179 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_JSGT_REG pc=229 dst=r3 src=r2 offset=-198 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 179 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
+#line 180 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXB pc=231 dst=r0 src=r1 offset=28 imm=0
+#line 180 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(28)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=232 dst=r1 src=r6 offset=0 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=233 dst=r2 src=r6 offset=8 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=234 dst=r2 src=r1 offset=0 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=235 dst=r3 src=r0 offset=0 imm=26
+#line 182 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_JSGT_REG pc=236 dst=r3 src=r2 offset=-205 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 182 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
+#line 183 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
+    // EBPF_OP_STXB pc=238 dst=r0 src=r1 offset=29 imm=0
+#line 183 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(29)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=239 dst=r1 src=r6 offset=0 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=240 dst=r2 src=r6 offset=8 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=241 dst=r2 src=r1 offset=0 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=242 dst=r3 src=r0 offset=0 imm=27
+#line 185 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_JSGT_REG pc=243 dst=r3 src=r2 offset=-212 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 185 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
+#line 186 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
+    // EBPF_OP_STXB pc=245 dst=r0 src=r1 offset=30 imm=0
+#line 186 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(30)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=246 dst=r1 src=r6 offset=0 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=247 dst=r2 src=r6 offset=8 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=248 dst=r2 src=r1 offset=0 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=249 dst=r3 src=r0 offset=0 imm=28
+#line 188 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_JSGT_REG pc=250 dst=r3 src=r2 offset=-219 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 188 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
+#line 189 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
+    // EBPF_OP_STXB pc=252 dst=r0 src=r1 offset=31 imm=0
+#line 189 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(31)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=253 dst=r1 src=r6 offset=0 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=254 dst=r2 src=r6 offset=8 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=255 dst=r2 src=r1 offset=0 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=256 dst=r3 src=r0 offset=0 imm=29
+#line 191 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_JSGT_REG pc=257 dst=r3 src=r2 offset=-226 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 191 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
+#line 192 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXB pc=259 dst=r0 src=r1 offset=32 imm=0
+#line 192 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(32)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=260 dst=r1 src=r6 offset=0 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=261 dst=r2 src=r6 offset=8 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=262 dst=r2 src=r1 offset=0 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=263 dst=r3 src=r0 offset=0 imm=30
+#line 194 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_JSGT_REG pc=264 dst=r3 src=r2 offset=-233 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 194 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
+#line 195 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_STXB pc=266 dst=r0 src=r1 offset=33 imm=0
+#line 195 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(33)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=267 dst=r1 src=r6 offset=0 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=268 dst=r2 src=r6 offset=8 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=269 dst=r2 src=r1 offset=0 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=270 dst=r3 src=r0 offset=0 imm=31
+#line 197 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(31);
+    // EBPF_OP_JSGT_REG pc=271 dst=r3 src=r2 offset=-240 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 197 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
+#line 198 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_STXB pc=273 dst=r0 src=r1 offset=34 imm=0
+#line 198 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(34)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=274 dst=r1 src=r6 offset=0 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=275 dst=r2 src=r6 offset=8 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=276 dst=r2 src=r1 offset=0 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=277 dst=r3 src=r0 offset=0 imm=32
+#line 200 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=278 dst=r3 src=r2 offset=-247 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 200 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
+#line 201 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_STXB pc=280 dst=r0 src=r1 offset=35 imm=0
+#line 201 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(35)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=281 dst=r1 src=r6 offset=0 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=282 dst=r2 src=r6 offset=8 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=283 dst=r2 src=r1 offset=0 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=284 dst=r3 src=r0 offset=0 imm=33
+#line 203 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(33);
+    // EBPF_OP_JSGT_REG pc=285 dst=r3 src=r2 offset=-254 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 203 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
+#line 204 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_STXB pc=287 dst=r0 src=r1 offset=36 imm=0
+#line 204 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(36)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=288 dst=r1 src=r6 offset=0 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=289 dst=r2 src=r6 offset=8 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=290 dst=r2 src=r1 offset=0 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=291 dst=r3 src=r0 offset=0 imm=34
+#line 206 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(34);
+    // EBPF_OP_JSGT_REG pc=292 dst=r3 src=r2 offset=-261 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 206 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
+#line 207 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_STXB pc=294 dst=r0 src=r1 offset=37 imm=0
+#line 207 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(37)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=295 dst=r1 src=r6 offset=0 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=296 dst=r2 src=r6 offset=8 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=297 dst=r2 src=r1 offset=0 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=298 dst=r3 src=r0 offset=0 imm=35
+#line 209 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(35);
+    // EBPF_OP_JSGT_REG pc=299 dst=r3 src=r2 offset=-268 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 209 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
+#line 210 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_STXB pc=301 dst=r0 src=r1 offset=38 imm=0
+#line 210 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(38)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=302 dst=r1 src=r6 offset=0 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=303 dst=r2 src=r6 offset=8 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=304 dst=r2 src=r1 offset=0 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=305 dst=r3 src=r0 offset=0 imm=36
+#line 212 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(36);
+    // EBPF_OP_JSGT_REG pc=306 dst=r3 src=r2 offset=-275 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 212 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
+#line 213 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_STXB pc=308 dst=r0 src=r1 offset=39 imm=0
+#line 213 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(39)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=309 dst=r1 src=r6 offset=0 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=310 dst=r2 src=r6 offset=8 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=311 dst=r2 src=r1 offset=0 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=312 dst=r3 src=r0 offset=0 imm=37
+#line 215 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(37);
+    // EBPF_OP_JSGT_REG pc=313 dst=r3 src=r2 offset=-282 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 215 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
+#line 216 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_STXB pc=315 dst=r0 src=r1 offset=40 imm=0
+#line 216 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(40)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=316 dst=r1 src=r6 offset=0 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=317 dst=r2 src=r6 offset=8 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=318 dst=r2 src=r1 offset=0 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=319 dst=r3 src=r0 offset=0 imm=38
+#line 218 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(38);
+    // EBPF_OP_JSGT_REG pc=320 dst=r3 src=r2 offset=-289 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 218 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
+#line 219 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_STXB pc=322 dst=r0 src=r1 offset=41 imm=0
+#line 219 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(41)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=323 dst=r1 src=r6 offset=0 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=324 dst=r2 src=r6 offset=8 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=325 dst=r2 src=r1 offset=0 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=326 dst=r3 src=r0 offset=0 imm=39
+#line 221 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(39);
+    // EBPF_OP_JSGT_REG pc=327 dst=r3 src=r2 offset=-296 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 221 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
+#line 222 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_STXB pc=329 dst=r0 src=r1 offset=42 imm=0
+#line 222 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(42)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=330 dst=r1 src=r6 offset=0 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=331 dst=r2 src=r6 offset=8 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=332 dst=r2 src=r1 offset=0 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=333 dst=r3 src=r0 offset=0 imm=40
+#line 224 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(40);
+    // EBPF_OP_JSGT_REG pc=334 dst=r3 src=r2 offset=-303 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 224 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
+#line 225 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_STXB pc=336 dst=r0 src=r1 offset=43 imm=0
+#line 225 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(43)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=337 dst=r1 src=r6 offset=0 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=338 dst=r2 src=r6 offset=8 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=339 dst=r2 src=r1 offset=0 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=340 dst=r3 src=r0 offset=0 imm=41
+#line 227 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(41);
+    // EBPF_OP_JSGT_REG pc=341 dst=r3 src=r2 offset=-310 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 227 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
+#line 228 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_STXB pc=343 dst=r0 src=r1 offset=44 imm=0
+#line 228 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(44)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=344 dst=r1 src=r6 offset=0 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=345 dst=r2 src=r6 offset=8 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=346 dst=r2 src=r1 offset=0 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=347 dst=r3 src=r0 offset=0 imm=42
+#line 230 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(42);
+    // EBPF_OP_JSGT_REG pc=348 dst=r3 src=r2 offset=-317 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 230 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
+#line 231 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_STXB pc=350 dst=r0 src=r1 offset=45 imm=0
+#line 231 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(45)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=351 dst=r1 src=r6 offset=0 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=352 dst=r2 src=r6 offset=8 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=353 dst=r2 src=r1 offset=0 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=354 dst=r3 src=r0 offset=0 imm=43
+#line 233 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(43);
+    // EBPF_OP_JSGT_REG pc=355 dst=r3 src=r2 offset=-324 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 233 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
+#line 234 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_STXB pc=357 dst=r0 src=r1 offset=46 imm=0
+#line 234 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(46)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=358 dst=r1 src=r6 offset=0 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=359 dst=r2 src=r6 offset=8 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=360 dst=r2 src=r1 offset=0 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=361 dst=r3 src=r0 offset=0 imm=44
+#line 236 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(44);
+    // EBPF_OP_JSGT_REG pc=362 dst=r3 src=r2 offset=-331 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 236 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
+#line 237 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_STXB pc=364 dst=r0 src=r1 offset=47 imm=0
+#line 237 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(47)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=365 dst=r1 src=r6 offset=0 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=366 dst=r2 src=r6 offset=8 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=367 dst=r2 src=r1 offset=0 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=368 dst=r3 src=r0 offset=0 imm=45
+#line 239 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(45);
+    // EBPF_OP_JSGT_REG pc=369 dst=r3 src=r2 offset=-338 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 239 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
+#line 240 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXB pc=371 dst=r0 src=r1 offset=48 imm=0
+#line 240 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(48)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=372 dst=r1 src=r6 offset=0 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=373 dst=r2 src=r6 offset=8 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=374 dst=r2 src=r1 offset=0 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=375 dst=r3 src=r0 offset=0 imm=46
+#line 242 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(46);
+    // EBPF_OP_JSGT_REG pc=376 dst=r3 src=r2 offset=-345 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 242 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
+#line 243 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
+    // EBPF_OP_STXB pc=378 dst=r0 src=r1 offset=49 imm=0
+#line 243 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(49)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=379 dst=r1 src=r6 offset=0 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=380 dst=r2 src=r6 offset=8 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=381 dst=r2 src=r1 offset=0 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=382 dst=r3 src=r0 offset=0 imm=47
+#line 245 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(47);
+    // EBPF_OP_JSGT_REG pc=383 dst=r3 src=r2 offset=-352 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 245 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
+#line 246 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
+    // EBPF_OP_STXB pc=385 dst=r0 src=r1 offset=50 imm=0
+#line 246 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(50)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=386 dst=r1 src=r6 offset=0 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=387 dst=r2 src=r6 offset=8 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=388 dst=r2 src=r1 offset=0 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=389 dst=r3 src=r0 offset=0 imm=48
+#line 248 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(48);
+    // EBPF_OP_JSGT_REG pc=390 dst=r3 src=r2 offset=-359 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 248 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
+#line 249 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
+    // EBPF_OP_STXB pc=392 dst=r0 src=r1 offset=51 imm=0
+#line 249 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(51)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=393 dst=r1 src=r6 offset=0 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=394 dst=r2 src=r6 offset=8 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=395 dst=r2 src=r1 offset=0 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=396 dst=r3 src=r0 offset=0 imm=49
+#line 251 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(49);
+    // EBPF_OP_JSGT_REG pc=397 dst=r3 src=r2 offset=-366 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 251 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
+#line 252 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXB pc=399 dst=r0 src=r1 offset=52 imm=0
+#line 252 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(52)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=400 dst=r1 src=r6 offset=0 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=401 dst=r2 src=r6 offset=8 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=402 dst=r2 src=r1 offset=0 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=403 dst=r3 src=r0 offset=0 imm=50
+#line 254 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(50);
+    // EBPF_OP_JSGT_REG pc=404 dst=r3 src=r2 offset=-373 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 254 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
+#line 255 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
+    // EBPF_OP_STXB pc=406 dst=r0 src=r1 offset=53 imm=0
+#line 255 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(53)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=407 dst=r1 src=r6 offset=0 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=408 dst=r2 src=r6 offset=8 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=409 dst=r2 src=r1 offset=0 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=410 dst=r3 src=r0 offset=0 imm=51
+#line 257 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(51);
+    // EBPF_OP_JSGT_REG pc=411 dst=r3 src=r2 offset=-380 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 257 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
+#line 258 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
+    // EBPF_OP_STXB pc=413 dst=r0 src=r1 offset=54 imm=0
+#line 258 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(54)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=414 dst=r1 src=r6 offset=0 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=415 dst=r2 src=r6 offset=8 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=416 dst=r2 src=r1 offset=0 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=417 dst=r3 src=r0 offset=0 imm=52
+#line 260 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(52);
+    // EBPF_OP_JSGT_REG pc=418 dst=r3 src=r2 offset=-387 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 260 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
+#line 261 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
+    // EBPF_OP_STXB pc=420 dst=r0 src=r1 offset=55 imm=0
+#line 261 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(55)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=421 dst=r1 src=r6 offset=0 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=422 dst=r2 src=r6 offset=8 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=423 dst=r2 src=r1 offset=0 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=424 dst=r3 src=r0 offset=0 imm=53
+#line 263 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(53);
+    // EBPF_OP_JSGT_REG pc=425 dst=r3 src=r2 offset=-394 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 263 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
+#line 264 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
+    // EBPF_OP_STXB pc=427 dst=r0 src=r1 offset=56 imm=0
+#line 264 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(56)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=428 dst=r1 src=r6 offset=0 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=429 dst=r2 src=r6 offset=8 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=430 dst=r2 src=r1 offset=0 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=431 dst=r3 src=r0 offset=0 imm=54
+#line 266 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(54);
+    // EBPF_OP_JSGT_REG pc=432 dst=r3 src=r2 offset=-401 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 266 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
+#line 267 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
+    // EBPF_OP_STXB pc=434 dst=r0 src=r1 offset=57 imm=0
+#line 267 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(57)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=435 dst=r1 src=r6 offset=0 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=436 dst=r2 src=r6 offset=8 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=437 dst=r2 src=r1 offset=0 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=438 dst=r3 src=r0 offset=0 imm=55
+#line 269 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(55);
+    // EBPF_OP_JSGT_REG pc=439 dst=r3 src=r2 offset=-408 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 269 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
+#line 270 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
+    // EBPF_OP_STXB pc=441 dst=r0 src=r1 offset=58 imm=0
+#line 270 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(58)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=442 dst=r1 src=r6 offset=0 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=443 dst=r2 src=r6 offset=8 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=444 dst=r2 src=r1 offset=0 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=445 dst=r3 src=r0 offset=0 imm=56
+#line 272 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(56);
+    // EBPF_OP_JSGT_REG pc=446 dst=r3 src=r2 offset=-415 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 272 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
+#line 273 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
+    // EBPF_OP_STXB pc=448 dst=r0 src=r1 offset=59 imm=0
+#line 273 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(59)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=449 dst=r1 src=r6 offset=0 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=450 dst=r2 src=r6 offset=8 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=451 dst=r2 src=r1 offset=0 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=452 dst=r3 src=r0 offset=0 imm=57
+#line 275 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(57);
+    // EBPF_OP_JSGT_REG pc=453 dst=r3 src=r2 offset=-422 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 275 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
+#line 276 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=455 dst=r0 src=r1 offset=60 imm=0
+#line 276 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(60)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=456 dst=r1 src=r6 offset=0 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=457 dst=r2 src=r6 offset=8 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=458 dst=r2 src=r1 offset=0 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=459 dst=r3 src=r0 offset=0 imm=58
+#line 278 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(58);
+    // EBPF_OP_JSGT_REG pc=460 dst=r3 src=r2 offset=-429 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 278 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
+#line 279 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
+    // EBPF_OP_STXB pc=462 dst=r0 src=r1 offset=61 imm=0
+#line 279 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(61)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=463 dst=r1 src=r6 offset=0 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=464 dst=r2 src=r6 offset=8 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=465 dst=r2 src=r1 offset=0 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=466 dst=r3 src=r0 offset=0 imm=59
+#line 281 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(59);
+    // EBPF_OP_JSGT_REG pc=467 dst=r3 src=r2 offset=-436 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 281 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
+#line 282 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
+    // EBPF_OP_STXB pc=469 dst=r0 src=r1 offset=62 imm=0
+#line 282 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(62)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=470 dst=r1 src=r6 offset=0 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=471 dst=r2 src=r6 offset=8 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=472 dst=r2 src=r1 offset=0 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=473 dst=r3 src=r0 offset=0 imm=60
+#line 284 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(60);
+    // EBPF_OP_JSGT_REG pc=474 dst=r3 src=r2 offset=-443 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 284 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
+#line 285 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
+    // EBPF_OP_STXB pc=476 dst=r0 src=r1 offset=63 imm=0
+#line 285 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(63)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=477 dst=r1 src=r6 offset=0 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=478 dst=r2 src=r6 offset=8 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=479 dst=r2 src=r1 offset=0 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=480 dst=r3 src=r0 offset=0 imm=61
+#line 287 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(61);
+    // EBPF_OP_JSGT_REG pc=481 dst=r3 src=r2 offset=-450 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 287 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
+#line 288 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
+    // EBPF_OP_STXB pc=483 dst=r0 src=r1 offset=64 imm=0
+#line 288 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(64)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=484 dst=r1 src=r6 offset=0 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=485 dst=r2 src=r6 offset=8 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=486 dst=r2 src=r1 offset=0 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=487 dst=r3 src=r0 offset=0 imm=62
+#line 290 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(62);
+    // EBPF_OP_JSGT_REG pc=488 dst=r3 src=r2 offset=-457 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 290 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
+#line 291 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
+    // EBPF_OP_STXB pc=490 dst=r0 src=r1 offset=65 imm=0
+#line 291 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(65)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=491 dst=r1 src=r6 offset=0 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=492 dst=r2 src=r6 offset=8 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=493 dst=r2 src=r1 offset=0 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=494 dst=r3 src=r0 offset=0 imm=63
+#line 293 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(63);
+    // EBPF_OP_JSGT_REG pc=495 dst=r3 src=r2 offset=-464 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 293 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
+#line 294 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
+    // EBPF_OP_STXB pc=497 dst=r0 src=r1 offset=66 imm=0
+#line 294 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(66)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=498 dst=r1 src=r6 offset=0 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=499 dst=r2 src=r6 offset=8 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=500 dst=r2 src=r1 offset=0 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=501 dst=r3 src=r0 offset=0 imm=64
+#line 296 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_JSGT_REG pc=502 dst=r3 src=r2 offset=-471 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 296 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
+    // EBPF_OP_STXB pc=504 dst=r0 src=r1 offset=67 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(67)) = (uint8_t)r1;
+    // EBPF_OP_JA pc=505 dst=r0 src=r0 offset=-474 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    goto label_2;
 label_4:
-    // EBPF_OP_MOV64_IMM pc=69 dst=r8 src=r0 offset=0 imm=1
-#line 176 "sample/bindmonitor_tailcall.c"
-    r8 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=70 dst=r1 src=r0 offset=0 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LDXW pc=506 dst=r1 src=r0 offset=0 imm=0
+#line 365 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_LDXW pc=71 dst=r2 src=r7 offset=0 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
-    if (r1 >= r2)
-#line 162 "sample/bindmonitor_tailcall.c"
-        goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
-#line 166 "sample/bindmonitor_tailcall.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
-#line 166 "sample/bindmonitor_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=15 imm=0
-#line 166 "sample/bindmonitor_tailcall.c"
-    goto label_8;
-label_5:
-    // EBPF_OP_LDXW pc=76 dst=r1 src=r0 offset=0 imm=0
-#line 169 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
-#line 169 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=507 dst=r1 src=r0 offset=6 imm=0
+#line 365 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
-#line 169 "sample/bindmonitor_tailcall.c"
-        goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
-#line 170 "sample/bindmonitor_tailcall.c"
+#line 365 "sample/bindmonitor_tailcall.c"
+        goto label_6;
+        // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
+#line 366 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
-    // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
-#line 170 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_STXW pc=509 dst=r0 src=r1 offset=0 imm=0
+#line 366 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-label_6:
-    // EBPF_OP_MOV64_IMM pc=80 dst=r8 src=r0 offset=0 imm=0
-#line 170 "sample/bindmonitor_tailcall.c"
+label_5:
+    // EBPF_OP_MOV64_IMM pc=510 dst=r8 src=r0 offset=0 imm=0
+#line 366 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
-    // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
+#line 372 "sample/bindmonitor_tailcall.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_RSH64_IMM pc=512 dst=r1 src=r0 offset=0 imm=32
+#line 372 "sample/bindmonitor_tailcall.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JNE_IMM pc=513 dst=r1 src=r0 offset=15 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
-#line 176 "sample/bindmonitor_tailcall.c"
+#line 372 "sample/bindmonitor_tailcall.c"
         goto label_9;
-label_7:
-    // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+label_6:
+    // EBPF_OP_LDXDW pc=514 dst=r1 src=r6 offset=16 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
-    // EBPF_OP_STXDW pc=85 dst=r10 src=r1 offset=-80 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_STXDW pc=515 dst=r10 src=r1 offset=-80 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=86 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=516 dst=r2 src=r10 offset=0 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=87 dst=r2 src=r0 offset=0 imm=-80
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_ADD64_IMM pc=517 dst=r2 src=r0 offset=0 imm=-80
+#line 373 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-80);
-    // EBPF_OP_LDDW pc=88 dst=r1 src=r0 offset=0 imm=0
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LDDW pc=518 dst=r1 src=r0 offset=0 imm=0
+#line 374 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_CALL pc=520 dst=r0 src=r0 offset=0 imm=3
+#line 374 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[2].address
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
         return 0;
+        // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
+#line 374 "sample/bindmonitor_tailcall.c"
+    goto label_8;
+label_7:
+    // EBPF_OP_MOV64_IMM pc=522 dst=r8 src=r0 offset=0 imm=1
+#line 374 "sample/bindmonitor_tailcall.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=523 dst=r1 src=r0 offset=0 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_LDXW pc=524 dst=r2 src=r7 offset=0 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_JGE_REG pc=525 dst=r1 src=r2 offset=3 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    if (r1 >= r2)
+#line 358 "sample/bindmonitor_tailcall.c"
+        goto label_9;
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
+#line 362 "sample/bindmonitor_tailcall.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
+#line 362 "sample/bindmonitor_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
 label_8:
-    // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=528 dst=r8 src=r0 offset=0 imm=0
+#line 362 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
 label_9:
-    // EBPF_OP_MOV64_REG pc=92 dst=r0 src=r8 offset=0 imm=0
-#line 182 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=529 dst=r0 src=r8 offset=0 imm=0
+#line 378 "sample/bindmonitor_tailcall.c"
     r0 = r8;
-    // EBPF_OP_EXIT pc=93 dst=r0 src=r0 offset=0 imm=0
-#line 182 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_EXIT pc=530 dst=r0 src=r0 offset=0 imm=0
+#line 378 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 182 "sample/bindmonitor_tailcall.c"
+#line 378 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -753,7 +2188,7 @@ static program_entry_t _programs[] = {
         2,
         BindMonitor_Callee1_helpers,
         3,
-        94,
+        531,
         &BindMonitor_Callee1_program_type_guid,
         &BindMonitor_Callee1_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -292,92 +292,92 @@ static uint16_t BindMonitor_maps[] = {
 #pragma code_seg(push, "bind")
 static uint64_t
 BindMonitor(void* context)
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
 {
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
-#line 114 "sample/bindmonitor_tailcall.c"
+#line 310 "sample/bindmonitor_tailcall.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-4 imm=0
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-4
-#line 116 "sample/bindmonitor_tailcall.c"
+#line 312 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_helpers[0].address
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
-#line 117 "sample/bindmonitor_tailcall.c"
+#line 313 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
-#line 119 "sample/bindmonitor_tailcall.c"
+#line 315 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
-#line 119 "sample/bindmonitor_tailcall.c"
+#line 315 "sample/bindmonitor_tailcall.c"
         goto label_1;
         // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r2 = POINTER(_maps[2].address);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=0
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r3 = IMMEDIATE(0);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_helpers[1].address
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
-#line 122 "sample/bindmonitor_tailcall.c"
+#line 318 "sample/bindmonitor_tailcall.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=15 dst=r0 src=r0 offset=0 imm=0
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 125 "sample/bindmonitor_tailcall.c"
+#line 321 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -399,92 +399,92 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
 {
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=0
-#line 130 "sample/bindmonitor_tailcall.c"
+#line 326 "sample/bindmonitor_tailcall.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-4 imm=0
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-4
-#line 132 "sample/bindmonitor_tailcall.c"
+#line 328 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[3].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[0].address
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
-#line 133 "sample/bindmonitor_tailcall.c"
+#line 329 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
-#line 135 "sample/bindmonitor_tailcall.c"
+#line 331 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
-#line 135 "sample/bindmonitor_tailcall.c"
+#line 331 "sample/bindmonitor_tailcall.c"
         goto label_1;
         // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r2 = POINTER(_maps[2].address);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=1
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=5
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[1].address
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
-#line 138 "sample/bindmonitor_tailcall.c"
+#line 334 "sample/bindmonitor_tailcall.c"
         return 0;
 label_1:
     // EBPF_OP_MOV64_IMM pc=14 dst=r0 src=r0 offset=0 imm=1
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_EXIT pc=15 dst=r0 src=r0 offset=0 imm=0
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 141 "sample/bindmonitor_tailcall.c"
+#line 337 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -507,82 +507,80 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
 {
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     // Prologue
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r0 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r1 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r2 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r3 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r4 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r5 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r6 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r7 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r8 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
-    register uint64_t r9 = 0;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r1 = (uintptr_t)context;
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r8 src=r0 offset=0 imm=0
-#line 146 "sample/bindmonitor_tailcall.c"
+#line 342 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r8 offset=-84 imm=0
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint32_t)r8;
     // EBPF_OP_MOV64_REG pc=3 dst=r2 src=r10 offset=0 imm=0
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=4 dst=r2 src=r0 offset=0 imm=-84
-#line 148 "sample/bindmonitor_tailcall.c"
+#line 344 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-84);
     // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=0
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[1].address);
     // EBPF_OP_CALL pc=7 dst=r0 src=r0 offset=0 imm=1
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
-#line 150 "sample/bindmonitor_tailcall.c"
+#line 346 "sample/bindmonitor_tailcall.c"
     r7 = r0;
-    // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=519 imm=0
+#line 347 "sample/bindmonitor_tailcall.c"
     if (r7 == IMMEDIATE(0))
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
         goto label_9;
         // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
-#line 151 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=517 imm=0
+#line 347 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
-#line 151 "sample/bindmonitor_tailcall.c"
+#line 347 "sample/bindmonitor_tailcall.c"
         goto label_9;
         // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
@@ -638,64 +636,87 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
-        goto label_1;
-        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
-#line 84 "sample/bindmonitor_tailcall.c"
-    goto label_3;
+        goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_MOV64_IMM pc=30 dst=r8 src=r0 offset=0 imm=0
+#line 84 "sample/bindmonitor_tailcall.c"
+    r8 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=31 dst=r0 src=r0 offset=497 imm=0
+#line 352 "sample/bindmonitor_tailcall.c"
+    if (r0 == IMMEDIATE(0))
+#line 352 "sample/bindmonitor_tailcall.c"
+        goto label_9;
+label_2:
+    // EBPF_OP_LDXW pc=32 dst=r1 src=r6 offset=44 imm=0
+#line 356 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=33 dst=r1 src=r0 offset=488 imm=0
+#line 356 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(0))
+#line 356 "sample/bindmonitor_tailcall.c"
+        goto label_7;
+        // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
+#line 356 "sample/bindmonitor_tailcall.c"
+    if (r1 == IMMEDIATE(2))
+#line 356 "sample/bindmonitor_tailcall.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_JA pc=36 dst=r0 src=r0 offset=473 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
+    goto label_5;
+label_3:
+    // EBPF_OP_LDXW pc=37 dst=r1 src=r6 offset=44 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JNE_IMM pc=32 dst=r1 src=r0 offset=58 imm=0
+    // EBPF_OP_JNE_IMM pc=38 dst=r1 src=r0 offset=489 imm=0
 #line 87 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
 #line 87 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
+    // EBPF_OP_JEQ_IMM pc=40 dst=r1 src=r0 offset=487 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
+    // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=485 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
 #line 90 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=44 dst=r8 src=r0 offset=0 imm=-8
 #line 90 "sample/bindmonitor_tailcall.c"
     r8 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=39 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=45 dst=r3 src=r10 offset=0 imm=0
 #line 90 "sample/bindmonitor_tailcall.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=40 dst=r3 src=r0 offset=0 imm=-80
+    // EBPF_OP_ADD64_IMM pc=46 dst=r3 src=r0 offset=0 imm=-80
 #line 90 "sample/bindmonitor_tailcall.c"
     r3 += IMMEDIATE(-80);
-    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
-#line 90 "sample/bindmonitor_tailcall.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_LDDW pc=42 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=44 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r2 = r8;
-    // EBPF_OP_MOV64_IMM pc=45 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=50 dst=r4 src=r0 offset=0 imm=0
 #line 93 "sample/bindmonitor_tailcall.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=51 dst=r0 src=r0 offset=0 imm=2
 #line 93 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[1].address
 #line 93 "sample/bindmonitor_tailcall.c"
@@ -704,13 +725,13 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 93 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=54 dst=r2 src=r8 offset=0 imm=0
 #line 94 "sample/bindmonitor_tailcall.c"
     r2 = r8;
-    // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=1
 #line 94 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
 #line 94 "sample/bindmonitor_tailcall.c"
@@ -719,163 +740,1577 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 94 "sample/bindmonitor_tailcall.c"
         return 0;
-        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
 #line 95 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 95 "sample/bindmonitor_tailcall.c"
         goto label_8;
-        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
-#line 95 "sample/bindmonitor_tailcall.c"
-    r1 = r0;
-    // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
-#line 95 "sample/bindmonitor_tailcall.c"
-    r1 += IMMEDIATE(4);
-label_2:
-    // EBPF_OP_LDXDW pc=54 dst=r2 src=r6 offset=0 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_ADD64_REG pc=55 dst=r2 src=r9 offset=0 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r2 += r9;
-    // EBPF_OP_LDXDW pc=56 dst=r3 src=r6 offset=8 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    r3 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
-    // EBPF_OP_JGE_REG pc=57 dst=r2 src=r3 offset=6 imm=0
-#line 99 "sample/bindmonitor_tailcall.c"
-    if (r2 >= r3)
-#line 99 "sample/bindmonitor_tailcall.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r3 += r9;
-    // EBPF_OP_LDXB pc=60 dst=r2 src=r2 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXB pc=61 dst=r3 src=r2 offset=0 imm=0
-#line 102 "sample/bindmonitor_tailcall.c"
-    *(uint8_t*)(uintptr_t)(r3 + OFFSET(0)) = (uint8_t)r2;
-    // EBPF_OP_ADD64_IMM pc=62 dst=r9 src=r0 offset=0 imm=1
-#line 98 "sample/bindmonitor_tailcall.c"
-    r9 += IMMEDIATE(1);
-    // EBPF_OP_JNE_IMM pc=63 dst=r9 src=r0 offset=-10 imm=64
-#line 98 "sample/bindmonitor_tailcall.c"
-    if (r9 != IMMEDIATE(64))
-#line 98 "sample/bindmonitor_tailcall.c"
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=58 dst=r2 src=r6 offset=8 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=59 dst=r2 src=r1 offset=0 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=60 dst=r3 src=r0 offset=0 imm=1
+#line 107 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_JSGT_REG pc=61 dst=r3 src=r2 offset=-32 imm=0
+#line 107 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 107 "sample/bindmonitor_tailcall.c"
+        goto label_1;
+        // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
+#line 108 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_STXB pc=63 dst=r0 src=r1 offset=4 imm=0
+#line 108 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(4)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=64 dst=r1 src=r6 offset=0 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=65 dst=r2 src=r6 offset=8 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=66 dst=r2 src=r1 offset=0 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=2
+#line 110 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_JSGT_REG pc=68 dst=r3 src=r2 offset=-37 imm=0
+#line 110 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 110 "sample/bindmonitor_tailcall.c"
         goto label_2;
-label_3:
-    // EBPF_OP_LDXW pc=64 dst=r1 src=r6 offset=44 imm=0
-#line 160 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=65 dst=r1 src=r0 offset=3 imm=0
-#line 160 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(0))
-#line 160 "sample/bindmonitor_tailcall.c"
-        goto label_4;
-        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
-#line 160 "sample/bindmonitor_tailcall.c"
-    if (r1 == IMMEDIATE(2))
-#line 160 "sample/bindmonitor_tailcall.c"
-        goto label_5;
-        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
+#line 111 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
+    // EBPF_OP_STXB pc=70 dst=r0 src=r1 offset=5 imm=0
+#line 111 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(5)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=72 dst=r2 src=r6 offset=8 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=73 dst=r2 src=r1 offset=0 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=74 dst=r3 src=r0 offset=0 imm=3
+#line 113 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_JSGT_REG pc=75 dst=r3 src=r2 offset=-44 imm=0
+#line 113 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 113 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
+#line 114 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
+    // EBPF_OP_STXB pc=77 dst=r0 src=r1 offset=6 imm=0
+#line 114 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(6)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=78 dst=r1 src=r6 offset=0 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=79 dst=r2 src=r6 offset=8 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=80 dst=r2 src=r1 offset=0 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=81 dst=r3 src=r0 offset=0 imm=4
+#line 116 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_JSGT_REG pc=82 dst=r3 src=r2 offset=-51 imm=0
+#line 116 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 116 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
+#line 117 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
+    // EBPF_OP_STXB pc=84 dst=r0 src=r1 offset=7 imm=0
+#line 117 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(7)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=85 dst=r1 src=r6 offset=0 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=86 dst=r2 src=r6 offset=8 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=87 dst=r2 src=r1 offset=0 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=88 dst=r3 src=r0 offset=0 imm=5
+#line 119 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_JSGT_REG pc=89 dst=r3 src=r2 offset=-58 imm=0
+#line 119 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 119 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
+#line 120 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_STXB pc=91 dst=r0 src=r1 offset=8 imm=0
+#line 120 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(8)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=92 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=93 dst=r2 src=r6 offset=8 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=94 dst=r2 src=r1 offset=0 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=95 dst=r3 src=r0 offset=0 imm=6
+#line 122 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_JSGT_REG pc=96 dst=r3 src=r2 offset=-65 imm=0
+#line 122 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 122 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
+    // EBPF_OP_STXB pc=98 dst=r0 src=r1 offset=9 imm=0
+#line 123 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(9)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=99 dst=r1 src=r6 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=100 dst=r2 src=r6 offset=8 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=101 dst=r2 src=r1 offset=0 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=102 dst=r3 src=r0 offset=0 imm=7
+#line 125 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_JSGT_REG pc=103 dst=r3 src=r2 offset=-72 imm=0
+#line 125 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 125 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
+#line 126 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
+    // EBPF_OP_STXB pc=105 dst=r0 src=r1 offset=10 imm=0
+#line 126 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(10)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=106 dst=r1 src=r6 offset=0 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=107 dst=r2 src=r6 offset=8 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=108 dst=r2 src=r1 offset=0 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=109 dst=r3 src=r0 offset=0 imm=8
+#line 128 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_JSGT_REG pc=110 dst=r3 src=r2 offset=-79 imm=0
+#line 128 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 128 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
+#line 129 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
+    // EBPF_OP_STXB pc=112 dst=r0 src=r1 offset=11 imm=0
+#line 129 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(11)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=113 dst=r1 src=r6 offset=0 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=114 dst=r2 src=r6 offset=8 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=115 dst=r2 src=r1 offset=0 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=116 dst=r3 src=r0 offset=0 imm=9
+#line 131 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_JSGT_REG pc=117 dst=r3 src=r2 offset=-86 imm=0
+#line 131 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 131 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
+#line 132 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXB pc=119 dst=r0 src=r1 offset=12 imm=0
+#line 132 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(12)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=120 dst=r1 src=r6 offset=0 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=121 dst=r2 src=r6 offset=8 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=122 dst=r2 src=r1 offset=0 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=123 dst=r3 src=r0 offset=0 imm=10
+#line 134 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_JSGT_REG pc=124 dst=r3 src=r2 offset=-93 imm=0
+#line 134 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 134 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
+#line 135 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_STXB pc=126 dst=r0 src=r1 offset=13 imm=0
+#line 135 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(13)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=127 dst=r1 src=r6 offset=0 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=128 dst=r2 src=r6 offset=8 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=129 dst=r2 src=r1 offset=0 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=130 dst=r3 src=r0 offset=0 imm=11
+#line 137 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_JSGT_REG pc=131 dst=r3 src=r2 offset=-100 imm=0
+#line 137 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 137 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
+#line 138 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_STXB pc=133 dst=r0 src=r1 offset=14 imm=0
+#line 138 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(14)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=134 dst=r1 src=r6 offset=0 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=135 dst=r2 src=r6 offset=8 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=136 dst=r2 src=r1 offset=0 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=137 dst=r3 src=r0 offset=0 imm=12
+#line 140 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_JSGT_REG pc=138 dst=r3 src=r2 offset=-107 imm=0
+#line 140 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 140 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_STXB pc=140 dst=r0 src=r1 offset=15 imm=0
+#line 141 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(15)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=141 dst=r1 src=r6 offset=0 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=142 dst=r2 src=r6 offset=8 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=143 dst=r2 src=r1 offset=0 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=144 dst=r3 src=r0 offset=0 imm=13
+#line 143 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_JSGT_REG pc=145 dst=r3 src=r2 offset=-114 imm=0
+#line 143 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 143 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
+#line 144 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_STXB pc=147 dst=r0 src=r1 offset=16 imm=0
+#line 144 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(16)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=148 dst=r1 src=r6 offset=0 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=149 dst=r2 src=r6 offset=8 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=150 dst=r2 src=r1 offset=0 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=151 dst=r3 src=r0 offset=0 imm=14
+#line 146 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_JSGT_REG pc=152 dst=r3 src=r2 offset=-121 imm=0
+#line 146 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 146 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
+#line 147 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_STXB pc=154 dst=r0 src=r1 offset=17 imm=0
+#line 147 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(17)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=155 dst=r1 src=r6 offset=0 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=156 dst=r2 src=r6 offset=8 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=157 dst=r2 src=r1 offset=0 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=158 dst=r3 src=r0 offset=0 imm=15
+#line 149 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_JSGT_REG pc=159 dst=r3 src=r2 offset=-128 imm=0
+#line 149 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 149 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
+#line 150 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_STXB pc=161 dst=r0 src=r1 offset=18 imm=0
+#line 150 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(18)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=162 dst=r1 src=r6 offset=0 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=163 dst=r2 src=r6 offset=8 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=164 dst=r2 src=r1 offset=0 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=165 dst=r3 src=r0 offset=0 imm=16
+#line 152 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_JSGT_REG pc=166 dst=r3 src=r2 offset=-135 imm=0
+#line 152 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 152 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
+#line 153 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_STXB pc=168 dst=r0 src=r1 offset=19 imm=0
+#line 153 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(19)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=169 dst=r1 src=r6 offset=0 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=170 dst=r2 src=r6 offset=8 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=171 dst=r2 src=r1 offset=0 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=172 dst=r3 src=r0 offset=0 imm=17
+#line 155 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_JSGT_REG pc=173 dst=r3 src=r2 offset=-142 imm=0
+#line 155 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 155 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_STXB pc=175 dst=r0 src=r1 offset=20 imm=0
+#line 156 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(20)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=176 dst=r1 src=r6 offset=0 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=177 dst=r2 src=r6 offset=8 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=178 dst=r2 src=r1 offset=0 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=179 dst=r3 src=r0 offset=0 imm=18
+#line 158 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_JSGT_REG pc=180 dst=r3 src=r2 offset=-149 imm=0
+#line 158 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 158 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
+#line 159 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_STXB pc=182 dst=r0 src=r1 offset=21 imm=0
+#line 159 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(21)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=183 dst=r1 src=r6 offset=0 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=184 dst=r2 src=r6 offset=8 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=185 dst=r2 src=r1 offset=0 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=186 dst=r3 src=r0 offset=0 imm=19
+#line 161 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_JSGT_REG pc=187 dst=r3 src=r2 offset=-156 imm=0
+#line 161 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 161 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
+#line 162 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_STXB pc=189 dst=r0 src=r1 offset=22 imm=0
+#line 162 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(22)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=190 dst=r1 src=r6 offset=0 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=191 dst=r2 src=r6 offset=8 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=192 dst=r2 src=r1 offset=0 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=193 dst=r3 src=r0 offset=0 imm=20
+#line 164 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_JSGT_REG pc=194 dst=r3 src=r2 offset=-163 imm=0
+#line 164 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 164 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
+#line 165 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_STXB pc=196 dst=r0 src=r1 offset=23 imm=0
+#line 165 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(23)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=197 dst=r1 src=r6 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=198 dst=r2 src=r6 offset=8 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=199 dst=r2 src=r1 offset=0 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=200 dst=r3 src=r0 offset=0 imm=21
+#line 167 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_JSGT_REG pc=201 dst=r3 src=r2 offset=-170 imm=0
+#line 167 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 167 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
+#line 168 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_STXB pc=203 dst=r0 src=r1 offset=24 imm=0
+#line 168 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(24)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=204 dst=r1 src=r6 offset=0 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=205 dst=r2 src=r6 offset=8 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=206 dst=r2 src=r1 offset=0 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=207 dst=r3 src=r0 offset=0 imm=22
+#line 170 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_JSGT_REG pc=208 dst=r3 src=r2 offset=-177 imm=0
+#line 170 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 170 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
+#line 171 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_STXB pc=210 dst=r0 src=r1 offset=25 imm=0
+#line 171 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(25)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=211 dst=r1 src=r6 offset=0 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=212 dst=r2 src=r6 offset=8 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=213 dst=r2 src=r1 offset=0 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=214 dst=r3 src=r0 offset=0 imm=23
+#line 173 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_JSGT_REG pc=215 dst=r3 src=r2 offset=-184 imm=0
+#line 173 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 173 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
+#line 174 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_STXB pc=217 dst=r0 src=r1 offset=26 imm=0
+#line 174 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(26)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=218 dst=r1 src=r6 offset=0 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=219 dst=r2 src=r6 offset=8 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
-    goto label_6;
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=220 dst=r2 src=r1 offset=0 imm=0
+#line 176 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=221 dst=r3 src=r0 offset=0 imm=24
+#line 176 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_JSGT_REG pc=222 dst=r3 src=r2 offset=-191 imm=0
+#line 176 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 176 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
+#line 177 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_STXB pc=224 dst=r0 src=r1 offset=27 imm=0
+#line 177 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(27)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=225 dst=r1 src=r6 offset=0 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=226 dst=r2 src=r6 offset=8 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=227 dst=r2 src=r1 offset=0 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=228 dst=r3 src=r0 offset=0 imm=25
+#line 179 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_JSGT_REG pc=229 dst=r3 src=r2 offset=-198 imm=0
+#line 179 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 179 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
+#line 180 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXB pc=231 dst=r0 src=r1 offset=28 imm=0
+#line 180 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(28)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=232 dst=r1 src=r6 offset=0 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=233 dst=r2 src=r6 offset=8 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=234 dst=r2 src=r1 offset=0 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=235 dst=r3 src=r0 offset=0 imm=26
+#line 182 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_JSGT_REG pc=236 dst=r3 src=r2 offset=-205 imm=0
+#line 182 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 182 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
+#line 183 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
+    // EBPF_OP_STXB pc=238 dst=r0 src=r1 offset=29 imm=0
+#line 183 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(29)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=239 dst=r1 src=r6 offset=0 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=240 dst=r2 src=r6 offset=8 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=241 dst=r2 src=r1 offset=0 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=242 dst=r3 src=r0 offset=0 imm=27
+#line 185 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_JSGT_REG pc=243 dst=r3 src=r2 offset=-212 imm=0
+#line 185 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 185 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
+#line 186 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
+    // EBPF_OP_STXB pc=245 dst=r0 src=r1 offset=30 imm=0
+#line 186 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(30)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=246 dst=r1 src=r6 offset=0 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=247 dst=r2 src=r6 offset=8 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=248 dst=r2 src=r1 offset=0 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=249 dst=r3 src=r0 offset=0 imm=28
+#line 188 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_JSGT_REG pc=250 dst=r3 src=r2 offset=-219 imm=0
+#line 188 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 188 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
+#line 189 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
+    // EBPF_OP_STXB pc=252 dst=r0 src=r1 offset=31 imm=0
+#line 189 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(31)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=253 dst=r1 src=r6 offset=0 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=254 dst=r2 src=r6 offset=8 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=255 dst=r2 src=r1 offset=0 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=256 dst=r3 src=r0 offset=0 imm=29
+#line 191 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_JSGT_REG pc=257 dst=r3 src=r2 offset=-226 imm=0
+#line 191 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 191 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
+#line 192 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXB pc=259 dst=r0 src=r1 offset=32 imm=0
+#line 192 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(32)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=260 dst=r1 src=r6 offset=0 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=261 dst=r2 src=r6 offset=8 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=262 dst=r2 src=r1 offset=0 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=263 dst=r3 src=r0 offset=0 imm=30
+#line 194 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_JSGT_REG pc=264 dst=r3 src=r2 offset=-233 imm=0
+#line 194 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 194 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
+#line 195 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_STXB pc=266 dst=r0 src=r1 offset=33 imm=0
+#line 195 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(33)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=267 dst=r1 src=r6 offset=0 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=268 dst=r2 src=r6 offset=8 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=269 dst=r2 src=r1 offset=0 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=270 dst=r3 src=r0 offset=0 imm=31
+#line 197 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(31);
+    // EBPF_OP_JSGT_REG pc=271 dst=r3 src=r2 offset=-240 imm=0
+#line 197 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 197 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
+#line 198 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_STXB pc=273 dst=r0 src=r1 offset=34 imm=0
+#line 198 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(34)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=274 dst=r1 src=r6 offset=0 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=275 dst=r2 src=r6 offset=8 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=276 dst=r2 src=r1 offset=0 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=277 dst=r3 src=r0 offset=0 imm=32
+#line 200 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=278 dst=r3 src=r2 offset=-247 imm=0
+#line 200 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 200 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
+#line 201 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_STXB pc=280 dst=r0 src=r1 offset=35 imm=0
+#line 201 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(35)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=281 dst=r1 src=r6 offset=0 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=282 dst=r2 src=r6 offset=8 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=283 dst=r2 src=r1 offset=0 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=284 dst=r3 src=r0 offset=0 imm=33
+#line 203 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(33);
+    // EBPF_OP_JSGT_REG pc=285 dst=r3 src=r2 offset=-254 imm=0
+#line 203 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 203 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
+#line 204 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_STXB pc=287 dst=r0 src=r1 offset=36 imm=0
+#line 204 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(36)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=288 dst=r1 src=r6 offset=0 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=289 dst=r2 src=r6 offset=8 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=290 dst=r2 src=r1 offset=0 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=291 dst=r3 src=r0 offset=0 imm=34
+#line 206 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(34);
+    // EBPF_OP_JSGT_REG pc=292 dst=r3 src=r2 offset=-261 imm=0
+#line 206 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 206 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
+#line 207 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_STXB pc=294 dst=r0 src=r1 offset=37 imm=0
+#line 207 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(37)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=295 dst=r1 src=r6 offset=0 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=296 dst=r2 src=r6 offset=8 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=297 dst=r2 src=r1 offset=0 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=298 dst=r3 src=r0 offset=0 imm=35
+#line 209 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(35);
+    // EBPF_OP_JSGT_REG pc=299 dst=r3 src=r2 offset=-268 imm=0
+#line 209 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 209 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
+#line 210 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_STXB pc=301 dst=r0 src=r1 offset=38 imm=0
+#line 210 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(38)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=302 dst=r1 src=r6 offset=0 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=303 dst=r2 src=r6 offset=8 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=304 dst=r2 src=r1 offset=0 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=305 dst=r3 src=r0 offset=0 imm=36
+#line 212 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(36);
+    // EBPF_OP_JSGT_REG pc=306 dst=r3 src=r2 offset=-275 imm=0
+#line 212 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 212 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
+#line 213 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_STXB pc=308 dst=r0 src=r1 offset=39 imm=0
+#line 213 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(39)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=309 dst=r1 src=r6 offset=0 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=310 dst=r2 src=r6 offset=8 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=311 dst=r2 src=r1 offset=0 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=312 dst=r3 src=r0 offset=0 imm=37
+#line 215 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(37);
+    // EBPF_OP_JSGT_REG pc=313 dst=r3 src=r2 offset=-282 imm=0
+#line 215 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 215 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
+#line 216 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_STXB pc=315 dst=r0 src=r1 offset=40 imm=0
+#line 216 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(40)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=316 dst=r1 src=r6 offset=0 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=317 dst=r2 src=r6 offset=8 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=318 dst=r2 src=r1 offset=0 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=319 dst=r3 src=r0 offset=0 imm=38
+#line 218 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(38);
+    // EBPF_OP_JSGT_REG pc=320 dst=r3 src=r2 offset=-289 imm=0
+#line 218 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 218 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
+#line 219 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_STXB pc=322 dst=r0 src=r1 offset=41 imm=0
+#line 219 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(41)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=323 dst=r1 src=r6 offset=0 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=324 dst=r2 src=r6 offset=8 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=325 dst=r2 src=r1 offset=0 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=326 dst=r3 src=r0 offset=0 imm=39
+#line 221 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(39);
+    // EBPF_OP_JSGT_REG pc=327 dst=r3 src=r2 offset=-296 imm=0
+#line 221 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 221 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
+#line 222 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_STXB pc=329 dst=r0 src=r1 offset=42 imm=0
+#line 222 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(42)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=330 dst=r1 src=r6 offset=0 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=331 dst=r2 src=r6 offset=8 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=332 dst=r2 src=r1 offset=0 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=333 dst=r3 src=r0 offset=0 imm=40
+#line 224 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(40);
+    // EBPF_OP_JSGT_REG pc=334 dst=r3 src=r2 offset=-303 imm=0
+#line 224 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 224 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
+#line 225 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_STXB pc=336 dst=r0 src=r1 offset=43 imm=0
+#line 225 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(43)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=337 dst=r1 src=r6 offset=0 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=338 dst=r2 src=r6 offset=8 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=339 dst=r2 src=r1 offset=0 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=340 dst=r3 src=r0 offset=0 imm=41
+#line 227 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(41);
+    // EBPF_OP_JSGT_REG pc=341 dst=r3 src=r2 offset=-310 imm=0
+#line 227 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 227 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
+#line 228 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_STXB pc=343 dst=r0 src=r1 offset=44 imm=0
+#line 228 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(44)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=344 dst=r1 src=r6 offset=0 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=345 dst=r2 src=r6 offset=8 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=346 dst=r2 src=r1 offset=0 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=347 dst=r3 src=r0 offset=0 imm=42
+#line 230 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(42);
+    // EBPF_OP_JSGT_REG pc=348 dst=r3 src=r2 offset=-317 imm=0
+#line 230 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 230 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
+#line 231 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_STXB pc=350 dst=r0 src=r1 offset=45 imm=0
+#line 231 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(45)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=351 dst=r1 src=r6 offset=0 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=352 dst=r2 src=r6 offset=8 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=353 dst=r2 src=r1 offset=0 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=354 dst=r3 src=r0 offset=0 imm=43
+#line 233 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(43);
+    // EBPF_OP_JSGT_REG pc=355 dst=r3 src=r2 offset=-324 imm=0
+#line 233 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 233 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
+#line 234 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_STXB pc=357 dst=r0 src=r1 offset=46 imm=0
+#line 234 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(46)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=358 dst=r1 src=r6 offset=0 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=359 dst=r2 src=r6 offset=8 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=360 dst=r2 src=r1 offset=0 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=361 dst=r3 src=r0 offset=0 imm=44
+#line 236 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(44);
+    // EBPF_OP_JSGT_REG pc=362 dst=r3 src=r2 offset=-331 imm=0
+#line 236 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 236 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
+#line 237 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_STXB pc=364 dst=r0 src=r1 offset=47 imm=0
+#line 237 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(47)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=365 dst=r1 src=r6 offset=0 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=366 dst=r2 src=r6 offset=8 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=367 dst=r2 src=r1 offset=0 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=368 dst=r3 src=r0 offset=0 imm=45
+#line 239 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(45);
+    // EBPF_OP_JSGT_REG pc=369 dst=r3 src=r2 offset=-338 imm=0
+#line 239 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 239 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
+#line 240 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXB pc=371 dst=r0 src=r1 offset=48 imm=0
+#line 240 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(48)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=372 dst=r1 src=r6 offset=0 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=373 dst=r2 src=r6 offset=8 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=374 dst=r2 src=r1 offset=0 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=375 dst=r3 src=r0 offset=0 imm=46
+#line 242 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(46);
+    // EBPF_OP_JSGT_REG pc=376 dst=r3 src=r2 offset=-345 imm=0
+#line 242 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 242 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
+#line 243 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
+    // EBPF_OP_STXB pc=378 dst=r0 src=r1 offset=49 imm=0
+#line 243 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(49)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=379 dst=r1 src=r6 offset=0 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=380 dst=r2 src=r6 offset=8 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=381 dst=r2 src=r1 offset=0 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=382 dst=r3 src=r0 offset=0 imm=47
+#line 245 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(47);
+    // EBPF_OP_JSGT_REG pc=383 dst=r3 src=r2 offset=-352 imm=0
+#line 245 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 245 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
+#line 246 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
+    // EBPF_OP_STXB pc=385 dst=r0 src=r1 offset=50 imm=0
+#line 246 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(50)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=386 dst=r1 src=r6 offset=0 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=387 dst=r2 src=r6 offset=8 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=388 dst=r2 src=r1 offset=0 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=389 dst=r3 src=r0 offset=0 imm=48
+#line 248 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(48);
+    // EBPF_OP_JSGT_REG pc=390 dst=r3 src=r2 offset=-359 imm=0
+#line 248 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 248 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
+#line 249 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
+    // EBPF_OP_STXB pc=392 dst=r0 src=r1 offset=51 imm=0
+#line 249 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(51)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=393 dst=r1 src=r6 offset=0 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=394 dst=r2 src=r6 offset=8 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=395 dst=r2 src=r1 offset=0 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=396 dst=r3 src=r0 offset=0 imm=49
+#line 251 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(49);
+    // EBPF_OP_JSGT_REG pc=397 dst=r3 src=r2 offset=-366 imm=0
+#line 251 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 251 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
+#line 252 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXB pc=399 dst=r0 src=r1 offset=52 imm=0
+#line 252 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(52)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=400 dst=r1 src=r6 offset=0 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=401 dst=r2 src=r6 offset=8 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=402 dst=r2 src=r1 offset=0 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=403 dst=r3 src=r0 offset=0 imm=50
+#line 254 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(50);
+    // EBPF_OP_JSGT_REG pc=404 dst=r3 src=r2 offset=-373 imm=0
+#line 254 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 254 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
+#line 255 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
+    // EBPF_OP_STXB pc=406 dst=r0 src=r1 offset=53 imm=0
+#line 255 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(53)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=407 dst=r1 src=r6 offset=0 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=408 dst=r2 src=r6 offset=8 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=409 dst=r2 src=r1 offset=0 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=410 dst=r3 src=r0 offset=0 imm=51
+#line 257 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(51);
+    // EBPF_OP_JSGT_REG pc=411 dst=r3 src=r2 offset=-380 imm=0
+#line 257 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 257 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
+#line 258 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
+    // EBPF_OP_STXB pc=413 dst=r0 src=r1 offset=54 imm=0
+#line 258 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(54)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=414 dst=r1 src=r6 offset=0 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=415 dst=r2 src=r6 offset=8 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=416 dst=r2 src=r1 offset=0 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=417 dst=r3 src=r0 offset=0 imm=52
+#line 260 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(52);
+    // EBPF_OP_JSGT_REG pc=418 dst=r3 src=r2 offset=-387 imm=0
+#line 260 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 260 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
+#line 261 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
+    // EBPF_OP_STXB pc=420 dst=r0 src=r1 offset=55 imm=0
+#line 261 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(55)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=421 dst=r1 src=r6 offset=0 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=422 dst=r2 src=r6 offset=8 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=423 dst=r2 src=r1 offset=0 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=424 dst=r3 src=r0 offset=0 imm=53
+#line 263 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(53);
+    // EBPF_OP_JSGT_REG pc=425 dst=r3 src=r2 offset=-394 imm=0
+#line 263 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 263 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
+#line 264 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
+    // EBPF_OP_STXB pc=427 dst=r0 src=r1 offset=56 imm=0
+#line 264 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(56)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=428 dst=r1 src=r6 offset=0 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=429 dst=r2 src=r6 offset=8 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=430 dst=r2 src=r1 offset=0 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=431 dst=r3 src=r0 offset=0 imm=54
+#line 266 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(54);
+    // EBPF_OP_JSGT_REG pc=432 dst=r3 src=r2 offset=-401 imm=0
+#line 266 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 266 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
+#line 267 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
+    // EBPF_OP_STXB pc=434 dst=r0 src=r1 offset=57 imm=0
+#line 267 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(57)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=435 dst=r1 src=r6 offset=0 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=436 dst=r2 src=r6 offset=8 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=437 dst=r2 src=r1 offset=0 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=438 dst=r3 src=r0 offset=0 imm=55
+#line 269 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(55);
+    // EBPF_OP_JSGT_REG pc=439 dst=r3 src=r2 offset=-408 imm=0
+#line 269 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 269 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
+#line 270 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
+    // EBPF_OP_STXB pc=441 dst=r0 src=r1 offset=58 imm=0
+#line 270 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(58)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=442 dst=r1 src=r6 offset=0 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=443 dst=r2 src=r6 offset=8 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=444 dst=r2 src=r1 offset=0 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=445 dst=r3 src=r0 offset=0 imm=56
+#line 272 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(56);
+    // EBPF_OP_JSGT_REG pc=446 dst=r3 src=r2 offset=-415 imm=0
+#line 272 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 272 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
+#line 273 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
+    // EBPF_OP_STXB pc=448 dst=r0 src=r1 offset=59 imm=0
+#line 273 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(59)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=449 dst=r1 src=r6 offset=0 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=450 dst=r2 src=r6 offset=8 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=451 dst=r2 src=r1 offset=0 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=452 dst=r3 src=r0 offset=0 imm=57
+#line 275 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(57);
+    // EBPF_OP_JSGT_REG pc=453 dst=r3 src=r2 offset=-422 imm=0
+#line 275 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 275 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
+#line 276 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=455 dst=r0 src=r1 offset=60 imm=0
+#line 276 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(60)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=456 dst=r1 src=r6 offset=0 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=457 dst=r2 src=r6 offset=8 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=458 dst=r2 src=r1 offset=0 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=459 dst=r3 src=r0 offset=0 imm=58
+#line 278 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(58);
+    // EBPF_OP_JSGT_REG pc=460 dst=r3 src=r2 offset=-429 imm=0
+#line 278 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 278 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
+#line 279 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
+    // EBPF_OP_STXB pc=462 dst=r0 src=r1 offset=61 imm=0
+#line 279 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(61)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=463 dst=r1 src=r6 offset=0 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=464 dst=r2 src=r6 offset=8 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=465 dst=r2 src=r1 offset=0 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=466 dst=r3 src=r0 offset=0 imm=59
+#line 281 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(59);
+    // EBPF_OP_JSGT_REG pc=467 dst=r3 src=r2 offset=-436 imm=0
+#line 281 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 281 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
+#line 282 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
+    // EBPF_OP_STXB pc=469 dst=r0 src=r1 offset=62 imm=0
+#line 282 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(62)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=470 dst=r1 src=r6 offset=0 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=471 dst=r2 src=r6 offset=8 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=472 dst=r2 src=r1 offset=0 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=473 dst=r3 src=r0 offset=0 imm=60
+#line 284 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(60);
+    // EBPF_OP_JSGT_REG pc=474 dst=r3 src=r2 offset=-443 imm=0
+#line 284 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 284 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
+#line 285 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
+    // EBPF_OP_STXB pc=476 dst=r0 src=r1 offset=63 imm=0
+#line 285 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(63)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=477 dst=r1 src=r6 offset=0 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=478 dst=r2 src=r6 offset=8 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=479 dst=r2 src=r1 offset=0 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=480 dst=r3 src=r0 offset=0 imm=61
+#line 287 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(61);
+    // EBPF_OP_JSGT_REG pc=481 dst=r3 src=r2 offset=-450 imm=0
+#line 287 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 287 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
+#line 288 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
+    // EBPF_OP_STXB pc=483 dst=r0 src=r1 offset=64 imm=0
+#line 288 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(64)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=484 dst=r1 src=r6 offset=0 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=485 dst=r2 src=r6 offset=8 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=486 dst=r2 src=r1 offset=0 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=487 dst=r3 src=r0 offset=0 imm=62
+#line 290 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(62);
+    // EBPF_OP_JSGT_REG pc=488 dst=r3 src=r2 offset=-457 imm=0
+#line 290 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 290 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
+#line 291 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
+    // EBPF_OP_STXB pc=490 dst=r0 src=r1 offset=65 imm=0
+#line 291 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(65)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=491 dst=r1 src=r6 offset=0 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=492 dst=r2 src=r6 offset=8 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=493 dst=r2 src=r1 offset=0 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=494 dst=r3 src=r0 offset=0 imm=63
+#line 293 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(63);
+    // EBPF_OP_JSGT_REG pc=495 dst=r3 src=r2 offset=-464 imm=0
+#line 293 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 293 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
+#line 294 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
+    // EBPF_OP_STXB pc=497 dst=r0 src=r1 offset=66 imm=0
+#line 294 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(66)) = (uint8_t)r1;
+    // EBPF_OP_LDXDW pc=498 dst=r1 src=r6 offset=0 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_LDXDW pc=499 dst=r2 src=r6 offset=8 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
+    // EBPF_OP_SUB64_REG pc=500 dst=r2 src=r1 offset=0 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    r2 -= r1;
+    // EBPF_OP_MOV64_IMM pc=501 dst=r3 src=r0 offset=0 imm=64
+#line 296 "sample/bindmonitor_tailcall.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_JSGT_REG pc=502 dst=r3 src=r2 offset=-471 imm=0
+#line 296 "sample/bindmonitor_tailcall.c"
+    if ((int64_t)r3 > (int64_t)r2)
+#line 296 "sample/bindmonitor_tailcall.c"
+        goto label_2;
+        // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
+    // EBPF_OP_STXB pc=504 dst=r0 src=r1 offset=67 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    *(uint8_t*)(uintptr_t)(r0 + OFFSET(67)) = (uint8_t)r1;
+    // EBPF_OP_JA pc=505 dst=r0 src=r0 offset=-474 imm=0
+#line 297 "sample/bindmonitor_tailcall.c"
+    goto label_2;
 label_4:
-    // EBPF_OP_MOV64_IMM pc=69 dst=r8 src=r0 offset=0 imm=1
-#line 176 "sample/bindmonitor_tailcall.c"
-    r8 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=70 dst=r1 src=r0 offset=0 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LDXW pc=506 dst=r1 src=r0 offset=0 imm=0
+#line 365 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_LDXW pc=71 dst=r2 src=r7 offset=0 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
-    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
-    // EBPF_OP_JGE_REG pc=72 dst=r1 src=r2 offset=19 imm=0
-#line 162 "sample/bindmonitor_tailcall.c"
-    if (r1 >= r2)
-#line 162 "sample/bindmonitor_tailcall.c"
-        goto label_9;
-        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
-#line 166 "sample/bindmonitor_tailcall.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
-#line 166 "sample/bindmonitor_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=15 imm=0
-#line 166 "sample/bindmonitor_tailcall.c"
-    goto label_8;
-label_5:
-    // EBPF_OP_LDXW pc=76 dst=r1 src=r0 offset=0 imm=0
-#line 169 "sample/bindmonitor_tailcall.c"
-    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=77 dst=r1 src=r0 offset=6 imm=0
-#line 169 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JEQ_IMM pc=507 dst=r1 src=r0 offset=6 imm=0
+#line 365 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(0))
-#line 169 "sample/bindmonitor_tailcall.c"
-        goto label_7;
-        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
-#line 170 "sample/bindmonitor_tailcall.c"
+#line 365 "sample/bindmonitor_tailcall.c"
+        goto label_6;
+        // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
+#line 366 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
-    // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
-#line 170 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_STXW pc=509 dst=r0 src=r1 offset=0 imm=0
+#line 366 "sample/bindmonitor_tailcall.c"
     *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
-label_6:
-    // EBPF_OP_MOV64_IMM pc=80 dst=r8 src=r0 offset=0 imm=0
-#line 170 "sample/bindmonitor_tailcall.c"
+label_5:
+    // EBPF_OP_MOV64_IMM pc=510 dst=r8 src=r0 offset=0 imm=0
+#line 366 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
-    // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
+#line 372 "sample/bindmonitor_tailcall.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_RSH64_IMM pc=512 dst=r1 src=r0 offset=0 imm=32
+#line 372 "sample/bindmonitor_tailcall.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
-#line 176 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_JNE_IMM pc=513 dst=r1 src=r0 offset=15 imm=0
+#line 372 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
-#line 176 "sample/bindmonitor_tailcall.c"
+#line 372 "sample/bindmonitor_tailcall.c"
         goto label_9;
-label_7:
-    // EBPF_OP_LDXDW pc=84 dst=r1 src=r6 offset=16 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+label_6:
+    // EBPF_OP_LDXDW pc=514 dst=r1 src=r6 offset=16 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
-    // EBPF_OP_STXDW pc=85 dst=r10 src=r1 offset=-80 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_STXDW pc=515 dst=r10 src=r1 offset=-80 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=86 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=516 dst=r2 src=r10 offset=0 imm=0
+#line 373 "sample/bindmonitor_tailcall.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=87 dst=r2 src=r0 offset=0 imm=-80
-#line 177 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_ADD64_IMM pc=517 dst=r2 src=r0 offset=0 imm=-80
+#line 373 "sample/bindmonitor_tailcall.c"
     r2 += IMMEDIATE(-80);
-    // EBPF_OP_LDDW pc=88 dst=r1 src=r0 offset=0 imm=0
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_LDDW pc=518 dst=r1 src=r0 offset=0 imm=0
+#line 374 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=3
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_CALL pc=520 dst=r0 src=r0 offset=0 imm=3
+#line 374 "sample/bindmonitor_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[2].address
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
-#line 178 "sample/bindmonitor_tailcall.c"
+#line 374 "sample/bindmonitor_tailcall.c"
         return 0;
+        // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
+#line 374 "sample/bindmonitor_tailcall.c"
+    goto label_8;
+label_7:
+    // EBPF_OP_MOV64_IMM pc=522 dst=r8 src=r0 offset=0 imm=1
+#line 374 "sample/bindmonitor_tailcall.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=523 dst=r1 src=r0 offset=0 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+    // EBPF_OP_LDXW pc=524 dst=r2 src=r7 offset=0 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    r2 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
+    // EBPF_OP_JGE_REG pc=525 dst=r1 src=r2 offset=3 imm=0
+#line 358 "sample/bindmonitor_tailcall.c"
+    if (r1 >= r2)
+#line 358 "sample/bindmonitor_tailcall.c"
+        goto label_9;
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
+#line 362 "sample/bindmonitor_tailcall.c"
+    r1 += IMMEDIATE(1);
+    // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
+#line 362 "sample/bindmonitor_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r0 + OFFSET(0)) = (uint32_t)r1;
 label_8:
-    // EBPF_OP_MOV64_IMM pc=91 dst=r8 src=r0 offset=0 imm=0
-#line 178 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=528 dst=r8 src=r0 offset=0 imm=0
+#line 362 "sample/bindmonitor_tailcall.c"
     r8 = IMMEDIATE(0);
 label_9:
-    // EBPF_OP_MOV64_REG pc=92 dst=r0 src=r8 offset=0 imm=0
-#line 182 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=529 dst=r0 src=r8 offset=0 imm=0
+#line 378 "sample/bindmonitor_tailcall.c"
     r0 = r8;
-    // EBPF_OP_EXIT pc=93 dst=r0 src=r0 offset=0 imm=0
-#line 182 "sample/bindmonitor_tailcall.c"
+    // EBPF_OP_EXIT pc=530 dst=r0 src=r0 offset=0 imm=0
+#line 378 "sample/bindmonitor_tailcall.c"
     return r0;
-#line 182 "sample/bindmonitor_tailcall.c"
+#line 378 "sample/bindmonitor_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -920,7 +2355,7 @@ static program_entry_t _programs[] = {
         2,
         BindMonitor_Callee1_helpers,
         3,
-        94,
+        531,
         &BindMonitor_Callee1_program_type_guid,
         &BindMonitor_Callee1_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -181,40 +181,40 @@ static uint16_t test_maps_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 test_maps(void* context)
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
 {
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     // Prologue
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r0 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r1 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r2 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r3 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r4 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r5 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r6 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r7 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r8 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r10 = 0;
 
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r1 = (uintptr_t)context;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=0
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -370,17 +370,17 @@ test_maps(void* context)
         goto label_2;
 label_1:
     // EBPF_OP_MOV64_REG pc=46 dst=r0 src=r6 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r0 = r6;
     // EBPF_OP_EXIT pc=47 dst=r0 src=r0 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     return r0;
 label_2:
     // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r10 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=49 dst=r2 src=r0 offset=0 imm=-4
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=0
 #line 105 "sample/map.c"
@@ -398,12 +398,12 @@ label_2:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=55 dst=r0 src=r0 offset=-10 imm=0
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=56 dst=r7 src=r0 offset=0 imm=0
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=57 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -584,12 +584,12 @@ label_4:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=110 dst=r0 src=r0 offset=-65 imm=0
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=111 dst=r7 src=r0 offset=0 imm=0
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=112 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -1090,12 +1090,12 @@ label_10:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=259 dst=r0 src=r0 offset=-214 imm=0
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=260 dst=r7 src=r0 offset=0 imm=0
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=261 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -1276,3056 +1276,3930 @@ label_12:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=314 dst=r0 src=r0 offset=-269 imm=0
-#line 203 "sample/map.c"
+#line 300 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 203 "sample/map.c"
+#line 300 "sample/map.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=0
-#line 203 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-4 imm=0
-#line 203 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=317 dst=r1 src=r0 offset=0 imm=1
-#line 203 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=318 dst=r10 src=r1 offset=-8 imm=0
+        // EBPF_OP_MOV64_IMM pc=315 dst=r7 src=r0 offset=0 imm=0
+#line 300 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=316 dst=r10 src=r7 offset=-4 imm=0
+#line 116 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=317 dst=r8 src=r0 offset=0 imm=1
+#line 116 "sample/map.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=318 dst=r10 src=r8 offset=-8 imm=0
 #line 117 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=319 dst=r7 src=r0 offset=0 imm=11
-#line 117 "sample/map.c"
-    r7 = IMMEDIATE(11);
-    // EBPF_OP_JA pc=320 dst=r0 src=r0 offset=12 imm=0
-#line 117 "sample/map.c"
-    goto label_14;
-label_13:
-    // EBPF_OP_LDXW pc=321 dst=r1 src=r10 offset=-4 imm=0
-#line 121 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_ADD64_IMM pc=322 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=323 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_LSH64_IMM pc=324 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=325 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JGT_REG pc=326 dst=r7 src=r1 offset=6 imm=0
-#line 121 "sample/map.c"
-    if (r7 > r1)
-#line 121 "sample/map.c"
-        goto label_14;
-        // EBPF_OP_MOV64_IMM pc=327 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=328 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=329 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=330 dst=r10 src=r1 offset=-8 imm=0
-#line 117 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=331 dst=r7 src=r0 offset=0 imm=11
-#line 117 "sample/map.c"
-    r7 = IMMEDIATE(11);
-    // EBPF_OP_JA pc=332 dst=r0 src=r0 offset=36 imm=0
-#line 117 "sample/map.c"
-    goto label_16;
-label_14:
-    // EBPF_OP_MOV64_REG pc=333 dst=r2 src=r10 offset=0 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=319 dst=r2 src=r10 offset=0 imm=0
 #line 117 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=334 dst=r2 src=r0 offset=0 imm=-4
+    // EBPF_OP_ADD64_IMM pc=320 dst=r2 src=r0 offset=0 imm=-4
 #line 117 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_MOV64_REG pc=335 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=321 dst=r3 src=r10 offset=0 imm=0
 #line 117 "sample/map.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=336 dst=r3 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=322 dst=r3 src=r0 offset=0 imm=-8
 #line 117 "sample/map.c"
     r3 += IMMEDIATE(-8);
-    // EBPF_OP_LDDW pc=337 dst=r1 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_LDDW pc=323 dst=r1 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r1 = POINTER(_maps[4].address);
-    // EBPF_OP_MOV64_IMM pc=339 dst=r4 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=325 dst=r4 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=340 dst=r0 src=r0 offset=0 imm=2
-#line 122 "sample/map.c"
+    // EBPF_OP_CALL pc=326 dst=r0 src=r0 offset=0 imm=2
+#line 131 "sample/map.c"
     r0 = test_maps_helpers[0].address
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=341 dst=r6 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=327 dst=r6 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=342 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=343 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=344 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=345 dst=r1 src=r0 offset=-25 imm=-1
-#line 123 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 123 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=328 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=329 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=330 dst=r7 src=r6 offset=144 imm=0
+#line 132 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 132 "sample/map.c"
         goto label_13;
-        // EBPF_OP_JA pc=346 dst=r0 src=r0 offset=-301 imm=0
-#line 123 "sample/map.c"
-    goto label_1;
-label_15:
-    // EBPF_OP_LDXW pc=347 dst=r1 src=r10 offset=-4 imm=0
-#line 121 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_ADD64_IMM pc=348 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=349 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_LSH64_IMM pc=350 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=351 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JGT_REG pc=352 dst=r7 src=r1 offset=16 imm=0
-#line 121 "sample/map.c"
-    if (r7 > r1)
-#line 121 "sample/map.c"
-        goto label_16;
-        // EBPF_OP_MOV64_IMM pc=353 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=354 dst=r10 src=r1 offset=-4 imm=0
-#line 173 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=355 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+        // EBPF_OP_STXW pc=331 dst=r10 src=r8 offset=-4 imm=0
+#line 136 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=332 dst=r2 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=356 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=333 dst=r2 src=r0 offset=0 imm=-4
+#line 136 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=357 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=359 dst=r0 src=r0 offset=0 imm=18
-#line 173 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 173 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 173 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 173 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=360 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = r0;
-    // EBPF_OP_LSH64_IMM pc=361 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=362 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=363 dst=r6 src=r0 offset=0 imm=-1
-#line 173 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-    // EBPF_OP_LDDW pc=364 dst=r2 src=r0 offset=0 imm=-7
-#line 173 "sample/map.c"
-    r2 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=366 dst=r1 src=r2 offset=16 imm=0
-#line 173 "sample/map.c"
-    if (r1 == r2)
-#line 173 "sample/map.c"
-        goto label_17;
-        // EBPF_OP_MOV64_REG pc=367 dst=r6 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_JA pc=368 dst=r0 src=r0 offset=14 imm=0
-#line 173 "sample/map.c"
-    goto label_17;
-label_16:
-    // EBPF_OP_MOV64_REG pc=369 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=370 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_MOV64_REG pc=371 dst=r3 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=334 dst=r3 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=372 dst=r3 src=r0 offset=0 imm=-8
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=335 dst=r3 src=r0 offset=0 imm=-8
+#line 136 "sample/map.c"
     r3 += IMMEDIATE(-8);
-    // EBPF_OP_LDDW pc=373 dst=r1 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = POINTER(_maps[5].address);
-    // EBPF_OP_MOV64_IMM pc=375 dst=r4 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_LDDW pc=336 dst=r1 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=338 dst=r4 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=376 dst=r0 src=r0 offset=0 imm=2
-#line 122 "sample/map.c"
+    // EBPF_OP_CALL pc=339 dst=r0 src=r0 offset=0 imm=2
+#line 137 "sample/map.c"
     r0 = test_maps_helpers[0].address
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=377 dst=r6 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=340 dst=r6 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=378 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=379 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=380 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=381 dst=r1 src=r0 offset=-35 imm=-1
-#line 123 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 123 "sample/map.c"
-        goto label_15;
-        // EBPF_OP_JA pc=382 dst=r0 src=r0 offset=-337 imm=0
-#line 123 "sample/map.c"
-    goto label_1;
-label_17:
-    // EBPF_OP_JNE_REG pc=383 dst=r1 src=r2 offset=170 imm=0
-#line 123 "sample/map.c"
-    if (r1 != r2)
-#line 123 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_LDXW pc=384 dst=r1 src=r10 offset=-4 imm=0
-#line 123 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JNE_IMM pc=385 dst=r1 src=r0 offset=168 imm=0
-#line 123 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 123 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=386 dst=r1 src=r0 offset=0 imm=0
-#line 123 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=387 dst=r10 src=r1 offset=-4 imm=0
-#line 174 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=388 dst=r2 src=r10 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=389 dst=r2 src=r0 offset=0 imm=-4
-#line 174 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=390 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=392 dst=r0 src=r0 offset=0 imm=17
-#line 174 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 174 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 174 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 174 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=393 dst=r1 src=r10 offset=-4 imm=0
-#line 174 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=394 dst=r7 src=r6 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JEQ_IMM pc=395 dst=r1 src=r0 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_18;
-        // EBPF_OP_MOV64_IMM pc=396 dst=r7 src=r0 offset=0 imm=-1
-#line 174 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_18:
-    // EBPF_OP_MOV64_REG pc=397 dst=r2 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=398 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=399 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=400 dst=r3 src=r0 offset=0 imm=-7
-#line 174 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=402 dst=r2 src=r3 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r2 == r3)
-#line 174 "sample/map.c"
-        goto label_19;
-        // EBPF_OP_MOV64_REG pc=403 dst=r7 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r0;
-label_19:
-    // EBPF_OP_MOV64_REG pc=404 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JNE_REG pc=405 dst=r2 src=r3 offset=148 imm=0
-#line 174 "sample/map.c"
-    if (r2 != r3)
-#line 174 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_REG pc=406 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JNE_IMM pc=407 dst=r1 src=r0 offset=146 imm=0
-#line 174 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=408 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=409 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=410 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=411 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=412 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=414 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=415 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=416 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=417 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=418 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=419 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=420 dst=r1 src=r0 offset=133 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=421 dst=r1 src=r0 offset=0 imm=1
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=422 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=423 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=424 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=425 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=427 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=428 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=429 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=430 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=431 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=432 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=433 dst=r1 src=r0 offset=1 imm=0
-#line 177 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_20;
-        // EBPF_OP_JA pc=434 dst=r0 src=r0 offset=119 imm=0
-#line 177 "sample/map.c"
-    goto label_21;
-label_20:
-    // EBPF_OP_MOV64_IMM pc=435 dst=r1 src=r0 offset=0 imm=2
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=341 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=342 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=343 dst=r7 src=r6 offset=131 imm=0
+#line 138 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 138 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=344 dst=r1 src=r0 offset=0 imm=2
+#line 138 "sample/map.c"
     r1 = IMMEDIATE(2);
-    // EBPF_OP_STXW pc=436 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=345 dst=r10 src=r1 offset=-4 imm=0
+#line 142 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=437 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=346 dst=r2 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=438 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=347 dst=r2 src=r0 offset=0 imm=-4
+#line 142 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=439 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=441 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=442 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=348 dst=r3 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=349 dst=r3 src=r0 offset=0 imm=-8
+#line 142 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=350 dst=r7 src=r0 offset=0 imm=0
+#line 142 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=351 dst=r1 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=353 dst=r4 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=354 dst=r0 src=r0 offset=0 imm=2
+#line 143 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 143 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 143 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 143 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=443 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=355 dst=r6 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=444 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=445 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=446 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=447 dst=r1 src=r0 offset=106 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=448 dst=r1 src=r0 offset=0 imm=3
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=356 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=357 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=358 dst=r7 src=r6 offset=116 imm=0
+#line 144 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 144 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=359 dst=r1 src=r0 offset=0 imm=3
+#line 144 "sample/map.c"
     r1 = IMMEDIATE(3);
-    // EBPF_OP_STXW pc=449 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=360 dst=r10 src=r1 offset=-4 imm=0
+#line 148 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=450 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=361 dst=r2 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=451 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=362 dst=r2 src=r0 offset=0 imm=-4
+#line 148 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=452 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=454 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=455 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=363 dst=r3 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=364 dst=r3 src=r0 offset=0 imm=-8
+#line 148 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=365 dst=r1 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=367 dst=r4 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=368 dst=r0 src=r0 offset=0 imm=2
+#line 149 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 149 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 149 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 149 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=369 dst=r6 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=370 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=371 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=372 dst=r7 src=r6 offset=102 imm=0
+#line 150 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 150 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=373 dst=r1 src=r0 offset=0 imm=4
+#line 150 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=374 dst=r10 src=r1 offset=-4 imm=0
+#line 154 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=375 dst=r2 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=376 dst=r2 src=r0 offset=0 imm=-4
+#line 154 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=377 dst=r3 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=378 dst=r3 src=r0 offset=0 imm=-8
+#line 154 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=379 dst=r7 src=r0 offset=0 imm=0
+#line 154 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=380 dst=r1 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=382 dst=r4 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=383 dst=r0 src=r0 offset=0 imm=2
+#line 155 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 155 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 155 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 155 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=384 dst=r6 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=385 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=386 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=387 dst=r7 src=r6 offset=87 imm=0
+#line 156 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 156 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=388 dst=r1 src=r0 offset=0 imm=5
+#line 156 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=389 dst=r10 src=r1 offset=-4 imm=0
+#line 160 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=390 dst=r2 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=391 dst=r2 src=r0 offset=0 imm=-4
+#line 160 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=392 dst=r3 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=393 dst=r3 src=r0 offset=0 imm=-8
+#line 160 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=394 dst=r1 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=396 dst=r4 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=397 dst=r0 src=r0 offset=0 imm=2
+#line 161 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 161 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 161 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 161 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=398 dst=r6 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=399 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=400 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=401 dst=r7 src=r6 offset=73 imm=0
+#line 162 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 162 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=402 dst=r1 src=r0 offset=0 imm=6
+#line 162 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=403 dst=r10 src=r1 offset=-4 imm=0
+#line 166 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=404 dst=r2 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=405 dst=r2 src=r0 offset=0 imm=-4
+#line 166 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=406 dst=r3 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=407 dst=r3 src=r0 offset=0 imm=-8
+#line 166 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=408 dst=r7 src=r0 offset=0 imm=0
+#line 166 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=409 dst=r1 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=411 dst=r4 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=412 dst=r0 src=r0 offset=0 imm=2
+#line 167 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 167 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 167 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 167 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=413 dst=r6 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=414 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=415 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=416 dst=r7 src=r6 offset=58 imm=0
+#line 168 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 168 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=417 dst=r1 src=r0 offset=0 imm=7
+#line 168 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=418 dst=r10 src=r1 offset=-4 imm=0
+#line 172 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=419 dst=r2 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=420 dst=r2 src=r0 offset=0 imm=-4
+#line 172 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=421 dst=r3 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=422 dst=r3 src=r0 offset=0 imm=-8
+#line 172 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=423 dst=r1 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=425 dst=r4 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=426 dst=r0 src=r0 offset=0 imm=2
+#line 173 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 173 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 173 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 173 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=427 dst=r6 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=428 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=429 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=430 dst=r7 src=r6 offset=44 imm=0
+#line 174 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 174 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=431 dst=r1 src=r0 offset=0 imm=8
+#line 174 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=432 dst=r10 src=r1 offset=-4 imm=0
+#line 178 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=433 dst=r2 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=434 dst=r2 src=r0 offset=0 imm=-4
+#line 178 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=435 dst=r3 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=436 dst=r3 src=r0 offset=0 imm=-8
+#line 178 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=437 dst=r7 src=r0 offset=0 imm=0
+#line 178 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=438 dst=r1 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=440 dst=r4 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=441 dst=r0 src=r0 offset=0 imm=2
+#line 179 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 179 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 179 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 179 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=442 dst=r6 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=443 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=444 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=445 dst=r7 src=r6 offset=29 imm=0
+#line 180 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 180 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=446 dst=r1 src=r0 offset=0 imm=9
+#line 180 "sample/map.c"
+    r1 = IMMEDIATE(9);
+    // EBPF_OP_STXW pc=447 dst=r10 src=r1 offset=-4 imm=0
+#line 184 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=448 dst=r2 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=449 dst=r2 src=r0 offset=0 imm=-4
+#line 184 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=450 dst=r3 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=451 dst=r3 src=r0 offset=0 imm=-8
+#line 184 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=452 dst=r1 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=454 dst=r4 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=455 dst=r0 src=r0 offset=0 imm=2
+#line 185 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 185 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 185 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 185 "sample/map.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=456 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+#line 185 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=457 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=458 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=459 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=460 dst=r1 src=r0 offset=93 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=461 dst=r1 src=r0 offset=0 imm=4
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(4);
-    // EBPF_OP_STXW pc=462 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=457 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=458 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=459 dst=r7 src=r6 offset=15 imm=0
+#line 186 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 186 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=460 dst=r1 src=r0 offset=0 imm=10
+#line 186 "sample/map.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=461 dst=r10 src=r1 offset=-4 imm=0
+#line 190 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=463 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=462 dst=r2 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=464 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=463 dst=r2 src=r0 offset=0 imm=-4
+#line 190 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=465 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=467 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=468 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=464 dst=r3 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=465 dst=r3 src=r0 offset=0 imm=-8
+#line 190 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=466 dst=r7 src=r0 offset=0 imm=0
+#line 190 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=467 dst=r1 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=469 dst=r4 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=470 dst=r0 src=r0 offset=0 imm=2
+#line 191 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 191 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 191 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 191 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=469 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=471 dst=r6 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=470 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=471 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=472 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=473 dst=r1 src=r0 offset=80 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=474 dst=r1 src=r0 offset=0 imm=5
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(5);
-    // EBPF_OP_STXW pc=475 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=476 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=472 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=473 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=474 dst=r6 src=r0 offset=1 imm=-1
+#line 191 "sample/map.c"
+    if ((int64_t)r6 > IMMEDIATE(-1))
+#line 191 "sample/map.c"
+        goto label_14;
+label_13:
+    // EBPF_OP_JA pc=475 dst=r0 src=r0 offset=-430 imm=0
+#line 191 "sample/map.c"
+    goto label_1;
+label_14:
+    // EBPF_OP_STXW pc=476 dst=r10 src=r7 offset=-4 imm=0
+#line 116 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=477 dst=r8 src=r0 offset=0 imm=1
+#line 116 "sample/map.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=478 dst=r10 src=r8 offset=-8 imm=0
+#line 117 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=479 dst=r2 src=r10 offset=0 imm=0
+#line 117 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=477 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=480 dst=r2 src=r0 offset=0 imm=-4
+#line 117 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=478 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=480 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=481 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=481 dst=r3 src=r10 offset=0 imm=0
+#line 117 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=482 dst=r3 src=r0 offset=0 imm=-8
+#line 117 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=483 dst=r1 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=485 dst=r4 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=486 dst=r0 src=r0 offset=0 imm=2
+#line 131 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 131 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 131 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 131 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=482 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=487 dst=r6 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=483 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=484 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=485 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=486 dst=r1 src=r0 offset=67 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=487 dst=r1 src=r0 offset=0 imm=6
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(6);
-    // EBPF_OP_STXW pc=488 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=489 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=490 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=491 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=493 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=494 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=495 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=496 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=497 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=498 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=499 dst=r1 src=r0 offset=54 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=500 dst=r1 src=r0 offset=0 imm=7
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(7);
-    // EBPF_OP_STXW pc=501 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=502 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=503 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=504 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=506 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=507 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=508 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=509 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=510 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=512 dst=r1 src=r0 offset=41 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=513 dst=r1 src=r0 offset=0 imm=8
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(8);
-    // EBPF_OP_STXW pc=514 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=515 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=516 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=517 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=519 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=520 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=521 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=522 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=523 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=524 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=525 dst=r1 src=r0 offset=28 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=526 dst=r1 src=r0 offset=0 imm=9
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(9);
-    // EBPF_OP_STXW pc=527 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=528 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=529 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=530 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=532 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=533 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=534 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=535 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=536 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=537 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=538 dst=r1 src=r0 offset=15 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=539 dst=r8 src=r0 offset=0 imm=10
-#line 177 "sample/map.c"
-    r8 = IMMEDIATE(10);
-    // EBPF_OP_STXW pc=540 dst=r10 src=r8 offset=-4 imm=0
-#line 180 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=488 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=489 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=490 dst=r7 src=r6 offset=145 imm=0
+#line 132 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 132 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_STXW pc=491 dst=r10 src=r8 offset=-4 imm=0
+#line 136 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=541 dst=r2 src=r10 offset=0 imm=0
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=492 dst=r2 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=542 dst=r2 src=r0 offset=0 imm=-4
-#line 180 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=493 dst=r2 src=r0 offset=0 imm=-4
+#line 136 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=543 dst=r1 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=545 dst=r3 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=546 dst=r0 src=r0 offset=0 imm=16
-#line 180 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=494 dst=r3 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=495 dst=r3 src=r0 offset=0 imm=-8
+#line 136 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=496 dst=r7 src=r0 offset=0 imm=0
+#line 136 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=497 dst=r1 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=499 dst=r4 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=500 dst=r0 src=r0 offset=0 imm=2
+#line 137 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 137 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 180 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 180 "sample/map.c"
+#line 137 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 137 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=547 dst=r6 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=501 dst=r6 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=548 dst=r1 src=r6 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=549 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=550 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=551 dst=r2 src=r0 offset=0 imm=-29
-#line 180 "sample/map.c"
-    r2 = (uint64_t)4294967267;
-    // EBPF_OP_JEQ_REG pc=553 dst=r1 src=r2 offset=198 imm=0
-#line 180 "sample/map.c"
-    if (r1 == r2)
-#line 180 "sample/map.c"
-        goto label_29;
-label_21:
-    // EBPF_OP_MOV64_REG pc=554 dst=r1 src=r6 offset=0 imm=0
-#line 208 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=555 dst=r1 src=r0 offset=0 imm=32
-#line 208 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=556 dst=r1 src=r0 offset=0 imm=32
-#line 208 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=557 dst=r2 src=r0 offset=0 imm=0
-#line 208 "sample/map.c"
-    r2 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=558 dst=r2 src=r1 offset=-513 imm=0
-#line 208 "sample/map.c"
-    if ((int64_t)r2 > (int64_t)r1)
-#line 208 "sample/map.c"
-        goto label_1;
-label_22:
-    // EBPF_OP_MOV64_IMM pc=559 dst=r1 src=r0 offset=0 imm=0
-#line 208 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=560 dst=r10 src=r1 offset=-4 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=502 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=503 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=504 dst=r7 src=r6 offset=131 imm=0
+#line 138 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 138 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=505 dst=r1 src=r0 offset=0 imm=2
+#line 138 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=506 dst=r10 src=r1 offset=-4 imm=0
+#line 142 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=561 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=507 dst=r2 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=562 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=508 dst=r2 src=r0 offset=0 imm=-4
+#line 142 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=563 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=565 dst=r0 src=r0 offset=0 imm=18
-#line 173 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=509 dst=r3 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=510 dst=r3 src=r0 offset=0 imm=-8
+#line 142 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=511 dst=r1 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=513 dst=r4 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=514 dst=r0 src=r0 offset=0 imm=2
+#line 143 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 143 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 173 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 173 "sample/map.c"
+#line 143 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 143 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=566 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = r0;
-    // EBPF_OP_LSH64_IMM pc=567 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=568 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=569 dst=r7 src=r0 offset=0 imm=-1
-#line 173 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-    // EBPF_OP_LDDW pc=570 dst=r2 src=r0 offset=0 imm=-7
-#line 173 "sample/map.c"
-    r2 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=572 dst=r1 src=r2 offset=1 imm=0
-#line 173 "sample/map.c"
-    if (r1 == r2)
-#line 173 "sample/map.c"
-        goto label_23;
-        // EBPF_OP_MOV64_REG pc=573 dst=r7 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r7 = r0;
-label_23:
-    // EBPF_OP_JNE_REG pc=574 dst=r1 src=r2 offset=170 imm=0
-#line 173 "sample/map.c"
-    if (r1 != r2)
-#line 173 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_LDXW pc=575 dst=r1 src=r10 offset=-4 imm=0
-#line 173 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JNE_IMM pc=576 dst=r1 src=r0 offset=168 imm=0
-#line 173 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 173 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=577 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = IMMEDIATE(0);
+        // EBPF_OP_MOV64_REG pc=515 dst=r6 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=516 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=517 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=518 dst=r7 src=r6 offset=117 imm=0
+#line 144 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 144 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=519 dst=r1 src=r0 offset=0 imm=3
+#line 144 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=520 dst=r10 src=r1 offset=-4 imm=0
+#line 148 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=521 dst=r2 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=522 dst=r2 src=r0 offset=0 imm=-4
+#line 148 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=523 dst=r3 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=524 dst=r3 src=r0 offset=0 imm=-8
+#line 148 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=525 dst=r7 src=r0 offset=0 imm=0
+#line 148 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=526 dst=r1 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=528 dst=r4 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=529 dst=r0 src=r0 offset=0 imm=2
+#line 149 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 149 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 149 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 149 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=530 dst=r6 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=531 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=532 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=533 dst=r7 src=r6 offset=102 imm=0
+#line 150 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 150 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=534 dst=r1 src=r0 offset=0 imm=4
+#line 150 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=535 dst=r10 src=r1 offset=-4 imm=0
+#line 154 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=536 dst=r2 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=537 dst=r2 src=r0 offset=0 imm=-4
+#line 154 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=538 dst=r3 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=539 dst=r3 src=r0 offset=0 imm=-8
+#line 154 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=540 dst=r1 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=542 dst=r4 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=543 dst=r0 src=r0 offset=0 imm=2
+#line 155 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 155 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 155 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 155 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=545 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=546 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=547 dst=r7 src=r6 offset=88 imm=0
+#line 156 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 156 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=548 dst=r1 src=r0 offset=0 imm=5
+#line 156 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=549 dst=r10 src=r1 offset=-4 imm=0
+#line 160 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=550 dst=r2 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=551 dst=r2 src=r0 offset=0 imm=-4
+#line 160 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=552 dst=r3 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=553 dst=r3 src=r0 offset=0 imm=-8
+#line 160 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=554 dst=r7 src=r0 offset=0 imm=0
+#line 160 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=555 dst=r1 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=557 dst=r4 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=558 dst=r0 src=r0 offset=0 imm=2
+#line 161 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 161 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 161 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 161 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=559 dst=r6 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=560 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=561 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=562 dst=r7 src=r6 offset=73 imm=0
+#line 162 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 162 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=563 dst=r1 src=r0 offset=0 imm=6
+#line 162 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=564 dst=r10 src=r1 offset=-4 imm=0
+#line 166 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=565 dst=r2 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=566 dst=r2 src=r0 offset=0 imm=-4
+#line 166 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=567 dst=r3 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=568 dst=r3 src=r0 offset=0 imm=-8
+#line 166 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=569 dst=r1 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=571 dst=r4 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=572 dst=r0 src=r0 offset=0 imm=2
+#line 167 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 167 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 167 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 167 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=573 dst=r6 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=574 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=575 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=576 dst=r7 src=r6 offset=59 imm=0
+#line 168 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 168 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=577 dst=r1 src=r0 offset=0 imm=7
+#line 168 "sample/map.c"
+    r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=578 dst=r10 src=r1 offset=-4 imm=0
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=579 dst=r2 src=r10 offset=0 imm=0
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=580 dst=r2 src=r0 offset=0 imm=-4
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=581 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=583 dst=r0 src=r0 offset=0 imm=17
-#line 174 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 174 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=581 dst=r3 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=582 dst=r3 src=r0 offset=0 imm=-8
+#line 172 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=583 dst=r7 src=r0 offset=0 imm=0
+#line 172 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=586 dst=r4 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=587 dst=r0 src=r0 offset=0 imm=2
+#line 173 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 173 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 174 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 174 "sample/map.c"
+#line 173 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 173 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=584 dst=r1 src=r10 offset=-4 imm=0
-#line 174 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=585 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JEQ_IMM pc=586 dst=r1 src=r0 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_24;
-        // EBPF_OP_MOV64_IMM pc=587 dst=r6 src=r0 offset=0 imm=-1
-#line 174 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_24:
-    // EBPF_OP_MOV64_REG pc=588 dst=r2 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=589 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=590 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=591 dst=r3 src=r0 offset=0 imm=-7
-#line 174 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=593 dst=r2 src=r3 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r2 == r3)
-#line 174 "sample/map.c"
-        goto label_25;
-        // EBPF_OP_MOV64_REG pc=594 dst=r6 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=588 dst=r6 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
     r6 = r0;
-label_25:
-    // EBPF_OP_MOV64_REG pc=595 dst=r7 src=r6 offset=0 imm=0
+    // EBPF_OP_LSH64_IMM pc=589 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=590 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=591 dst=r7 src=r6 offset=44 imm=0
 #line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JNE_REG pc=596 dst=r2 src=r3 offset=148 imm=0
+    if ((int64_t)r7 > (int64_t)r6)
 #line 174 "sample/map.c"
-    if (r2 != r3)
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=592 dst=r1 src=r0 offset=0 imm=8
 #line 174 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_REG pc=597 dst=r7 src=r6 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JNE_IMM pc=598 dst=r1 src=r0 offset=146 imm=0
-#line 174 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=599 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=600 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=601 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=602 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=603 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=605 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=606 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=607 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=608 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=609 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=610 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=611 dst=r1 src=r0 offset=133 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=612 dst=r1 src=r0 offset=0 imm=1
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=613 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=614 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=615 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=616 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=618 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=619 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=620 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=621 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=622 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=623 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=624 dst=r1 src=r0 offset=1 imm=0
-#line 177 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_26;
-        // EBPF_OP_JA pc=625 dst=r0 src=r0 offset=119 imm=0
-#line 177 "sample/map.c"
-    goto label_27;
-label_26:
-    // EBPF_OP_MOV64_IMM pc=626 dst=r1 src=r0 offset=0 imm=2
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(2);
-    // EBPF_OP_STXW pc=627 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=628 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=629 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=630 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=632 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=633 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=634 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=635 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=636 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=637 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=638 dst=r1 src=r0 offset=106 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=639 dst=r1 src=r0 offset=0 imm=3
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(3);
-    // EBPF_OP_STXW pc=640 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=641 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=642 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=643 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=645 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=646 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=647 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=648 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=649 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=650 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=651 dst=r1 src=r0 offset=93 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=652 dst=r1 src=r0 offset=0 imm=4
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(4);
-    // EBPF_OP_STXW pc=653 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=654 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=655 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=656 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=658 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=659 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=660 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=661 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=662 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=663 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=664 dst=r1 src=r0 offset=80 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=665 dst=r1 src=r0 offset=0 imm=5
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(5);
-    // EBPF_OP_STXW pc=666 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=667 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=668 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=669 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=671 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=672 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=673 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=674 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=675 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=676 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=677 dst=r1 src=r0 offset=67 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=678 dst=r1 src=r0 offset=0 imm=6
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(6);
-    // EBPF_OP_STXW pc=679 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=680 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=681 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=682 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=684 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=685 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=686 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=687 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=688 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=689 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=690 dst=r1 src=r0 offset=54 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=691 dst=r1 src=r0 offset=0 imm=7
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(7);
-    // EBPF_OP_STXW pc=692 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=693 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=694 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=695 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=697 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=698 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=699 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=700 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=701 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=702 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=703 dst=r1 src=r0 offset=41 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=704 dst=r1 src=r0 offset=0 imm=8
-#line 177 "sample/map.c"
     r1 = IMMEDIATE(8);
-    // EBPF_OP_STXW pc=705 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=593 dst=r10 src=r1 offset=-4 imm=0
+#line 178 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=706 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=594 dst=r2 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=707 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=595 dst=r2 src=r0 offset=0 imm=-4
+#line 178 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=708 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=710 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=711 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=596 dst=r3 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=597 dst=r3 src=r0 offset=0 imm=-8
+#line 178 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=598 dst=r1 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=600 dst=r4 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=601 dst=r0 src=r0 offset=0 imm=2
+#line 179 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 179 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 179 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 179 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=712 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=713 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=714 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=715 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=716 dst=r1 src=r0 offset=28 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=717 dst=r1 src=r0 offset=0 imm=9
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=602 dst=r6 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=603 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=604 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=605 dst=r7 src=r6 offset=30 imm=0
+#line 180 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 180 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=606 dst=r1 src=r0 offset=0 imm=9
+#line 180 "sample/map.c"
     r1 = IMMEDIATE(9);
-    // EBPF_OP_STXW pc=718 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=607 dst=r10 src=r1 offset=-4 imm=0
+#line 184 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=719 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=608 dst=r2 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=720 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=609 dst=r2 src=r0 offset=0 imm=-4
+#line 184 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=721 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=723 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=724 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=610 dst=r3 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=611 dst=r3 src=r0 offset=0 imm=-8
+#line 184 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=612 dst=r7 src=r0 offset=0 imm=0
+#line 184 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=613 dst=r1 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=615 dst=r4 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=616 dst=r0 src=r0 offset=0 imm=2
+#line 185 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 185 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 185 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 185 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=725 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=726 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=727 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=728 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=729 dst=r1 src=r0 offset=15 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=730 dst=r8 src=r0 offset=0 imm=10
-#line 177 "sample/map.c"
-    r8 = IMMEDIATE(10);
-    // EBPF_OP_STXW pc=731 dst=r10 src=r8 offset=-4 imm=0
-#line 180 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=732 dst=r2 src=r10 offset=0 imm=0
-#line 180 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=617 dst=r6 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=618 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=619 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=620 dst=r7 src=r6 offset=15 imm=0
+#line 186 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 186 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=621 dst=r1 src=r0 offset=0 imm=10
+#line 186 "sample/map.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=622 dst=r10 src=r1 offset=-4 imm=0
+#line 190 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=623 dst=r2 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=733 dst=r2 src=r0 offset=0 imm=-4
-#line 180 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=624 dst=r2 src=r0 offset=0 imm=-4
+#line 190 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=734 dst=r1 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=736 dst=r3 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=737 dst=r0 src=r0 offset=0 imm=16
-#line 180 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=625 dst=r3 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=626 dst=r3 src=r0 offset=0 imm=-8
+#line 190 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=627 dst=r7 src=r0 offset=0 imm=0
+#line 190 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=628 dst=r1 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=630 dst=r4 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=631 dst=r0 src=r0 offset=0 imm=2
+#line 191 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 191 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 180 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 180 "sample/map.c"
+#line 191 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 191 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=738 dst=r7 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=739 dst=r1 src=r7 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=740 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=741 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=742 dst=r2 src=r0 offset=0 imm=-29
-#line 180 "sample/map.c"
-    r2 = (uint64_t)4294967267;
-    // EBPF_OP_JEQ_REG pc=744 dst=r1 src=r2 offset=34 imm=0
-#line 180 "sample/map.c"
-    if (r1 == r2)
-#line 180 "sample/map.c"
-        goto label_31;
-label_27:
-    // EBPF_OP_MOV64_IMM pc=745 dst=r6 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_REG pc=746 dst=r1 src=r7 offset=0 imm=0
-#line 209 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=747 dst=r1 src=r0 offset=0 imm=32
-#line 209 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=748 dst=r1 src=r0 offset=0 imm=32
-#line 209 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=749 dst=r1 src=r0 offset=-704 imm=-1
-#line 209 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 209 "sample/map.c"
-        goto label_1;
-label_28:
-    // EBPF_OP_MOV64_REG pc=750 dst=r6 src=r7 offset=0 imm=0
-#line 209 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JA pc=751 dst=r0 src=r0 offset=-706 imm=0
-#line 209 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=632 dst=r6 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=633 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=634 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=635 dst=r6 src=r0 offset=1 imm=-1
+#line 191 "sample/map.c"
+    if ((int64_t)r6 > IMMEDIATE(-1))
+#line 191 "sample/map.c"
+        goto label_16;
+label_15:
+    // EBPF_OP_JA pc=636 dst=r0 src=r0 offset=-591 imm=0
+#line 191 "sample/map.c"
     goto label_1;
-label_29:
-    // EBPF_OP_STXW pc=752 dst=r10 src=r8 offset=-4 imm=0
-#line 181 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=753 dst=r2 src=r10 offset=0 imm=0
-#line 181 "sample/map.c"
+label_16:
+    // EBPF_OP_STXW pc=637 dst=r10 src=r7 offset=-4 imm=0
+#line 242 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_REG pc=638 dst=r2 src=r10 offset=0 imm=0
+#line 242 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=754 dst=r2 src=r0 offset=0 imm=-4
-#line 181 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=639 dst=r2 src=r0 offset=0 imm=-4
+#line 242 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=755 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
+    // EBPF_OP_LDDW pc=640 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=757 dst=r3 src=r0 offset=0 imm=2
-#line 181 "sample/map.c"
-    r3 = IMMEDIATE(2);
-    // EBPF_OP_CALL pc=758 dst=r0 src=r0 offset=0 imm=16
-#line 181 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 181 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 181 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 181 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=759 dst=r6 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=760 dst=r1 src=r6 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=761 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=762 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=763 dst=r1 src=r0 offset=1 imm=0
-#line 181 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_30;
-        // EBPF_OP_MOV64_REG pc=764 dst=r7 src=r6 offset=0 imm=0
-#line 181 "sample/map.c"
-    r7 = r6;
-label_30:
-    // EBPF_OP_JNE_IMM pc=765 dst=r1 src=r0 offset=-212 imm=0
-#line 181 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=766 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=767 dst=r10 src=r1 offset=-4 imm=0
-#line 183 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=768 dst=r2 src=r10 offset=0 imm=0
-#line 183 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=769 dst=r2 src=r0 offset=0 imm=-4
-#line 183 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=770 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=772 dst=r0 src=r0 offset=0 imm=18
-#line 183 "sample/map.c"
+    // EBPF_OP_CALL pc=642 dst=r0 src=r0 offset=0 imm=18
+#line 242 "sample/map.c"
     r0 = test_maps_helpers[4].address
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=773 dst=r6 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=643 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=644 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=645 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=646 dst=r6 src=r0 offset=0 imm=-1
+#line 242 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+    // EBPF_OP_LDDW pc=647 dst=r2 src=r0 offset=0 imm=-7
+#line 242 "sample/map.c"
+    r2 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=649 dst=r1 src=r2 offset=1 imm=0
+#line 242 "sample/map.c"
+    if (r1 == r2)
+#line 242 "sample/map.c"
+        goto label_17;
+        // EBPF_OP_MOV64_REG pc=650 dst=r6 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=774 dst=r1 src=r6 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=775 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=776 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=777 dst=r1 src=r0 offset=28 imm=0
-#line 183 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 183 "sample/map.c"
-        goto label_33;
-        // EBPF_OP_JA pc=778 dst=r0 src=r0 offset=-225 imm=0
-#line 183 "sample/map.c"
-    goto label_21;
-label_31:
-    // EBPF_OP_STXW pc=779 dst=r10 src=r8 offset=-4 imm=0
-#line 181 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=780 dst=r2 src=r10 offset=0 imm=0
-#line 181 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=781 dst=r2 src=r0 offset=0 imm=-4
-#line 181 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=782 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=784 dst=r3 src=r0 offset=0 imm=2
-#line 181 "sample/map.c"
-    r3 = IMMEDIATE(2);
-    // EBPF_OP_CALL pc=785 dst=r0 src=r0 offset=0 imm=16
-#line 181 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 181 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 181 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 181 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=786 dst=r7 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=787 dst=r1 src=r7 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=788 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=789 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=790 dst=r1 src=r0 offset=1 imm=0
-#line 181 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_32;
-        // EBPF_OP_MOV64_REG pc=791 dst=r6 src=r7 offset=0 imm=0
-#line 181 "sample/map.c"
-    r6 = r7;
-label_32:
-    // EBPF_OP_JNE_IMM pc=792 dst=r1 src=r0 offset=-48 imm=0
-#line 181 "sample/map.c"
+label_17:
+    // EBPF_OP_JNE_REG pc=651 dst=r1 src=r2 offset=409 imm=0
+#line 242 "sample/map.c"
+    if (r1 != r2)
+#line 242 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_LDXW pc=652 dst=r1 src=r10 offset=-4 imm=0
+#line 242 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=653 dst=r1 src=r0 offset=407 imm=0
+#line 242 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=793 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
+#line 242 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=654 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=655 dst=r10 src=r1 offset=-4 imm=0
+#line 243 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=656 dst=r2 src=r10 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=657 dst=r2 src=r0 offset=0 imm=-4
+#line 243 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=658 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=660 dst=r0 src=r0 offset=0 imm=17
+#line 243 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 243 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 243 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 243 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=661 dst=r1 src=r10 offset=-4 imm=0
+#line 243 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=662 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JEQ_IMM pc=663 dst=r1 src=r0 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_18;
+        // EBPF_OP_MOV64_IMM pc=664 dst=r7 src=r0 offset=0 imm=-1
+#line 243 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_18:
+    // EBPF_OP_MOV64_REG pc=665 dst=r2 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=666 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=667 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=668 dst=r3 src=r0 offset=0 imm=-7
+#line 243 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=670 dst=r2 src=r3 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r2 == r3)
+#line 243 "sample/map.c"
+        goto label_19;
+        // EBPF_OP_MOV64_REG pc=671 dst=r7 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r0;
+label_19:
+    // EBPF_OP_MOV64_REG pc=672 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JNE_REG pc=673 dst=r2 src=r3 offset=387 imm=0
+#line 243 "sample/map.c"
+    if (r2 != r3)
+#line 243 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_REG pc=674 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JNE_IMM pc=675 dst=r1 src=r0 offset=385 imm=0
+#line 243 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=676 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=677 dst=r10 src=r1 offset=-4 imm=0
+#line 251 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=678 dst=r2 src=r10 offset=0 imm=0
+#line 251 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=679 dst=r2 src=r0 offset=0 imm=-4
+#line 251 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=680 dst=r1 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=682 dst=r3 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=683 dst=r0 src=r0 offset=0 imm=16
+#line 251 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 251 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 251 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 251 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=684 dst=r6 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=685 dst=r1 src=r6 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=686 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=687 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=688 dst=r1 src=r0 offset=372 imm=0
+#line 251 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 251 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=689 dst=r1 src=r0 offset=0 imm=1
+#line 251 "sample/map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=690 dst=r10 src=r1 offset=-4 imm=0
+#line 252 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=691 dst=r2 src=r10 offset=0 imm=0
+#line 252 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=692 dst=r2 src=r0 offset=0 imm=-4
+#line 252 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=693 dst=r1 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=695 dst=r3 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=696 dst=r0 src=r0 offset=0 imm=16
+#line 252 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 252 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 252 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 252 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=697 dst=r6 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=698 dst=r1 src=r6 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=699 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=700 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=701 dst=r1 src=r0 offset=359 imm=0
+#line 252 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 252 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=702 dst=r1 src=r0 offset=0 imm=2
+#line 252 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=703 dst=r10 src=r1 offset=-4 imm=0
+#line 253 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=704 dst=r2 src=r10 offset=0 imm=0
+#line 253 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=705 dst=r2 src=r0 offset=0 imm=-4
+#line 253 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=706 dst=r1 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=708 dst=r3 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=709 dst=r0 src=r0 offset=0 imm=16
+#line 253 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 253 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 253 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 253 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=710 dst=r6 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=711 dst=r1 src=r6 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=712 dst=r1 src=r0 offset=0 imm=32
+#line 253 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=713 dst=r1 src=r0 offset=0 imm=32
+#line 253 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=714 dst=r1 src=r0 offset=346 imm=0
+#line 253 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 253 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=715 dst=r1 src=r0 offset=0 imm=3
+#line 253 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=716 dst=r10 src=r1 offset=-4 imm=0
+#line 254 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=717 dst=r2 src=r10 offset=0 imm=0
+#line 254 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=718 dst=r2 src=r0 offset=0 imm=-4
+#line 254 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=719 dst=r1 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=721 dst=r3 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=722 dst=r0 src=r0 offset=0 imm=16
+#line 254 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 254 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 254 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 254 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=723 dst=r6 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=724 dst=r1 src=r6 offset=0 imm=0
+#line 254 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=725 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=726 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=727 dst=r1 src=r0 offset=333 imm=0
+#line 254 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 254 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=728 dst=r1 src=r0 offset=0 imm=4
+#line 254 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=729 dst=r10 src=r1 offset=-4 imm=0
+#line 255 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=730 dst=r2 src=r10 offset=0 imm=0
+#line 255 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=731 dst=r2 src=r0 offset=0 imm=-4
+#line 255 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=732 dst=r1 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=734 dst=r3 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=735 dst=r0 src=r0 offset=0 imm=16
+#line 255 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 255 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 255 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 255 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=737 dst=r1 src=r6 offset=0 imm=0
+#line 255 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=738 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=739 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=740 dst=r1 src=r0 offset=320 imm=0
+#line 255 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 255 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=741 dst=r1 src=r0 offset=0 imm=5
+#line 255 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=742 dst=r10 src=r1 offset=-4 imm=0
+#line 256 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=743 dst=r2 src=r10 offset=0 imm=0
+#line 256 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=744 dst=r2 src=r0 offset=0 imm=-4
+#line 256 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=745 dst=r1 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=747 dst=r3 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=748 dst=r0 src=r0 offset=0 imm=16
+#line 256 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 256 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 256 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 256 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=749 dst=r6 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=750 dst=r1 src=r6 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=751 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=752 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=753 dst=r1 src=r0 offset=307 imm=0
+#line 256 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 256 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=754 dst=r1 src=r0 offset=0 imm=6
+#line 256 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=755 dst=r10 src=r1 offset=-4 imm=0
+#line 257 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=756 dst=r2 src=r10 offset=0 imm=0
+#line 257 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=757 dst=r2 src=r0 offset=0 imm=-4
+#line 257 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=758 dst=r1 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=760 dst=r3 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=761 dst=r0 src=r0 offset=0 imm=16
+#line 257 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 257 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 257 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 257 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=762 dst=r6 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=763 dst=r1 src=r6 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=764 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=765 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=766 dst=r1 src=r0 offset=294 imm=0
+#line 257 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 257 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=767 dst=r1 src=r0 offset=0 imm=7
+#line 257 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=768 dst=r10 src=r1 offset=-4 imm=0
+#line 258 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=769 dst=r2 src=r10 offset=0 imm=0
+#line 258 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=770 dst=r2 src=r0 offset=0 imm=-4
+#line 258 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=771 dst=r1 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=773 dst=r3 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=774 dst=r0 src=r0 offset=0 imm=16
+#line 258 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 258 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 258 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 258 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=775 dst=r6 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=776 dst=r1 src=r6 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=777 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=778 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=779 dst=r1 src=r0 offset=281 imm=0
+#line 258 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 258 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=780 dst=r1 src=r0 offset=0 imm=8
+#line 258 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=781 dst=r10 src=r1 offset=-4 imm=0
+#line 259 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=782 dst=r2 src=r10 offset=0 imm=0
+#line 259 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=783 dst=r2 src=r0 offset=0 imm=-4
+#line 259 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=784 dst=r1 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=786 dst=r3 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=787 dst=r0 src=r0 offset=0 imm=16
+#line 259 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 259 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 259 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 259 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=788 dst=r6 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=789 dst=r1 src=r6 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=790 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=791 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=792 dst=r1 src=r0 offset=268 imm=0
+#line 259 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 259 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=793 dst=r1 src=r0 offset=0 imm=9
+#line 259 "sample/map.c"
+    r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=794 dst=r10 src=r1 offset=-4 imm=0
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=795 dst=r2 src=r10 offset=0 imm=0
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=796 dst=r2 src=r0 offset=0 imm=-4
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=797 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=799 dst=r0 src=r0 offset=0 imm=18
-#line 183 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 183 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 183 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=800 dst=r7 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=801 dst=r1 src=r7 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=802 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=803 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=804 dst=r1 src=r0 offset=36 imm=0
-#line 183 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 183 "sample/map.c"
-        goto label_37;
-        // EBPF_OP_JA pc=805 dst=r0 src=r0 offset=-61 imm=0
-#line 183 "sample/map.c"
-    goto label_27;
-label_33:
-    // EBPF_OP_LDXW pc=806 dst=r1 src=r10 offset=-4 imm=0
-#line 183 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=807 dst=r6 src=r0 offset=0 imm=-1
-#line 183 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=809 dst=r1 src=r0 offset=-764 imm=1
-#line 183 "sample/map.c"
-    if (r1 != IMMEDIATE(1))
-#line 183 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=810 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=811 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=812 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=813 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=814 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 260 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=816 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=799 dst=r3 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=800 dst=r0 src=r0 offset=0 imm=16
+#line 260 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 260 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 260 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 260 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=817 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=801 dst=r6 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=818 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=802 dst=r1 src=r6 offset=0 imm=0
+#line 260 "sample/map.c"
     r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=819 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=803 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=820 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=804 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=821 dst=r1 src=r0 offset=1 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=805 dst=r1 src=r0 offset=255 imm=0
+#line 260 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 260 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=806 dst=r8 src=r0 offset=0 imm=10
+#line 260 "sample/map.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=807 dst=r10 src=r8 offset=-4 imm=0
+#line 263 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=808 dst=r2 src=r10 offset=0 imm=0
+#line 263 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=809 dst=r2 src=r0 offset=0 imm=-4
+#line 263 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=810 dst=r1 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=812 dst=r3 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=813 dst=r0 src=r0 offset=0 imm=16
+#line 263 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 263 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 263 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 263 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=814 dst=r6 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=815 dst=r1 src=r6 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=816 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=817 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=818 dst=r2 src=r0 offset=0 imm=-29
+#line 263 "sample/map.c"
+    r2 = (uint64_t)4294967267;
+    // EBPF_OP_JNE_REG pc=820 dst=r1 src=r2 offset=240 imm=0
+#line 263 "sample/map.c"
+    if (r1 != r2)
+#line 263 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_STXW pc=821 dst=r10 src=r8 offset=-4 imm=0
+#line 264 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=822 dst=r2 src=r10 offset=0 imm=0
+#line 264 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=823 dst=r2 src=r0 offset=0 imm=-4
+#line 264 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=824 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=826 dst=r3 src=r0 offset=0 imm=2
+#line 264 "sample/map.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=827 dst=r0 src=r0 offset=0 imm=16
+#line 264 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 264 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 264 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 264 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=828 dst=r6 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=829 dst=r1 src=r6 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=830 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=831 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=832 dst=r1 src=r0 offset=1 imm=0
+#line 264 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_34;
-        // EBPF_OP_JA pc=822 dst=r0 src=r0 offset=17 imm=0
-#line 186 "sample/map.c"
+#line 264 "sample/map.c"
+        goto label_20;
+        // EBPF_OP_MOV64_REG pc=833 dst=r7 src=r6 offset=0 imm=0
+#line 264 "sample/map.c"
+    r7 = r6;
+label_20:
+    // EBPF_OP_JNE_IMM pc=834 dst=r1 src=r0 offset=226 imm=0
+#line 264 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 264 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=835 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=836 dst=r10 src=r1 offset=-4 imm=0
+#line 266 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=837 dst=r2 src=r10 offset=0 imm=0
+#line 266 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=838 dst=r2 src=r0 offset=0 imm=-4
+#line 266 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=839 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=841 dst=r0 src=r0 offset=0 imm=18
+#line 266 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 266 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 266 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 266 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=842 dst=r6 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=843 dst=r1 src=r6 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=844 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=845 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=846 dst=r1 src=r0 offset=1 imm=0
+#line 266 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 266 "sample/map.c"
+        goto label_21;
+        // EBPF_OP_JA pc=847 dst=r0 src=r0 offset=213 imm=0
+#line 266 "sample/map.c"
     goto label_36;
-label_34:
-    // EBPF_OP_LDXW pc=823 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+label_21:
+    // EBPF_OP_LDXW pc=848 dst=r1 src=r10 offset=-4 imm=0
+#line 266 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=824 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=849 dst=r6 src=r0 offset=0 imm=-1
+#line 266 "sample/map.c"
     r6 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=826 dst=r1 src=r0 offset=1 imm=1
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(1))
-#line 186 "sample/map.c"
-        goto label_35;
-        // EBPF_OP_JA pc=827 dst=r0 src=r0 offset=-782 imm=0
-#line 186 "sample/map.c"
-    goto label_1;
-label_35:
-    // EBPF_OP_MOV64_IMM pc=828 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=851 dst=r1 src=r0 offset=-806 imm=1
+#line 266 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 266 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=852 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=829 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=853 dst=r10 src=r1 offset=-4 imm=0
+#line 274 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=830 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=854 dst=r2 src=r10 offset=0 imm=0
+#line 274 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=831 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=855 dst=r2 src=r0 offset=0 imm=-4
+#line 274 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=832 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=856 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=834 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_CALL pc=858 dst=r0 src=r0 offset=0 imm=17
+#line 274 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=835 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=859 dst=r6 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=836 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=860 dst=r1 src=r6 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=837 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=861 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=838 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=862 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=839 dst=r1 src=r0 offset=36 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=863 dst=r1 src=r0 offset=1 imm=0
+#line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_41;
-label_36:
-    // EBPF_OP_JA pc=840 dst=r0 src=r0 offset=-287 imm=0
-#line 186 "sample/map.c"
-    goto label_21;
-label_37:
-    // EBPF_OP_LDXW pc=841 dst=r1 src=r10 offset=-4 imm=0
-#line 183 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=842 dst=r7 src=r0 offset=0 imm=-1
-#line 183 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=844 dst=r1 src=r0 offset=-95 imm=10
-#line 183 "sample/map.c"
-    if (r1 != IMMEDIATE(10))
-#line 183 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=845 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=846 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=847 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=848 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=849 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=851 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=852 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=853 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=854 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=855 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=856 dst=r1 src=r0 offset=1 imm=0
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_38;
-        // EBPF_OP_JA pc=857 dst=r0 src=r0 offset=17 imm=0
-#line 186 "sample/map.c"
-    goto label_40;
-label_38:
-    // EBPF_OP_LDXW pc=858 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=859 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=861 dst=r1 src=r0 offset=1 imm=10
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(10))
-#line 186 "sample/map.c"
-        goto label_39;
-        // EBPF_OP_JA pc=862 dst=r0 src=r0 offset=-113 imm=0
-#line 186 "sample/map.c"
-    goto label_28;
-label_39:
-    // EBPF_OP_MOV64_IMM pc=863 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=864 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=865 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=866 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=867 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=869 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=870 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=871 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=872 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=873 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=874 dst=r1 src=r0 offset=174 imm=0
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_47;
-label_40:
-    // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=-131 imm=0
-#line 186 "sample/map.c"
-    goto label_27;
-label_41:
-    // EBPF_OP_LDXW pc=876 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=877 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=879 dst=r1 src=r0 offset=-834 imm=2
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(2))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=880 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=881 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=882 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=883 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=884 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=886 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=887 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=888 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=889 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=890 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=891 dst=r1 src=r0 offset=-52 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=892 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=893 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=895 dst=r1 src=r0 offset=-850 imm=3
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(3))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=896 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=897 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=898 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=899 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=900 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=902 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=903 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=904 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=905 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=906 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=907 dst=r1 src=r0 offset=-68 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=908 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=909 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=911 dst=r1 src=r0 offset=-866 imm=4
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(4))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=912 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=913 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=914 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=915 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=916 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=918 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=919 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=920 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=921 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=922 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=923 dst=r1 src=r0 offset=-84 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=924 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=925 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=927 dst=r1 src=r0 offset=-882 imm=5
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(5))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=928 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=929 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=930 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=931 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=932 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=934 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=935 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=936 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=937 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=938 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=939 dst=r1 src=r0 offset=-100 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=940 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=941 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=943 dst=r1 src=r0 offset=-898 imm=6
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(6))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=944 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=945 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=946 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=947 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=948 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=950 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=951 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=952 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=953 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=954 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=955 dst=r1 src=r0 offset=-116 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=956 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=957 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=959 dst=r1 src=r0 offset=-914 imm=7
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(7))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=960 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=961 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=962 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=963 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=964 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=966 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=967 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=968 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=969 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=970 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=971 dst=r1 src=r0 offset=-132 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=972 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=973 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=975 dst=r1 src=r0 offset=-930 imm=8
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(8))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=976 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=977 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=978 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=979 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=980 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=982 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=983 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=984 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=985 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=986 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=987 dst=r1 src=r0 offset=-148 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=988 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=989 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=991 dst=r1 src=r0 offset=-946 imm=9
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(9))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=992 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=993 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=994 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=995 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=996 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=998 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=1000 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=1001 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1002 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1003 dst=r1 src=r0 offset=-164 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=1004 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1005 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1007 dst=r1 src=r0 offset=-962 imm=10
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(10))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=1008 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1009 dst=r10 src=r1 offset=-4 imm=0
-#line 189 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1010 dst=r2 src=r10 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1011 dst=r2 src=r0 offset=0 imm=-4
-#line 189 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1012 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=1014 dst=r0 src=r0 offset=0 imm=18
-#line 189 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 189 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 189 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=1015 dst=r1 src=r10 offset=-4 imm=0
-#line 189 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=1016 dst=r6 src=r7 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JEQ_IMM pc=1017 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_42;
-        // EBPF_OP_MOV64_IMM pc=1018 dst=r6 src=r0 offset=0 imm=-1
-#line 189 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_42:
-    // EBPF_OP_MOV64_REG pc=1019 dst=r2 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1020 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1021 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1022 dst=r3 src=r0 offset=0 imm=-7
-#line 189 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1024 dst=r2 src=r3 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r2 == r3)
-#line 189 "sample/map.c"
-        goto label_43;
-        // EBPF_OP_MOV64_REG pc=1025 dst=r6 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = r0;
-label_43:
-    // EBPF_OP_JNE_REG pc=1026 dst=r2 src=r3 offset=-473 imm=0
-#line 189 "sample/map.c"
-    if (r2 != r3)
-#line 189 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_JEQ_IMM pc=1027 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_44;
-        // EBPF_OP_JA pc=1028 dst=r0 src=r0 offset=-475 imm=0
-#line 189 "sample/map.c"
-    goto label_21;
-label_44:
-    // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1030 dst=r10 src=r1 offset=-4 imm=0
-#line 190 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1031 dst=r2 src=r10 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1032 dst=r2 src=r0 offset=0 imm=-4
-#line 190 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1033 dst=r1 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=1035 dst=r0 src=r0 offset=0 imm=17
-#line 190 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 190 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 190 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=1036 dst=r1 src=r10 offset=-4 imm=0
-#line 190 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JEQ_IMM pc=1037 dst=r1 src=r0 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
-        goto label_45;
-        // EBPF_OP_MOV64_IMM pc=1038 dst=r6 src=r0 offset=0 imm=-1
-#line 190 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_45:
-    // EBPF_OP_MOV64_REG pc=1039 dst=r2 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1040 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1041 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1042 dst=r3 src=r0 offset=0 imm=-7
-#line 190 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1044 dst=r2 src=r3 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r2 == r3)
-#line 190 "sample/map.c"
-        goto label_46;
-        // EBPF_OP_MOV64_REG pc=1045 dst=r6 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r6 = r0;
-label_46:
-    // EBPF_OP_JNE_REG pc=1046 dst=r2 src=r3 offset=-493 imm=0
-#line 190 "sample/map.c"
-    if (r2 != r3)
-#line 190 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_JEQ_IMM pc=1047 dst=r1 src=r0 offset=-489 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
+#line 274 "sample/map.c"
         goto label_22;
-        // EBPF_OP_JA pc=1048 dst=r0 src=r0 offset=-495 imm=0
-#line 190 "sample/map.c"
-    goto label_21;
-label_47:
-    // EBPF_OP_LDXW pc=1049 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_JA pc=864 dst=r0 src=r0 offset=196 imm=0
+#line 274 "sample/map.c"
+    goto label_36;
+label_22:
+    // EBPF_OP_LDXW pc=865 dst=r1 src=r10 offset=-4 imm=0
+#line 274 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1050 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1052 dst=r1 src=r0 offset=-303 imm=9
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(9))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1053 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=866 dst=r6 src=r0 offset=0 imm=-1
+#line 274 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=868 dst=r1 src=r0 offset=-823 imm=1
+#line 274 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 274 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=869 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1054 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=870 dst=r10 src=r1 offset=-4 imm=0
+#line 275 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1055 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=871 dst=r2 src=r10 offset=0 imm=0
+#line 275 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1056 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=872 dst=r2 src=r0 offset=0 imm=-4
+#line 275 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1057 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1059 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=873 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=875 dst=r0 src=r0 offset=0 imm=17
+#line 275 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1060 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1061 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1062 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=876 dst=r6 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=877 dst=r1 src=r6 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=878 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1063 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=879 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1064 dst=r1 src=r0 offset=-190 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1065 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=880 dst=r1 src=r0 offset=1 imm=0
+#line 275 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 275 "sample/map.c"
+        goto label_23;
+        // EBPF_OP_JA pc=881 dst=r0 src=r0 offset=179 imm=0
+#line 275 "sample/map.c"
+    goto label_36;
+label_23:
+    // EBPF_OP_LDXW pc=882 dst=r1 src=r10 offset=-4 imm=0
+#line 275 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1066 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1068 dst=r1 src=r0 offset=-319 imm=8
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(8))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1069 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=883 dst=r6 src=r0 offset=0 imm=-1
+#line 275 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=885 dst=r1 src=r0 offset=-840 imm=2
+#line 275 "sample/map.c"
+    if (r1 != IMMEDIATE(2))
+#line 275 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=886 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1070 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=887 dst=r10 src=r1 offset=-4 imm=0
+#line 276 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1071 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=888 dst=r2 src=r10 offset=0 imm=0
+#line 276 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1072 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=889 dst=r2 src=r0 offset=0 imm=-4
+#line 276 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1073 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1075 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=890 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=892 dst=r0 src=r0 offset=0 imm=17
+#line 276 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1076 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1077 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1078 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=893 dst=r6 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=894 dst=r1 src=r6 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=895 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1079 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=896 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1080 dst=r1 src=r0 offset=-206 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1081 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=897 dst=r1 src=r0 offset=1 imm=0
+#line 276 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 276 "sample/map.c"
+        goto label_24;
+        // EBPF_OP_JA pc=898 dst=r0 src=r0 offset=162 imm=0
+#line 276 "sample/map.c"
+    goto label_36;
+label_24:
+    // EBPF_OP_LDXW pc=899 dst=r1 src=r10 offset=-4 imm=0
+#line 276 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1082 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1084 dst=r1 src=r0 offset=-335 imm=7
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(7))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1085 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=900 dst=r6 src=r0 offset=0 imm=-1
+#line 276 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=902 dst=r1 src=r0 offset=-857 imm=3
+#line 276 "sample/map.c"
+    if (r1 != IMMEDIATE(3))
+#line 276 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=903 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1086 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=904 dst=r10 src=r1 offset=-4 imm=0
+#line 277 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1087 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=905 dst=r2 src=r10 offset=0 imm=0
+#line 277 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1088 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=906 dst=r2 src=r0 offset=0 imm=-4
+#line 277 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1089 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1091 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=907 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=909 dst=r0 src=r0 offset=0 imm=17
+#line 277 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1092 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1093 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1094 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=910 dst=r6 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=911 dst=r1 src=r6 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=912 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1095 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=913 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1096 dst=r1 src=r0 offset=-222 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1097 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=914 dst=r1 src=r0 offset=1 imm=0
+#line 277 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 277 "sample/map.c"
+        goto label_25;
+        // EBPF_OP_JA pc=915 dst=r0 src=r0 offset=145 imm=0
+#line 277 "sample/map.c"
+    goto label_36;
+label_25:
+    // EBPF_OP_LDXW pc=916 dst=r1 src=r10 offset=-4 imm=0
+#line 277 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1098 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1100 dst=r1 src=r0 offset=-351 imm=6
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(6))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1101 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1102 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1103 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1104 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1105 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1107 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=1108 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1109 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1110 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1111 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1112 dst=r1 src=r0 offset=-238 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1113 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1114 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1116 dst=r1 src=r0 offset=-367 imm=5
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(5))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1117 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1118 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1119 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1120 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1121 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1123 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=1124 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1125 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1126 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1127 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1128 dst=r1 src=r0 offset=-254 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1129 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1130 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1132 dst=r1 src=r0 offset=-383 imm=4
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=917 dst=r6 src=r0 offset=0 imm=-1
+#line 277 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=919 dst=r1 src=r0 offset=-874 imm=4
+#line 277 "sample/map.c"
     if (r1 != IMMEDIATE(4))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1133 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=920 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1134 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=921 dst=r10 src=r1 offset=-4 imm=0
+#line 278 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1135 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=922 dst=r2 src=r10 offset=0 imm=0
+#line 278 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1136 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=923 dst=r2 src=r0 offset=0 imm=-4
+#line 278 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1137 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1139 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=924 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=926 dst=r0 src=r0 offset=0 imm=17
+#line 278 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=927 dst=r6 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=928 dst=r1 src=r6 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=929 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=930 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=931 dst=r1 src=r0 offset=1 imm=0
+#line 278 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 278 "sample/map.c"
+        goto label_26;
+        // EBPF_OP_JA pc=932 dst=r0 src=r0 offset=128 imm=0
+#line 278 "sample/map.c"
+    goto label_36;
+label_26:
+    // EBPF_OP_LDXW pc=933 dst=r1 src=r10 offset=-4 imm=0
+#line 278 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=934 dst=r6 src=r0 offset=0 imm=-1
+#line 278 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=936 dst=r1 src=r0 offset=-891 imm=5
+#line 278 "sample/map.c"
+    if (r1 != IMMEDIATE(5))
+#line 278 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=937 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=938 dst=r10 src=r1 offset=-4 imm=0
+#line 279 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=939 dst=r2 src=r10 offset=0 imm=0
+#line 279 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=940 dst=r2 src=r0 offset=0 imm=-4
+#line 279 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=941 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=943 dst=r0 src=r0 offset=0 imm=17
+#line 279 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 279 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 279 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 279 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=944 dst=r6 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=945 dst=r1 src=r6 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=946 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=947 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=948 dst=r1 src=r0 offset=1 imm=0
+#line 279 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 279 "sample/map.c"
+        goto label_27;
+        // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=111 imm=0
+#line 279 "sample/map.c"
+    goto label_36;
+label_27:
+    // EBPF_OP_LDXW pc=950 dst=r1 src=r10 offset=-4 imm=0
+#line 279 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=951 dst=r6 src=r0 offset=0 imm=-1
+#line 279 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=953 dst=r1 src=r0 offset=-908 imm=6
+#line 279 "sample/map.c"
+    if (r1 != IMMEDIATE(6))
+#line 279 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=954 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=955 dst=r10 src=r1 offset=-4 imm=0
+#line 280 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=956 dst=r2 src=r10 offset=0 imm=0
+#line 280 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=957 dst=r2 src=r0 offset=0 imm=-4
+#line 280 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=958 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=960 dst=r0 src=r0 offset=0 imm=17
+#line 280 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 280 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 280 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 280 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=961 dst=r6 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=962 dst=r1 src=r6 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=963 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=964 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=965 dst=r1 src=r0 offset=1 imm=0
+#line 280 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 280 "sample/map.c"
+        goto label_28;
+        // EBPF_OP_JA pc=966 dst=r0 src=r0 offset=94 imm=0
+#line 280 "sample/map.c"
+    goto label_36;
+label_28:
+    // EBPF_OP_LDXW pc=967 dst=r1 src=r10 offset=-4 imm=0
+#line 280 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=968 dst=r6 src=r0 offset=0 imm=-1
+#line 280 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=970 dst=r1 src=r0 offset=-925 imm=7
+#line 280 "sample/map.c"
+    if (r1 != IMMEDIATE(7))
+#line 280 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=971 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=972 dst=r10 src=r1 offset=-4 imm=0
+#line 281 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=973 dst=r2 src=r10 offset=0 imm=0
+#line 281 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=974 dst=r2 src=r0 offset=0 imm=-4
+#line 281 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=975 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=977 dst=r0 src=r0 offset=0 imm=17
+#line 281 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 281 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 281 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 281 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=978 dst=r6 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=979 dst=r1 src=r6 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=980 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=981 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=982 dst=r1 src=r0 offset=1 imm=0
+#line 281 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 281 "sample/map.c"
+        goto label_29;
+        // EBPF_OP_JA pc=983 dst=r0 src=r0 offset=77 imm=0
+#line 281 "sample/map.c"
+    goto label_36;
+label_29:
+    // EBPF_OP_LDXW pc=984 dst=r1 src=r10 offset=-4 imm=0
+#line 281 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=985 dst=r6 src=r0 offset=0 imm=-1
+#line 281 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=987 dst=r1 src=r0 offset=-942 imm=8
+#line 281 "sample/map.c"
+    if (r1 != IMMEDIATE(8))
+#line 281 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=988 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=989 dst=r10 src=r1 offset=-4 imm=0
+#line 282 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=990 dst=r2 src=r10 offset=0 imm=0
+#line 282 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=991 dst=r2 src=r0 offset=0 imm=-4
+#line 282 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=992 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=994 dst=r0 src=r0 offset=0 imm=17
+#line 282 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 282 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 282 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 282 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=995 dst=r6 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=996 dst=r1 src=r6 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=997 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=998 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=999 dst=r1 src=r0 offset=1 imm=0
+#line 282 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 282 "sample/map.c"
+        goto label_30;
+        // EBPF_OP_JA pc=1000 dst=r0 src=r0 offset=60 imm=0
+#line 282 "sample/map.c"
+    goto label_36;
+label_30:
+    // EBPF_OP_LDXW pc=1001 dst=r1 src=r10 offset=-4 imm=0
+#line 282 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=1002 dst=r6 src=r0 offset=0 imm=-1
+#line 282 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=1004 dst=r1 src=r0 offset=-959 imm=9
+#line 282 "sample/map.c"
+    if (r1 != IMMEDIATE(9))
+#line 282 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=1005 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1006 dst=r10 src=r1 offset=-4 imm=0
+#line 283 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1007 dst=r2 src=r10 offset=0 imm=0
+#line 283 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1008 dst=r2 src=r0 offset=0 imm=-4
+#line 283 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1009 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1011 dst=r0 src=r0 offset=0 imm=17
+#line 283 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 283 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 283 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 283 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1012 dst=r6 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=1013 dst=r1 src=r6 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=1014 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1015 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1016 dst=r1 src=r0 offset=1 imm=0
+#line 283 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 283 "sample/map.c"
+        goto label_31;
+        // EBPF_OP_JA pc=1017 dst=r0 src=r0 offset=43 imm=0
+#line 283 "sample/map.c"
+    goto label_36;
+label_31:
+    // EBPF_OP_LDXW pc=1018 dst=r1 src=r10 offset=-4 imm=0
+#line 283 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=1019 dst=r6 src=r0 offset=0 imm=-1
+#line 283 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=1021 dst=r1 src=r0 offset=-976 imm=10
+#line 283 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 283 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=1022 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1023 dst=r10 src=r1 offset=-4 imm=0
+#line 286 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1024 dst=r2 src=r10 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1025 dst=r2 src=r0 offset=0 imm=-4
+#line 286 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1026 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1028 dst=r0 src=r0 offset=0 imm=18
+#line 286 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 286 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 286 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 286 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1029 dst=r1 src=r10 offset=-4 imm=0
+#line 286 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1030 dst=r6 src=r7 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JEQ_IMM pc=1031 dst=r1 src=r0 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_32;
+        // EBPF_OP_MOV64_IMM pc=1032 dst=r6 src=r0 offset=0 imm=-1
+#line 286 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_32:
+    // EBPF_OP_MOV64_REG pc=1033 dst=r2 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1034 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1035 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1036 dst=r3 src=r0 offset=0 imm=-7
+#line 286 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1038 dst=r2 src=r3 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r2 == r3)
+#line 286 "sample/map.c"
+        goto label_33;
+        // EBPF_OP_MOV64_REG pc=1039 dst=r6 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = r0;
+label_33:
+    // EBPF_OP_JNE_REG pc=1040 dst=r2 src=r3 offset=20 imm=0
+#line 286 "sample/map.c"
+    if (r2 != r3)
+#line 286 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_JNE_IMM pc=1041 dst=r1 src=r0 offset=19 imm=0
+#line 286 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1043 dst=r10 src=r1 offset=-4 imm=0
+#line 287 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1044 dst=r2 src=r10 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1045 dst=r2 src=r0 offset=0 imm=-4
+#line 287 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1046 dst=r1 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1048 dst=r0 src=r0 offset=0 imm=17
+#line 287 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 287 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 287 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 287 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1049 dst=r1 src=r10 offset=-4 imm=0
+#line 287 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JEQ_IMM pc=1050 dst=r1 src=r0 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_34;
+        // EBPF_OP_MOV64_IMM pc=1051 dst=r6 src=r0 offset=0 imm=-1
+#line 287 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_34:
+    // EBPF_OP_MOV64_REG pc=1052 dst=r2 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1053 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1054 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1055 dst=r3 src=r0 offset=0 imm=-7
+#line 287 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1057 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 == r3)
+#line 287 "sample/map.c"
+        goto label_35;
+        // EBPF_OP_MOV64_REG pc=1058 dst=r6 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r6 = r0;
+label_35:
+    // EBPF_OP_JNE_REG pc=1059 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 != r3)
+#line 287 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_JEQ_IMM pc=1060 dst=r1 src=r0 offset=5 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_37;
+label_36:
+    // EBPF_OP_MOV64_REG pc=1061 dst=r1 src=r6 offset=0 imm=0
+#line 305 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=1062 dst=r1 src=r0 offset=0 imm=32
+#line 305 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=1063 dst=r1 src=r0 offset=0 imm=32
+#line 305 "sample/map.c"
+    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=1064 dst=r2 src=r0 offset=0 imm=0
+#line 305 "sample/map.c"
+    r2 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=1065 dst=r2 src=r1 offset=-1020 imm=0
+#line 305 "sample/map.c"
+    if ((int64_t)r2 > (int64_t)r1)
+#line 305 "sample/map.c"
+        goto label_1;
+label_37:
+    // EBPF_OP_MOV64_IMM pc=1066 dst=r1 src=r0 offset=0 imm=0
+#line 305 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1067 dst=r10 src=r1 offset=-4 imm=0
+#line 242 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1068 dst=r2 src=r10 offset=0 imm=0
+#line 242 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1069 dst=r2 src=r0 offset=0 imm=-4
+#line 242 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1070 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1072 dst=r0 src=r0 offset=0 imm=18
+#line 242 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 242 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 242 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 242 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1073 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1074 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1075 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=1076 dst=r7 src=r0 offset=0 imm=-1
+#line 242 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+    // EBPF_OP_LDDW pc=1077 dst=r2 src=r0 offset=0 imm=-7
+#line 242 "sample/map.c"
+    r2 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1079 dst=r1 src=r2 offset=1 imm=0
+#line 242 "sample/map.c"
+    if (r1 == r2)
+#line 242 "sample/map.c"
+        goto label_38;
+        // EBPF_OP_MOV64_REG pc=1080 dst=r7 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r7 = r0;
+label_38:
+    // EBPF_OP_JNE_REG pc=1081 dst=r1 src=r2 offset=380 imm=0
+#line 242 "sample/map.c"
+    if (r1 != r2)
+#line 242 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_LDXW pc=1082 dst=r1 src=r10 offset=-4 imm=0
+#line 242 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1083 dst=r1 src=r0 offset=378 imm=0
+#line 242 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 242 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1084 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1085 dst=r10 src=r1 offset=-4 imm=0
+#line 243 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1086 dst=r2 src=r10 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1087 dst=r2 src=r0 offset=0 imm=-4
+#line 243 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1088 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1090 dst=r0 src=r0 offset=0 imm=17
+#line 243 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 243 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 243 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 243 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1091 dst=r1 src=r10 offset=-4 imm=0
+#line 243 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1092 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JEQ_IMM pc=1093 dst=r1 src=r0 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_39;
+        // EBPF_OP_MOV64_IMM pc=1094 dst=r6 src=r0 offset=0 imm=-1
+#line 243 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_39:
+    // EBPF_OP_MOV64_REG pc=1095 dst=r2 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1096 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1097 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1098 dst=r3 src=r0 offset=0 imm=-7
+#line 243 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1100 dst=r2 src=r3 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r2 == r3)
+#line 243 "sample/map.c"
+        goto label_40;
+        // EBPF_OP_MOV64_REG pc=1101 dst=r6 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r0;
+label_40:
+    // EBPF_OP_MOV64_REG pc=1102 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JNE_REG pc=1103 dst=r2 src=r3 offset=358 imm=0
+#line 243 "sample/map.c"
+    if (r2 != r3)
+#line 243 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_REG pc=1104 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JNE_IMM pc=1105 dst=r1 src=r0 offset=356 imm=0
+#line 243 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1106 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1107 dst=r10 src=r1 offset=-4 imm=0
+#line 251 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1108 dst=r2 src=r10 offset=0 imm=0
+#line 251 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1109 dst=r2 src=r0 offset=0 imm=-4
+#line 251 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1110 dst=r1 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1112 dst=r3 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1113 dst=r0 src=r0 offset=0 imm=16
+#line 251 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 251 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 251 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 251 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1114 dst=r7 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1115 dst=r1 src=r7 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1116 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1117 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1118 dst=r1 src=r0 offset=343 imm=0
+#line 251 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 251 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1119 dst=r1 src=r0 offset=0 imm=1
+#line 251 "sample/map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=1120 dst=r10 src=r1 offset=-4 imm=0
+#line 252 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1121 dst=r2 src=r10 offset=0 imm=0
+#line 252 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1122 dst=r2 src=r0 offset=0 imm=-4
+#line 252 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1123 dst=r1 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1125 dst=r3 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1126 dst=r0 src=r0 offset=0 imm=16
+#line 252 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 252 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 252 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 252 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1127 dst=r7 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1128 dst=r1 src=r7 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1129 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1130 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1131 dst=r1 src=r0 offset=330 imm=0
+#line 252 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 252 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1132 dst=r1 src=r0 offset=0 imm=2
+#line 252 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=1133 dst=r10 src=r1 offset=-4 imm=0
+#line 253 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1134 dst=r2 src=r10 offset=0 imm=0
+#line 253 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1135 dst=r2 src=r0 offset=0 imm=-4
+#line 253 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1136 dst=r1 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1138 dst=r3 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1139 dst=r0 src=r0 offset=0 imm=16
+#line 253 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 253 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 253 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 253 "sample/map.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=1140 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1141 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 = r7;
     // EBPF_OP_LSH64_IMM pc=1142 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 <<= IMMEDIATE(32);
     // EBPF_OP_RSH64_IMM pc=1143 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1144 dst=r1 src=r0 offset=-270 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1144 dst=r1 src=r0 offset=317 imm=0
+#line 253 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1145 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1146 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1148 dst=r1 src=r0 offset=-399 imm=3
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(3))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1149 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1150 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1145 dst=r1 src=r0 offset=0 imm=3
+#line 253 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=1146 dst=r10 src=r1 offset=-4 imm=0
+#line 254 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1151 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1147 dst=r2 src=r10 offset=0 imm=0
+#line 254 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1152 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1148 dst=r2 src=r0 offset=0 imm=-4
+#line 254 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1153 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=1149 dst=r1 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1155 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1151 dst=r3 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1152 dst=r0 src=r0 offset=0 imm=16
+#line 254 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 254 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 254 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 254 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1156 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1153 dst=r7 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
     r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1157 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1154 dst=r1 src=r7 offset=0 imm=0
+#line 254 "sample/map.c"
     r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1158 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=1155 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1159 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=1156 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1160 dst=r1 src=r0 offset=-286 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1157 dst=r1 src=r0 offset=304 imm=0
+#line 254 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1161 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1162 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1164 dst=r1 src=r0 offset=-415 imm=2
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(2))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1165 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1166 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+#line 254 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1158 dst=r1 src=r0 offset=0 imm=4
+#line 254 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=1159 dst=r10 src=r1 offset=-4 imm=0
+#line 255 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1167 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1160 dst=r2 src=r10 offset=0 imm=0
+#line 255 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1168 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1161 dst=r2 src=r0 offset=0 imm=-4
+#line 255 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1169 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=1162 dst=r1 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1171 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1164 dst=r3 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1165 dst=r0 src=r0 offset=0 imm=16
+#line 255 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 255 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 255 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 255 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1172 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1166 dst=r7 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
     r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1173 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1167 dst=r1 src=r7 offset=0 imm=0
+#line 255 "sample/map.c"
     r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1174 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=1168 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1175 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=1169 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1176 dst=r1 src=r0 offset=-302 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1170 dst=r1 src=r0 offset=291 imm=0
+#line 255 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1177 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1178 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1180 dst=r1 src=r0 offset=-431 imm=1
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(1))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1181 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1182 dst=r10 src=r1 offset=-4 imm=0
-#line 189 "sample/map.c"
+#line 255 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1171 dst=r1 src=r0 offset=0 imm=5
+#line 255 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=1172 dst=r10 src=r1 offset=-4 imm=0
+#line 256 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1183 dst=r2 src=r10 offset=0 imm=0
-#line 189 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1173 dst=r2 src=r10 offset=0 imm=0
+#line 256 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1184 dst=r2 src=r0 offset=0 imm=-4
-#line 189 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1174 dst=r2 src=r0 offset=0 imm=-4
+#line 256 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1185 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
+    // EBPF_OP_LDDW pc=1175 dst=r1 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1187 dst=r0 src=r0 offset=0 imm=18
-#line 189 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 189 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1177 dst=r3 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1178 dst=r0 src=r0 offset=0 imm=16
+#line 256 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 256 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 189 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 189 "sample/map.c"
+#line 256 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 256 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=1188 dst=r1 src=r10 offset=-4 imm=0
-#line 189 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=1189 dst=r7 src=r6 offset=0 imm=0
-#line 189 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JEQ_IMM pc=1190 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_48;
-        // EBPF_OP_MOV64_IMM pc=1191 dst=r7 src=r0 offset=0 imm=-1
-#line 189 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_48:
-    // EBPF_OP_MOV64_REG pc=1192 dst=r2 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1193 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1194 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1195 dst=r3 src=r0 offset=0 imm=-7
-#line 189 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1197 dst=r2 src=r3 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r2 == r3)
-#line 189 "sample/map.c"
-        goto label_49;
-        // EBPF_OP_MOV64_REG pc=1198 dst=r7 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1179 dst=r7 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
     r7 = r0;
-label_49:
-    // EBPF_OP_JNE_REG pc=1199 dst=r2 src=r3 offset=-455 imm=0
-#line 189 "sample/map.c"
-    if (r2 != r3)
-#line 189 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_JEQ_IMM pc=1200 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_50;
-        // EBPF_OP_JA pc=1201 dst=r0 src=r0 offset=-457 imm=0
-#line 189 "sample/map.c"
-    goto label_27;
-label_50:
-    // EBPF_OP_MOV64_IMM pc=1202 dst=r6 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1203 dst=r10 src=r6 offset=-4 imm=0
-#line 190 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
-    // EBPF_OP_MOV64_REG pc=1204 dst=r2 src=r10 offset=0 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1180 dst=r1 src=r7 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1181 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1182 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1183 dst=r1 src=r0 offset=278 imm=0
+#line 256 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 256 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1184 dst=r1 src=r0 offset=0 imm=6
+#line 256 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=1185 dst=r10 src=r1 offset=-4 imm=0
+#line 257 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1186 dst=r2 src=r10 offset=0 imm=0
+#line 257 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1205 dst=r2 src=r0 offset=0 imm=-4
-#line 190 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1187 dst=r2 src=r0 offset=0 imm=-4
+#line 257 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1206 dst=r1 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_LDDW pc=1188 dst=r1 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1208 dst=r0 src=r0 offset=0 imm=17
-#line 190 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1190 dst=r3 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1191 dst=r0 src=r0 offset=0 imm=16
+#line 257 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 257 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 190 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 190 "sample/map.c"
+#line 257 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 257 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=1209 dst=r1 src=r10 offset=-4 imm=0
-#line 190 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JEQ_IMM pc=1210 dst=r1 src=r0 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
-        goto label_51;
-        // EBPF_OP_MOV64_IMM pc=1211 dst=r7 src=r0 offset=0 imm=-1
-#line 190 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_51:
-    // EBPF_OP_MOV64_REG pc=1212 dst=r2 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1213 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1214 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1215 dst=r3 src=r0 offset=0 imm=-7
-#line 190 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1217 dst=r2 src=r3 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r2 == r3)
-#line 190 "sample/map.c"
-        goto label_52;
+        // EBPF_OP_MOV64_REG pc=1192 dst=r7 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1193 dst=r1 src=r7 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1194 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1195 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1196 dst=r1 src=r0 offset=265 imm=0
+#line 257 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 257 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1197 dst=r1 src=r0 offset=0 imm=7
+#line 257 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=1198 dst=r10 src=r1 offset=-4 imm=0
+#line 258 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1199 dst=r2 src=r10 offset=0 imm=0
+#line 258 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1200 dst=r2 src=r0 offset=0 imm=-4
+#line 258 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1201 dst=r1 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1203 dst=r3 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1204 dst=r0 src=r0 offset=0 imm=16
+#line 258 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 258 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 258 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 258 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1205 dst=r7 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1206 dst=r1 src=r7 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1207 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1208 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1209 dst=r1 src=r0 offset=252 imm=0
+#line 258 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 258 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1210 dst=r1 src=r0 offset=0 imm=8
+#line 258 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=1211 dst=r10 src=r1 offset=-4 imm=0
+#line 259 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1212 dst=r2 src=r10 offset=0 imm=0
+#line 259 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1213 dst=r2 src=r0 offset=0 imm=-4
+#line 259 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1214 dst=r1 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1216 dst=r3 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1217 dst=r0 src=r0 offset=0 imm=16
+#line 259 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 259 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 259 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 259 "sample/map.c"
+        return 0;
         // EBPF_OP_MOV64_REG pc=1218 dst=r7 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
+#line 259 "sample/map.c"
     r7 = r0;
-label_52:
-    // EBPF_OP_JNE_REG pc=1219 dst=r2 src=r3 offset=-475 imm=0
-#line 190 "sample/map.c"
-    if (r2 != r3)
-#line 190 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_JEQ_IMM pc=1220 dst=r1 src=r0 offset=-1175 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1219 dst=r1 src=r7 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1220 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1221 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1222 dst=r1 src=r0 offset=239 imm=0
+#line 259 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 259 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1223 dst=r1 src=r0 offset=0 imm=9
+#line 259 "sample/map.c"
+    r1 = IMMEDIATE(9);
+    // EBPF_OP_STXW pc=1224 dst=r10 src=r1 offset=-4 imm=0
+#line 260 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1225 dst=r2 src=r10 offset=0 imm=0
+#line 260 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1226 dst=r2 src=r0 offset=0 imm=-4
+#line 260 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1227 dst=r1 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1229 dst=r3 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1230 dst=r0 src=r0 offset=0 imm=16
+#line 260 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 260 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 260 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 260 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1231 dst=r7 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1232 dst=r1 src=r7 offset=0 imm=0
+#line 260 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1233 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1234 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1235 dst=r1 src=r0 offset=226 imm=0
+#line 260 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 260 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1236 dst=r8 src=r0 offset=0 imm=10
+#line 260 "sample/map.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=1237 dst=r10 src=r8 offset=-4 imm=0
+#line 263 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=1238 dst=r2 src=r10 offset=0 imm=0
+#line 263 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1239 dst=r2 src=r0 offset=0 imm=-4
+#line 263 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1240 dst=r1 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1242 dst=r3 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1243 dst=r0 src=r0 offset=0 imm=16
+#line 263 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 263 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 263 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 263 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1244 dst=r7 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1245 dst=r1 src=r7 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1246 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1247 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1248 dst=r2 src=r0 offset=0 imm=-29
+#line 263 "sample/map.c"
+    r2 = (uint64_t)4294967267;
+    // EBPF_OP_JNE_REG pc=1250 dst=r1 src=r2 offset=211 imm=0
+#line 263 "sample/map.c"
+    if (r1 != r2)
+#line 263 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_STXW pc=1251 dst=r10 src=r8 offset=-4 imm=0
+#line 264 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=1252 dst=r2 src=r10 offset=0 imm=0
+#line 264 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1253 dst=r2 src=r0 offset=0 imm=-4
+#line 264 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1254 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1256 dst=r3 src=r0 offset=0 imm=2
+#line 264 "sample/map.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=1257 dst=r0 src=r0 offset=0 imm=16
+#line 264 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 264 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 264 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 264 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1258 dst=r7 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1259 dst=r1 src=r7 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1260 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1261 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1262 dst=r1 src=r0 offset=1 imm=0
+#line 264 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
+#line 264 "sample/map.c"
+        goto label_41;
+        // EBPF_OP_MOV64_REG pc=1263 dst=r6 src=r7 offset=0 imm=0
+#line 264 "sample/map.c"
+    r6 = r7;
+label_41:
+    // EBPF_OP_JNE_IMM pc=1264 dst=r1 src=r0 offset=197 imm=0
+#line 264 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 264 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1265 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1266 dst=r10 src=r1 offset=-4 imm=0
+#line 266 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1267 dst=r2 src=r10 offset=0 imm=0
+#line 266 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1268 dst=r2 src=r0 offset=0 imm=-4
+#line 266 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1269 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1271 dst=r0 src=r0 offset=0 imm=18
+#line 266 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 266 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 266 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 266 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1272 dst=r7 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1273 dst=r1 src=r7 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1274 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1275 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1276 dst=r1 src=r0 offset=1 imm=0
+#line 266 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 266 "sample/map.c"
+        goto label_42;
+        // EBPF_OP_JA pc=1277 dst=r0 src=r0 offset=184 imm=0
+#line 266 "sample/map.c"
+    goto label_58;
+label_42:
+    // EBPF_OP_LDDW pc=1278 dst=r7 src=r0 offset=0 imm=-1
+#line 266 "sample/map.c"
+    r7 = (uint64_t)4294967295;
+    // EBPF_OP_LDXW pc=1280 dst=r1 src=r10 offset=-4 imm=0
+#line 266 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1281 dst=r1 src=r0 offset=185 imm=10
+#line 266 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 266 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1282 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1283 dst=r10 src=r1 offset=-4 imm=0
+#line 274 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1284 dst=r2 src=r10 offset=0 imm=0
+#line 274 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1285 dst=r2 src=r0 offset=0 imm=-4
+#line 274 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1286 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1288 dst=r0 src=r0 offset=0 imm=17
+#line 274 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 274 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 274 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 274 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1289 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1290 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1291 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1292 dst=r1 src=r0 offset=2 imm=0
+#line 274 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 274 "sample/map.c"
+        goto label_44;
+label_43:
+    // EBPF_OP_MOV64_REG pc=1293 dst=r7 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_JA pc=1294 dst=r0 src=r0 offset=167 imm=0
+#line 274 "sample/map.c"
+    goto label_58;
+label_44:
+    // EBPF_OP_LDXW pc=1295 dst=r1 src=r10 offset=-4 imm=0
+#line 274 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1296 dst=r1 src=r0 offset=170 imm=10
+#line 274 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 274 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1297 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1298 dst=r10 src=r1 offset=-4 imm=0
+#line 275 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1299 dst=r2 src=r10 offset=0 imm=0
+#line 275 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1300 dst=r2 src=r0 offset=0 imm=-4
+#line 275 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1301 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1303 dst=r0 src=r0 offset=0 imm=17
+#line 275 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 275 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 275 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 275 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1304 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1305 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1306 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1307 dst=r1 src=r0 offset=1 imm=0
+#line 275 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 275 "sample/map.c"
+        goto label_45;
+        // EBPF_OP_JA pc=1308 dst=r0 src=r0 offset=-16 imm=0
+#line 275 "sample/map.c"
+    goto label_43;
+label_45:
+    // EBPF_OP_LDXW pc=1309 dst=r1 src=r10 offset=-4 imm=0
+#line 275 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1310 dst=r1 src=r0 offset=156 imm=9
+#line 275 "sample/map.c"
+    if (r1 != IMMEDIATE(9))
+#line 275 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1311 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1312 dst=r10 src=r1 offset=-4 imm=0
+#line 276 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1313 dst=r2 src=r10 offset=0 imm=0
+#line 276 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1314 dst=r2 src=r0 offset=0 imm=-4
+#line 276 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1315 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1317 dst=r0 src=r0 offset=0 imm=17
+#line 276 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 276 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 276 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 276 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1318 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1319 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1320 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1321 dst=r1 src=r0 offset=1 imm=0
+#line 276 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 276 "sample/map.c"
+        goto label_46;
+        // EBPF_OP_JA pc=1322 dst=r0 src=r0 offset=-30 imm=0
+#line 276 "sample/map.c"
+    goto label_43;
+label_46:
+    // EBPF_OP_LDXW pc=1323 dst=r1 src=r10 offset=-4 imm=0
+#line 276 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1324 dst=r1 src=r0 offset=142 imm=8
+#line 276 "sample/map.c"
+    if (r1 != IMMEDIATE(8))
+#line 276 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1325 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1326 dst=r10 src=r1 offset=-4 imm=0
+#line 277 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1327 dst=r2 src=r10 offset=0 imm=0
+#line 277 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1328 dst=r2 src=r0 offset=0 imm=-4
+#line 277 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1329 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1331 dst=r0 src=r0 offset=0 imm=17
+#line 277 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 277 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 277 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 277 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1332 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1333 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1334 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1335 dst=r1 src=r0 offset=1 imm=0
+#line 277 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 277 "sample/map.c"
+        goto label_47;
+        // EBPF_OP_JA pc=1336 dst=r0 src=r0 offset=-44 imm=0
+#line 277 "sample/map.c"
+    goto label_43;
+label_47:
+    // EBPF_OP_LDXW pc=1337 dst=r1 src=r10 offset=-4 imm=0
+#line 277 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1338 dst=r1 src=r0 offset=128 imm=7
+#line 277 "sample/map.c"
+    if (r1 != IMMEDIATE(7))
+#line 277 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1340 dst=r10 src=r1 offset=-4 imm=0
+#line 278 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1341 dst=r2 src=r10 offset=0 imm=0
+#line 278 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1342 dst=r2 src=r0 offset=0 imm=-4
+#line 278 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1343 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1345 dst=r0 src=r0 offset=0 imm=17
+#line 278 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 278 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 278 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 278 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1346 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1347 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1348 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1349 dst=r1 src=r0 offset=1 imm=0
+#line 278 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 278 "sample/map.c"
+        goto label_48;
+        // EBPF_OP_JA pc=1350 dst=r0 src=r0 offset=-58 imm=0
+#line 278 "sample/map.c"
+    goto label_43;
+label_48:
+    // EBPF_OP_LDXW pc=1351 dst=r1 src=r10 offset=-4 imm=0
+#line 278 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1352 dst=r1 src=r0 offset=114 imm=6
+#line 278 "sample/map.c"
+    if (r1 != IMMEDIATE(6))
+#line 278 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1353 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1354 dst=r10 src=r1 offset=-4 imm=0
+#line 279 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1355 dst=r2 src=r10 offset=0 imm=0
+#line 279 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1356 dst=r2 src=r0 offset=0 imm=-4
+#line 279 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1357 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1359 dst=r0 src=r0 offset=0 imm=17
+#line 279 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 279 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 279 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 279 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1360 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1361 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1362 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1363 dst=r1 src=r0 offset=1 imm=0
+#line 279 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 279 "sample/map.c"
+        goto label_49;
+        // EBPF_OP_JA pc=1364 dst=r0 src=r0 offset=-72 imm=0
+#line 279 "sample/map.c"
+    goto label_43;
+label_49:
+    // EBPF_OP_LDXW pc=1365 dst=r1 src=r10 offset=-4 imm=0
+#line 279 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1366 dst=r1 src=r0 offset=100 imm=5
+#line 279 "sample/map.c"
+    if (r1 != IMMEDIATE(5))
+#line 279 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1367 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1368 dst=r10 src=r1 offset=-4 imm=0
+#line 280 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1369 dst=r2 src=r10 offset=0 imm=0
+#line 280 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1370 dst=r2 src=r0 offset=0 imm=-4
+#line 280 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1371 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1373 dst=r0 src=r0 offset=0 imm=17
+#line 280 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 280 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 280 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 280 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1374 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1375 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1376 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1377 dst=r1 src=r0 offset=1 imm=0
+#line 280 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 280 "sample/map.c"
+        goto label_50;
+        // EBPF_OP_JA pc=1378 dst=r0 src=r0 offset=-86 imm=0
+#line 280 "sample/map.c"
+    goto label_43;
+label_50:
+    // EBPF_OP_LDXW pc=1379 dst=r1 src=r10 offset=-4 imm=0
+#line 280 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1380 dst=r1 src=r0 offset=86 imm=4
+#line 280 "sample/map.c"
+    if (r1 != IMMEDIATE(4))
+#line 280 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1381 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1382 dst=r10 src=r1 offset=-4 imm=0
+#line 281 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1383 dst=r2 src=r10 offset=0 imm=0
+#line 281 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1384 dst=r2 src=r0 offset=0 imm=-4
+#line 281 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1385 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1387 dst=r0 src=r0 offset=0 imm=17
+#line 281 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 281 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 281 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 281 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1388 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1389 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1390 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1391 dst=r1 src=r0 offset=1 imm=0
+#line 281 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 281 "sample/map.c"
+        goto label_51;
+        // EBPF_OP_JA pc=1392 dst=r0 src=r0 offset=-100 imm=0
+#line 281 "sample/map.c"
+    goto label_43;
+label_51:
+    // EBPF_OP_LDXW pc=1393 dst=r1 src=r10 offset=-4 imm=0
+#line 281 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1394 dst=r1 src=r0 offset=72 imm=3
+#line 281 "sample/map.c"
+    if (r1 != IMMEDIATE(3))
+#line 281 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1395 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1396 dst=r10 src=r1 offset=-4 imm=0
+#line 282 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1397 dst=r2 src=r10 offset=0 imm=0
+#line 282 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1398 dst=r2 src=r0 offset=0 imm=-4
+#line 282 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1399 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1401 dst=r0 src=r0 offset=0 imm=17
+#line 282 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 282 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 282 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 282 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1402 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1403 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1404 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1405 dst=r1 src=r0 offset=1 imm=0
+#line 282 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 282 "sample/map.c"
+        goto label_52;
+        // EBPF_OP_JA pc=1406 dst=r0 src=r0 offset=-114 imm=0
+#line 282 "sample/map.c"
+    goto label_43;
+label_52:
+    // EBPF_OP_LDXW pc=1407 dst=r1 src=r10 offset=-4 imm=0
+#line 282 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1408 dst=r1 src=r0 offset=58 imm=2
+#line 282 "sample/map.c"
+    if (r1 != IMMEDIATE(2))
+#line 282 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1409 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1410 dst=r10 src=r1 offset=-4 imm=0
+#line 283 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1411 dst=r2 src=r10 offset=0 imm=0
+#line 283 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1412 dst=r2 src=r0 offset=0 imm=-4
+#line 283 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1413 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1415 dst=r0 src=r0 offset=0 imm=17
+#line 283 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 283 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 283 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 283 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1416 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1417 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1418 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1419 dst=r1 src=r0 offset=1 imm=0
+#line 283 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 283 "sample/map.c"
+        goto label_53;
+        // EBPF_OP_JA pc=1420 dst=r0 src=r0 offset=-128 imm=0
+#line 283 "sample/map.c"
+    goto label_43;
+label_53:
+    // EBPF_OP_LDXW pc=1421 dst=r1 src=r10 offset=-4 imm=0
+#line 283 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1422 dst=r1 src=r0 offset=44 imm=1
+#line 283 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 283 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1423 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1424 dst=r10 src=r1 offset=-4 imm=0
+#line 286 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1425 dst=r2 src=r10 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1426 dst=r2 src=r0 offset=0 imm=-4
+#line 286 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1427 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1429 dst=r0 src=r0 offset=0 imm=18
+#line 286 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 286 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 286 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 286 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1430 dst=r1 src=r10 offset=-4 imm=0
+#line 286 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1431 dst=r7 src=r6 offset=0 imm=0
+#line 286 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JEQ_IMM pc=1432 dst=r1 src=r0 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_54;
+        // EBPF_OP_MOV64_IMM pc=1433 dst=r7 src=r0 offset=0 imm=-1
+#line 286 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_54:
+    // EBPF_OP_MOV64_REG pc=1434 dst=r2 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1435 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1436 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1437 dst=r3 src=r0 offset=0 imm=-7
+#line 286 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1439 dst=r2 src=r3 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r2 == r3)
+#line 286 "sample/map.c"
+        goto label_55;
+        // EBPF_OP_MOV64_REG pc=1440 dst=r7 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r7 = r0;
+label_55:
+    // EBPF_OP_JNE_REG pc=1441 dst=r2 src=r3 offset=20 imm=0
+#line 286 "sample/map.c"
+    if (r2 != r3)
+#line 286 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_JNE_IMM pc=1442 dst=r1 src=r0 offset=19 imm=0
+#line 286 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1443 dst=r6 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1444 dst=r10 src=r6 offset=-4 imm=0
+#line 287 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
+    // EBPF_OP_MOV64_REG pc=1445 dst=r2 src=r10 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1446 dst=r2 src=r0 offset=0 imm=-4
+#line 287 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1447 dst=r1 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1449 dst=r0 src=r0 offset=0 imm=17
+#line 287 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 287 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 287 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 287 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1450 dst=r1 src=r10 offset=-4 imm=0
+#line 287 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JEQ_IMM pc=1451 dst=r1 src=r0 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_56;
+        // EBPF_OP_MOV64_IMM pc=1452 dst=r7 src=r0 offset=0 imm=-1
+#line 287 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_56:
+    // EBPF_OP_MOV64_REG pc=1453 dst=r2 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1454 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1455 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1456 dst=r3 src=r0 offset=0 imm=-7
+#line 287 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1458 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 == r3)
+#line 287 "sample/map.c"
+        goto label_57;
+        // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r7 = r0;
+label_57:
+    // EBPF_OP_JNE_REG pc=1460 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 != r3)
+#line 287 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_JEQ_IMM pc=1461 dst=r1 src=r0 offset=-1416 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
         goto label_1;
-        // EBPF_OP_JA pc=1221 dst=r0 src=r0 offset=-477 imm=0
-#line 190 "sample/map.c"
-    goto label_27;
-#line 190 "sample/map.c"
+label_58:
+    // EBPF_OP_MOV64_IMM pc=1462 dst=r6 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_REG pc=1463 dst=r1 src=r7 offset=0 imm=0
+#line 306 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1464 dst=r1 src=r0 offset=0 imm=32
+#line 306 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=1465 dst=r1 src=r0 offset=0 imm=32
+#line 306 "sample/map.c"
+    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=1466 dst=r1 src=r0 offset=-1421 imm=-1
+#line 306 "sample/map.c"
+    if ((int64_t)r1 > IMMEDIATE(-1))
+#line 306 "sample/map.c"
+        goto label_1;
+label_59:
+    // EBPF_OP_MOV64_REG pc=1467 dst=r6 src=r7 offset=0 imm=0
+#line 306 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JA pc=1468 dst=r0 src=r0 offset=-1423 imm=0
+#line 306 "sample/map.c"
+    goto label_1;
+#line 306 "sample/map.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -4342,7 +5216,7 @@ static program_entry_t _programs[] = {
         8,
         test_maps_helpers,
         7,
-        1222,
+        1469,
         &test_maps_program_type_guid,
         &test_maps_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -147,40 +147,40 @@ static uint16_t test_maps_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 test_maps(void* context)
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
 {
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     // Prologue
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r0 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r1 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r2 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r3 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r4 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r5 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r6 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r7 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r8 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r10 = 0;
 
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r1 = (uintptr_t)context;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=0
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -336,17 +336,17 @@ test_maps(void* context)
         goto label_2;
 label_1:
     // EBPF_OP_MOV64_REG pc=46 dst=r0 src=r6 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r0 = r6;
     // EBPF_OP_EXIT pc=47 dst=r0 src=r0 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     return r0;
 label_2:
     // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r10 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=49 dst=r2 src=r0 offset=0 imm=-4
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=0
 #line 105 "sample/map.c"
@@ -364,12 +364,12 @@ label_2:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=55 dst=r0 src=r0 offset=-10 imm=0
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=56 dst=r7 src=r0 offset=0 imm=0
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=57 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -550,12 +550,12 @@ label_4:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=110 dst=r0 src=r0 offset=-65 imm=0
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=111 dst=r7 src=r0 offset=0 imm=0
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=112 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -1056,12 +1056,12 @@ label_10:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=259 dst=r0 src=r0 offset=-214 imm=0
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=260 dst=r7 src=r0 offset=0 imm=0
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=261 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -1242,3056 +1242,3930 @@ label_12:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=314 dst=r0 src=r0 offset=-269 imm=0
-#line 203 "sample/map.c"
+#line 300 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 203 "sample/map.c"
+#line 300 "sample/map.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=0
-#line 203 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-4 imm=0
-#line 203 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=317 dst=r1 src=r0 offset=0 imm=1
-#line 203 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=318 dst=r10 src=r1 offset=-8 imm=0
+        // EBPF_OP_MOV64_IMM pc=315 dst=r7 src=r0 offset=0 imm=0
+#line 300 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=316 dst=r10 src=r7 offset=-4 imm=0
+#line 116 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=317 dst=r8 src=r0 offset=0 imm=1
+#line 116 "sample/map.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=318 dst=r10 src=r8 offset=-8 imm=0
 #line 117 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=319 dst=r7 src=r0 offset=0 imm=11
-#line 117 "sample/map.c"
-    r7 = IMMEDIATE(11);
-    // EBPF_OP_JA pc=320 dst=r0 src=r0 offset=12 imm=0
-#line 117 "sample/map.c"
-    goto label_14;
-label_13:
-    // EBPF_OP_LDXW pc=321 dst=r1 src=r10 offset=-4 imm=0
-#line 121 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_ADD64_IMM pc=322 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=323 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_LSH64_IMM pc=324 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=325 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JGT_REG pc=326 dst=r7 src=r1 offset=6 imm=0
-#line 121 "sample/map.c"
-    if (r7 > r1)
-#line 121 "sample/map.c"
-        goto label_14;
-        // EBPF_OP_MOV64_IMM pc=327 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=328 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=329 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=330 dst=r10 src=r1 offset=-8 imm=0
-#line 117 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=331 dst=r7 src=r0 offset=0 imm=11
-#line 117 "sample/map.c"
-    r7 = IMMEDIATE(11);
-    // EBPF_OP_JA pc=332 dst=r0 src=r0 offset=36 imm=0
-#line 117 "sample/map.c"
-    goto label_16;
-label_14:
-    // EBPF_OP_MOV64_REG pc=333 dst=r2 src=r10 offset=0 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=319 dst=r2 src=r10 offset=0 imm=0
 #line 117 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=334 dst=r2 src=r0 offset=0 imm=-4
+    // EBPF_OP_ADD64_IMM pc=320 dst=r2 src=r0 offset=0 imm=-4
 #line 117 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_MOV64_REG pc=335 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=321 dst=r3 src=r10 offset=0 imm=0
 #line 117 "sample/map.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=336 dst=r3 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=322 dst=r3 src=r0 offset=0 imm=-8
 #line 117 "sample/map.c"
     r3 += IMMEDIATE(-8);
-    // EBPF_OP_LDDW pc=337 dst=r1 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_LDDW pc=323 dst=r1 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r1 = POINTER(_maps[4].address);
-    // EBPF_OP_MOV64_IMM pc=339 dst=r4 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=325 dst=r4 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=340 dst=r0 src=r0 offset=0 imm=2
-#line 122 "sample/map.c"
+    // EBPF_OP_CALL pc=326 dst=r0 src=r0 offset=0 imm=2
+#line 131 "sample/map.c"
     r0 = test_maps_helpers[0].address
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=341 dst=r6 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=327 dst=r6 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=342 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=343 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=344 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=345 dst=r1 src=r0 offset=-25 imm=-1
-#line 123 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 123 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=328 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=329 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=330 dst=r7 src=r6 offset=144 imm=0
+#line 132 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 132 "sample/map.c"
         goto label_13;
-        // EBPF_OP_JA pc=346 dst=r0 src=r0 offset=-301 imm=0
-#line 123 "sample/map.c"
-    goto label_1;
-label_15:
-    // EBPF_OP_LDXW pc=347 dst=r1 src=r10 offset=-4 imm=0
-#line 121 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_ADD64_IMM pc=348 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=349 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_LSH64_IMM pc=350 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=351 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JGT_REG pc=352 dst=r7 src=r1 offset=16 imm=0
-#line 121 "sample/map.c"
-    if (r7 > r1)
-#line 121 "sample/map.c"
-        goto label_16;
-        // EBPF_OP_MOV64_IMM pc=353 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=354 dst=r10 src=r1 offset=-4 imm=0
-#line 173 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=355 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+        // EBPF_OP_STXW pc=331 dst=r10 src=r8 offset=-4 imm=0
+#line 136 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=332 dst=r2 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=356 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=333 dst=r2 src=r0 offset=0 imm=-4
+#line 136 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=357 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=359 dst=r0 src=r0 offset=0 imm=18
-#line 173 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 173 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 173 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 173 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=360 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = r0;
-    // EBPF_OP_LSH64_IMM pc=361 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=362 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=363 dst=r6 src=r0 offset=0 imm=-1
-#line 173 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-    // EBPF_OP_LDDW pc=364 dst=r2 src=r0 offset=0 imm=-7
-#line 173 "sample/map.c"
-    r2 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=366 dst=r1 src=r2 offset=16 imm=0
-#line 173 "sample/map.c"
-    if (r1 == r2)
-#line 173 "sample/map.c"
-        goto label_17;
-        // EBPF_OP_MOV64_REG pc=367 dst=r6 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_JA pc=368 dst=r0 src=r0 offset=14 imm=0
-#line 173 "sample/map.c"
-    goto label_17;
-label_16:
-    // EBPF_OP_MOV64_REG pc=369 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=370 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_MOV64_REG pc=371 dst=r3 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=334 dst=r3 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=372 dst=r3 src=r0 offset=0 imm=-8
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=335 dst=r3 src=r0 offset=0 imm=-8
+#line 136 "sample/map.c"
     r3 += IMMEDIATE(-8);
-    // EBPF_OP_LDDW pc=373 dst=r1 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = POINTER(_maps[5].address);
-    // EBPF_OP_MOV64_IMM pc=375 dst=r4 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_LDDW pc=336 dst=r1 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=338 dst=r4 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=376 dst=r0 src=r0 offset=0 imm=2
-#line 122 "sample/map.c"
+    // EBPF_OP_CALL pc=339 dst=r0 src=r0 offset=0 imm=2
+#line 137 "sample/map.c"
     r0 = test_maps_helpers[0].address
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=377 dst=r6 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=340 dst=r6 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=378 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=379 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=380 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=381 dst=r1 src=r0 offset=-35 imm=-1
-#line 123 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 123 "sample/map.c"
-        goto label_15;
-        // EBPF_OP_JA pc=382 dst=r0 src=r0 offset=-337 imm=0
-#line 123 "sample/map.c"
-    goto label_1;
-label_17:
-    // EBPF_OP_JNE_REG pc=383 dst=r1 src=r2 offset=170 imm=0
-#line 123 "sample/map.c"
-    if (r1 != r2)
-#line 123 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_LDXW pc=384 dst=r1 src=r10 offset=-4 imm=0
-#line 123 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JNE_IMM pc=385 dst=r1 src=r0 offset=168 imm=0
-#line 123 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 123 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=386 dst=r1 src=r0 offset=0 imm=0
-#line 123 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=387 dst=r10 src=r1 offset=-4 imm=0
-#line 174 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=388 dst=r2 src=r10 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=389 dst=r2 src=r0 offset=0 imm=-4
-#line 174 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=390 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=392 dst=r0 src=r0 offset=0 imm=17
-#line 174 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 174 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 174 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 174 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=393 dst=r1 src=r10 offset=-4 imm=0
-#line 174 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=394 dst=r7 src=r6 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JEQ_IMM pc=395 dst=r1 src=r0 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_18;
-        // EBPF_OP_MOV64_IMM pc=396 dst=r7 src=r0 offset=0 imm=-1
-#line 174 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_18:
-    // EBPF_OP_MOV64_REG pc=397 dst=r2 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=398 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=399 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=400 dst=r3 src=r0 offset=0 imm=-7
-#line 174 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=402 dst=r2 src=r3 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r2 == r3)
-#line 174 "sample/map.c"
-        goto label_19;
-        // EBPF_OP_MOV64_REG pc=403 dst=r7 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r0;
-label_19:
-    // EBPF_OP_MOV64_REG pc=404 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JNE_REG pc=405 dst=r2 src=r3 offset=148 imm=0
-#line 174 "sample/map.c"
-    if (r2 != r3)
-#line 174 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_REG pc=406 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JNE_IMM pc=407 dst=r1 src=r0 offset=146 imm=0
-#line 174 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=408 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=409 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=410 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=411 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=412 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=414 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=415 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=416 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=417 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=418 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=419 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=420 dst=r1 src=r0 offset=133 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=421 dst=r1 src=r0 offset=0 imm=1
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=422 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=423 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=424 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=425 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=427 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=428 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=429 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=430 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=431 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=432 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=433 dst=r1 src=r0 offset=1 imm=0
-#line 177 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_20;
-        // EBPF_OP_JA pc=434 dst=r0 src=r0 offset=119 imm=0
-#line 177 "sample/map.c"
-    goto label_21;
-label_20:
-    // EBPF_OP_MOV64_IMM pc=435 dst=r1 src=r0 offset=0 imm=2
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=341 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=342 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=343 dst=r7 src=r6 offset=131 imm=0
+#line 138 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 138 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=344 dst=r1 src=r0 offset=0 imm=2
+#line 138 "sample/map.c"
     r1 = IMMEDIATE(2);
-    // EBPF_OP_STXW pc=436 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=345 dst=r10 src=r1 offset=-4 imm=0
+#line 142 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=437 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=346 dst=r2 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=438 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=347 dst=r2 src=r0 offset=0 imm=-4
+#line 142 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=439 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=441 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=442 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=348 dst=r3 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=349 dst=r3 src=r0 offset=0 imm=-8
+#line 142 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=350 dst=r7 src=r0 offset=0 imm=0
+#line 142 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=351 dst=r1 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=353 dst=r4 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=354 dst=r0 src=r0 offset=0 imm=2
+#line 143 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 143 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 143 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 143 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=443 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=355 dst=r6 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=444 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=445 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=446 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=447 dst=r1 src=r0 offset=106 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=448 dst=r1 src=r0 offset=0 imm=3
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=356 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=357 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=358 dst=r7 src=r6 offset=116 imm=0
+#line 144 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 144 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=359 dst=r1 src=r0 offset=0 imm=3
+#line 144 "sample/map.c"
     r1 = IMMEDIATE(3);
-    // EBPF_OP_STXW pc=449 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=360 dst=r10 src=r1 offset=-4 imm=0
+#line 148 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=450 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=361 dst=r2 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=451 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=362 dst=r2 src=r0 offset=0 imm=-4
+#line 148 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=452 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=454 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=455 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=363 dst=r3 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=364 dst=r3 src=r0 offset=0 imm=-8
+#line 148 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=365 dst=r1 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=367 dst=r4 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=368 dst=r0 src=r0 offset=0 imm=2
+#line 149 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 149 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 149 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 149 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=369 dst=r6 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=370 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=371 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=372 dst=r7 src=r6 offset=102 imm=0
+#line 150 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 150 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=373 dst=r1 src=r0 offset=0 imm=4
+#line 150 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=374 dst=r10 src=r1 offset=-4 imm=0
+#line 154 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=375 dst=r2 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=376 dst=r2 src=r0 offset=0 imm=-4
+#line 154 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=377 dst=r3 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=378 dst=r3 src=r0 offset=0 imm=-8
+#line 154 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=379 dst=r7 src=r0 offset=0 imm=0
+#line 154 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=380 dst=r1 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=382 dst=r4 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=383 dst=r0 src=r0 offset=0 imm=2
+#line 155 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 155 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 155 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 155 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=384 dst=r6 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=385 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=386 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=387 dst=r7 src=r6 offset=87 imm=0
+#line 156 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 156 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=388 dst=r1 src=r0 offset=0 imm=5
+#line 156 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=389 dst=r10 src=r1 offset=-4 imm=0
+#line 160 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=390 dst=r2 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=391 dst=r2 src=r0 offset=0 imm=-4
+#line 160 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=392 dst=r3 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=393 dst=r3 src=r0 offset=0 imm=-8
+#line 160 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=394 dst=r1 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=396 dst=r4 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=397 dst=r0 src=r0 offset=0 imm=2
+#line 161 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 161 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 161 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 161 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=398 dst=r6 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=399 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=400 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=401 dst=r7 src=r6 offset=73 imm=0
+#line 162 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 162 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=402 dst=r1 src=r0 offset=0 imm=6
+#line 162 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=403 dst=r10 src=r1 offset=-4 imm=0
+#line 166 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=404 dst=r2 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=405 dst=r2 src=r0 offset=0 imm=-4
+#line 166 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=406 dst=r3 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=407 dst=r3 src=r0 offset=0 imm=-8
+#line 166 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=408 dst=r7 src=r0 offset=0 imm=0
+#line 166 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=409 dst=r1 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=411 dst=r4 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=412 dst=r0 src=r0 offset=0 imm=2
+#line 167 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 167 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 167 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 167 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=413 dst=r6 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=414 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=415 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=416 dst=r7 src=r6 offset=58 imm=0
+#line 168 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 168 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=417 dst=r1 src=r0 offset=0 imm=7
+#line 168 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=418 dst=r10 src=r1 offset=-4 imm=0
+#line 172 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=419 dst=r2 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=420 dst=r2 src=r0 offset=0 imm=-4
+#line 172 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=421 dst=r3 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=422 dst=r3 src=r0 offset=0 imm=-8
+#line 172 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=423 dst=r1 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=425 dst=r4 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=426 dst=r0 src=r0 offset=0 imm=2
+#line 173 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 173 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 173 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 173 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=427 dst=r6 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=428 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=429 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=430 dst=r7 src=r6 offset=44 imm=0
+#line 174 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 174 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=431 dst=r1 src=r0 offset=0 imm=8
+#line 174 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=432 dst=r10 src=r1 offset=-4 imm=0
+#line 178 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=433 dst=r2 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=434 dst=r2 src=r0 offset=0 imm=-4
+#line 178 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=435 dst=r3 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=436 dst=r3 src=r0 offset=0 imm=-8
+#line 178 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=437 dst=r7 src=r0 offset=0 imm=0
+#line 178 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=438 dst=r1 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=440 dst=r4 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=441 dst=r0 src=r0 offset=0 imm=2
+#line 179 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 179 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 179 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 179 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=442 dst=r6 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=443 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=444 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=445 dst=r7 src=r6 offset=29 imm=0
+#line 180 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 180 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=446 dst=r1 src=r0 offset=0 imm=9
+#line 180 "sample/map.c"
+    r1 = IMMEDIATE(9);
+    // EBPF_OP_STXW pc=447 dst=r10 src=r1 offset=-4 imm=0
+#line 184 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=448 dst=r2 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=449 dst=r2 src=r0 offset=0 imm=-4
+#line 184 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=450 dst=r3 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=451 dst=r3 src=r0 offset=0 imm=-8
+#line 184 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=452 dst=r1 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=454 dst=r4 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=455 dst=r0 src=r0 offset=0 imm=2
+#line 185 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 185 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 185 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 185 "sample/map.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=456 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+#line 185 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=457 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=458 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=459 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=460 dst=r1 src=r0 offset=93 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=461 dst=r1 src=r0 offset=0 imm=4
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(4);
-    // EBPF_OP_STXW pc=462 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=457 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=458 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=459 dst=r7 src=r6 offset=15 imm=0
+#line 186 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 186 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=460 dst=r1 src=r0 offset=0 imm=10
+#line 186 "sample/map.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=461 dst=r10 src=r1 offset=-4 imm=0
+#line 190 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=463 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=462 dst=r2 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=464 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=463 dst=r2 src=r0 offset=0 imm=-4
+#line 190 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=465 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=467 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=468 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=464 dst=r3 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=465 dst=r3 src=r0 offset=0 imm=-8
+#line 190 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=466 dst=r7 src=r0 offset=0 imm=0
+#line 190 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=467 dst=r1 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=469 dst=r4 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=470 dst=r0 src=r0 offset=0 imm=2
+#line 191 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 191 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 191 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 191 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=469 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=471 dst=r6 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=470 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=471 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=472 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=473 dst=r1 src=r0 offset=80 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=474 dst=r1 src=r0 offset=0 imm=5
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(5);
-    // EBPF_OP_STXW pc=475 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=476 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=472 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=473 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=474 dst=r6 src=r0 offset=1 imm=-1
+#line 191 "sample/map.c"
+    if ((int64_t)r6 > IMMEDIATE(-1))
+#line 191 "sample/map.c"
+        goto label_14;
+label_13:
+    // EBPF_OP_JA pc=475 dst=r0 src=r0 offset=-430 imm=0
+#line 191 "sample/map.c"
+    goto label_1;
+label_14:
+    // EBPF_OP_STXW pc=476 dst=r10 src=r7 offset=-4 imm=0
+#line 116 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=477 dst=r8 src=r0 offset=0 imm=1
+#line 116 "sample/map.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=478 dst=r10 src=r8 offset=-8 imm=0
+#line 117 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=479 dst=r2 src=r10 offset=0 imm=0
+#line 117 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=477 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=480 dst=r2 src=r0 offset=0 imm=-4
+#line 117 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=478 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=480 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=481 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=481 dst=r3 src=r10 offset=0 imm=0
+#line 117 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=482 dst=r3 src=r0 offset=0 imm=-8
+#line 117 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=483 dst=r1 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=485 dst=r4 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=486 dst=r0 src=r0 offset=0 imm=2
+#line 131 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 131 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 131 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 131 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=482 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=487 dst=r6 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=483 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=484 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=485 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=486 dst=r1 src=r0 offset=67 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=487 dst=r1 src=r0 offset=0 imm=6
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(6);
-    // EBPF_OP_STXW pc=488 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=489 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=490 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=491 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=493 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=494 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=495 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=496 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=497 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=498 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=499 dst=r1 src=r0 offset=54 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=500 dst=r1 src=r0 offset=0 imm=7
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(7);
-    // EBPF_OP_STXW pc=501 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=502 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=503 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=504 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=506 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=507 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=508 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=509 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=510 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=512 dst=r1 src=r0 offset=41 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=513 dst=r1 src=r0 offset=0 imm=8
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(8);
-    // EBPF_OP_STXW pc=514 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=515 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=516 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=517 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=519 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=520 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=521 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=522 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=523 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=524 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=525 dst=r1 src=r0 offset=28 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=526 dst=r1 src=r0 offset=0 imm=9
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(9);
-    // EBPF_OP_STXW pc=527 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=528 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=529 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=530 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=532 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=533 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=534 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=535 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=536 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=537 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=538 dst=r1 src=r0 offset=15 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=539 dst=r8 src=r0 offset=0 imm=10
-#line 177 "sample/map.c"
-    r8 = IMMEDIATE(10);
-    // EBPF_OP_STXW pc=540 dst=r10 src=r8 offset=-4 imm=0
-#line 180 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=488 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=489 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=490 dst=r7 src=r6 offset=145 imm=0
+#line 132 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 132 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_STXW pc=491 dst=r10 src=r8 offset=-4 imm=0
+#line 136 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=541 dst=r2 src=r10 offset=0 imm=0
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=492 dst=r2 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=542 dst=r2 src=r0 offset=0 imm=-4
-#line 180 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=493 dst=r2 src=r0 offset=0 imm=-4
+#line 136 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=543 dst=r1 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=545 dst=r3 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=546 dst=r0 src=r0 offset=0 imm=16
-#line 180 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=494 dst=r3 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=495 dst=r3 src=r0 offset=0 imm=-8
+#line 136 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=496 dst=r7 src=r0 offset=0 imm=0
+#line 136 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=497 dst=r1 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=499 dst=r4 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=500 dst=r0 src=r0 offset=0 imm=2
+#line 137 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 137 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 180 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 180 "sample/map.c"
+#line 137 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 137 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=547 dst=r6 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=501 dst=r6 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=548 dst=r1 src=r6 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=549 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=550 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=551 dst=r2 src=r0 offset=0 imm=-29
-#line 180 "sample/map.c"
-    r2 = (uint64_t)4294967267;
-    // EBPF_OP_JEQ_REG pc=553 dst=r1 src=r2 offset=198 imm=0
-#line 180 "sample/map.c"
-    if (r1 == r2)
-#line 180 "sample/map.c"
-        goto label_29;
-label_21:
-    // EBPF_OP_MOV64_REG pc=554 dst=r1 src=r6 offset=0 imm=0
-#line 208 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=555 dst=r1 src=r0 offset=0 imm=32
-#line 208 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=556 dst=r1 src=r0 offset=0 imm=32
-#line 208 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=557 dst=r2 src=r0 offset=0 imm=0
-#line 208 "sample/map.c"
-    r2 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=558 dst=r2 src=r1 offset=-513 imm=0
-#line 208 "sample/map.c"
-    if ((int64_t)r2 > (int64_t)r1)
-#line 208 "sample/map.c"
-        goto label_1;
-label_22:
-    // EBPF_OP_MOV64_IMM pc=559 dst=r1 src=r0 offset=0 imm=0
-#line 208 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=560 dst=r10 src=r1 offset=-4 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=502 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=503 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=504 dst=r7 src=r6 offset=131 imm=0
+#line 138 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 138 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=505 dst=r1 src=r0 offset=0 imm=2
+#line 138 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=506 dst=r10 src=r1 offset=-4 imm=0
+#line 142 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=561 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=507 dst=r2 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=562 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=508 dst=r2 src=r0 offset=0 imm=-4
+#line 142 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=563 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=565 dst=r0 src=r0 offset=0 imm=18
-#line 173 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=509 dst=r3 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=510 dst=r3 src=r0 offset=0 imm=-8
+#line 142 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=511 dst=r1 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=513 dst=r4 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=514 dst=r0 src=r0 offset=0 imm=2
+#line 143 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 143 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 173 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 173 "sample/map.c"
+#line 143 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 143 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=566 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = r0;
-    // EBPF_OP_LSH64_IMM pc=567 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=568 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=569 dst=r7 src=r0 offset=0 imm=-1
-#line 173 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-    // EBPF_OP_LDDW pc=570 dst=r2 src=r0 offset=0 imm=-7
-#line 173 "sample/map.c"
-    r2 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=572 dst=r1 src=r2 offset=1 imm=0
-#line 173 "sample/map.c"
-    if (r1 == r2)
-#line 173 "sample/map.c"
-        goto label_23;
-        // EBPF_OP_MOV64_REG pc=573 dst=r7 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r7 = r0;
-label_23:
-    // EBPF_OP_JNE_REG pc=574 dst=r1 src=r2 offset=170 imm=0
-#line 173 "sample/map.c"
-    if (r1 != r2)
-#line 173 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_LDXW pc=575 dst=r1 src=r10 offset=-4 imm=0
-#line 173 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JNE_IMM pc=576 dst=r1 src=r0 offset=168 imm=0
-#line 173 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 173 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=577 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = IMMEDIATE(0);
+        // EBPF_OP_MOV64_REG pc=515 dst=r6 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=516 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=517 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=518 dst=r7 src=r6 offset=117 imm=0
+#line 144 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 144 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=519 dst=r1 src=r0 offset=0 imm=3
+#line 144 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=520 dst=r10 src=r1 offset=-4 imm=0
+#line 148 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=521 dst=r2 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=522 dst=r2 src=r0 offset=0 imm=-4
+#line 148 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=523 dst=r3 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=524 dst=r3 src=r0 offset=0 imm=-8
+#line 148 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=525 dst=r7 src=r0 offset=0 imm=0
+#line 148 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=526 dst=r1 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=528 dst=r4 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=529 dst=r0 src=r0 offset=0 imm=2
+#line 149 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 149 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 149 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 149 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=530 dst=r6 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=531 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=532 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=533 dst=r7 src=r6 offset=102 imm=0
+#line 150 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 150 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=534 dst=r1 src=r0 offset=0 imm=4
+#line 150 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=535 dst=r10 src=r1 offset=-4 imm=0
+#line 154 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=536 dst=r2 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=537 dst=r2 src=r0 offset=0 imm=-4
+#line 154 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=538 dst=r3 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=539 dst=r3 src=r0 offset=0 imm=-8
+#line 154 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=540 dst=r1 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=542 dst=r4 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=543 dst=r0 src=r0 offset=0 imm=2
+#line 155 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 155 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 155 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 155 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=545 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=546 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=547 dst=r7 src=r6 offset=88 imm=0
+#line 156 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 156 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=548 dst=r1 src=r0 offset=0 imm=5
+#line 156 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=549 dst=r10 src=r1 offset=-4 imm=0
+#line 160 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=550 dst=r2 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=551 dst=r2 src=r0 offset=0 imm=-4
+#line 160 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=552 dst=r3 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=553 dst=r3 src=r0 offset=0 imm=-8
+#line 160 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=554 dst=r7 src=r0 offset=0 imm=0
+#line 160 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=555 dst=r1 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=557 dst=r4 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=558 dst=r0 src=r0 offset=0 imm=2
+#line 161 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 161 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 161 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 161 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=559 dst=r6 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=560 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=561 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=562 dst=r7 src=r6 offset=73 imm=0
+#line 162 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 162 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=563 dst=r1 src=r0 offset=0 imm=6
+#line 162 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=564 dst=r10 src=r1 offset=-4 imm=0
+#line 166 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=565 dst=r2 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=566 dst=r2 src=r0 offset=0 imm=-4
+#line 166 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=567 dst=r3 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=568 dst=r3 src=r0 offset=0 imm=-8
+#line 166 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=569 dst=r1 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=571 dst=r4 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=572 dst=r0 src=r0 offset=0 imm=2
+#line 167 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 167 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 167 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 167 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=573 dst=r6 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=574 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=575 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=576 dst=r7 src=r6 offset=59 imm=0
+#line 168 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 168 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=577 dst=r1 src=r0 offset=0 imm=7
+#line 168 "sample/map.c"
+    r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=578 dst=r10 src=r1 offset=-4 imm=0
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=579 dst=r2 src=r10 offset=0 imm=0
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=580 dst=r2 src=r0 offset=0 imm=-4
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=581 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=583 dst=r0 src=r0 offset=0 imm=17
-#line 174 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 174 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=581 dst=r3 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=582 dst=r3 src=r0 offset=0 imm=-8
+#line 172 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=583 dst=r7 src=r0 offset=0 imm=0
+#line 172 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=586 dst=r4 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=587 dst=r0 src=r0 offset=0 imm=2
+#line 173 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 173 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 174 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 174 "sample/map.c"
+#line 173 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 173 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=584 dst=r1 src=r10 offset=-4 imm=0
-#line 174 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=585 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JEQ_IMM pc=586 dst=r1 src=r0 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_24;
-        // EBPF_OP_MOV64_IMM pc=587 dst=r6 src=r0 offset=0 imm=-1
-#line 174 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_24:
-    // EBPF_OP_MOV64_REG pc=588 dst=r2 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=589 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=590 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=591 dst=r3 src=r0 offset=0 imm=-7
-#line 174 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=593 dst=r2 src=r3 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r2 == r3)
-#line 174 "sample/map.c"
-        goto label_25;
-        // EBPF_OP_MOV64_REG pc=594 dst=r6 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=588 dst=r6 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
     r6 = r0;
-label_25:
-    // EBPF_OP_MOV64_REG pc=595 dst=r7 src=r6 offset=0 imm=0
+    // EBPF_OP_LSH64_IMM pc=589 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=590 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=591 dst=r7 src=r6 offset=44 imm=0
 #line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JNE_REG pc=596 dst=r2 src=r3 offset=148 imm=0
+    if ((int64_t)r7 > (int64_t)r6)
 #line 174 "sample/map.c"
-    if (r2 != r3)
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=592 dst=r1 src=r0 offset=0 imm=8
 #line 174 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_REG pc=597 dst=r7 src=r6 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JNE_IMM pc=598 dst=r1 src=r0 offset=146 imm=0
-#line 174 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=599 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=600 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=601 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=602 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=603 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=605 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=606 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=607 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=608 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=609 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=610 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=611 dst=r1 src=r0 offset=133 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=612 dst=r1 src=r0 offset=0 imm=1
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=613 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=614 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=615 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=616 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=618 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=619 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=620 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=621 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=622 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=623 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=624 dst=r1 src=r0 offset=1 imm=0
-#line 177 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_26;
-        // EBPF_OP_JA pc=625 dst=r0 src=r0 offset=119 imm=0
-#line 177 "sample/map.c"
-    goto label_27;
-label_26:
-    // EBPF_OP_MOV64_IMM pc=626 dst=r1 src=r0 offset=0 imm=2
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(2);
-    // EBPF_OP_STXW pc=627 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=628 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=629 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=630 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=632 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=633 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=634 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=635 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=636 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=637 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=638 dst=r1 src=r0 offset=106 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=639 dst=r1 src=r0 offset=0 imm=3
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(3);
-    // EBPF_OP_STXW pc=640 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=641 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=642 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=643 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=645 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=646 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=647 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=648 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=649 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=650 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=651 dst=r1 src=r0 offset=93 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=652 dst=r1 src=r0 offset=0 imm=4
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(4);
-    // EBPF_OP_STXW pc=653 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=654 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=655 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=656 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=658 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=659 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=660 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=661 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=662 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=663 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=664 dst=r1 src=r0 offset=80 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=665 dst=r1 src=r0 offset=0 imm=5
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(5);
-    // EBPF_OP_STXW pc=666 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=667 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=668 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=669 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=671 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=672 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=673 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=674 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=675 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=676 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=677 dst=r1 src=r0 offset=67 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=678 dst=r1 src=r0 offset=0 imm=6
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(6);
-    // EBPF_OP_STXW pc=679 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=680 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=681 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=682 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=684 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=685 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=686 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=687 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=688 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=689 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=690 dst=r1 src=r0 offset=54 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=691 dst=r1 src=r0 offset=0 imm=7
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(7);
-    // EBPF_OP_STXW pc=692 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=693 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=694 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=695 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=697 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=698 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=699 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=700 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=701 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=702 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=703 dst=r1 src=r0 offset=41 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=704 dst=r1 src=r0 offset=0 imm=8
-#line 177 "sample/map.c"
     r1 = IMMEDIATE(8);
-    // EBPF_OP_STXW pc=705 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=593 dst=r10 src=r1 offset=-4 imm=0
+#line 178 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=706 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=594 dst=r2 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=707 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=595 dst=r2 src=r0 offset=0 imm=-4
+#line 178 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=708 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=710 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=711 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=596 dst=r3 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=597 dst=r3 src=r0 offset=0 imm=-8
+#line 178 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=598 dst=r1 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=600 dst=r4 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=601 dst=r0 src=r0 offset=0 imm=2
+#line 179 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 179 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 179 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 179 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=712 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=713 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=714 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=715 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=716 dst=r1 src=r0 offset=28 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=717 dst=r1 src=r0 offset=0 imm=9
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=602 dst=r6 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=603 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=604 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=605 dst=r7 src=r6 offset=30 imm=0
+#line 180 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 180 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=606 dst=r1 src=r0 offset=0 imm=9
+#line 180 "sample/map.c"
     r1 = IMMEDIATE(9);
-    // EBPF_OP_STXW pc=718 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=607 dst=r10 src=r1 offset=-4 imm=0
+#line 184 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=719 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=608 dst=r2 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=720 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=609 dst=r2 src=r0 offset=0 imm=-4
+#line 184 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=721 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=723 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=724 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=610 dst=r3 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=611 dst=r3 src=r0 offset=0 imm=-8
+#line 184 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=612 dst=r7 src=r0 offset=0 imm=0
+#line 184 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=613 dst=r1 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=615 dst=r4 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=616 dst=r0 src=r0 offset=0 imm=2
+#line 185 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 185 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 185 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 185 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=725 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=726 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=727 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=728 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=729 dst=r1 src=r0 offset=15 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=730 dst=r8 src=r0 offset=0 imm=10
-#line 177 "sample/map.c"
-    r8 = IMMEDIATE(10);
-    // EBPF_OP_STXW pc=731 dst=r10 src=r8 offset=-4 imm=0
-#line 180 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=732 dst=r2 src=r10 offset=0 imm=0
-#line 180 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=617 dst=r6 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=618 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=619 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=620 dst=r7 src=r6 offset=15 imm=0
+#line 186 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 186 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=621 dst=r1 src=r0 offset=0 imm=10
+#line 186 "sample/map.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=622 dst=r10 src=r1 offset=-4 imm=0
+#line 190 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=623 dst=r2 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=733 dst=r2 src=r0 offset=0 imm=-4
-#line 180 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=624 dst=r2 src=r0 offset=0 imm=-4
+#line 190 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=734 dst=r1 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=736 dst=r3 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=737 dst=r0 src=r0 offset=0 imm=16
-#line 180 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=625 dst=r3 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=626 dst=r3 src=r0 offset=0 imm=-8
+#line 190 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=627 dst=r7 src=r0 offset=0 imm=0
+#line 190 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=628 dst=r1 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=630 dst=r4 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=631 dst=r0 src=r0 offset=0 imm=2
+#line 191 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 191 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 180 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 180 "sample/map.c"
+#line 191 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 191 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=738 dst=r7 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=739 dst=r1 src=r7 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=740 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=741 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=742 dst=r2 src=r0 offset=0 imm=-29
-#line 180 "sample/map.c"
-    r2 = (uint64_t)4294967267;
-    // EBPF_OP_JEQ_REG pc=744 dst=r1 src=r2 offset=34 imm=0
-#line 180 "sample/map.c"
-    if (r1 == r2)
-#line 180 "sample/map.c"
-        goto label_31;
-label_27:
-    // EBPF_OP_MOV64_IMM pc=745 dst=r6 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_REG pc=746 dst=r1 src=r7 offset=0 imm=0
-#line 209 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=747 dst=r1 src=r0 offset=0 imm=32
-#line 209 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=748 dst=r1 src=r0 offset=0 imm=32
-#line 209 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=749 dst=r1 src=r0 offset=-704 imm=-1
-#line 209 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 209 "sample/map.c"
-        goto label_1;
-label_28:
-    // EBPF_OP_MOV64_REG pc=750 dst=r6 src=r7 offset=0 imm=0
-#line 209 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JA pc=751 dst=r0 src=r0 offset=-706 imm=0
-#line 209 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=632 dst=r6 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=633 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=634 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=635 dst=r6 src=r0 offset=1 imm=-1
+#line 191 "sample/map.c"
+    if ((int64_t)r6 > IMMEDIATE(-1))
+#line 191 "sample/map.c"
+        goto label_16;
+label_15:
+    // EBPF_OP_JA pc=636 dst=r0 src=r0 offset=-591 imm=0
+#line 191 "sample/map.c"
     goto label_1;
-label_29:
-    // EBPF_OP_STXW pc=752 dst=r10 src=r8 offset=-4 imm=0
-#line 181 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=753 dst=r2 src=r10 offset=0 imm=0
-#line 181 "sample/map.c"
+label_16:
+    // EBPF_OP_STXW pc=637 dst=r10 src=r7 offset=-4 imm=0
+#line 242 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_REG pc=638 dst=r2 src=r10 offset=0 imm=0
+#line 242 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=754 dst=r2 src=r0 offset=0 imm=-4
-#line 181 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=639 dst=r2 src=r0 offset=0 imm=-4
+#line 242 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=755 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
+    // EBPF_OP_LDDW pc=640 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=757 dst=r3 src=r0 offset=0 imm=2
-#line 181 "sample/map.c"
-    r3 = IMMEDIATE(2);
-    // EBPF_OP_CALL pc=758 dst=r0 src=r0 offset=0 imm=16
-#line 181 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 181 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 181 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 181 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=759 dst=r6 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=760 dst=r1 src=r6 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=761 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=762 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=763 dst=r1 src=r0 offset=1 imm=0
-#line 181 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_30;
-        // EBPF_OP_MOV64_REG pc=764 dst=r7 src=r6 offset=0 imm=0
-#line 181 "sample/map.c"
-    r7 = r6;
-label_30:
-    // EBPF_OP_JNE_IMM pc=765 dst=r1 src=r0 offset=-212 imm=0
-#line 181 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=766 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=767 dst=r10 src=r1 offset=-4 imm=0
-#line 183 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=768 dst=r2 src=r10 offset=0 imm=0
-#line 183 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=769 dst=r2 src=r0 offset=0 imm=-4
-#line 183 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=770 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=772 dst=r0 src=r0 offset=0 imm=18
-#line 183 "sample/map.c"
+    // EBPF_OP_CALL pc=642 dst=r0 src=r0 offset=0 imm=18
+#line 242 "sample/map.c"
     r0 = test_maps_helpers[4].address
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=773 dst=r6 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=643 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=644 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=645 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=646 dst=r6 src=r0 offset=0 imm=-1
+#line 242 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+    // EBPF_OP_LDDW pc=647 dst=r2 src=r0 offset=0 imm=-7
+#line 242 "sample/map.c"
+    r2 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=649 dst=r1 src=r2 offset=1 imm=0
+#line 242 "sample/map.c"
+    if (r1 == r2)
+#line 242 "sample/map.c"
+        goto label_17;
+        // EBPF_OP_MOV64_REG pc=650 dst=r6 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=774 dst=r1 src=r6 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=775 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=776 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=777 dst=r1 src=r0 offset=28 imm=0
-#line 183 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 183 "sample/map.c"
-        goto label_33;
-        // EBPF_OP_JA pc=778 dst=r0 src=r0 offset=-225 imm=0
-#line 183 "sample/map.c"
-    goto label_21;
-label_31:
-    // EBPF_OP_STXW pc=779 dst=r10 src=r8 offset=-4 imm=0
-#line 181 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=780 dst=r2 src=r10 offset=0 imm=0
-#line 181 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=781 dst=r2 src=r0 offset=0 imm=-4
-#line 181 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=782 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=784 dst=r3 src=r0 offset=0 imm=2
-#line 181 "sample/map.c"
-    r3 = IMMEDIATE(2);
-    // EBPF_OP_CALL pc=785 dst=r0 src=r0 offset=0 imm=16
-#line 181 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 181 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 181 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 181 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=786 dst=r7 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=787 dst=r1 src=r7 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=788 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=789 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=790 dst=r1 src=r0 offset=1 imm=0
-#line 181 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_32;
-        // EBPF_OP_MOV64_REG pc=791 dst=r6 src=r7 offset=0 imm=0
-#line 181 "sample/map.c"
-    r6 = r7;
-label_32:
-    // EBPF_OP_JNE_IMM pc=792 dst=r1 src=r0 offset=-48 imm=0
-#line 181 "sample/map.c"
+label_17:
+    // EBPF_OP_JNE_REG pc=651 dst=r1 src=r2 offset=409 imm=0
+#line 242 "sample/map.c"
+    if (r1 != r2)
+#line 242 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_LDXW pc=652 dst=r1 src=r10 offset=-4 imm=0
+#line 242 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=653 dst=r1 src=r0 offset=407 imm=0
+#line 242 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=793 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
+#line 242 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=654 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=655 dst=r10 src=r1 offset=-4 imm=0
+#line 243 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=656 dst=r2 src=r10 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=657 dst=r2 src=r0 offset=0 imm=-4
+#line 243 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=658 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=660 dst=r0 src=r0 offset=0 imm=17
+#line 243 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 243 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 243 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 243 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=661 dst=r1 src=r10 offset=-4 imm=0
+#line 243 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=662 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JEQ_IMM pc=663 dst=r1 src=r0 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_18;
+        // EBPF_OP_MOV64_IMM pc=664 dst=r7 src=r0 offset=0 imm=-1
+#line 243 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_18:
+    // EBPF_OP_MOV64_REG pc=665 dst=r2 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=666 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=667 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=668 dst=r3 src=r0 offset=0 imm=-7
+#line 243 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=670 dst=r2 src=r3 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r2 == r3)
+#line 243 "sample/map.c"
+        goto label_19;
+        // EBPF_OP_MOV64_REG pc=671 dst=r7 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r0;
+label_19:
+    // EBPF_OP_MOV64_REG pc=672 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JNE_REG pc=673 dst=r2 src=r3 offset=387 imm=0
+#line 243 "sample/map.c"
+    if (r2 != r3)
+#line 243 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_REG pc=674 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JNE_IMM pc=675 dst=r1 src=r0 offset=385 imm=0
+#line 243 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=676 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=677 dst=r10 src=r1 offset=-4 imm=0
+#line 251 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=678 dst=r2 src=r10 offset=0 imm=0
+#line 251 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=679 dst=r2 src=r0 offset=0 imm=-4
+#line 251 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=680 dst=r1 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=682 dst=r3 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=683 dst=r0 src=r0 offset=0 imm=16
+#line 251 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 251 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 251 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 251 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=684 dst=r6 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=685 dst=r1 src=r6 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=686 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=687 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=688 dst=r1 src=r0 offset=372 imm=0
+#line 251 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 251 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=689 dst=r1 src=r0 offset=0 imm=1
+#line 251 "sample/map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=690 dst=r10 src=r1 offset=-4 imm=0
+#line 252 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=691 dst=r2 src=r10 offset=0 imm=0
+#line 252 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=692 dst=r2 src=r0 offset=0 imm=-4
+#line 252 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=693 dst=r1 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=695 dst=r3 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=696 dst=r0 src=r0 offset=0 imm=16
+#line 252 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 252 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 252 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 252 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=697 dst=r6 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=698 dst=r1 src=r6 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=699 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=700 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=701 dst=r1 src=r0 offset=359 imm=0
+#line 252 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 252 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=702 dst=r1 src=r0 offset=0 imm=2
+#line 252 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=703 dst=r10 src=r1 offset=-4 imm=0
+#line 253 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=704 dst=r2 src=r10 offset=0 imm=0
+#line 253 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=705 dst=r2 src=r0 offset=0 imm=-4
+#line 253 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=706 dst=r1 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=708 dst=r3 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=709 dst=r0 src=r0 offset=0 imm=16
+#line 253 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 253 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 253 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 253 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=710 dst=r6 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=711 dst=r1 src=r6 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=712 dst=r1 src=r0 offset=0 imm=32
+#line 253 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=713 dst=r1 src=r0 offset=0 imm=32
+#line 253 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=714 dst=r1 src=r0 offset=346 imm=0
+#line 253 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 253 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=715 dst=r1 src=r0 offset=0 imm=3
+#line 253 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=716 dst=r10 src=r1 offset=-4 imm=0
+#line 254 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=717 dst=r2 src=r10 offset=0 imm=0
+#line 254 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=718 dst=r2 src=r0 offset=0 imm=-4
+#line 254 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=719 dst=r1 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=721 dst=r3 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=722 dst=r0 src=r0 offset=0 imm=16
+#line 254 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 254 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 254 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 254 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=723 dst=r6 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=724 dst=r1 src=r6 offset=0 imm=0
+#line 254 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=725 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=726 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=727 dst=r1 src=r0 offset=333 imm=0
+#line 254 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 254 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=728 dst=r1 src=r0 offset=0 imm=4
+#line 254 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=729 dst=r10 src=r1 offset=-4 imm=0
+#line 255 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=730 dst=r2 src=r10 offset=0 imm=0
+#line 255 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=731 dst=r2 src=r0 offset=0 imm=-4
+#line 255 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=732 dst=r1 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=734 dst=r3 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=735 dst=r0 src=r0 offset=0 imm=16
+#line 255 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 255 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 255 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 255 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=737 dst=r1 src=r6 offset=0 imm=0
+#line 255 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=738 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=739 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=740 dst=r1 src=r0 offset=320 imm=0
+#line 255 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 255 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=741 dst=r1 src=r0 offset=0 imm=5
+#line 255 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=742 dst=r10 src=r1 offset=-4 imm=0
+#line 256 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=743 dst=r2 src=r10 offset=0 imm=0
+#line 256 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=744 dst=r2 src=r0 offset=0 imm=-4
+#line 256 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=745 dst=r1 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=747 dst=r3 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=748 dst=r0 src=r0 offset=0 imm=16
+#line 256 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 256 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 256 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 256 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=749 dst=r6 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=750 dst=r1 src=r6 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=751 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=752 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=753 dst=r1 src=r0 offset=307 imm=0
+#line 256 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 256 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=754 dst=r1 src=r0 offset=0 imm=6
+#line 256 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=755 dst=r10 src=r1 offset=-4 imm=0
+#line 257 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=756 dst=r2 src=r10 offset=0 imm=0
+#line 257 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=757 dst=r2 src=r0 offset=0 imm=-4
+#line 257 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=758 dst=r1 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=760 dst=r3 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=761 dst=r0 src=r0 offset=0 imm=16
+#line 257 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 257 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 257 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 257 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=762 dst=r6 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=763 dst=r1 src=r6 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=764 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=765 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=766 dst=r1 src=r0 offset=294 imm=0
+#line 257 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 257 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=767 dst=r1 src=r0 offset=0 imm=7
+#line 257 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=768 dst=r10 src=r1 offset=-4 imm=0
+#line 258 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=769 dst=r2 src=r10 offset=0 imm=0
+#line 258 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=770 dst=r2 src=r0 offset=0 imm=-4
+#line 258 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=771 dst=r1 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=773 dst=r3 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=774 dst=r0 src=r0 offset=0 imm=16
+#line 258 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 258 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 258 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 258 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=775 dst=r6 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=776 dst=r1 src=r6 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=777 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=778 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=779 dst=r1 src=r0 offset=281 imm=0
+#line 258 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 258 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=780 dst=r1 src=r0 offset=0 imm=8
+#line 258 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=781 dst=r10 src=r1 offset=-4 imm=0
+#line 259 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=782 dst=r2 src=r10 offset=0 imm=0
+#line 259 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=783 dst=r2 src=r0 offset=0 imm=-4
+#line 259 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=784 dst=r1 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=786 dst=r3 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=787 dst=r0 src=r0 offset=0 imm=16
+#line 259 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 259 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 259 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 259 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=788 dst=r6 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=789 dst=r1 src=r6 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=790 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=791 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=792 dst=r1 src=r0 offset=268 imm=0
+#line 259 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 259 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=793 dst=r1 src=r0 offset=0 imm=9
+#line 259 "sample/map.c"
+    r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=794 dst=r10 src=r1 offset=-4 imm=0
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=795 dst=r2 src=r10 offset=0 imm=0
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=796 dst=r2 src=r0 offset=0 imm=-4
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=797 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=799 dst=r0 src=r0 offset=0 imm=18
-#line 183 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 183 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 183 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=800 dst=r7 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=801 dst=r1 src=r7 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=802 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=803 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=804 dst=r1 src=r0 offset=36 imm=0
-#line 183 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 183 "sample/map.c"
-        goto label_37;
-        // EBPF_OP_JA pc=805 dst=r0 src=r0 offset=-61 imm=0
-#line 183 "sample/map.c"
-    goto label_27;
-label_33:
-    // EBPF_OP_LDXW pc=806 dst=r1 src=r10 offset=-4 imm=0
-#line 183 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=807 dst=r6 src=r0 offset=0 imm=-1
-#line 183 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=809 dst=r1 src=r0 offset=-764 imm=1
-#line 183 "sample/map.c"
-    if (r1 != IMMEDIATE(1))
-#line 183 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=810 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=811 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=812 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=813 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=814 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 260 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=816 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=799 dst=r3 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=800 dst=r0 src=r0 offset=0 imm=16
+#line 260 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 260 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 260 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 260 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=817 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=801 dst=r6 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=818 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=802 dst=r1 src=r6 offset=0 imm=0
+#line 260 "sample/map.c"
     r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=819 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=803 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=820 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=804 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=821 dst=r1 src=r0 offset=1 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=805 dst=r1 src=r0 offset=255 imm=0
+#line 260 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 260 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=806 dst=r8 src=r0 offset=0 imm=10
+#line 260 "sample/map.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=807 dst=r10 src=r8 offset=-4 imm=0
+#line 263 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=808 dst=r2 src=r10 offset=0 imm=0
+#line 263 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=809 dst=r2 src=r0 offset=0 imm=-4
+#line 263 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=810 dst=r1 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=812 dst=r3 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=813 dst=r0 src=r0 offset=0 imm=16
+#line 263 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 263 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 263 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 263 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=814 dst=r6 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=815 dst=r1 src=r6 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=816 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=817 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=818 dst=r2 src=r0 offset=0 imm=-29
+#line 263 "sample/map.c"
+    r2 = (uint64_t)4294967267;
+    // EBPF_OP_JNE_REG pc=820 dst=r1 src=r2 offset=240 imm=0
+#line 263 "sample/map.c"
+    if (r1 != r2)
+#line 263 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_STXW pc=821 dst=r10 src=r8 offset=-4 imm=0
+#line 264 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=822 dst=r2 src=r10 offset=0 imm=0
+#line 264 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=823 dst=r2 src=r0 offset=0 imm=-4
+#line 264 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=824 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=826 dst=r3 src=r0 offset=0 imm=2
+#line 264 "sample/map.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=827 dst=r0 src=r0 offset=0 imm=16
+#line 264 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 264 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 264 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 264 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=828 dst=r6 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=829 dst=r1 src=r6 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=830 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=831 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=832 dst=r1 src=r0 offset=1 imm=0
+#line 264 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_34;
-        // EBPF_OP_JA pc=822 dst=r0 src=r0 offset=17 imm=0
-#line 186 "sample/map.c"
+#line 264 "sample/map.c"
+        goto label_20;
+        // EBPF_OP_MOV64_REG pc=833 dst=r7 src=r6 offset=0 imm=0
+#line 264 "sample/map.c"
+    r7 = r6;
+label_20:
+    // EBPF_OP_JNE_IMM pc=834 dst=r1 src=r0 offset=226 imm=0
+#line 264 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 264 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=835 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=836 dst=r10 src=r1 offset=-4 imm=0
+#line 266 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=837 dst=r2 src=r10 offset=0 imm=0
+#line 266 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=838 dst=r2 src=r0 offset=0 imm=-4
+#line 266 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=839 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=841 dst=r0 src=r0 offset=0 imm=18
+#line 266 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 266 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 266 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 266 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=842 dst=r6 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=843 dst=r1 src=r6 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=844 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=845 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=846 dst=r1 src=r0 offset=1 imm=0
+#line 266 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 266 "sample/map.c"
+        goto label_21;
+        // EBPF_OP_JA pc=847 dst=r0 src=r0 offset=213 imm=0
+#line 266 "sample/map.c"
     goto label_36;
-label_34:
-    // EBPF_OP_LDXW pc=823 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+label_21:
+    // EBPF_OP_LDXW pc=848 dst=r1 src=r10 offset=-4 imm=0
+#line 266 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=824 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=849 dst=r6 src=r0 offset=0 imm=-1
+#line 266 "sample/map.c"
     r6 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=826 dst=r1 src=r0 offset=1 imm=1
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(1))
-#line 186 "sample/map.c"
-        goto label_35;
-        // EBPF_OP_JA pc=827 dst=r0 src=r0 offset=-782 imm=0
-#line 186 "sample/map.c"
-    goto label_1;
-label_35:
-    // EBPF_OP_MOV64_IMM pc=828 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=851 dst=r1 src=r0 offset=-806 imm=1
+#line 266 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 266 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=852 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=829 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=853 dst=r10 src=r1 offset=-4 imm=0
+#line 274 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=830 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=854 dst=r2 src=r10 offset=0 imm=0
+#line 274 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=831 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=855 dst=r2 src=r0 offset=0 imm=-4
+#line 274 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=832 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=856 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=834 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_CALL pc=858 dst=r0 src=r0 offset=0 imm=17
+#line 274 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=835 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=859 dst=r6 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=836 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=860 dst=r1 src=r6 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=837 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=861 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=838 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=862 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=839 dst=r1 src=r0 offset=36 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=863 dst=r1 src=r0 offset=1 imm=0
+#line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_41;
-label_36:
-    // EBPF_OP_JA pc=840 dst=r0 src=r0 offset=-287 imm=0
-#line 186 "sample/map.c"
-    goto label_21;
-label_37:
-    // EBPF_OP_LDXW pc=841 dst=r1 src=r10 offset=-4 imm=0
-#line 183 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=842 dst=r7 src=r0 offset=0 imm=-1
-#line 183 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=844 dst=r1 src=r0 offset=-95 imm=10
-#line 183 "sample/map.c"
-    if (r1 != IMMEDIATE(10))
-#line 183 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=845 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=846 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=847 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=848 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=849 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=851 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=852 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=853 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=854 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=855 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=856 dst=r1 src=r0 offset=1 imm=0
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_38;
-        // EBPF_OP_JA pc=857 dst=r0 src=r0 offset=17 imm=0
-#line 186 "sample/map.c"
-    goto label_40;
-label_38:
-    // EBPF_OP_LDXW pc=858 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=859 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=861 dst=r1 src=r0 offset=1 imm=10
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(10))
-#line 186 "sample/map.c"
-        goto label_39;
-        // EBPF_OP_JA pc=862 dst=r0 src=r0 offset=-113 imm=0
-#line 186 "sample/map.c"
-    goto label_28;
-label_39:
-    // EBPF_OP_MOV64_IMM pc=863 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=864 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=865 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=866 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=867 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=869 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=870 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=871 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=872 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=873 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=874 dst=r1 src=r0 offset=174 imm=0
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_47;
-label_40:
-    // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=-131 imm=0
-#line 186 "sample/map.c"
-    goto label_27;
-label_41:
-    // EBPF_OP_LDXW pc=876 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=877 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=879 dst=r1 src=r0 offset=-834 imm=2
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(2))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=880 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=881 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=882 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=883 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=884 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=886 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=887 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=888 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=889 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=890 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=891 dst=r1 src=r0 offset=-52 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=892 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=893 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=895 dst=r1 src=r0 offset=-850 imm=3
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(3))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=896 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=897 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=898 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=899 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=900 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=902 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=903 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=904 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=905 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=906 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=907 dst=r1 src=r0 offset=-68 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=908 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=909 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=911 dst=r1 src=r0 offset=-866 imm=4
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(4))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=912 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=913 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=914 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=915 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=916 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=918 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=919 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=920 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=921 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=922 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=923 dst=r1 src=r0 offset=-84 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=924 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=925 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=927 dst=r1 src=r0 offset=-882 imm=5
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(5))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=928 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=929 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=930 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=931 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=932 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=934 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=935 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=936 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=937 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=938 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=939 dst=r1 src=r0 offset=-100 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=940 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=941 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=943 dst=r1 src=r0 offset=-898 imm=6
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(6))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=944 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=945 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=946 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=947 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=948 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=950 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=951 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=952 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=953 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=954 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=955 dst=r1 src=r0 offset=-116 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=956 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=957 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=959 dst=r1 src=r0 offset=-914 imm=7
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(7))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=960 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=961 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=962 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=963 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=964 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=966 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=967 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=968 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=969 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=970 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=971 dst=r1 src=r0 offset=-132 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=972 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=973 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=975 dst=r1 src=r0 offset=-930 imm=8
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(8))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=976 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=977 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=978 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=979 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=980 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=982 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=983 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=984 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=985 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=986 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=987 dst=r1 src=r0 offset=-148 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=988 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=989 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=991 dst=r1 src=r0 offset=-946 imm=9
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(9))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=992 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=993 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=994 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=995 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=996 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=998 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=1000 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=1001 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1002 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1003 dst=r1 src=r0 offset=-164 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=1004 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1005 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1007 dst=r1 src=r0 offset=-962 imm=10
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(10))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=1008 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1009 dst=r10 src=r1 offset=-4 imm=0
-#line 189 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1010 dst=r2 src=r10 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1011 dst=r2 src=r0 offset=0 imm=-4
-#line 189 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1012 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=1014 dst=r0 src=r0 offset=0 imm=18
-#line 189 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 189 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 189 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=1015 dst=r1 src=r10 offset=-4 imm=0
-#line 189 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=1016 dst=r6 src=r7 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JEQ_IMM pc=1017 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_42;
-        // EBPF_OP_MOV64_IMM pc=1018 dst=r6 src=r0 offset=0 imm=-1
-#line 189 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_42:
-    // EBPF_OP_MOV64_REG pc=1019 dst=r2 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1020 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1021 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1022 dst=r3 src=r0 offset=0 imm=-7
-#line 189 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1024 dst=r2 src=r3 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r2 == r3)
-#line 189 "sample/map.c"
-        goto label_43;
-        // EBPF_OP_MOV64_REG pc=1025 dst=r6 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = r0;
-label_43:
-    // EBPF_OP_JNE_REG pc=1026 dst=r2 src=r3 offset=-473 imm=0
-#line 189 "sample/map.c"
-    if (r2 != r3)
-#line 189 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_JEQ_IMM pc=1027 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_44;
-        // EBPF_OP_JA pc=1028 dst=r0 src=r0 offset=-475 imm=0
-#line 189 "sample/map.c"
-    goto label_21;
-label_44:
-    // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1030 dst=r10 src=r1 offset=-4 imm=0
-#line 190 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1031 dst=r2 src=r10 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1032 dst=r2 src=r0 offset=0 imm=-4
-#line 190 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1033 dst=r1 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=1035 dst=r0 src=r0 offset=0 imm=17
-#line 190 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 190 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 190 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=1036 dst=r1 src=r10 offset=-4 imm=0
-#line 190 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JEQ_IMM pc=1037 dst=r1 src=r0 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
-        goto label_45;
-        // EBPF_OP_MOV64_IMM pc=1038 dst=r6 src=r0 offset=0 imm=-1
-#line 190 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_45:
-    // EBPF_OP_MOV64_REG pc=1039 dst=r2 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1040 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1041 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1042 dst=r3 src=r0 offset=0 imm=-7
-#line 190 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1044 dst=r2 src=r3 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r2 == r3)
-#line 190 "sample/map.c"
-        goto label_46;
-        // EBPF_OP_MOV64_REG pc=1045 dst=r6 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r6 = r0;
-label_46:
-    // EBPF_OP_JNE_REG pc=1046 dst=r2 src=r3 offset=-493 imm=0
-#line 190 "sample/map.c"
-    if (r2 != r3)
-#line 190 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_JEQ_IMM pc=1047 dst=r1 src=r0 offset=-489 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
+#line 274 "sample/map.c"
         goto label_22;
-        // EBPF_OP_JA pc=1048 dst=r0 src=r0 offset=-495 imm=0
-#line 190 "sample/map.c"
-    goto label_21;
-label_47:
-    // EBPF_OP_LDXW pc=1049 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_JA pc=864 dst=r0 src=r0 offset=196 imm=0
+#line 274 "sample/map.c"
+    goto label_36;
+label_22:
+    // EBPF_OP_LDXW pc=865 dst=r1 src=r10 offset=-4 imm=0
+#line 274 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1050 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1052 dst=r1 src=r0 offset=-303 imm=9
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(9))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1053 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=866 dst=r6 src=r0 offset=0 imm=-1
+#line 274 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=868 dst=r1 src=r0 offset=-823 imm=1
+#line 274 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 274 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=869 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1054 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=870 dst=r10 src=r1 offset=-4 imm=0
+#line 275 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1055 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=871 dst=r2 src=r10 offset=0 imm=0
+#line 275 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1056 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=872 dst=r2 src=r0 offset=0 imm=-4
+#line 275 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1057 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1059 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=873 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=875 dst=r0 src=r0 offset=0 imm=17
+#line 275 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1060 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1061 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1062 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=876 dst=r6 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=877 dst=r1 src=r6 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=878 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1063 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=879 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1064 dst=r1 src=r0 offset=-190 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1065 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=880 dst=r1 src=r0 offset=1 imm=0
+#line 275 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 275 "sample/map.c"
+        goto label_23;
+        // EBPF_OP_JA pc=881 dst=r0 src=r0 offset=179 imm=0
+#line 275 "sample/map.c"
+    goto label_36;
+label_23:
+    // EBPF_OP_LDXW pc=882 dst=r1 src=r10 offset=-4 imm=0
+#line 275 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1066 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1068 dst=r1 src=r0 offset=-319 imm=8
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(8))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1069 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=883 dst=r6 src=r0 offset=0 imm=-1
+#line 275 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=885 dst=r1 src=r0 offset=-840 imm=2
+#line 275 "sample/map.c"
+    if (r1 != IMMEDIATE(2))
+#line 275 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=886 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1070 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=887 dst=r10 src=r1 offset=-4 imm=0
+#line 276 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1071 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=888 dst=r2 src=r10 offset=0 imm=0
+#line 276 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1072 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=889 dst=r2 src=r0 offset=0 imm=-4
+#line 276 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1073 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1075 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=890 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=892 dst=r0 src=r0 offset=0 imm=17
+#line 276 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1076 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1077 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1078 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=893 dst=r6 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=894 dst=r1 src=r6 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=895 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1079 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=896 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1080 dst=r1 src=r0 offset=-206 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1081 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=897 dst=r1 src=r0 offset=1 imm=0
+#line 276 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 276 "sample/map.c"
+        goto label_24;
+        // EBPF_OP_JA pc=898 dst=r0 src=r0 offset=162 imm=0
+#line 276 "sample/map.c"
+    goto label_36;
+label_24:
+    // EBPF_OP_LDXW pc=899 dst=r1 src=r10 offset=-4 imm=0
+#line 276 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1082 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1084 dst=r1 src=r0 offset=-335 imm=7
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(7))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1085 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=900 dst=r6 src=r0 offset=0 imm=-1
+#line 276 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=902 dst=r1 src=r0 offset=-857 imm=3
+#line 276 "sample/map.c"
+    if (r1 != IMMEDIATE(3))
+#line 276 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=903 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1086 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=904 dst=r10 src=r1 offset=-4 imm=0
+#line 277 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1087 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=905 dst=r2 src=r10 offset=0 imm=0
+#line 277 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1088 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=906 dst=r2 src=r0 offset=0 imm=-4
+#line 277 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1089 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1091 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=907 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=909 dst=r0 src=r0 offset=0 imm=17
+#line 277 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1092 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1093 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1094 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=910 dst=r6 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=911 dst=r1 src=r6 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=912 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1095 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=913 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1096 dst=r1 src=r0 offset=-222 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1097 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=914 dst=r1 src=r0 offset=1 imm=0
+#line 277 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 277 "sample/map.c"
+        goto label_25;
+        // EBPF_OP_JA pc=915 dst=r0 src=r0 offset=145 imm=0
+#line 277 "sample/map.c"
+    goto label_36;
+label_25:
+    // EBPF_OP_LDXW pc=916 dst=r1 src=r10 offset=-4 imm=0
+#line 277 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1098 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1100 dst=r1 src=r0 offset=-351 imm=6
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(6))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1101 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1102 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1103 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1104 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1105 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1107 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=1108 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1109 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1110 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1111 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1112 dst=r1 src=r0 offset=-238 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1113 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1114 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1116 dst=r1 src=r0 offset=-367 imm=5
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(5))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1117 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1118 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1119 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1120 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1121 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1123 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=1124 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1125 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1126 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1127 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1128 dst=r1 src=r0 offset=-254 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1129 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1130 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1132 dst=r1 src=r0 offset=-383 imm=4
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=917 dst=r6 src=r0 offset=0 imm=-1
+#line 277 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=919 dst=r1 src=r0 offset=-874 imm=4
+#line 277 "sample/map.c"
     if (r1 != IMMEDIATE(4))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1133 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=920 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1134 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=921 dst=r10 src=r1 offset=-4 imm=0
+#line 278 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1135 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=922 dst=r2 src=r10 offset=0 imm=0
+#line 278 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1136 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=923 dst=r2 src=r0 offset=0 imm=-4
+#line 278 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1137 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1139 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=924 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=926 dst=r0 src=r0 offset=0 imm=17
+#line 278 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=927 dst=r6 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=928 dst=r1 src=r6 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=929 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=930 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=931 dst=r1 src=r0 offset=1 imm=0
+#line 278 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 278 "sample/map.c"
+        goto label_26;
+        // EBPF_OP_JA pc=932 dst=r0 src=r0 offset=128 imm=0
+#line 278 "sample/map.c"
+    goto label_36;
+label_26:
+    // EBPF_OP_LDXW pc=933 dst=r1 src=r10 offset=-4 imm=0
+#line 278 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=934 dst=r6 src=r0 offset=0 imm=-1
+#line 278 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=936 dst=r1 src=r0 offset=-891 imm=5
+#line 278 "sample/map.c"
+    if (r1 != IMMEDIATE(5))
+#line 278 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=937 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=938 dst=r10 src=r1 offset=-4 imm=0
+#line 279 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=939 dst=r2 src=r10 offset=0 imm=0
+#line 279 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=940 dst=r2 src=r0 offset=0 imm=-4
+#line 279 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=941 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=943 dst=r0 src=r0 offset=0 imm=17
+#line 279 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 279 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 279 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 279 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=944 dst=r6 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=945 dst=r1 src=r6 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=946 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=947 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=948 dst=r1 src=r0 offset=1 imm=0
+#line 279 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 279 "sample/map.c"
+        goto label_27;
+        // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=111 imm=0
+#line 279 "sample/map.c"
+    goto label_36;
+label_27:
+    // EBPF_OP_LDXW pc=950 dst=r1 src=r10 offset=-4 imm=0
+#line 279 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=951 dst=r6 src=r0 offset=0 imm=-1
+#line 279 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=953 dst=r1 src=r0 offset=-908 imm=6
+#line 279 "sample/map.c"
+    if (r1 != IMMEDIATE(6))
+#line 279 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=954 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=955 dst=r10 src=r1 offset=-4 imm=0
+#line 280 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=956 dst=r2 src=r10 offset=0 imm=0
+#line 280 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=957 dst=r2 src=r0 offset=0 imm=-4
+#line 280 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=958 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=960 dst=r0 src=r0 offset=0 imm=17
+#line 280 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 280 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 280 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 280 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=961 dst=r6 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=962 dst=r1 src=r6 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=963 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=964 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=965 dst=r1 src=r0 offset=1 imm=0
+#line 280 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 280 "sample/map.c"
+        goto label_28;
+        // EBPF_OP_JA pc=966 dst=r0 src=r0 offset=94 imm=0
+#line 280 "sample/map.c"
+    goto label_36;
+label_28:
+    // EBPF_OP_LDXW pc=967 dst=r1 src=r10 offset=-4 imm=0
+#line 280 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=968 dst=r6 src=r0 offset=0 imm=-1
+#line 280 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=970 dst=r1 src=r0 offset=-925 imm=7
+#line 280 "sample/map.c"
+    if (r1 != IMMEDIATE(7))
+#line 280 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=971 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=972 dst=r10 src=r1 offset=-4 imm=0
+#line 281 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=973 dst=r2 src=r10 offset=0 imm=0
+#line 281 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=974 dst=r2 src=r0 offset=0 imm=-4
+#line 281 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=975 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=977 dst=r0 src=r0 offset=0 imm=17
+#line 281 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 281 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 281 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 281 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=978 dst=r6 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=979 dst=r1 src=r6 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=980 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=981 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=982 dst=r1 src=r0 offset=1 imm=0
+#line 281 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 281 "sample/map.c"
+        goto label_29;
+        // EBPF_OP_JA pc=983 dst=r0 src=r0 offset=77 imm=0
+#line 281 "sample/map.c"
+    goto label_36;
+label_29:
+    // EBPF_OP_LDXW pc=984 dst=r1 src=r10 offset=-4 imm=0
+#line 281 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=985 dst=r6 src=r0 offset=0 imm=-1
+#line 281 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=987 dst=r1 src=r0 offset=-942 imm=8
+#line 281 "sample/map.c"
+    if (r1 != IMMEDIATE(8))
+#line 281 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=988 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=989 dst=r10 src=r1 offset=-4 imm=0
+#line 282 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=990 dst=r2 src=r10 offset=0 imm=0
+#line 282 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=991 dst=r2 src=r0 offset=0 imm=-4
+#line 282 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=992 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=994 dst=r0 src=r0 offset=0 imm=17
+#line 282 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 282 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 282 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 282 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=995 dst=r6 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=996 dst=r1 src=r6 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=997 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=998 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=999 dst=r1 src=r0 offset=1 imm=0
+#line 282 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 282 "sample/map.c"
+        goto label_30;
+        // EBPF_OP_JA pc=1000 dst=r0 src=r0 offset=60 imm=0
+#line 282 "sample/map.c"
+    goto label_36;
+label_30:
+    // EBPF_OP_LDXW pc=1001 dst=r1 src=r10 offset=-4 imm=0
+#line 282 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=1002 dst=r6 src=r0 offset=0 imm=-1
+#line 282 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=1004 dst=r1 src=r0 offset=-959 imm=9
+#line 282 "sample/map.c"
+    if (r1 != IMMEDIATE(9))
+#line 282 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=1005 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1006 dst=r10 src=r1 offset=-4 imm=0
+#line 283 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1007 dst=r2 src=r10 offset=0 imm=0
+#line 283 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1008 dst=r2 src=r0 offset=0 imm=-4
+#line 283 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1009 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1011 dst=r0 src=r0 offset=0 imm=17
+#line 283 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 283 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 283 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 283 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1012 dst=r6 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=1013 dst=r1 src=r6 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=1014 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1015 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1016 dst=r1 src=r0 offset=1 imm=0
+#line 283 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 283 "sample/map.c"
+        goto label_31;
+        // EBPF_OP_JA pc=1017 dst=r0 src=r0 offset=43 imm=0
+#line 283 "sample/map.c"
+    goto label_36;
+label_31:
+    // EBPF_OP_LDXW pc=1018 dst=r1 src=r10 offset=-4 imm=0
+#line 283 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=1019 dst=r6 src=r0 offset=0 imm=-1
+#line 283 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=1021 dst=r1 src=r0 offset=-976 imm=10
+#line 283 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 283 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=1022 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1023 dst=r10 src=r1 offset=-4 imm=0
+#line 286 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1024 dst=r2 src=r10 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1025 dst=r2 src=r0 offset=0 imm=-4
+#line 286 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1026 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1028 dst=r0 src=r0 offset=0 imm=18
+#line 286 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 286 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 286 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 286 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1029 dst=r1 src=r10 offset=-4 imm=0
+#line 286 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1030 dst=r6 src=r7 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JEQ_IMM pc=1031 dst=r1 src=r0 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_32;
+        // EBPF_OP_MOV64_IMM pc=1032 dst=r6 src=r0 offset=0 imm=-1
+#line 286 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_32:
+    // EBPF_OP_MOV64_REG pc=1033 dst=r2 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1034 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1035 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1036 dst=r3 src=r0 offset=0 imm=-7
+#line 286 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1038 dst=r2 src=r3 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r2 == r3)
+#line 286 "sample/map.c"
+        goto label_33;
+        // EBPF_OP_MOV64_REG pc=1039 dst=r6 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = r0;
+label_33:
+    // EBPF_OP_JNE_REG pc=1040 dst=r2 src=r3 offset=20 imm=0
+#line 286 "sample/map.c"
+    if (r2 != r3)
+#line 286 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_JNE_IMM pc=1041 dst=r1 src=r0 offset=19 imm=0
+#line 286 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1043 dst=r10 src=r1 offset=-4 imm=0
+#line 287 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1044 dst=r2 src=r10 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1045 dst=r2 src=r0 offset=0 imm=-4
+#line 287 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1046 dst=r1 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1048 dst=r0 src=r0 offset=0 imm=17
+#line 287 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 287 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 287 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 287 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1049 dst=r1 src=r10 offset=-4 imm=0
+#line 287 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JEQ_IMM pc=1050 dst=r1 src=r0 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_34;
+        // EBPF_OP_MOV64_IMM pc=1051 dst=r6 src=r0 offset=0 imm=-1
+#line 287 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_34:
+    // EBPF_OP_MOV64_REG pc=1052 dst=r2 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1053 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1054 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1055 dst=r3 src=r0 offset=0 imm=-7
+#line 287 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1057 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 == r3)
+#line 287 "sample/map.c"
+        goto label_35;
+        // EBPF_OP_MOV64_REG pc=1058 dst=r6 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r6 = r0;
+label_35:
+    // EBPF_OP_JNE_REG pc=1059 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 != r3)
+#line 287 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_JEQ_IMM pc=1060 dst=r1 src=r0 offset=5 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_37;
+label_36:
+    // EBPF_OP_MOV64_REG pc=1061 dst=r1 src=r6 offset=0 imm=0
+#line 305 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=1062 dst=r1 src=r0 offset=0 imm=32
+#line 305 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=1063 dst=r1 src=r0 offset=0 imm=32
+#line 305 "sample/map.c"
+    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=1064 dst=r2 src=r0 offset=0 imm=0
+#line 305 "sample/map.c"
+    r2 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=1065 dst=r2 src=r1 offset=-1020 imm=0
+#line 305 "sample/map.c"
+    if ((int64_t)r2 > (int64_t)r1)
+#line 305 "sample/map.c"
+        goto label_1;
+label_37:
+    // EBPF_OP_MOV64_IMM pc=1066 dst=r1 src=r0 offset=0 imm=0
+#line 305 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1067 dst=r10 src=r1 offset=-4 imm=0
+#line 242 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1068 dst=r2 src=r10 offset=0 imm=0
+#line 242 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1069 dst=r2 src=r0 offset=0 imm=-4
+#line 242 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1070 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1072 dst=r0 src=r0 offset=0 imm=18
+#line 242 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 242 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 242 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 242 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1073 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1074 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1075 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=1076 dst=r7 src=r0 offset=0 imm=-1
+#line 242 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+    // EBPF_OP_LDDW pc=1077 dst=r2 src=r0 offset=0 imm=-7
+#line 242 "sample/map.c"
+    r2 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1079 dst=r1 src=r2 offset=1 imm=0
+#line 242 "sample/map.c"
+    if (r1 == r2)
+#line 242 "sample/map.c"
+        goto label_38;
+        // EBPF_OP_MOV64_REG pc=1080 dst=r7 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r7 = r0;
+label_38:
+    // EBPF_OP_JNE_REG pc=1081 dst=r1 src=r2 offset=380 imm=0
+#line 242 "sample/map.c"
+    if (r1 != r2)
+#line 242 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_LDXW pc=1082 dst=r1 src=r10 offset=-4 imm=0
+#line 242 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1083 dst=r1 src=r0 offset=378 imm=0
+#line 242 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 242 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1084 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1085 dst=r10 src=r1 offset=-4 imm=0
+#line 243 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1086 dst=r2 src=r10 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1087 dst=r2 src=r0 offset=0 imm=-4
+#line 243 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1088 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1090 dst=r0 src=r0 offset=0 imm=17
+#line 243 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 243 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 243 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 243 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1091 dst=r1 src=r10 offset=-4 imm=0
+#line 243 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1092 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JEQ_IMM pc=1093 dst=r1 src=r0 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_39;
+        // EBPF_OP_MOV64_IMM pc=1094 dst=r6 src=r0 offset=0 imm=-1
+#line 243 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_39:
+    // EBPF_OP_MOV64_REG pc=1095 dst=r2 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1096 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1097 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1098 dst=r3 src=r0 offset=0 imm=-7
+#line 243 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1100 dst=r2 src=r3 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r2 == r3)
+#line 243 "sample/map.c"
+        goto label_40;
+        // EBPF_OP_MOV64_REG pc=1101 dst=r6 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r0;
+label_40:
+    // EBPF_OP_MOV64_REG pc=1102 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JNE_REG pc=1103 dst=r2 src=r3 offset=358 imm=0
+#line 243 "sample/map.c"
+    if (r2 != r3)
+#line 243 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_REG pc=1104 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JNE_IMM pc=1105 dst=r1 src=r0 offset=356 imm=0
+#line 243 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1106 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1107 dst=r10 src=r1 offset=-4 imm=0
+#line 251 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1108 dst=r2 src=r10 offset=0 imm=0
+#line 251 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1109 dst=r2 src=r0 offset=0 imm=-4
+#line 251 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1110 dst=r1 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1112 dst=r3 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1113 dst=r0 src=r0 offset=0 imm=16
+#line 251 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 251 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 251 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 251 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1114 dst=r7 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1115 dst=r1 src=r7 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1116 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1117 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1118 dst=r1 src=r0 offset=343 imm=0
+#line 251 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 251 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1119 dst=r1 src=r0 offset=0 imm=1
+#line 251 "sample/map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=1120 dst=r10 src=r1 offset=-4 imm=0
+#line 252 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1121 dst=r2 src=r10 offset=0 imm=0
+#line 252 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1122 dst=r2 src=r0 offset=0 imm=-4
+#line 252 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1123 dst=r1 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1125 dst=r3 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1126 dst=r0 src=r0 offset=0 imm=16
+#line 252 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 252 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 252 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 252 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1127 dst=r7 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1128 dst=r1 src=r7 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1129 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1130 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1131 dst=r1 src=r0 offset=330 imm=0
+#line 252 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 252 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1132 dst=r1 src=r0 offset=0 imm=2
+#line 252 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=1133 dst=r10 src=r1 offset=-4 imm=0
+#line 253 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1134 dst=r2 src=r10 offset=0 imm=0
+#line 253 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1135 dst=r2 src=r0 offset=0 imm=-4
+#line 253 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1136 dst=r1 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1138 dst=r3 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1139 dst=r0 src=r0 offset=0 imm=16
+#line 253 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 253 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 253 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 253 "sample/map.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=1140 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1141 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 = r7;
     // EBPF_OP_LSH64_IMM pc=1142 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 <<= IMMEDIATE(32);
     // EBPF_OP_RSH64_IMM pc=1143 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1144 dst=r1 src=r0 offset=-270 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1144 dst=r1 src=r0 offset=317 imm=0
+#line 253 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1145 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1146 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1148 dst=r1 src=r0 offset=-399 imm=3
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(3))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1149 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1150 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1145 dst=r1 src=r0 offset=0 imm=3
+#line 253 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=1146 dst=r10 src=r1 offset=-4 imm=0
+#line 254 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1151 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1147 dst=r2 src=r10 offset=0 imm=0
+#line 254 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1152 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1148 dst=r2 src=r0 offset=0 imm=-4
+#line 254 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1153 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=1149 dst=r1 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1155 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1151 dst=r3 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1152 dst=r0 src=r0 offset=0 imm=16
+#line 254 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 254 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 254 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 254 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1156 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1153 dst=r7 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
     r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1157 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1154 dst=r1 src=r7 offset=0 imm=0
+#line 254 "sample/map.c"
     r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1158 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=1155 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1159 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=1156 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1160 dst=r1 src=r0 offset=-286 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1157 dst=r1 src=r0 offset=304 imm=0
+#line 254 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1161 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1162 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1164 dst=r1 src=r0 offset=-415 imm=2
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(2))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1165 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1166 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+#line 254 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1158 dst=r1 src=r0 offset=0 imm=4
+#line 254 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=1159 dst=r10 src=r1 offset=-4 imm=0
+#line 255 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1167 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1160 dst=r2 src=r10 offset=0 imm=0
+#line 255 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1168 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1161 dst=r2 src=r0 offset=0 imm=-4
+#line 255 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1169 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=1162 dst=r1 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1171 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1164 dst=r3 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1165 dst=r0 src=r0 offset=0 imm=16
+#line 255 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 255 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 255 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 255 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1172 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1166 dst=r7 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
     r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1173 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1167 dst=r1 src=r7 offset=0 imm=0
+#line 255 "sample/map.c"
     r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1174 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=1168 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1175 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=1169 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1176 dst=r1 src=r0 offset=-302 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1170 dst=r1 src=r0 offset=291 imm=0
+#line 255 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1177 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1178 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1180 dst=r1 src=r0 offset=-431 imm=1
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(1))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1181 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1182 dst=r10 src=r1 offset=-4 imm=0
-#line 189 "sample/map.c"
+#line 255 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1171 dst=r1 src=r0 offset=0 imm=5
+#line 255 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=1172 dst=r10 src=r1 offset=-4 imm=0
+#line 256 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1183 dst=r2 src=r10 offset=0 imm=0
-#line 189 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1173 dst=r2 src=r10 offset=0 imm=0
+#line 256 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1184 dst=r2 src=r0 offset=0 imm=-4
-#line 189 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1174 dst=r2 src=r0 offset=0 imm=-4
+#line 256 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1185 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
+    // EBPF_OP_LDDW pc=1175 dst=r1 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1187 dst=r0 src=r0 offset=0 imm=18
-#line 189 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 189 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1177 dst=r3 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1178 dst=r0 src=r0 offset=0 imm=16
+#line 256 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 256 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 189 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 189 "sample/map.c"
+#line 256 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 256 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=1188 dst=r1 src=r10 offset=-4 imm=0
-#line 189 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=1189 dst=r7 src=r6 offset=0 imm=0
-#line 189 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JEQ_IMM pc=1190 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_48;
-        // EBPF_OP_MOV64_IMM pc=1191 dst=r7 src=r0 offset=0 imm=-1
-#line 189 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_48:
-    // EBPF_OP_MOV64_REG pc=1192 dst=r2 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1193 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1194 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1195 dst=r3 src=r0 offset=0 imm=-7
-#line 189 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1197 dst=r2 src=r3 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r2 == r3)
-#line 189 "sample/map.c"
-        goto label_49;
-        // EBPF_OP_MOV64_REG pc=1198 dst=r7 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1179 dst=r7 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
     r7 = r0;
-label_49:
-    // EBPF_OP_JNE_REG pc=1199 dst=r2 src=r3 offset=-455 imm=0
-#line 189 "sample/map.c"
-    if (r2 != r3)
-#line 189 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_JEQ_IMM pc=1200 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_50;
-        // EBPF_OP_JA pc=1201 dst=r0 src=r0 offset=-457 imm=0
-#line 189 "sample/map.c"
-    goto label_27;
-label_50:
-    // EBPF_OP_MOV64_IMM pc=1202 dst=r6 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1203 dst=r10 src=r6 offset=-4 imm=0
-#line 190 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
-    // EBPF_OP_MOV64_REG pc=1204 dst=r2 src=r10 offset=0 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1180 dst=r1 src=r7 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1181 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1182 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1183 dst=r1 src=r0 offset=278 imm=0
+#line 256 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 256 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1184 dst=r1 src=r0 offset=0 imm=6
+#line 256 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=1185 dst=r10 src=r1 offset=-4 imm=0
+#line 257 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1186 dst=r2 src=r10 offset=0 imm=0
+#line 257 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1205 dst=r2 src=r0 offset=0 imm=-4
-#line 190 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1187 dst=r2 src=r0 offset=0 imm=-4
+#line 257 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1206 dst=r1 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_LDDW pc=1188 dst=r1 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1208 dst=r0 src=r0 offset=0 imm=17
-#line 190 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1190 dst=r3 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1191 dst=r0 src=r0 offset=0 imm=16
+#line 257 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 257 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 190 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 190 "sample/map.c"
+#line 257 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 257 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=1209 dst=r1 src=r10 offset=-4 imm=0
-#line 190 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JEQ_IMM pc=1210 dst=r1 src=r0 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
-        goto label_51;
-        // EBPF_OP_MOV64_IMM pc=1211 dst=r7 src=r0 offset=0 imm=-1
-#line 190 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_51:
-    // EBPF_OP_MOV64_REG pc=1212 dst=r2 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1213 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1214 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1215 dst=r3 src=r0 offset=0 imm=-7
-#line 190 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1217 dst=r2 src=r3 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r2 == r3)
-#line 190 "sample/map.c"
-        goto label_52;
+        // EBPF_OP_MOV64_REG pc=1192 dst=r7 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1193 dst=r1 src=r7 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1194 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1195 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1196 dst=r1 src=r0 offset=265 imm=0
+#line 257 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 257 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1197 dst=r1 src=r0 offset=0 imm=7
+#line 257 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=1198 dst=r10 src=r1 offset=-4 imm=0
+#line 258 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1199 dst=r2 src=r10 offset=0 imm=0
+#line 258 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1200 dst=r2 src=r0 offset=0 imm=-4
+#line 258 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1201 dst=r1 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1203 dst=r3 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1204 dst=r0 src=r0 offset=0 imm=16
+#line 258 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 258 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 258 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 258 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1205 dst=r7 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1206 dst=r1 src=r7 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1207 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1208 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1209 dst=r1 src=r0 offset=252 imm=0
+#line 258 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 258 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1210 dst=r1 src=r0 offset=0 imm=8
+#line 258 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=1211 dst=r10 src=r1 offset=-4 imm=0
+#line 259 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1212 dst=r2 src=r10 offset=0 imm=0
+#line 259 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1213 dst=r2 src=r0 offset=0 imm=-4
+#line 259 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1214 dst=r1 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1216 dst=r3 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1217 dst=r0 src=r0 offset=0 imm=16
+#line 259 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 259 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 259 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 259 "sample/map.c"
+        return 0;
         // EBPF_OP_MOV64_REG pc=1218 dst=r7 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
+#line 259 "sample/map.c"
     r7 = r0;
-label_52:
-    // EBPF_OP_JNE_REG pc=1219 dst=r2 src=r3 offset=-475 imm=0
-#line 190 "sample/map.c"
-    if (r2 != r3)
-#line 190 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_JEQ_IMM pc=1220 dst=r1 src=r0 offset=-1175 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1219 dst=r1 src=r7 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1220 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1221 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1222 dst=r1 src=r0 offset=239 imm=0
+#line 259 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 259 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1223 dst=r1 src=r0 offset=0 imm=9
+#line 259 "sample/map.c"
+    r1 = IMMEDIATE(9);
+    // EBPF_OP_STXW pc=1224 dst=r10 src=r1 offset=-4 imm=0
+#line 260 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1225 dst=r2 src=r10 offset=0 imm=0
+#line 260 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1226 dst=r2 src=r0 offset=0 imm=-4
+#line 260 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1227 dst=r1 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1229 dst=r3 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1230 dst=r0 src=r0 offset=0 imm=16
+#line 260 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 260 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 260 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 260 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1231 dst=r7 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1232 dst=r1 src=r7 offset=0 imm=0
+#line 260 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1233 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1234 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1235 dst=r1 src=r0 offset=226 imm=0
+#line 260 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 260 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1236 dst=r8 src=r0 offset=0 imm=10
+#line 260 "sample/map.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=1237 dst=r10 src=r8 offset=-4 imm=0
+#line 263 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=1238 dst=r2 src=r10 offset=0 imm=0
+#line 263 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1239 dst=r2 src=r0 offset=0 imm=-4
+#line 263 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1240 dst=r1 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1242 dst=r3 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1243 dst=r0 src=r0 offset=0 imm=16
+#line 263 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 263 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 263 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 263 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1244 dst=r7 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1245 dst=r1 src=r7 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1246 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1247 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1248 dst=r2 src=r0 offset=0 imm=-29
+#line 263 "sample/map.c"
+    r2 = (uint64_t)4294967267;
+    // EBPF_OP_JNE_REG pc=1250 dst=r1 src=r2 offset=211 imm=0
+#line 263 "sample/map.c"
+    if (r1 != r2)
+#line 263 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_STXW pc=1251 dst=r10 src=r8 offset=-4 imm=0
+#line 264 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=1252 dst=r2 src=r10 offset=0 imm=0
+#line 264 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1253 dst=r2 src=r0 offset=0 imm=-4
+#line 264 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1254 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1256 dst=r3 src=r0 offset=0 imm=2
+#line 264 "sample/map.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=1257 dst=r0 src=r0 offset=0 imm=16
+#line 264 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 264 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 264 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 264 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1258 dst=r7 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1259 dst=r1 src=r7 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1260 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1261 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1262 dst=r1 src=r0 offset=1 imm=0
+#line 264 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
+#line 264 "sample/map.c"
+        goto label_41;
+        // EBPF_OP_MOV64_REG pc=1263 dst=r6 src=r7 offset=0 imm=0
+#line 264 "sample/map.c"
+    r6 = r7;
+label_41:
+    // EBPF_OP_JNE_IMM pc=1264 dst=r1 src=r0 offset=197 imm=0
+#line 264 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 264 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1265 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1266 dst=r10 src=r1 offset=-4 imm=0
+#line 266 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1267 dst=r2 src=r10 offset=0 imm=0
+#line 266 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1268 dst=r2 src=r0 offset=0 imm=-4
+#line 266 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1269 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1271 dst=r0 src=r0 offset=0 imm=18
+#line 266 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 266 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 266 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 266 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1272 dst=r7 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1273 dst=r1 src=r7 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1274 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1275 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1276 dst=r1 src=r0 offset=1 imm=0
+#line 266 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 266 "sample/map.c"
+        goto label_42;
+        // EBPF_OP_JA pc=1277 dst=r0 src=r0 offset=184 imm=0
+#line 266 "sample/map.c"
+    goto label_58;
+label_42:
+    // EBPF_OP_LDDW pc=1278 dst=r7 src=r0 offset=0 imm=-1
+#line 266 "sample/map.c"
+    r7 = (uint64_t)4294967295;
+    // EBPF_OP_LDXW pc=1280 dst=r1 src=r10 offset=-4 imm=0
+#line 266 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1281 dst=r1 src=r0 offset=185 imm=10
+#line 266 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 266 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1282 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1283 dst=r10 src=r1 offset=-4 imm=0
+#line 274 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1284 dst=r2 src=r10 offset=0 imm=0
+#line 274 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1285 dst=r2 src=r0 offset=0 imm=-4
+#line 274 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1286 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1288 dst=r0 src=r0 offset=0 imm=17
+#line 274 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 274 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 274 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 274 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1289 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1290 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1291 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1292 dst=r1 src=r0 offset=2 imm=0
+#line 274 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 274 "sample/map.c"
+        goto label_44;
+label_43:
+    // EBPF_OP_MOV64_REG pc=1293 dst=r7 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_JA pc=1294 dst=r0 src=r0 offset=167 imm=0
+#line 274 "sample/map.c"
+    goto label_58;
+label_44:
+    // EBPF_OP_LDXW pc=1295 dst=r1 src=r10 offset=-4 imm=0
+#line 274 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1296 dst=r1 src=r0 offset=170 imm=10
+#line 274 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 274 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1297 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1298 dst=r10 src=r1 offset=-4 imm=0
+#line 275 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1299 dst=r2 src=r10 offset=0 imm=0
+#line 275 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1300 dst=r2 src=r0 offset=0 imm=-4
+#line 275 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1301 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1303 dst=r0 src=r0 offset=0 imm=17
+#line 275 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 275 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 275 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 275 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1304 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1305 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1306 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1307 dst=r1 src=r0 offset=1 imm=0
+#line 275 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 275 "sample/map.c"
+        goto label_45;
+        // EBPF_OP_JA pc=1308 dst=r0 src=r0 offset=-16 imm=0
+#line 275 "sample/map.c"
+    goto label_43;
+label_45:
+    // EBPF_OP_LDXW pc=1309 dst=r1 src=r10 offset=-4 imm=0
+#line 275 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1310 dst=r1 src=r0 offset=156 imm=9
+#line 275 "sample/map.c"
+    if (r1 != IMMEDIATE(9))
+#line 275 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1311 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1312 dst=r10 src=r1 offset=-4 imm=0
+#line 276 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1313 dst=r2 src=r10 offset=0 imm=0
+#line 276 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1314 dst=r2 src=r0 offset=0 imm=-4
+#line 276 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1315 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1317 dst=r0 src=r0 offset=0 imm=17
+#line 276 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 276 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 276 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 276 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1318 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1319 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1320 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1321 dst=r1 src=r0 offset=1 imm=0
+#line 276 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 276 "sample/map.c"
+        goto label_46;
+        // EBPF_OP_JA pc=1322 dst=r0 src=r0 offset=-30 imm=0
+#line 276 "sample/map.c"
+    goto label_43;
+label_46:
+    // EBPF_OP_LDXW pc=1323 dst=r1 src=r10 offset=-4 imm=0
+#line 276 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1324 dst=r1 src=r0 offset=142 imm=8
+#line 276 "sample/map.c"
+    if (r1 != IMMEDIATE(8))
+#line 276 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1325 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1326 dst=r10 src=r1 offset=-4 imm=0
+#line 277 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1327 dst=r2 src=r10 offset=0 imm=0
+#line 277 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1328 dst=r2 src=r0 offset=0 imm=-4
+#line 277 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1329 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1331 dst=r0 src=r0 offset=0 imm=17
+#line 277 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 277 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 277 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 277 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1332 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1333 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1334 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1335 dst=r1 src=r0 offset=1 imm=0
+#line 277 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 277 "sample/map.c"
+        goto label_47;
+        // EBPF_OP_JA pc=1336 dst=r0 src=r0 offset=-44 imm=0
+#line 277 "sample/map.c"
+    goto label_43;
+label_47:
+    // EBPF_OP_LDXW pc=1337 dst=r1 src=r10 offset=-4 imm=0
+#line 277 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1338 dst=r1 src=r0 offset=128 imm=7
+#line 277 "sample/map.c"
+    if (r1 != IMMEDIATE(7))
+#line 277 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1340 dst=r10 src=r1 offset=-4 imm=0
+#line 278 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1341 dst=r2 src=r10 offset=0 imm=0
+#line 278 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1342 dst=r2 src=r0 offset=0 imm=-4
+#line 278 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1343 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1345 dst=r0 src=r0 offset=0 imm=17
+#line 278 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 278 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 278 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 278 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1346 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1347 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1348 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1349 dst=r1 src=r0 offset=1 imm=0
+#line 278 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 278 "sample/map.c"
+        goto label_48;
+        // EBPF_OP_JA pc=1350 dst=r0 src=r0 offset=-58 imm=0
+#line 278 "sample/map.c"
+    goto label_43;
+label_48:
+    // EBPF_OP_LDXW pc=1351 dst=r1 src=r10 offset=-4 imm=0
+#line 278 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1352 dst=r1 src=r0 offset=114 imm=6
+#line 278 "sample/map.c"
+    if (r1 != IMMEDIATE(6))
+#line 278 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1353 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1354 dst=r10 src=r1 offset=-4 imm=0
+#line 279 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1355 dst=r2 src=r10 offset=0 imm=0
+#line 279 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1356 dst=r2 src=r0 offset=0 imm=-4
+#line 279 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1357 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1359 dst=r0 src=r0 offset=0 imm=17
+#line 279 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 279 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 279 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 279 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1360 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1361 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1362 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1363 dst=r1 src=r0 offset=1 imm=0
+#line 279 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 279 "sample/map.c"
+        goto label_49;
+        // EBPF_OP_JA pc=1364 dst=r0 src=r0 offset=-72 imm=0
+#line 279 "sample/map.c"
+    goto label_43;
+label_49:
+    // EBPF_OP_LDXW pc=1365 dst=r1 src=r10 offset=-4 imm=0
+#line 279 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1366 dst=r1 src=r0 offset=100 imm=5
+#line 279 "sample/map.c"
+    if (r1 != IMMEDIATE(5))
+#line 279 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1367 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1368 dst=r10 src=r1 offset=-4 imm=0
+#line 280 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1369 dst=r2 src=r10 offset=0 imm=0
+#line 280 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1370 dst=r2 src=r0 offset=0 imm=-4
+#line 280 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1371 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1373 dst=r0 src=r0 offset=0 imm=17
+#line 280 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 280 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 280 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 280 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1374 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1375 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1376 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1377 dst=r1 src=r0 offset=1 imm=0
+#line 280 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 280 "sample/map.c"
+        goto label_50;
+        // EBPF_OP_JA pc=1378 dst=r0 src=r0 offset=-86 imm=0
+#line 280 "sample/map.c"
+    goto label_43;
+label_50:
+    // EBPF_OP_LDXW pc=1379 dst=r1 src=r10 offset=-4 imm=0
+#line 280 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1380 dst=r1 src=r0 offset=86 imm=4
+#line 280 "sample/map.c"
+    if (r1 != IMMEDIATE(4))
+#line 280 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1381 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1382 dst=r10 src=r1 offset=-4 imm=0
+#line 281 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1383 dst=r2 src=r10 offset=0 imm=0
+#line 281 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1384 dst=r2 src=r0 offset=0 imm=-4
+#line 281 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1385 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1387 dst=r0 src=r0 offset=0 imm=17
+#line 281 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 281 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 281 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 281 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1388 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1389 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1390 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1391 dst=r1 src=r0 offset=1 imm=0
+#line 281 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 281 "sample/map.c"
+        goto label_51;
+        // EBPF_OP_JA pc=1392 dst=r0 src=r0 offset=-100 imm=0
+#line 281 "sample/map.c"
+    goto label_43;
+label_51:
+    // EBPF_OP_LDXW pc=1393 dst=r1 src=r10 offset=-4 imm=0
+#line 281 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1394 dst=r1 src=r0 offset=72 imm=3
+#line 281 "sample/map.c"
+    if (r1 != IMMEDIATE(3))
+#line 281 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1395 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1396 dst=r10 src=r1 offset=-4 imm=0
+#line 282 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1397 dst=r2 src=r10 offset=0 imm=0
+#line 282 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1398 dst=r2 src=r0 offset=0 imm=-4
+#line 282 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1399 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1401 dst=r0 src=r0 offset=0 imm=17
+#line 282 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 282 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 282 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 282 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1402 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1403 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1404 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1405 dst=r1 src=r0 offset=1 imm=0
+#line 282 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 282 "sample/map.c"
+        goto label_52;
+        // EBPF_OP_JA pc=1406 dst=r0 src=r0 offset=-114 imm=0
+#line 282 "sample/map.c"
+    goto label_43;
+label_52:
+    // EBPF_OP_LDXW pc=1407 dst=r1 src=r10 offset=-4 imm=0
+#line 282 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1408 dst=r1 src=r0 offset=58 imm=2
+#line 282 "sample/map.c"
+    if (r1 != IMMEDIATE(2))
+#line 282 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1409 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1410 dst=r10 src=r1 offset=-4 imm=0
+#line 283 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1411 dst=r2 src=r10 offset=0 imm=0
+#line 283 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1412 dst=r2 src=r0 offset=0 imm=-4
+#line 283 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1413 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1415 dst=r0 src=r0 offset=0 imm=17
+#line 283 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 283 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 283 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 283 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1416 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1417 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1418 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1419 dst=r1 src=r0 offset=1 imm=0
+#line 283 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 283 "sample/map.c"
+        goto label_53;
+        // EBPF_OP_JA pc=1420 dst=r0 src=r0 offset=-128 imm=0
+#line 283 "sample/map.c"
+    goto label_43;
+label_53:
+    // EBPF_OP_LDXW pc=1421 dst=r1 src=r10 offset=-4 imm=0
+#line 283 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1422 dst=r1 src=r0 offset=44 imm=1
+#line 283 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 283 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1423 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1424 dst=r10 src=r1 offset=-4 imm=0
+#line 286 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1425 dst=r2 src=r10 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1426 dst=r2 src=r0 offset=0 imm=-4
+#line 286 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1427 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1429 dst=r0 src=r0 offset=0 imm=18
+#line 286 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 286 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 286 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 286 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1430 dst=r1 src=r10 offset=-4 imm=0
+#line 286 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1431 dst=r7 src=r6 offset=0 imm=0
+#line 286 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JEQ_IMM pc=1432 dst=r1 src=r0 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_54;
+        // EBPF_OP_MOV64_IMM pc=1433 dst=r7 src=r0 offset=0 imm=-1
+#line 286 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_54:
+    // EBPF_OP_MOV64_REG pc=1434 dst=r2 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1435 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1436 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1437 dst=r3 src=r0 offset=0 imm=-7
+#line 286 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1439 dst=r2 src=r3 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r2 == r3)
+#line 286 "sample/map.c"
+        goto label_55;
+        // EBPF_OP_MOV64_REG pc=1440 dst=r7 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r7 = r0;
+label_55:
+    // EBPF_OP_JNE_REG pc=1441 dst=r2 src=r3 offset=20 imm=0
+#line 286 "sample/map.c"
+    if (r2 != r3)
+#line 286 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_JNE_IMM pc=1442 dst=r1 src=r0 offset=19 imm=0
+#line 286 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1443 dst=r6 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1444 dst=r10 src=r6 offset=-4 imm=0
+#line 287 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
+    // EBPF_OP_MOV64_REG pc=1445 dst=r2 src=r10 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1446 dst=r2 src=r0 offset=0 imm=-4
+#line 287 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1447 dst=r1 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1449 dst=r0 src=r0 offset=0 imm=17
+#line 287 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 287 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 287 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 287 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1450 dst=r1 src=r10 offset=-4 imm=0
+#line 287 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JEQ_IMM pc=1451 dst=r1 src=r0 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_56;
+        // EBPF_OP_MOV64_IMM pc=1452 dst=r7 src=r0 offset=0 imm=-1
+#line 287 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_56:
+    // EBPF_OP_MOV64_REG pc=1453 dst=r2 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1454 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1455 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1456 dst=r3 src=r0 offset=0 imm=-7
+#line 287 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1458 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 == r3)
+#line 287 "sample/map.c"
+        goto label_57;
+        // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r7 = r0;
+label_57:
+    // EBPF_OP_JNE_REG pc=1460 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 != r3)
+#line 287 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_JEQ_IMM pc=1461 dst=r1 src=r0 offset=-1416 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
         goto label_1;
-        // EBPF_OP_JA pc=1221 dst=r0 src=r0 offset=-477 imm=0
-#line 190 "sample/map.c"
-    goto label_27;
-#line 190 "sample/map.c"
+label_58:
+    // EBPF_OP_MOV64_IMM pc=1462 dst=r6 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_REG pc=1463 dst=r1 src=r7 offset=0 imm=0
+#line 306 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1464 dst=r1 src=r0 offset=0 imm=32
+#line 306 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=1465 dst=r1 src=r0 offset=0 imm=32
+#line 306 "sample/map.c"
+    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=1466 dst=r1 src=r0 offset=-1421 imm=-1
+#line 306 "sample/map.c"
+    if ((int64_t)r1 > IMMEDIATE(-1))
+#line 306 "sample/map.c"
+        goto label_1;
+label_59:
+    // EBPF_OP_MOV64_REG pc=1467 dst=r6 src=r7 offset=0 imm=0
+#line 306 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JA pc=1468 dst=r0 src=r0 offset=-1423 imm=0
+#line 306 "sample/map.c"
+    goto label_1;
+#line 306 "sample/map.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -4308,7 +5182,7 @@ static program_entry_t _programs[] = {
         8,
         test_maps_helpers,
         7,
-        1222,
+        1469,
         &test_maps_program_type_guid,
         &test_maps_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -314,40 +314,40 @@ static uint16_t test_maps_maps[] = {
 #pragma code_seg(push, "xdp_prog")
 static uint64_t
 test_maps(void* context)
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
 {
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     // Prologue
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r0 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r1 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r2 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r3 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r4 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r5 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r6 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r7 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r8 = 0;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     register uint64_t r10 = 0;
 
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r1 = (uintptr_t)context;
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=0
-#line 195 "sample/map.c"
+#line 292 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=1 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -503,17 +503,17 @@ test_maps(void* context)
         goto label_2;
 label_1:
     // EBPF_OP_MOV64_REG pc=46 dst=r0 src=r6 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r0 = r6;
     // EBPF_OP_EXIT pc=47 dst=r0 src=r0 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     return r0;
 label_2:
     // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r10 offset=0 imm=0
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=49 dst=r2 src=r0 offset=0 imm=-4
-#line 211 "sample/map.c"
+#line 308 "sample/map.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=0
 #line 105 "sample/map.c"
@@ -531,12 +531,12 @@ label_2:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=55 dst=r0 src=r0 offset=-10 imm=0
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=56 dst=r7 src=r0 offset=0 imm=0
-#line 198 "sample/map.c"
+#line 295 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=57 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -717,12 +717,12 @@ label_4:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=110 dst=r0 src=r0 offset=-65 imm=0
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=111 dst=r7 src=r0 offset=0 imm=0
-#line 199 "sample/map.c"
+#line 296 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=112 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -1223,12 +1223,12 @@ label_10:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=259 dst=r0 src=r0 offset=-214 imm=0
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
         goto label_1;
         // EBPF_OP_MOV64_IMM pc=260 dst=r7 src=r0 offset=0 imm=0
-#line 202 "sample/map.c"
+#line 299 "sample/map.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=261 dst=r10 src=r7 offset=-4 imm=0
 #line 72 "sample/map.c"
@@ -1409,3056 +1409,3930 @@ label_12:
 #line 105 "sample/map.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JEQ_IMM pc=314 dst=r0 src=r0 offset=-269 imm=0
-#line 203 "sample/map.c"
+#line 300 "sample/map.c"
     if (r0 == IMMEDIATE(0))
-#line 203 "sample/map.c"
+#line 300 "sample/map.c"
         goto label_1;
-        // EBPF_OP_MOV64_IMM pc=315 dst=r1 src=r0 offset=0 imm=0
-#line 203 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=316 dst=r10 src=r1 offset=-4 imm=0
-#line 203 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=317 dst=r1 src=r0 offset=0 imm=1
-#line 203 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=318 dst=r10 src=r1 offset=-8 imm=0
+        // EBPF_OP_MOV64_IMM pc=315 dst=r7 src=r0 offset=0 imm=0
+#line 300 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=316 dst=r10 src=r7 offset=-4 imm=0
+#line 116 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=317 dst=r8 src=r0 offset=0 imm=1
+#line 116 "sample/map.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=318 dst=r10 src=r8 offset=-8 imm=0
 #line 117 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=319 dst=r7 src=r0 offset=0 imm=11
-#line 117 "sample/map.c"
-    r7 = IMMEDIATE(11);
-    // EBPF_OP_JA pc=320 dst=r0 src=r0 offset=12 imm=0
-#line 117 "sample/map.c"
-    goto label_14;
-label_13:
-    // EBPF_OP_LDXW pc=321 dst=r1 src=r10 offset=-4 imm=0
-#line 121 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_ADD64_IMM pc=322 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=323 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_LSH64_IMM pc=324 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=325 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JGT_REG pc=326 dst=r7 src=r1 offset=6 imm=0
-#line 121 "sample/map.c"
-    if (r7 > r1)
-#line 121 "sample/map.c"
-        goto label_14;
-        // EBPF_OP_MOV64_IMM pc=327 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=328 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=329 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=330 dst=r10 src=r1 offset=-8 imm=0
-#line 117 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_IMM pc=331 dst=r7 src=r0 offset=0 imm=11
-#line 117 "sample/map.c"
-    r7 = IMMEDIATE(11);
-    // EBPF_OP_JA pc=332 dst=r0 src=r0 offset=36 imm=0
-#line 117 "sample/map.c"
-    goto label_16;
-label_14:
-    // EBPF_OP_MOV64_REG pc=333 dst=r2 src=r10 offset=0 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=319 dst=r2 src=r10 offset=0 imm=0
 #line 117 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=334 dst=r2 src=r0 offset=0 imm=-4
+    // EBPF_OP_ADD64_IMM pc=320 dst=r2 src=r0 offset=0 imm=-4
 #line 117 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_MOV64_REG pc=335 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=321 dst=r3 src=r10 offset=0 imm=0
 #line 117 "sample/map.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=336 dst=r3 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=322 dst=r3 src=r0 offset=0 imm=-8
 #line 117 "sample/map.c"
     r3 += IMMEDIATE(-8);
-    // EBPF_OP_LDDW pc=337 dst=r1 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_LDDW pc=323 dst=r1 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r1 = POINTER(_maps[4].address);
-    // EBPF_OP_MOV64_IMM pc=339 dst=r4 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=325 dst=r4 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=340 dst=r0 src=r0 offset=0 imm=2
-#line 122 "sample/map.c"
+    // EBPF_OP_CALL pc=326 dst=r0 src=r0 offset=0 imm=2
+#line 131 "sample/map.c"
     r0 = test_maps_helpers[0].address
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
-#line 122 "sample/map.c"
+#line 131 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=341 dst=r6 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=327 dst=r6 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=342 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=343 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=344 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=345 dst=r1 src=r0 offset=-25 imm=-1
-#line 123 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 123 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=328 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=329 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=330 dst=r7 src=r6 offset=144 imm=0
+#line 132 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 132 "sample/map.c"
         goto label_13;
-        // EBPF_OP_JA pc=346 dst=r0 src=r0 offset=-301 imm=0
-#line 123 "sample/map.c"
-    goto label_1;
-label_15:
-    // EBPF_OP_LDXW pc=347 dst=r1 src=r10 offset=-4 imm=0
-#line 121 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_ADD64_IMM pc=348 dst=r1 src=r0 offset=0 imm=1
-#line 121 "sample/map.c"
-    r1 += IMMEDIATE(1);
-    // EBPF_OP_STXW pc=349 dst=r10 src=r1 offset=-4 imm=0
-#line 121 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_LSH64_IMM pc=350 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=351 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JGT_REG pc=352 dst=r7 src=r1 offset=16 imm=0
-#line 121 "sample/map.c"
-    if (r7 > r1)
-#line 121 "sample/map.c"
-        goto label_16;
-        // EBPF_OP_MOV64_IMM pc=353 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=354 dst=r10 src=r1 offset=-4 imm=0
-#line 173 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=355 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+        // EBPF_OP_STXW pc=331 dst=r10 src=r8 offset=-4 imm=0
+#line 136 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=332 dst=r2 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=356 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=333 dst=r2 src=r0 offset=0 imm=-4
+#line 136 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=357 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=359 dst=r0 src=r0 offset=0 imm=18
-#line 173 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 173 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 173 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 173 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=360 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = r0;
-    // EBPF_OP_LSH64_IMM pc=361 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=362 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=363 dst=r6 src=r0 offset=0 imm=-1
-#line 173 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-    // EBPF_OP_LDDW pc=364 dst=r2 src=r0 offset=0 imm=-7
-#line 173 "sample/map.c"
-    r2 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=366 dst=r1 src=r2 offset=16 imm=0
-#line 173 "sample/map.c"
-    if (r1 == r2)
-#line 173 "sample/map.c"
-        goto label_17;
-        // EBPF_OP_MOV64_REG pc=367 dst=r6 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_JA pc=368 dst=r0 src=r0 offset=14 imm=0
-#line 173 "sample/map.c"
-    goto label_17;
-label_16:
-    // EBPF_OP_MOV64_REG pc=369 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=370 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_MOV64_REG pc=371 dst=r3 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=334 dst=r3 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=372 dst=r3 src=r0 offset=0 imm=-8
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=335 dst=r3 src=r0 offset=0 imm=-8
+#line 136 "sample/map.c"
     r3 += IMMEDIATE(-8);
-    // EBPF_OP_LDDW pc=373 dst=r1 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = POINTER(_maps[5].address);
-    // EBPF_OP_MOV64_IMM pc=375 dst=r4 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+    // EBPF_OP_LDDW pc=336 dst=r1 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=338 dst=r4 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=376 dst=r0 src=r0 offset=0 imm=2
-#line 122 "sample/map.c"
+    // EBPF_OP_CALL pc=339 dst=r0 src=r0 offset=0 imm=2
+#line 137 "sample/map.c"
     r0 = test_maps_helpers[0].address
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
     if ((test_maps_helpers[0].tail_call) && (r0 == 0))
-#line 122 "sample/map.c"
+#line 137 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=377 dst=r6 src=r0 offset=0 imm=0
-#line 122 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=340 dst=r6 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=378 dst=r1 src=r6 offset=0 imm=0
-#line 122 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=379 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=380 dst=r1 src=r0 offset=0 imm=32
-#line 122 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=381 dst=r1 src=r0 offset=-35 imm=-1
-#line 123 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 123 "sample/map.c"
-        goto label_15;
-        // EBPF_OP_JA pc=382 dst=r0 src=r0 offset=-337 imm=0
-#line 123 "sample/map.c"
-    goto label_1;
-label_17:
-    // EBPF_OP_JNE_REG pc=383 dst=r1 src=r2 offset=170 imm=0
-#line 123 "sample/map.c"
-    if (r1 != r2)
-#line 123 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_LDXW pc=384 dst=r1 src=r10 offset=-4 imm=0
-#line 123 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JNE_IMM pc=385 dst=r1 src=r0 offset=168 imm=0
-#line 123 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 123 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=386 dst=r1 src=r0 offset=0 imm=0
-#line 123 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=387 dst=r10 src=r1 offset=-4 imm=0
-#line 174 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=388 dst=r2 src=r10 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=389 dst=r2 src=r0 offset=0 imm=-4
-#line 174 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=390 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=392 dst=r0 src=r0 offset=0 imm=17
-#line 174 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 174 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 174 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 174 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=393 dst=r1 src=r10 offset=-4 imm=0
-#line 174 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=394 dst=r7 src=r6 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JEQ_IMM pc=395 dst=r1 src=r0 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_18;
-        // EBPF_OP_MOV64_IMM pc=396 dst=r7 src=r0 offset=0 imm=-1
-#line 174 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_18:
-    // EBPF_OP_MOV64_REG pc=397 dst=r2 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=398 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=399 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=400 dst=r3 src=r0 offset=0 imm=-7
-#line 174 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=402 dst=r2 src=r3 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r2 == r3)
-#line 174 "sample/map.c"
-        goto label_19;
-        // EBPF_OP_MOV64_REG pc=403 dst=r7 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r0;
-label_19:
-    // EBPF_OP_MOV64_REG pc=404 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JNE_REG pc=405 dst=r2 src=r3 offset=148 imm=0
-#line 174 "sample/map.c"
-    if (r2 != r3)
-#line 174 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_REG pc=406 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JNE_IMM pc=407 dst=r1 src=r0 offset=146 imm=0
-#line 174 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=408 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=409 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=410 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=411 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=412 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=414 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=415 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=416 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=417 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=418 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=419 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=420 dst=r1 src=r0 offset=133 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=421 dst=r1 src=r0 offset=0 imm=1
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=422 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=423 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=424 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=425 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=427 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=428 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=429 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=430 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=431 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=432 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=433 dst=r1 src=r0 offset=1 imm=0
-#line 177 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_20;
-        // EBPF_OP_JA pc=434 dst=r0 src=r0 offset=119 imm=0
-#line 177 "sample/map.c"
-    goto label_21;
-label_20:
-    // EBPF_OP_MOV64_IMM pc=435 dst=r1 src=r0 offset=0 imm=2
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=341 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=342 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=343 dst=r7 src=r6 offset=131 imm=0
+#line 138 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 138 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=344 dst=r1 src=r0 offset=0 imm=2
+#line 138 "sample/map.c"
     r1 = IMMEDIATE(2);
-    // EBPF_OP_STXW pc=436 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=345 dst=r10 src=r1 offset=-4 imm=0
+#line 142 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=437 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=346 dst=r2 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=438 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=347 dst=r2 src=r0 offset=0 imm=-4
+#line 142 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=439 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=441 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=442 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=348 dst=r3 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=349 dst=r3 src=r0 offset=0 imm=-8
+#line 142 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=350 dst=r7 src=r0 offset=0 imm=0
+#line 142 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=351 dst=r1 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=353 dst=r4 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=354 dst=r0 src=r0 offset=0 imm=2
+#line 143 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 143 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 143 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 143 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=443 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=355 dst=r6 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=444 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=445 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=446 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=447 dst=r1 src=r0 offset=106 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=448 dst=r1 src=r0 offset=0 imm=3
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=356 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=357 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=358 dst=r7 src=r6 offset=116 imm=0
+#line 144 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 144 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=359 dst=r1 src=r0 offset=0 imm=3
+#line 144 "sample/map.c"
     r1 = IMMEDIATE(3);
-    // EBPF_OP_STXW pc=449 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=360 dst=r10 src=r1 offset=-4 imm=0
+#line 148 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=450 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=361 dst=r2 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=451 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=362 dst=r2 src=r0 offset=0 imm=-4
+#line 148 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=452 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=454 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=455 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=363 dst=r3 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=364 dst=r3 src=r0 offset=0 imm=-8
+#line 148 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=365 dst=r1 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=367 dst=r4 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=368 dst=r0 src=r0 offset=0 imm=2
+#line 149 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 149 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 149 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 149 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=369 dst=r6 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=370 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=371 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=372 dst=r7 src=r6 offset=102 imm=0
+#line 150 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 150 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=373 dst=r1 src=r0 offset=0 imm=4
+#line 150 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=374 dst=r10 src=r1 offset=-4 imm=0
+#line 154 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=375 dst=r2 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=376 dst=r2 src=r0 offset=0 imm=-4
+#line 154 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=377 dst=r3 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=378 dst=r3 src=r0 offset=0 imm=-8
+#line 154 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=379 dst=r7 src=r0 offset=0 imm=0
+#line 154 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=380 dst=r1 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=382 dst=r4 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=383 dst=r0 src=r0 offset=0 imm=2
+#line 155 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 155 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 155 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 155 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=384 dst=r6 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=385 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=386 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=387 dst=r7 src=r6 offset=87 imm=0
+#line 156 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 156 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=388 dst=r1 src=r0 offset=0 imm=5
+#line 156 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=389 dst=r10 src=r1 offset=-4 imm=0
+#line 160 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=390 dst=r2 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=391 dst=r2 src=r0 offset=0 imm=-4
+#line 160 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=392 dst=r3 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=393 dst=r3 src=r0 offset=0 imm=-8
+#line 160 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=394 dst=r1 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=396 dst=r4 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=397 dst=r0 src=r0 offset=0 imm=2
+#line 161 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 161 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 161 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 161 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=398 dst=r6 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=399 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=400 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=401 dst=r7 src=r6 offset=73 imm=0
+#line 162 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 162 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=402 dst=r1 src=r0 offset=0 imm=6
+#line 162 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=403 dst=r10 src=r1 offset=-4 imm=0
+#line 166 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=404 dst=r2 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=405 dst=r2 src=r0 offset=0 imm=-4
+#line 166 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=406 dst=r3 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=407 dst=r3 src=r0 offset=0 imm=-8
+#line 166 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=408 dst=r7 src=r0 offset=0 imm=0
+#line 166 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=409 dst=r1 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=411 dst=r4 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=412 dst=r0 src=r0 offset=0 imm=2
+#line 167 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 167 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 167 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 167 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=413 dst=r6 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=414 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=415 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=416 dst=r7 src=r6 offset=58 imm=0
+#line 168 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 168 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=417 dst=r1 src=r0 offset=0 imm=7
+#line 168 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=418 dst=r10 src=r1 offset=-4 imm=0
+#line 172 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=419 dst=r2 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=420 dst=r2 src=r0 offset=0 imm=-4
+#line 172 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=421 dst=r3 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=422 dst=r3 src=r0 offset=0 imm=-8
+#line 172 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=423 dst=r1 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=425 dst=r4 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=426 dst=r0 src=r0 offset=0 imm=2
+#line 173 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 173 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 173 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 173 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=427 dst=r6 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=428 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=429 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=430 dst=r7 src=r6 offset=44 imm=0
+#line 174 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 174 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=431 dst=r1 src=r0 offset=0 imm=8
+#line 174 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=432 dst=r10 src=r1 offset=-4 imm=0
+#line 178 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=433 dst=r2 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=434 dst=r2 src=r0 offset=0 imm=-4
+#line 178 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=435 dst=r3 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=436 dst=r3 src=r0 offset=0 imm=-8
+#line 178 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=437 dst=r7 src=r0 offset=0 imm=0
+#line 178 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=438 dst=r1 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=440 dst=r4 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=441 dst=r0 src=r0 offset=0 imm=2
+#line 179 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 179 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 179 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 179 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=442 dst=r6 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=443 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=444 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=445 dst=r7 src=r6 offset=29 imm=0
+#line 180 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 180 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=446 dst=r1 src=r0 offset=0 imm=9
+#line 180 "sample/map.c"
+    r1 = IMMEDIATE(9);
+    // EBPF_OP_STXW pc=447 dst=r10 src=r1 offset=-4 imm=0
+#line 184 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=448 dst=r2 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=449 dst=r2 src=r0 offset=0 imm=-4
+#line 184 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=450 dst=r3 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=451 dst=r3 src=r0 offset=0 imm=-8
+#line 184 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=452 dst=r1 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=454 dst=r4 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=455 dst=r0 src=r0 offset=0 imm=2
+#line 185 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 185 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 185 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 185 "sample/map.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=456 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+#line 185 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=457 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=458 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=459 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=460 dst=r1 src=r0 offset=93 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=461 dst=r1 src=r0 offset=0 imm=4
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(4);
-    // EBPF_OP_STXW pc=462 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=457 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=458 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=459 dst=r7 src=r6 offset=15 imm=0
+#line 186 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 186 "sample/map.c"
+        goto label_13;
+        // EBPF_OP_MOV64_IMM pc=460 dst=r1 src=r0 offset=0 imm=10
+#line 186 "sample/map.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=461 dst=r10 src=r1 offset=-4 imm=0
+#line 190 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=463 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=462 dst=r2 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=464 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=463 dst=r2 src=r0 offset=0 imm=-4
+#line 190 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=465 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=467 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=468 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=464 dst=r3 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=465 dst=r3 src=r0 offset=0 imm=-8
+#line 190 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=466 dst=r7 src=r0 offset=0 imm=0
+#line 190 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=467 dst=r1 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r1 = POINTER(_maps[4].address);
+    // EBPF_OP_MOV64_IMM pc=469 dst=r4 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=470 dst=r0 src=r0 offset=0 imm=2
+#line 191 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 191 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 191 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 191 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=469 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=471 dst=r6 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=470 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=471 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=472 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=473 dst=r1 src=r0 offset=80 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=474 dst=r1 src=r0 offset=0 imm=5
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(5);
-    // EBPF_OP_STXW pc=475 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=476 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=472 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=473 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=474 dst=r6 src=r0 offset=1 imm=-1
+#line 191 "sample/map.c"
+    if ((int64_t)r6 > IMMEDIATE(-1))
+#line 191 "sample/map.c"
+        goto label_14;
+label_13:
+    // EBPF_OP_JA pc=475 dst=r0 src=r0 offset=-430 imm=0
+#line 191 "sample/map.c"
+    goto label_1;
+label_14:
+    // EBPF_OP_STXW pc=476 dst=r10 src=r7 offset=-4 imm=0
+#line 116 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=477 dst=r8 src=r0 offset=0 imm=1
+#line 116 "sample/map.c"
+    r8 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=478 dst=r10 src=r8 offset=-8 imm=0
+#line 117 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=479 dst=r2 src=r10 offset=0 imm=0
+#line 117 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=477 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=480 dst=r2 src=r0 offset=0 imm=-4
+#line 117 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=478 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=480 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=481 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=481 dst=r3 src=r10 offset=0 imm=0
+#line 117 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=482 dst=r3 src=r0 offset=0 imm=-8
+#line 117 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=483 dst=r1 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=485 dst=r4 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=486 dst=r0 src=r0 offset=0 imm=2
+#line 131 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 131 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 131 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 131 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=482 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=487 dst=r6 src=r0 offset=0 imm=0
+#line 131 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=483 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=484 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=485 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=486 dst=r1 src=r0 offset=67 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=487 dst=r1 src=r0 offset=0 imm=6
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(6);
-    // EBPF_OP_STXW pc=488 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=489 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=490 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=491 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=493 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=494 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=495 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=496 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=497 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=498 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=499 dst=r1 src=r0 offset=54 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=500 dst=r1 src=r0 offset=0 imm=7
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(7);
-    // EBPF_OP_STXW pc=501 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=502 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=503 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=504 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=506 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=507 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=508 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=509 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=510 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=512 dst=r1 src=r0 offset=41 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=513 dst=r1 src=r0 offset=0 imm=8
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(8);
-    // EBPF_OP_STXW pc=514 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=515 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=516 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=517 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=519 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=520 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=521 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=522 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=523 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=524 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=525 dst=r1 src=r0 offset=28 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=526 dst=r1 src=r0 offset=0 imm=9
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(9);
-    // EBPF_OP_STXW pc=527 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=528 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=529 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=530 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=532 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=533 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=534 dst=r6 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=535 dst=r1 src=r6 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=536 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=537 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=538 dst=r1 src=r0 offset=15 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=539 dst=r8 src=r0 offset=0 imm=10
-#line 177 "sample/map.c"
-    r8 = IMMEDIATE(10);
-    // EBPF_OP_STXW pc=540 dst=r10 src=r8 offset=-4 imm=0
-#line 180 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=488 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=489 dst=r6 src=r0 offset=0 imm=32
+#line 131 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=490 dst=r7 src=r6 offset=145 imm=0
+#line 132 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 132 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_STXW pc=491 dst=r10 src=r8 offset=-4 imm=0
+#line 136 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=541 dst=r2 src=r10 offset=0 imm=0
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=492 dst=r2 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=542 dst=r2 src=r0 offset=0 imm=-4
-#line 180 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=493 dst=r2 src=r0 offset=0 imm=-4
+#line 136 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=543 dst=r1 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=545 dst=r3 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=546 dst=r0 src=r0 offset=0 imm=16
-#line 180 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=494 dst=r3 src=r10 offset=0 imm=0
+#line 136 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=495 dst=r3 src=r0 offset=0 imm=-8
+#line 136 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=496 dst=r7 src=r0 offset=0 imm=0
+#line 136 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=497 dst=r1 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=499 dst=r4 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=500 dst=r0 src=r0 offset=0 imm=2
+#line 137 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 137 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 180 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 180 "sample/map.c"
+#line 137 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 137 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=547 dst=r6 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=501 dst=r6 src=r0 offset=0 imm=0
+#line 137 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=548 dst=r1 src=r6 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=549 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=550 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=551 dst=r2 src=r0 offset=0 imm=-29
-#line 180 "sample/map.c"
-    r2 = (uint64_t)4294967267;
-    // EBPF_OP_JEQ_REG pc=553 dst=r1 src=r2 offset=198 imm=0
-#line 180 "sample/map.c"
-    if (r1 == r2)
-#line 180 "sample/map.c"
-        goto label_29;
-label_21:
-    // EBPF_OP_MOV64_REG pc=554 dst=r1 src=r6 offset=0 imm=0
-#line 208 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=555 dst=r1 src=r0 offset=0 imm=32
-#line 208 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=556 dst=r1 src=r0 offset=0 imm=32
-#line 208 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=557 dst=r2 src=r0 offset=0 imm=0
-#line 208 "sample/map.c"
-    r2 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=558 dst=r2 src=r1 offset=-513 imm=0
-#line 208 "sample/map.c"
-    if ((int64_t)r2 > (int64_t)r1)
-#line 208 "sample/map.c"
-        goto label_1;
-label_22:
-    // EBPF_OP_MOV64_IMM pc=559 dst=r1 src=r0 offset=0 imm=0
-#line 208 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=560 dst=r10 src=r1 offset=-4 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=502 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=503 dst=r6 src=r0 offset=0 imm=32
+#line 137 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=504 dst=r7 src=r6 offset=131 imm=0
+#line 138 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 138 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=505 dst=r1 src=r0 offset=0 imm=2
+#line 138 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=506 dst=r10 src=r1 offset=-4 imm=0
+#line 142 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=561 dst=r2 src=r10 offset=0 imm=0
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=507 dst=r2 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=562 dst=r2 src=r0 offset=0 imm=-4
-#line 173 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=508 dst=r2 src=r0 offset=0 imm=-4
+#line 142 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=563 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=565 dst=r0 src=r0 offset=0 imm=18
-#line 173 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 173 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=509 dst=r3 src=r10 offset=0 imm=0
+#line 142 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=510 dst=r3 src=r0 offset=0 imm=-8
+#line 142 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=511 dst=r1 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=513 dst=r4 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=514 dst=r0 src=r0 offset=0 imm=2
+#line 143 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 143 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 173 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 173 "sample/map.c"
+#line 143 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 143 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=566 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = r0;
-    // EBPF_OP_LSH64_IMM pc=567 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=568 dst=r1 src=r0 offset=0 imm=32
-#line 173 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_MOV64_IMM pc=569 dst=r7 src=r0 offset=0 imm=-1
-#line 173 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-    // EBPF_OP_LDDW pc=570 dst=r2 src=r0 offset=0 imm=-7
-#line 173 "sample/map.c"
-    r2 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=572 dst=r1 src=r2 offset=1 imm=0
-#line 173 "sample/map.c"
-    if (r1 == r2)
-#line 173 "sample/map.c"
-        goto label_23;
-        // EBPF_OP_MOV64_REG pc=573 dst=r7 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r7 = r0;
-label_23:
-    // EBPF_OP_JNE_REG pc=574 dst=r1 src=r2 offset=170 imm=0
-#line 173 "sample/map.c"
-    if (r1 != r2)
-#line 173 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_LDXW pc=575 dst=r1 src=r10 offset=-4 imm=0
-#line 173 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JNE_IMM pc=576 dst=r1 src=r0 offset=168 imm=0
-#line 173 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 173 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=577 dst=r1 src=r0 offset=0 imm=0
-#line 173 "sample/map.c"
-    r1 = IMMEDIATE(0);
+        // EBPF_OP_MOV64_REG pc=515 dst=r6 src=r0 offset=0 imm=0
+#line 143 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=516 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=517 dst=r6 src=r0 offset=0 imm=32
+#line 143 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=518 dst=r7 src=r6 offset=117 imm=0
+#line 144 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 144 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=519 dst=r1 src=r0 offset=0 imm=3
+#line 144 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=520 dst=r10 src=r1 offset=-4 imm=0
+#line 148 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=521 dst=r2 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=522 dst=r2 src=r0 offset=0 imm=-4
+#line 148 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=523 dst=r3 src=r10 offset=0 imm=0
+#line 148 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=524 dst=r3 src=r0 offset=0 imm=-8
+#line 148 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=525 dst=r7 src=r0 offset=0 imm=0
+#line 148 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=526 dst=r1 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=528 dst=r4 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=529 dst=r0 src=r0 offset=0 imm=2
+#line 149 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 149 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 149 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 149 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=530 dst=r6 src=r0 offset=0 imm=0
+#line 149 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=531 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=532 dst=r6 src=r0 offset=0 imm=32
+#line 149 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=533 dst=r7 src=r6 offset=102 imm=0
+#line 150 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 150 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=534 dst=r1 src=r0 offset=0 imm=4
+#line 150 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=535 dst=r10 src=r1 offset=-4 imm=0
+#line 154 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=536 dst=r2 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=537 dst=r2 src=r0 offset=0 imm=-4
+#line 154 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=538 dst=r3 src=r10 offset=0 imm=0
+#line 154 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=539 dst=r3 src=r0 offset=0 imm=-8
+#line 154 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=540 dst=r1 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=542 dst=r4 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=543 dst=r0 src=r0 offset=0 imm=2
+#line 155 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 155 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 155 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 155 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=544 dst=r6 src=r0 offset=0 imm=0
+#line 155 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=545 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=546 dst=r6 src=r0 offset=0 imm=32
+#line 155 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=547 dst=r7 src=r6 offset=88 imm=0
+#line 156 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 156 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=548 dst=r1 src=r0 offset=0 imm=5
+#line 156 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=549 dst=r10 src=r1 offset=-4 imm=0
+#line 160 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=550 dst=r2 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=551 dst=r2 src=r0 offset=0 imm=-4
+#line 160 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=552 dst=r3 src=r10 offset=0 imm=0
+#line 160 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=553 dst=r3 src=r0 offset=0 imm=-8
+#line 160 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=554 dst=r7 src=r0 offset=0 imm=0
+#line 160 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=555 dst=r1 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=557 dst=r4 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=558 dst=r0 src=r0 offset=0 imm=2
+#line 161 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 161 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 161 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 161 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=559 dst=r6 src=r0 offset=0 imm=0
+#line 161 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=560 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=561 dst=r6 src=r0 offset=0 imm=32
+#line 161 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=562 dst=r7 src=r6 offset=73 imm=0
+#line 162 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 162 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=563 dst=r1 src=r0 offset=0 imm=6
+#line 162 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=564 dst=r10 src=r1 offset=-4 imm=0
+#line 166 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=565 dst=r2 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=566 dst=r2 src=r0 offset=0 imm=-4
+#line 166 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_MOV64_REG pc=567 dst=r3 src=r10 offset=0 imm=0
+#line 166 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=568 dst=r3 src=r0 offset=0 imm=-8
+#line 166 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=569 dst=r1 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=571 dst=r4 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=572 dst=r0 src=r0 offset=0 imm=2
+#line 167 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 167 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 167 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 167 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=573 dst=r6 src=r0 offset=0 imm=0
+#line 167 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=574 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=575 dst=r6 src=r0 offset=0 imm=32
+#line 167 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=576 dst=r7 src=r6 offset=59 imm=0
+#line 168 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 168 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=577 dst=r1 src=r0 offset=0 imm=7
+#line 168 "sample/map.c"
+    r1 = IMMEDIATE(7);
     // EBPF_OP_STXW pc=578 dst=r10 src=r1 offset=-4 imm=0
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=579 dst=r2 src=r10 offset=0 imm=0
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=580 dst=r2 src=r0 offset=0 imm=-4
-#line 174 "sample/map.c"
+#line 172 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=581 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=583 dst=r0 src=r0 offset=0 imm=17
-#line 174 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 174 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=581 dst=r3 src=r10 offset=0 imm=0
+#line 172 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=582 dst=r3 src=r0 offset=0 imm=-8
+#line 172 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=583 dst=r7 src=r0 offset=0 imm=0
+#line 172 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=584 dst=r1 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=586 dst=r4 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=587 dst=r0 src=r0 offset=0 imm=2
+#line 173 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 173 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 174 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 174 "sample/map.c"
+#line 173 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 173 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=584 dst=r1 src=r10 offset=-4 imm=0
-#line 174 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=585 dst=r6 src=r7 offset=0 imm=0
-#line 174 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JEQ_IMM pc=586 dst=r1 src=r0 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_24;
-        // EBPF_OP_MOV64_IMM pc=587 dst=r6 src=r0 offset=0 imm=-1
-#line 174 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_24:
-    // EBPF_OP_MOV64_REG pc=588 dst=r2 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=589 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=590 dst=r2 src=r0 offset=0 imm=32
-#line 174 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=591 dst=r3 src=r0 offset=0 imm=-7
-#line 174 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=593 dst=r2 src=r3 offset=1 imm=0
-#line 174 "sample/map.c"
-    if (r2 == r3)
-#line 174 "sample/map.c"
-        goto label_25;
-        // EBPF_OP_MOV64_REG pc=594 dst=r6 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=588 dst=r6 src=r0 offset=0 imm=0
+#line 173 "sample/map.c"
     r6 = r0;
-label_25:
-    // EBPF_OP_MOV64_REG pc=595 dst=r7 src=r6 offset=0 imm=0
+    // EBPF_OP_LSH64_IMM pc=589 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=590 dst=r6 src=r0 offset=0 imm=32
+#line 173 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=591 dst=r7 src=r6 offset=44 imm=0
 #line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JNE_REG pc=596 dst=r2 src=r3 offset=148 imm=0
+    if ((int64_t)r7 > (int64_t)r6)
 #line 174 "sample/map.c"
-    if (r2 != r3)
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=592 dst=r1 src=r0 offset=0 imm=8
 #line 174 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_REG pc=597 dst=r7 src=r6 offset=0 imm=0
-#line 174 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JNE_IMM pc=598 dst=r1 src=r0 offset=146 imm=0
-#line 174 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 174 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=599 dst=r1 src=r0 offset=0 imm=0
-#line 174 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=600 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=601 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=602 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=603 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=605 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=606 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=607 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=608 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=609 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=610 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=611 dst=r1 src=r0 offset=133 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=612 dst=r1 src=r0 offset=0 imm=1
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_STXW pc=613 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=614 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=615 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=616 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=618 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=619 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=620 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=621 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=622 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=623 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=624 dst=r1 src=r0 offset=1 imm=0
-#line 177 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_26;
-        // EBPF_OP_JA pc=625 dst=r0 src=r0 offset=119 imm=0
-#line 177 "sample/map.c"
-    goto label_27;
-label_26:
-    // EBPF_OP_MOV64_IMM pc=626 dst=r1 src=r0 offset=0 imm=2
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(2);
-    // EBPF_OP_STXW pc=627 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=628 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=629 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=630 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=632 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=633 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=634 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=635 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=636 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=637 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=638 dst=r1 src=r0 offset=106 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=639 dst=r1 src=r0 offset=0 imm=3
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(3);
-    // EBPF_OP_STXW pc=640 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=641 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=642 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=643 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=645 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=646 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=647 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=648 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=649 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=650 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=651 dst=r1 src=r0 offset=93 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=652 dst=r1 src=r0 offset=0 imm=4
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(4);
-    // EBPF_OP_STXW pc=653 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=654 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=655 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=656 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=658 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=659 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=660 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=661 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=662 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=663 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=664 dst=r1 src=r0 offset=80 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=665 dst=r1 src=r0 offset=0 imm=5
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(5);
-    // EBPF_OP_STXW pc=666 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=667 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=668 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=669 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=671 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=672 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=673 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=674 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=675 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=676 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=677 dst=r1 src=r0 offset=67 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=678 dst=r1 src=r0 offset=0 imm=6
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(6);
-    // EBPF_OP_STXW pc=679 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=680 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=681 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=682 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=684 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=685 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=686 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=687 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=688 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=689 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=690 dst=r1 src=r0 offset=54 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=691 dst=r1 src=r0 offset=0 imm=7
-#line 177 "sample/map.c"
-    r1 = IMMEDIATE(7);
-    // EBPF_OP_STXW pc=692 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=693 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=694 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=695 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=697 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=698 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=699 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=700 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=701 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=702 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=703 dst=r1 src=r0 offset=41 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=704 dst=r1 src=r0 offset=0 imm=8
-#line 177 "sample/map.c"
     r1 = IMMEDIATE(8);
-    // EBPF_OP_STXW pc=705 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=593 dst=r10 src=r1 offset=-4 imm=0
+#line 178 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=706 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=594 dst=r2 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=707 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=595 dst=r2 src=r0 offset=0 imm=-4
+#line 178 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=708 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=710 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=711 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=596 dst=r3 src=r10 offset=0 imm=0
+#line 178 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=597 dst=r3 src=r0 offset=0 imm=-8
+#line 178 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_LDDW pc=598 dst=r1 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=600 dst=r4 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=601 dst=r0 src=r0 offset=0 imm=2
+#line 179 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 179 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 179 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 179 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=712 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=713 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=714 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=715 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=716 dst=r1 src=r0 offset=28 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=717 dst=r1 src=r0 offset=0 imm=9
-#line 177 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=602 dst=r6 src=r0 offset=0 imm=0
+#line 179 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=603 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=604 dst=r6 src=r0 offset=0 imm=32
+#line 179 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=605 dst=r7 src=r6 offset=30 imm=0
+#line 180 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 180 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=606 dst=r1 src=r0 offset=0 imm=9
+#line 180 "sample/map.c"
     r1 = IMMEDIATE(9);
-    // EBPF_OP_STXW pc=718 dst=r10 src=r1 offset=-4 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_STXW pc=607 dst=r10 src=r1 offset=-4 imm=0
+#line 184 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=719 dst=r2 src=r10 offset=0 imm=0
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=608 dst=r2 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=720 dst=r2 src=r0 offset=0 imm=-4
-#line 177 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=609 dst=r2 src=r0 offset=0 imm=-4
+#line 184 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=721 dst=r1 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=723 dst=r3 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=724 dst=r0 src=r0 offset=0 imm=16
-#line 177 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 177 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=610 dst=r3 src=r10 offset=0 imm=0
+#line 184 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=611 dst=r3 src=r0 offset=0 imm=-8
+#line 184 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=612 dst=r7 src=r0 offset=0 imm=0
+#line 184 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=613 dst=r1 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=615 dst=r4 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=616 dst=r0 src=r0 offset=0 imm=2
+#line 185 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 185 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 177 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 177 "sample/map.c"
+#line 185 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 185 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=725 dst=r7 src=r0 offset=0 imm=0
-#line 177 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=726 dst=r1 src=r7 offset=0 imm=0
-#line 177 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=727 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=728 dst=r1 src=r0 offset=0 imm=32
-#line 177 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=729 dst=r1 src=r0 offset=15 imm=0
-#line 177 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 177 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=730 dst=r8 src=r0 offset=0 imm=10
-#line 177 "sample/map.c"
-    r8 = IMMEDIATE(10);
-    // EBPF_OP_STXW pc=731 dst=r10 src=r8 offset=-4 imm=0
-#line 180 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=732 dst=r2 src=r10 offset=0 imm=0
-#line 180 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=617 dst=r6 src=r0 offset=0 imm=0
+#line 185 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=618 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=619 dst=r6 src=r0 offset=0 imm=32
+#line 185 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_REG pc=620 dst=r7 src=r6 offset=15 imm=0
+#line 186 "sample/map.c"
+    if ((int64_t)r7 > (int64_t)r6)
+#line 186 "sample/map.c"
+        goto label_15;
+        // EBPF_OP_MOV64_IMM pc=621 dst=r1 src=r0 offset=0 imm=10
+#line 186 "sample/map.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=622 dst=r10 src=r1 offset=-4 imm=0
+#line 190 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=623 dst=r2 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=733 dst=r2 src=r0 offset=0 imm=-4
-#line 180 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=624 dst=r2 src=r0 offset=0 imm=-4
+#line 190 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=734 dst=r1 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=736 dst=r3 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=737 dst=r0 src=r0 offset=0 imm=16
-#line 180 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 180 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=625 dst=r3 src=r10 offset=0 imm=0
+#line 190 "sample/map.c"
+    r3 = r10;
+    // EBPF_OP_ADD64_IMM pc=626 dst=r3 src=r0 offset=0 imm=-8
+#line 190 "sample/map.c"
+    r3 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_IMM pc=627 dst=r7 src=r0 offset=0 imm=0
+#line 190 "sample/map.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_LDDW pc=628 dst=r1 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r1 = POINTER(_maps[5].address);
+    // EBPF_OP_MOV64_IMM pc=630 dst=r4 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=631 dst=r0 src=r0 offset=0 imm=2
+#line 191 "sample/map.c"
+    r0 = test_maps_helpers[0].address
+#line 191 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 180 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 180 "sample/map.c"
+#line 191 "sample/map.c"
+    if ((test_maps_helpers[0].tail_call) && (r0 == 0))
+#line 191 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=738 dst=r7 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=739 dst=r1 src=r7 offset=0 imm=0
-#line 180 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=740 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=741 dst=r1 src=r0 offset=0 imm=32
-#line 180 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=742 dst=r2 src=r0 offset=0 imm=-29
-#line 180 "sample/map.c"
-    r2 = (uint64_t)4294967267;
-    // EBPF_OP_JEQ_REG pc=744 dst=r1 src=r2 offset=34 imm=0
-#line 180 "sample/map.c"
-    if (r1 == r2)
-#line 180 "sample/map.c"
-        goto label_31;
-label_27:
-    // EBPF_OP_MOV64_IMM pc=745 dst=r6 src=r0 offset=0 imm=0
-#line 180 "sample/map.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_REG pc=746 dst=r1 src=r7 offset=0 imm=0
-#line 209 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=747 dst=r1 src=r0 offset=0 imm=32
-#line 209 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_ARSH64_IMM pc=748 dst=r1 src=r0 offset=0 imm=32
-#line 209 "sample/map.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
-    // EBPF_OP_JSGT_IMM pc=749 dst=r1 src=r0 offset=-704 imm=-1
-#line 209 "sample/map.c"
-    if ((int64_t)r1 > IMMEDIATE(-1))
-#line 209 "sample/map.c"
-        goto label_1;
-label_28:
-    // EBPF_OP_MOV64_REG pc=750 dst=r6 src=r7 offset=0 imm=0
-#line 209 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JA pc=751 dst=r0 src=r0 offset=-706 imm=0
-#line 209 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=632 dst=r6 src=r0 offset=0 imm=0
+#line 191 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_LSH64_IMM pc=633 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=634 dst=r6 src=r0 offset=0 imm=32
+#line 191 "sample/map.c"
+    r6 = (int64_t)r6 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=635 dst=r6 src=r0 offset=1 imm=-1
+#line 191 "sample/map.c"
+    if ((int64_t)r6 > IMMEDIATE(-1))
+#line 191 "sample/map.c"
+        goto label_16;
+label_15:
+    // EBPF_OP_JA pc=636 dst=r0 src=r0 offset=-591 imm=0
+#line 191 "sample/map.c"
     goto label_1;
-label_29:
-    // EBPF_OP_STXW pc=752 dst=r10 src=r8 offset=-4 imm=0
-#line 181 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=753 dst=r2 src=r10 offset=0 imm=0
-#line 181 "sample/map.c"
+label_16:
+    // EBPF_OP_STXW pc=637 dst=r10 src=r7 offset=-4 imm=0
+#line 242 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_REG pc=638 dst=r2 src=r10 offset=0 imm=0
+#line 242 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=754 dst=r2 src=r0 offset=0 imm=-4
-#line 181 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=639 dst=r2 src=r0 offset=0 imm=-4
+#line 242 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=755 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
+    // EBPF_OP_LDDW pc=640 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_MOV64_IMM pc=757 dst=r3 src=r0 offset=0 imm=2
-#line 181 "sample/map.c"
-    r3 = IMMEDIATE(2);
-    // EBPF_OP_CALL pc=758 dst=r0 src=r0 offset=0 imm=16
-#line 181 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 181 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 181 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 181 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=759 dst=r6 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=760 dst=r1 src=r6 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=761 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=762 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=763 dst=r1 src=r0 offset=1 imm=0
-#line 181 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_30;
-        // EBPF_OP_MOV64_REG pc=764 dst=r7 src=r6 offset=0 imm=0
-#line 181 "sample/map.c"
-    r7 = r6;
-label_30:
-    // EBPF_OP_JNE_IMM pc=765 dst=r1 src=r0 offset=-212 imm=0
-#line 181 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_MOV64_IMM pc=766 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=767 dst=r10 src=r1 offset=-4 imm=0
-#line 183 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=768 dst=r2 src=r10 offset=0 imm=0
-#line 183 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=769 dst=r2 src=r0 offset=0 imm=-4
-#line 183 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=770 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=772 dst=r0 src=r0 offset=0 imm=18
-#line 183 "sample/map.c"
+    // EBPF_OP_CALL pc=642 dst=r0 src=r0 offset=0 imm=18
+#line 242 "sample/map.c"
     r0 = test_maps_helpers[4].address
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
     if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 183 "sample/map.c"
+#line 242 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=773 dst=r6 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=643 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=644 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=645 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=646 dst=r6 src=r0 offset=0 imm=-1
+#line 242 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+    // EBPF_OP_LDDW pc=647 dst=r2 src=r0 offset=0 imm=-7
+#line 242 "sample/map.c"
+    r2 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=649 dst=r1 src=r2 offset=1 imm=0
+#line 242 "sample/map.c"
+    if (r1 == r2)
+#line 242 "sample/map.c"
+        goto label_17;
+        // EBPF_OP_MOV64_REG pc=650 dst=r6 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=774 dst=r1 src=r6 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=775 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=776 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=777 dst=r1 src=r0 offset=28 imm=0
-#line 183 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 183 "sample/map.c"
-        goto label_33;
-        // EBPF_OP_JA pc=778 dst=r0 src=r0 offset=-225 imm=0
-#line 183 "sample/map.c"
-    goto label_21;
-label_31:
-    // EBPF_OP_STXW pc=779 dst=r10 src=r8 offset=-4 imm=0
-#line 181 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
-    // EBPF_OP_MOV64_REG pc=780 dst=r2 src=r10 offset=0 imm=0
-#line 181 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=781 dst=r2 src=r0 offset=0 imm=-4
-#line 181 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=782 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_MOV64_IMM pc=784 dst=r3 src=r0 offset=0 imm=2
-#line 181 "sample/map.c"
-    r3 = IMMEDIATE(2);
-    // EBPF_OP_CALL pc=785 dst=r0 src=r0 offset=0 imm=16
-#line 181 "sample/map.c"
-    r0 = test_maps_helpers[6].address
-#line 181 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 181 "sample/map.c"
-    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
-#line 181 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=786 dst=r7 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=787 dst=r1 src=r7 offset=0 imm=0
-#line 181 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=788 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=789 dst=r1 src=r0 offset=0 imm=32
-#line 181 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=790 dst=r1 src=r0 offset=1 imm=0
-#line 181 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_32;
-        // EBPF_OP_MOV64_REG pc=791 dst=r6 src=r7 offset=0 imm=0
-#line 181 "sample/map.c"
-    r6 = r7;
-label_32:
-    // EBPF_OP_JNE_IMM pc=792 dst=r1 src=r0 offset=-48 imm=0
-#line 181 "sample/map.c"
+label_17:
+    // EBPF_OP_JNE_REG pc=651 dst=r1 src=r2 offset=409 imm=0
+#line 242 "sample/map.c"
+    if (r1 != r2)
+#line 242 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_LDXW pc=652 dst=r1 src=r10 offset=-4 imm=0
+#line 242 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=653 dst=r1 src=r0 offset=407 imm=0
+#line 242 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 181 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_MOV64_IMM pc=793 dst=r1 src=r0 offset=0 imm=0
-#line 181 "sample/map.c"
+#line 242 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=654 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
     r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=655 dst=r10 src=r1 offset=-4 imm=0
+#line 243 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=656 dst=r2 src=r10 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=657 dst=r2 src=r0 offset=0 imm=-4
+#line 243 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=658 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=660 dst=r0 src=r0 offset=0 imm=17
+#line 243 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 243 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 243 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 243 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=661 dst=r1 src=r10 offset=-4 imm=0
+#line 243 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=662 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JEQ_IMM pc=663 dst=r1 src=r0 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_18;
+        // EBPF_OP_MOV64_IMM pc=664 dst=r7 src=r0 offset=0 imm=-1
+#line 243 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_18:
+    // EBPF_OP_MOV64_REG pc=665 dst=r2 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=666 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=667 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=668 dst=r3 src=r0 offset=0 imm=-7
+#line 243 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=670 dst=r2 src=r3 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r2 == r3)
+#line 243 "sample/map.c"
+        goto label_19;
+        // EBPF_OP_MOV64_REG pc=671 dst=r7 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r0;
+label_19:
+    // EBPF_OP_MOV64_REG pc=672 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JNE_REG pc=673 dst=r2 src=r3 offset=387 imm=0
+#line 243 "sample/map.c"
+    if (r2 != r3)
+#line 243 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_REG pc=674 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JNE_IMM pc=675 dst=r1 src=r0 offset=385 imm=0
+#line 243 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=676 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=677 dst=r10 src=r1 offset=-4 imm=0
+#line 251 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=678 dst=r2 src=r10 offset=0 imm=0
+#line 251 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=679 dst=r2 src=r0 offset=0 imm=-4
+#line 251 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=680 dst=r1 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=682 dst=r3 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=683 dst=r0 src=r0 offset=0 imm=16
+#line 251 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 251 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 251 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 251 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=684 dst=r6 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=685 dst=r1 src=r6 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=686 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=687 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=688 dst=r1 src=r0 offset=372 imm=0
+#line 251 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 251 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=689 dst=r1 src=r0 offset=0 imm=1
+#line 251 "sample/map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=690 dst=r10 src=r1 offset=-4 imm=0
+#line 252 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=691 dst=r2 src=r10 offset=0 imm=0
+#line 252 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=692 dst=r2 src=r0 offset=0 imm=-4
+#line 252 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=693 dst=r1 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=695 dst=r3 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=696 dst=r0 src=r0 offset=0 imm=16
+#line 252 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 252 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 252 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 252 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=697 dst=r6 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=698 dst=r1 src=r6 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=699 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=700 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=701 dst=r1 src=r0 offset=359 imm=0
+#line 252 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 252 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=702 dst=r1 src=r0 offset=0 imm=2
+#line 252 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=703 dst=r10 src=r1 offset=-4 imm=0
+#line 253 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=704 dst=r2 src=r10 offset=0 imm=0
+#line 253 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=705 dst=r2 src=r0 offset=0 imm=-4
+#line 253 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=706 dst=r1 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=708 dst=r3 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=709 dst=r0 src=r0 offset=0 imm=16
+#line 253 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 253 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 253 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 253 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=710 dst=r6 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=711 dst=r1 src=r6 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=712 dst=r1 src=r0 offset=0 imm=32
+#line 253 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=713 dst=r1 src=r0 offset=0 imm=32
+#line 253 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=714 dst=r1 src=r0 offset=346 imm=0
+#line 253 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 253 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=715 dst=r1 src=r0 offset=0 imm=3
+#line 253 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=716 dst=r10 src=r1 offset=-4 imm=0
+#line 254 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=717 dst=r2 src=r10 offset=0 imm=0
+#line 254 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=718 dst=r2 src=r0 offset=0 imm=-4
+#line 254 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=719 dst=r1 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=721 dst=r3 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=722 dst=r0 src=r0 offset=0 imm=16
+#line 254 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 254 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 254 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 254 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=723 dst=r6 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=724 dst=r1 src=r6 offset=0 imm=0
+#line 254 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=725 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=726 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=727 dst=r1 src=r0 offset=333 imm=0
+#line 254 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 254 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=728 dst=r1 src=r0 offset=0 imm=4
+#line 254 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=729 dst=r10 src=r1 offset=-4 imm=0
+#line 255 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=730 dst=r2 src=r10 offset=0 imm=0
+#line 255 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=731 dst=r2 src=r0 offset=0 imm=-4
+#line 255 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=732 dst=r1 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=734 dst=r3 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=735 dst=r0 src=r0 offset=0 imm=16
+#line 255 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 255 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 255 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 255 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=736 dst=r6 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=737 dst=r1 src=r6 offset=0 imm=0
+#line 255 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=738 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=739 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=740 dst=r1 src=r0 offset=320 imm=0
+#line 255 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 255 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=741 dst=r1 src=r0 offset=0 imm=5
+#line 255 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=742 dst=r10 src=r1 offset=-4 imm=0
+#line 256 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=743 dst=r2 src=r10 offset=0 imm=0
+#line 256 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=744 dst=r2 src=r0 offset=0 imm=-4
+#line 256 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=745 dst=r1 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=747 dst=r3 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=748 dst=r0 src=r0 offset=0 imm=16
+#line 256 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 256 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 256 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 256 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=749 dst=r6 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=750 dst=r1 src=r6 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=751 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=752 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=753 dst=r1 src=r0 offset=307 imm=0
+#line 256 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 256 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=754 dst=r1 src=r0 offset=0 imm=6
+#line 256 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=755 dst=r10 src=r1 offset=-4 imm=0
+#line 257 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=756 dst=r2 src=r10 offset=0 imm=0
+#line 257 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=757 dst=r2 src=r0 offset=0 imm=-4
+#line 257 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=758 dst=r1 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=760 dst=r3 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=761 dst=r0 src=r0 offset=0 imm=16
+#line 257 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 257 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 257 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 257 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=762 dst=r6 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=763 dst=r1 src=r6 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=764 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=765 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=766 dst=r1 src=r0 offset=294 imm=0
+#line 257 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 257 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=767 dst=r1 src=r0 offset=0 imm=7
+#line 257 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=768 dst=r10 src=r1 offset=-4 imm=0
+#line 258 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=769 dst=r2 src=r10 offset=0 imm=0
+#line 258 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=770 dst=r2 src=r0 offset=0 imm=-4
+#line 258 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=771 dst=r1 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=773 dst=r3 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=774 dst=r0 src=r0 offset=0 imm=16
+#line 258 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 258 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 258 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 258 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=775 dst=r6 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=776 dst=r1 src=r6 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=777 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=778 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=779 dst=r1 src=r0 offset=281 imm=0
+#line 258 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 258 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=780 dst=r1 src=r0 offset=0 imm=8
+#line 258 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=781 dst=r10 src=r1 offset=-4 imm=0
+#line 259 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=782 dst=r2 src=r10 offset=0 imm=0
+#line 259 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=783 dst=r2 src=r0 offset=0 imm=-4
+#line 259 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=784 dst=r1 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=786 dst=r3 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=787 dst=r0 src=r0 offset=0 imm=16
+#line 259 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 259 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 259 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 259 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=788 dst=r6 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=789 dst=r1 src=r6 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=790 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=791 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=792 dst=r1 src=r0 offset=268 imm=0
+#line 259 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 259 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=793 dst=r1 src=r0 offset=0 imm=9
+#line 259 "sample/map.c"
+    r1 = IMMEDIATE(9);
     // EBPF_OP_STXW pc=794 dst=r10 src=r1 offset=-4 imm=0
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=795 dst=r2 src=r10 offset=0 imm=0
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=796 dst=r2 src=r0 offset=0 imm=-4
-#line 183 "sample/map.c"
+#line 260 "sample/map.c"
     r2 += IMMEDIATE(-4);
     // EBPF_OP_LDDW pc=797 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=799 dst=r0 src=r0 offset=0 imm=18
-#line 183 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 183 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 183 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 183 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=800 dst=r7 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=801 dst=r1 src=r7 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=802 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=803 dst=r1 src=r0 offset=0 imm=32
-#line 183 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=804 dst=r1 src=r0 offset=36 imm=0
-#line 183 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 183 "sample/map.c"
-        goto label_37;
-        // EBPF_OP_JA pc=805 dst=r0 src=r0 offset=-61 imm=0
-#line 183 "sample/map.c"
-    goto label_27;
-label_33:
-    // EBPF_OP_LDXW pc=806 dst=r1 src=r10 offset=-4 imm=0
-#line 183 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=807 dst=r6 src=r0 offset=0 imm=-1
-#line 183 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=809 dst=r1 src=r0 offset=-764 imm=1
-#line 183 "sample/map.c"
-    if (r1 != IMMEDIATE(1))
-#line 183 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=810 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=811 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=812 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=813 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=814 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 260 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=816 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=799 dst=r3 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=800 dst=r0 src=r0 offset=0 imm=16
+#line 260 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 260 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 260 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 260 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=817 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=801 dst=r6 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=818 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=802 dst=r1 src=r6 offset=0 imm=0
+#line 260 "sample/map.c"
     r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=819 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=803 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=820 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=804 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=821 dst=r1 src=r0 offset=1 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=805 dst=r1 src=r0 offset=255 imm=0
+#line 260 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 260 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=806 dst=r8 src=r0 offset=0 imm=10
+#line 260 "sample/map.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=807 dst=r10 src=r8 offset=-4 imm=0
+#line 263 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=808 dst=r2 src=r10 offset=0 imm=0
+#line 263 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=809 dst=r2 src=r0 offset=0 imm=-4
+#line 263 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=810 dst=r1 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=812 dst=r3 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=813 dst=r0 src=r0 offset=0 imm=16
+#line 263 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 263 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 263 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 263 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=814 dst=r6 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=815 dst=r1 src=r6 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=816 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=817 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=818 dst=r2 src=r0 offset=0 imm=-29
+#line 263 "sample/map.c"
+    r2 = (uint64_t)4294967267;
+    // EBPF_OP_JNE_REG pc=820 dst=r1 src=r2 offset=240 imm=0
+#line 263 "sample/map.c"
+    if (r1 != r2)
+#line 263 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_STXW pc=821 dst=r10 src=r8 offset=-4 imm=0
+#line 264 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=822 dst=r2 src=r10 offset=0 imm=0
+#line 264 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=823 dst=r2 src=r0 offset=0 imm=-4
+#line 264 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=824 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_MOV64_IMM pc=826 dst=r3 src=r0 offset=0 imm=2
+#line 264 "sample/map.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=827 dst=r0 src=r0 offset=0 imm=16
+#line 264 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 264 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 264 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 264 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=828 dst=r6 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=829 dst=r1 src=r6 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=830 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=831 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=832 dst=r1 src=r0 offset=1 imm=0
+#line 264 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_34;
-        // EBPF_OP_JA pc=822 dst=r0 src=r0 offset=17 imm=0
-#line 186 "sample/map.c"
+#line 264 "sample/map.c"
+        goto label_20;
+        // EBPF_OP_MOV64_REG pc=833 dst=r7 src=r6 offset=0 imm=0
+#line 264 "sample/map.c"
+    r7 = r6;
+label_20:
+    // EBPF_OP_JNE_IMM pc=834 dst=r1 src=r0 offset=226 imm=0
+#line 264 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 264 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=835 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=836 dst=r10 src=r1 offset=-4 imm=0
+#line 266 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=837 dst=r2 src=r10 offset=0 imm=0
+#line 266 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=838 dst=r2 src=r0 offset=0 imm=-4
+#line 266 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=839 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=841 dst=r0 src=r0 offset=0 imm=18
+#line 266 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 266 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 266 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 266 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=842 dst=r6 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=843 dst=r1 src=r6 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=844 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=845 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=846 dst=r1 src=r0 offset=1 imm=0
+#line 266 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 266 "sample/map.c"
+        goto label_21;
+        // EBPF_OP_JA pc=847 dst=r0 src=r0 offset=213 imm=0
+#line 266 "sample/map.c"
     goto label_36;
-label_34:
-    // EBPF_OP_LDXW pc=823 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+label_21:
+    // EBPF_OP_LDXW pc=848 dst=r1 src=r10 offset=-4 imm=0
+#line 266 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=824 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=849 dst=r6 src=r0 offset=0 imm=-1
+#line 266 "sample/map.c"
     r6 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=826 dst=r1 src=r0 offset=1 imm=1
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(1))
-#line 186 "sample/map.c"
-        goto label_35;
-        // EBPF_OP_JA pc=827 dst=r0 src=r0 offset=-782 imm=0
-#line 186 "sample/map.c"
-    goto label_1;
-label_35:
-    // EBPF_OP_MOV64_IMM pc=828 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=851 dst=r1 src=r0 offset=-806 imm=1
+#line 266 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 266 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=852 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=829 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=853 dst=r10 src=r1 offset=-4 imm=0
+#line 274 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=830 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=854 dst=r2 src=r10 offset=0 imm=0
+#line 274 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=831 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=855 dst=r2 src=r0 offset=0 imm=-4
+#line 274 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=832 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=856 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=834 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_CALL pc=858 dst=r0 src=r0 offset=0 imm=17
+#line 274 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 274 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=835 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=859 dst=r6 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r6 = r0;
-    // EBPF_OP_MOV64_REG pc=836 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=860 dst=r1 src=r6 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=837 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=861 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=838 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=862 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=839 dst=r1 src=r0 offset=36 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=863 dst=r1 src=r0 offset=1 imm=0
+#line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_41;
-label_36:
-    // EBPF_OP_JA pc=840 dst=r0 src=r0 offset=-287 imm=0
-#line 186 "sample/map.c"
-    goto label_21;
-label_37:
-    // EBPF_OP_LDXW pc=841 dst=r1 src=r10 offset=-4 imm=0
-#line 183 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=842 dst=r7 src=r0 offset=0 imm=-1
-#line 183 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=844 dst=r1 src=r0 offset=-95 imm=10
-#line 183 "sample/map.c"
-    if (r1 != IMMEDIATE(10))
-#line 183 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=845 dst=r1 src=r0 offset=0 imm=0
-#line 183 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=846 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=847 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=848 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=849 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=851 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=852 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=853 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=854 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=855 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=856 dst=r1 src=r0 offset=1 imm=0
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_38;
-        // EBPF_OP_JA pc=857 dst=r0 src=r0 offset=17 imm=0
-#line 186 "sample/map.c"
-    goto label_40;
-label_38:
-    // EBPF_OP_LDXW pc=858 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=859 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JEQ_IMM pc=861 dst=r1 src=r0 offset=1 imm=10
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(10))
-#line 186 "sample/map.c"
-        goto label_39;
-        // EBPF_OP_JA pc=862 dst=r0 src=r0 offset=-113 imm=0
-#line 186 "sample/map.c"
-    goto label_28;
-label_39:
-    // EBPF_OP_MOV64_IMM pc=863 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=864 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=865 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=866 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=867 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=869 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=870 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=871 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=872 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=873 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JEQ_IMM pc=874 dst=r1 src=r0 offset=174 imm=0
-#line 186 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_47;
-label_40:
-    // EBPF_OP_JA pc=875 dst=r0 src=r0 offset=-131 imm=0
-#line 186 "sample/map.c"
-    goto label_27;
-label_41:
-    // EBPF_OP_LDXW pc=876 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=877 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=879 dst=r1 src=r0 offset=-834 imm=2
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(2))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=880 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=881 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=882 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=883 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=884 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=886 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=887 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=888 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=889 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=890 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=891 dst=r1 src=r0 offset=-52 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=892 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=893 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=895 dst=r1 src=r0 offset=-850 imm=3
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(3))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=896 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=897 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=898 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=899 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=900 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=902 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=903 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=904 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=905 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=906 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=907 dst=r1 src=r0 offset=-68 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=908 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=909 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=911 dst=r1 src=r0 offset=-866 imm=4
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(4))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=912 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=913 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=914 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=915 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=916 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=918 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=919 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=920 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=921 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=922 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=923 dst=r1 src=r0 offset=-84 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=924 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=925 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=927 dst=r1 src=r0 offset=-882 imm=5
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(5))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=928 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=929 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=930 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=931 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=932 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=934 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=935 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=936 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=937 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=938 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=939 dst=r1 src=r0 offset=-100 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=940 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=941 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=943 dst=r1 src=r0 offset=-898 imm=6
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(6))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=944 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=945 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=946 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=947 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=948 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=950 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=951 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=952 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=953 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=954 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=955 dst=r1 src=r0 offset=-116 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=956 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=957 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=959 dst=r1 src=r0 offset=-914 imm=7
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(7))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=960 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=961 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=962 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=963 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=964 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=966 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=967 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=968 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=969 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=970 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=971 dst=r1 src=r0 offset=-132 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=972 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=973 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=975 dst=r1 src=r0 offset=-930 imm=8
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(8))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=976 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=977 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=978 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=979 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=980 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=982 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=983 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=984 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=985 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=986 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=987 dst=r1 src=r0 offset=-148 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=988 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=989 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=991 dst=r1 src=r0 offset=-946 imm=9
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(9))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=992 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=993 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=994 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=995 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=996 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=998 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=999 dst=r6 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r6 = r0;
-    // EBPF_OP_MOV64_REG pc=1000 dst=r1 src=r6 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r6;
-    // EBPF_OP_LSH64_IMM pc=1001 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1002 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1003 dst=r1 src=r0 offset=-164 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_36;
-        // EBPF_OP_LDXW pc=1004 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1005 dst=r6 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1007 dst=r1 src=r0 offset=-962 imm=10
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(10))
-#line 186 "sample/map.c"
-        goto label_1;
-        // EBPF_OP_MOV64_IMM pc=1008 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1009 dst=r10 src=r1 offset=-4 imm=0
-#line 189 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1010 dst=r2 src=r10 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1011 dst=r2 src=r0 offset=0 imm=-4
-#line 189 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1012 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=1014 dst=r0 src=r0 offset=0 imm=18
-#line 189 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 189 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 189 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 189 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=1015 dst=r1 src=r10 offset=-4 imm=0
-#line 189 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=1016 dst=r6 src=r7 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = r7;
-    // EBPF_OP_JEQ_IMM pc=1017 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_42;
-        // EBPF_OP_MOV64_IMM pc=1018 dst=r6 src=r0 offset=0 imm=-1
-#line 189 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_42:
-    // EBPF_OP_MOV64_REG pc=1019 dst=r2 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1020 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1021 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1022 dst=r3 src=r0 offset=0 imm=-7
-#line 189 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1024 dst=r2 src=r3 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r2 == r3)
-#line 189 "sample/map.c"
-        goto label_43;
-        // EBPF_OP_MOV64_REG pc=1025 dst=r6 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = r0;
-label_43:
-    // EBPF_OP_JNE_REG pc=1026 dst=r2 src=r3 offset=-473 imm=0
-#line 189 "sample/map.c"
-    if (r2 != r3)
-#line 189 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_JEQ_IMM pc=1027 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_44;
-        // EBPF_OP_JA pc=1028 dst=r0 src=r0 offset=-475 imm=0
-#line 189 "sample/map.c"
-    goto label_21;
-label_44:
-    // EBPF_OP_MOV64_IMM pc=1029 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1030 dst=r10 src=r1 offset=-4 imm=0
-#line 190 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1031 dst=r2 src=r10 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1032 dst=r2 src=r0 offset=0 imm=-4
-#line 190 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1033 dst=r1 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r1 = POINTER(_maps[6].address);
-    // EBPF_OP_CALL pc=1035 dst=r0 src=r0 offset=0 imm=17
-#line 190 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 190 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 190 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 190 "sample/map.c"
-        return 0;
-        // EBPF_OP_LDXW pc=1036 dst=r1 src=r10 offset=-4 imm=0
-#line 190 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JEQ_IMM pc=1037 dst=r1 src=r0 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
-        goto label_45;
-        // EBPF_OP_MOV64_IMM pc=1038 dst=r6 src=r0 offset=0 imm=-1
-#line 190 "sample/map.c"
-    r6 = IMMEDIATE(-1);
-label_45:
-    // EBPF_OP_MOV64_REG pc=1039 dst=r2 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1040 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1041 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1042 dst=r3 src=r0 offset=0 imm=-7
-#line 190 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1044 dst=r2 src=r3 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r2 == r3)
-#line 190 "sample/map.c"
-        goto label_46;
-        // EBPF_OP_MOV64_REG pc=1045 dst=r6 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r6 = r0;
-label_46:
-    // EBPF_OP_JNE_REG pc=1046 dst=r2 src=r3 offset=-493 imm=0
-#line 190 "sample/map.c"
-    if (r2 != r3)
-#line 190 "sample/map.c"
-        goto label_21;
-        // EBPF_OP_JEQ_IMM pc=1047 dst=r1 src=r0 offset=-489 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
+#line 274 "sample/map.c"
         goto label_22;
-        // EBPF_OP_JA pc=1048 dst=r0 src=r0 offset=-495 imm=0
-#line 190 "sample/map.c"
-    goto label_21;
-label_47:
-    // EBPF_OP_LDXW pc=1049 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_JA pc=864 dst=r0 src=r0 offset=196 imm=0
+#line 274 "sample/map.c"
+    goto label_36;
+label_22:
+    // EBPF_OP_LDXW pc=865 dst=r1 src=r10 offset=-4 imm=0
+#line 274 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1050 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1052 dst=r1 src=r0 offset=-303 imm=9
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(9))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1053 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=866 dst=r6 src=r0 offset=0 imm=-1
+#line 274 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=868 dst=r1 src=r0 offset=-823 imm=1
+#line 274 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 274 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=869 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1054 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=870 dst=r10 src=r1 offset=-4 imm=0
+#line 275 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1055 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=871 dst=r2 src=r10 offset=0 imm=0
+#line 275 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1056 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=872 dst=r2 src=r0 offset=0 imm=-4
+#line 275 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1057 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1059 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=873 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=875 dst=r0 src=r0 offset=0 imm=17
+#line 275 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 275 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1060 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1061 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1062 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=876 dst=r6 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=877 dst=r1 src=r6 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=878 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1063 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=879 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1064 dst=r1 src=r0 offset=-190 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1065 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=880 dst=r1 src=r0 offset=1 imm=0
+#line 275 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 275 "sample/map.c"
+        goto label_23;
+        // EBPF_OP_JA pc=881 dst=r0 src=r0 offset=179 imm=0
+#line 275 "sample/map.c"
+    goto label_36;
+label_23:
+    // EBPF_OP_LDXW pc=882 dst=r1 src=r10 offset=-4 imm=0
+#line 275 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1066 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1068 dst=r1 src=r0 offset=-319 imm=8
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(8))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1069 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=883 dst=r6 src=r0 offset=0 imm=-1
+#line 275 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=885 dst=r1 src=r0 offset=-840 imm=2
+#line 275 "sample/map.c"
+    if (r1 != IMMEDIATE(2))
+#line 275 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=886 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1070 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=887 dst=r10 src=r1 offset=-4 imm=0
+#line 276 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1071 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=888 dst=r2 src=r10 offset=0 imm=0
+#line 276 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1072 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=889 dst=r2 src=r0 offset=0 imm=-4
+#line 276 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1073 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1075 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=890 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=892 dst=r0 src=r0 offset=0 imm=17
+#line 276 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 276 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1076 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1077 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1078 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=893 dst=r6 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=894 dst=r1 src=r6 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=895 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1079 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=896 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1080 dst=r1 src=r0 offset=-206 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1081 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=897 dst=r1 src=r0 offset=1 imm=0
+#line 276 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 276 "sample/map.c"
+        goto label_24;
+        // EBPF_OP_JA pc=898 dst=r0 src=r0 offset=162 imm=0
+#line 276 "sample/map.c"
+    goto label_36;
+label_24:
+    // EBPF_OP_LDXW pc=899 dst=r1 src=r10 offset=-4 imm=0
+#line 276 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1082 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1084 dst=r1 src=r0 offset=-335 imm=7
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(7))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1085 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=900 dst=r6 src=r0 offset=0 imm=-1
+#line 276 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=902 dst=r1 src=r0 offset=-857 imm=3
+#line 276 "sample/map.c"
+    if (r1 != IMMEDIATE(3))
+#line 276 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=903 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1086 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=904 dst=r10 src=r1 offset=-4 imm=0
+#line 277 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1087 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=905 dst=r2 src=r10 offset=0 imm=0
+#line 277 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1088 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=906 dst=r2 src=r0 offset=0 imm=-4
+#line 277 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1089 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1091 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=907 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=909 dst=r0 src=r0 offset=0 imm=17
+#line 277 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1092 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1093 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1094 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=910 dst=r6 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=911 dst=r1 src=r6 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=912 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1095 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=913 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1096 dst=r1 src=r0 offset=-222 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1097 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JEQ_IMM pc=914 dst=r1 src=r0 offset=1 imm=0
+#line 277 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 277 "sample/map.c"
+        goto label_25;
+        // EBPF_OP_JA pc=915 dst=r0 src=r0 offset=145 imm=0
+#line 277 "sample/map.c"
+    goto label_36;
+label_25:
+    // EBPF_OP_LDXW pc=916 dst=r1 src=r10 offset=-4 imm=0
+#line 277 "sample/map.c"
     r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1098 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1100 dst=r1 src=r0 offset=-351 imm=6
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(6))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1101 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1102 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1103 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1104 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1105 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1107 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=1108 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1109 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1110 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1111 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1112 dst=r1 src=r0 offset=-238 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1113 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1114 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1116 dst=r1 src=r0 offset=-367 imm=5
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(5))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1117 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1118 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1119 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1120 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
-    r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1121 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1123 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
-         (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=1124 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1125 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1126 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1127 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1128 dst=r1 src=r0 offset=-254 imm=0
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1129 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1130 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1132 dst=r1 src=r0 offset=-383 imm=4
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=917 dst=r6 src=r0 offset=0 imm=-1
+#line 277 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=919 dst=r1 src=r0 offset=-874 imm=4
+#line 277 "sample/map.c"
     if (r1 != IMMEDIATE(4))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1133 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 277 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=920 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1134 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_STXW pc=921 dst=r10 src=r1 offset=-4 imm=0
+#line 278 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1135 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=922 dst=r2 src=r10 offset=0 imm=0
+#line 278 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1136 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=923 dst=r2 src=r0 offset=0 imm=-4
+#line 278 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1137 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1139 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=924 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=926 dst=r0 src=r0 offset=0 imm=17
+#line 278 "sample/map.c"
     r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
     if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 278 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=927 dst=r6 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=928 dst=r1 src=r6 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=929 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=930 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=931 dst=r1 src=r0 offset=1 imm=0
+#line 278 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 278 "sample/map.c"
+        goto label_26;
+        // EBPF_OP_JA pc=932 dst=r0 src=r0 offset=128 imm=0
+#line 278 "sample/map.c"
+    goto label_36;
+label_26:
+    // EBPF_OP_LDXW pc=933 dst=r1 src=r10 offset=-4 imm=0
+#line 278 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=934 dst=r6 src=r0 offset=0 imm=-1
+#line 278 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=936 dst=r1 src=r0 offset=-891 imm=5
+#line 278 "sample/map.c"
+    if (r1 != IMMEDIATE(5))
+#line 278 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=937 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=938 dst=r10 src=r1 offset=-4 imm=0
+#line 279 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=939 dst=r2 src=r10 offset=0 imm=0
+#line 279 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=940 dst=r2 src=r0 offset=0 imm=-4
+#line 279 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=941 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=943 dst=r0 src=r0 offset=0 imm=17
+#line 279 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 279 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 279 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 279 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=944 dst=r6 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=945 dst=r1 src=r6 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=946 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=947 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=948 dst=r1 src=r0 offset=1 imm=0
+#line 279 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 279 "sample/map.c"
+        goto label_27;
+        // EBPF_OP_JA pc=949 dst=r0 src=r0 offset=111 imm=0
+#line 279 "sample/map.c"
+    goto label_36;
+label_27:
+    // EBPF_OP_LDXW pc=950 dst=r1 src=r10 offset=-4 imm=0
+#line 279 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=951 dst=r6 src=r0 offset=0 imm=-1
+#line 279 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=953 dst=r1 src=r0 offset=-908 imm=6
+#line 279 "sample/map.c"
+    if (r1 != IMMEDIATE(6))
+#line 279 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=954 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=955 dst=r10 src=r1 offset=-4 imm=0
+#line 280 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=956 dst=r2 src=r10 offset=0 imm=0
+#line 280 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=957 dst=r2 src=r0 offset=0 imm=-4
+#line 280 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=958 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=960 dst=r0 src=r0 offset=0 imm=17
+#line 280 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 280 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 280 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 280 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=961 dst=r6 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=962 dst=r1 src=r6 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=963 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=964 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=965 dst=r1 src=r0 offset=1 imm=0
+#line 280 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 280 "sample/map.c"
+        goto label_28;
+        // EBPF_OP_JA pc=966 dst=r0 src=r0 offset=94 imm=0
+#line 280 "sample/map.c"
+    goto label_36;
+label_28:
+    // EBPF_OP_LDXW pc=967 dst=r1 src=r10 offset=-4 imm=0
+#line 280 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=968 dst=r6 src=r0 offset=0 imm=-1
+#line 280 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=970 dst=r1 src=r0 offset=-925 imm=7
+#line 280 "sample/map.c"
+    if (r1 != IMMEDIATE(7))
+#line 280 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=971 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=972 dst=r10 src=r1 offset=-4 imm=0
+#line 281 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=973 dst=r2 src=r10 offset=0 imm=0
+#line 281 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=974 dst=r2 src=r0 offset=0 imm=-4
+#line 281 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=975 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=977 dst=r0 src=r0 offset=0 imm=17
+#line 281 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 281 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 281 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 281 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=978 dst=r6 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=979 dst=r1 src=r6 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=980 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=981 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=982 dst=r1 src=r0 offset=1 imm=0
+#line 281 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 281 "sample/map.c"
+        goto label_29;
+        // EBPF_OP_JA pc=983 dst=r0 src=r0 offset=77 imm=0
+#line 281 "sample/map.c"
+    goto label_36;
+label_29:
+    // EBPF_OP_LDXW pc=984 dst=r1 src=r10 offset=-4 imm=0
+#line 281 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=985 dst=r6 src=r0 offset=0 imm=-1
+#line 281 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=987 dst=r1 src=r0 offset=-942 imm=8
+#line 281 "sample/map.c"
+    if (r1 != IMMEDIATE(8))
+#line 281 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=988 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=989 dst=r10 src=r1 offset=-4 imm=0
+#line 282 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=990 dst=r2 src=r10 offset=0 imm=0
+#line 282 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=991 dst=r2 src=r0 offset=0 imm=-4
+#line 282 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=992 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=994 dst=r0 src=r0 offset=0 imm=17
+#line 282 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 282 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 282 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 282 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=995 dst=r6 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=996 dst=r1 src=r6 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=997 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=998 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=999 dst=r1 src=r0 offset=1 imm=0
+#line 282 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 282 "sample/map.c"
+        goto label_30;
+        // EBPF_OP_JA pc=1000 dst=r0 src=r0 offset=60 imm=0
+#line 282 "sample/map.c"
+    goto label_36;
+label_30:
+    // EBPF_OP_LDXW pc=1001 dst=r1 src=r10 offset=-4 imm=0
+#line 282 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=1002 dst=r6 src=r0 offset=0 imm=-1
+#line 282 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=1004 dst=r1 src=r0 offset=-959 imm=9
+#line 282 "sample/map.c"
+    if (r1 != IMMEDIATE(9))
+#line 282 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=1005 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1006 dst=r10 src=r1 offset=-4 imm=0
+#line 283 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1007 dst=r2 src=r10 offset=0 imm=0
+#line 283 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1008 dst=r2 src=r0 offset=0 imm=-4
+#line 283 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1009 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1011 dst=r0 src=r0 offset=0 imm=17
+#line 283 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 283 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 283 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 283 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1012 dst=r6 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r6 = r0;
+    // EBPF_OP_MOV64_REG pc=1013 dst=r1 src=r6 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=1014 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1015 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1016 dst=r1 src=r0 offset=1 imm=0
+#line 283 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 283 "sample/map.c"
+        goto label_31;
+        // EBPF_OP_JA pc=1017 dst=r0 src=r0 offset=43 imm=0
+#line 283 "sample/map.c"
+    goto label_36;
+label_31:
+    // EBPF_OP_LDXW pc=1018 dst=r1 src=r10 offset=-4 imm=0
+#line 283 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_LDDW pc=1019 dst=r6 src=r0 offset=0 imm=-1
+#line 283 "sample/map.c"
+    r6 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=1021 dst=r1 src=r0 offset=-976 imm=10
+#line 283 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 283 "sample/map.c"
+        goto label_1;
+        // EBPF_OP_MOV64_IMM pc=1022 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1023 dst=r10 src=r1 offset=-4 imm=0
+#line 286 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1024 dst=r2 src=r10 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1025 dst=r2 src=r0 offset=0 imm=-4
+#line 286 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1026 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1028 dst=r0 src=r0 offset=0 imm=18
+#line 286 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 286 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 286 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 286 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1029 dst=r1 src=r10 offset=-4 imm=0
+#line 286 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1030 dst=r6 src=r7 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JEQ_IMM pc=1031 dst=r1 src=r0 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_32;
+        // EBPF_OP_MOV64_IMM pc=1032 dst=r6 src=r0 offset=0 imm=-1
+#line 286 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_32:
+    // EBPF_OP_MOV64_REG pc=1033 dst=r2 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1034 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1035 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1036 dst=r3 src=r0 offset=0 imm=-7
+#line 286 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1038 dst=r2 src=r3 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r2 == r3)
+#line 286 "sample/map.c"
+        goto label_33;
+        // EBPF_OP_MOV64_REG pc=1039 dst=r6 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = r0;
+label_33:
+    // EBPF_OP_JNE_REG pc=1040 dst=r2 src=r3 offset=20 imm=0
+#line 286 "sample/map.c"
+    if (r2 != r3)
+#line 286 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_JNE_IMM pc=1041 dst=r1 src=r0 offset=19 imm=0
+#line 286 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_MOV64_IMM pc=1042 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1043 dst=r10 src=r1 offset=-4 imm=0
+#line 287 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1044 dst=r2 src=r10 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1045 dst=r2 src=r0 offset=0 imm=-4
+#line 287 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1046 dst=r1 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r1 = POINTER(_maps[6].address);
+    // EBPF_OP_CALL pc=1048 dst=r0 src=r0 offset=0 imm=17
+#line 287 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 287 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 287 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 287 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1049 dst=r1 src=r10 offset=-4 imm=0
+#line 287 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JEQ_IMM pc=1050 dst=r1 src=r0 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_34;
+        // EBPF_OP_MOV64_IMM pc=1051 dst=r6 src=r0 offset=0 imm=-1
+#line 287 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_34:
+    // EBPF_OP_MOV64_REG pc=1052 dst=r2 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1053 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1054 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1055 dst=r3 src=r0 offset=0 imm=-7
+#line 287 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1057 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 == r3)
+#line 287 "sample/map.c"
+        goto label_35;
+        // EBPF_OP_MOV64_REG pc=1058 dst=r6 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r6 = r0;
+label_35:
+    // EBPF_OP_JNE_REG pc=1059 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 != r3)
+#line 287 "sample/map.c"
+        goto label_36;
+        // EBPF_OP_JEQ_IMM pc=1060 dst=r1 src=r0 offset=5 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_37;
+label_36:
+    // EBPF_OP_MOV64_REG pc=1061 dst=r1 src=r6 offset=0 imm=0
+#line 305 "sample/map.c"
+    r1 = r6;
+    // EBPF_OP_LSH64_IMM pc=1062 dst=r1 src=r0 offset=0 imm=32
+#line 305 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=1063 dst=r1 src=r0 offset=0 imm=32
+#line 305 "sample/map.c"
+    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=1064 dst=r2 src=r0 offset=0 imm=0
+#line 305 "sample/map.c"
+    r2 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=1065 dst=r2 src=r1 offset=-1020 imm=0
+#line 305 "sample/map.c"
+    if ((int64_t)r2 > (int64_t)r1)
+#line 305 "sample/map.c"
+        goto label_1;
+label_37:
+    // EBPF_OP_MOV64_IMM pc=1066 dst=r1 src=r0 offset=0 imm=0
+#line 305 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1067 dst=r10 src=r1 offset=-4 imm=0
+#line 242 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1068 dst=r2 src=r10 offset=0 imm=0
+#line 242 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1069 dst=r2 src=r0 offset=0 imm=-4
+#line 242 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1070 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1072 dst=r0 src=r0 offset=0 imm=18
+#line 242 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 242 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 242 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 242 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1073 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1074 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1075 dst=r1 src=r0 offset=0 imm=32
+#line 242 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_MOV64_IMM pc=1076 dst=r7 src=r0 offset=0 imm=-1
+#line 242 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+    // EBPF_OP_LDDW pc=1077 dst=r2 src=r0 offset=0 imm=-7
+#line 242 "sample/map.c"
+    r2 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1079 dst=r1 src=r2 offset=1 imm=0
+#line 242 "sample/map.c"
+    if (r1 == r2)
+#line 242 "sample/map.c"
+        goto label_38;
+        // EBPF_OP_MOV64_REG pc=1080 dst=r7 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r7 = r0;
+label_38:
+    // EBPF_OP_JNE_REG pc=1081 dst=r1 src=r2 offset=380 imm=0
+#line 242 "sample/map.c"
+    if (r1 != r2)
+#line 242 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_LDXW pc=1082 dst=r1 src=r10 offset=-4 imm=0
+#line 242 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1083 dst=r1 src=r0 offset=378 imm=0
+#line 242 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 242 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1084 dst=r1 src=r0 offset=0 imm=0
+#line 242 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1085 dst=r10 src=r1 offset=-4 imm=0
+#line 243 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1086 dst=r2 src=r10 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1087 dst=r2 src=r0 offset=0 imm=-4
+#line 243 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1088 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1090 dst=r0 src=r0 offset=0 imm=17
+#line 243 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 243 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 243 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 243 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1091 dst=r1 src=r10 offset=-4 imm=0
+#line 243 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1092 dst=r6 src=r7 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JEQ_IMM pc=1093 dst=r1 src=r0 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_39;
+        // EBPF_OP_MOV64_IMM pc=1094 dst=r6 src=r0 offset=0 imm=-1
+#line 243 "sample/map.c"
+    r6 = IMMEDIATE(-1);
+label_39:
+    // EBPF_OP_MOV64_REG pc=1095 dst=r2 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1096 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1097 dst=r2 src=r0 offset=0 imm=32
+#line 243 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1098 dst=r3 src=r0 offset=0 imm=-7
+#line 243 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1100 dst=r2 src=r3 offset=1 imm=0
+#line 243 "sample/map.c"
+    if (r2 == r3)
+#line 243 "sample/map.c"
+        goto label_40;
+        // EBPF_OP_MOV64_REG pc=1101 dst=r6 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r6 = r0;
+label_40:
+    // EBPF_OP_MOV64_REG pc=1102 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JNE_REG pc=1103 dst=r2 src=r3 offset=358 imm=0
+#line 243 "sample/map.c"
+    if (r2 != r3)
+#line 243 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_REG pc=1104 dst=r7 src=r6 offset=0 imm=0
+#line 243 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JNE_IMM pc=1105 dst=r1 src=r0 offset=356 imm=0
+#line 243 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 243 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1106 dst=r1 src=r0 offset=0 imm=0
+#line 243 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1107 dst=r10 src=r1 offset=-4 imm=0
+#line 251 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1108 dst=r2 src=r10 offset=0 imm=0
+#line 251 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1109 dst=r2 src=r0 offset=0 imm=-4
+#line 251 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1110 dst=r1 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1112 dst=r3 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1113 dst=r0 src=r0 offset=0 imm=16
+#line 251 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 251 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 251 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 251 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1114 dst=r7 src=r0 offset=0 imm=0
+#line 251 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1115 dst=r1 src=r7 offset=0 imm=0
+#line 251 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1116 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1117 dst=r1 src=r0 offset=0 imm=32
+#line 251 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1118 dst=r1 src=r0 offset=343 imm=0
+#line 251 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 251 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1119 dst=r1 src=r0 offset=0 imm=1
+#line 251 "sample/map.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_STXW pc=1120 dst=r10 src=r1 offset=-4 imm=0
+#line 252 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1121 dst=r2 src=r10 offset=0 imm=0
+#line 252 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1122 dst=r2 src=r0 offset=0 imm=-4
+#line 252 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1123 dst=r1 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1125 dst=r3 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1126 dst=r0 src=r0 offset=0 imm=16
+#line 252 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 252 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 252 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 252 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1127 dst=r7 src=r0 offset=0 imm=0
+#line 252 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1128 dst=r1 src=r7 offset=0 imm=0
+#line 252 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1129 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1130 dst=r1 src=r0 offset=0 imm=32
+#line 252 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1131 dst=r1 src=r0 offset=330 imm=0
+#line 252 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 252 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1132 dst=r1 src=r0 offset=0 imm=2
+#line 252 "sample/map.c"
+    r1 = IMMEDIATE(2);
+    // EBPF_OP_STXW pc=1133 dst=r10 src=r1 offset=-4 imm=0
+#line 253 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1134 dst=r2 src=r10 offset=0 imm=0
+#line 253 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1135 dst=r2 src=r0 offset=0 imm=-4
+#line 253 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1136 dst=r1 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1138 dst=r3 src=r0 offset=0 imm=0
+#line 253 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1139 dst=r0 src=r0 offset=0 imm=16
+#line 253 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 253 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 253 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 253 "sample/map.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=1140 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r7 = r0;
     // EBPF_OP_MOV64_REG pc=1141 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 = r7;
     // EBPF_OP_LSH64_IMM pc=1142 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 <<= IMMEDIATE(32);
     // EBPF_OP_RSH64_IMM pc=1143 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1144 dst=r1 src=r0 offset=-270 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1144 dst=r1 src=r0 offset=317 imm=0
+#line 253 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1145 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1146 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1148 dst=r1 src=r0 offset=-399 imm=3
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(3))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1149 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1150 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+#line 253 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1145 dst=r1 src=r0 offset=0 imm=3
+#line 253 "sample/map.c"
+    r1 = IMMEDIATE(3);
+    // EBPF_OP_STXW pc=1146 dst=r10 src=r1 offset=-4 imm=0
+#line 254 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1151 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1147 dst=r2 src=r10 offset=0 imm=0
+#line 254 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1152 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1148 dst=r2 src=r0 offset=0 imm=-4
+#line 254 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1153 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=1149 dst=r1 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1155 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1151 dst=r3 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1152 dst=r0 src=r0 offset=0 imm=16
+#line 254 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 254 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 254 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 254 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1156 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1153 dst=r7 src=r0 offset=0 imm=0
+#line 254 "sample/map.c"
     r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1157 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1154 dst=r1 src=r7 offset=0 imm=0
+#line 254 "sample/map.c"
     r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1158 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=1155 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1159 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=1156 dst=r1 src=r0 offset=0 imm=32
+#line 254 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1160 dst=r1 src=r0 offset=-286 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1157 dst=r1 src=r0 offset=304 imm=0
+#line 254 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1161 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1162 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1164 dst=r1 src=r0 offset=-415 imm=2
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(2))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1165 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1166 dst=r10 src=r1 offset=-4 imm=0
-#line 186 "sample/map.c"
+#line 254 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1158 dst=r1 src=r0 offset=0 imm=4
+#line 254 "sample/map.c"
+    r1 = IMMEDIATE(4);
+    // EBPF_OP_STXW pc=1159 dst=r10 src=r1 offset=-4 imm=0
+#line 255 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1167 dst=r2 src=r10 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1160 dst=r2 src=r10 offset=0 imm=0
+#line 255 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1168 dst=r2 src=r0 offset=0 imm=-4
-#line 186 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1161 dst=r2 src=r0 offset=0 imm=-4
+#line 255 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1169 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_LDDW pc=1162 dst=r1 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1171 dst=r0 src=r0 offset=0 imm=17
-#line 186 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1164 dst=r3 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1165 dst=r0 src=r0 offset=0 imm=16
+#line 255 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 255 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 186 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 186 "sample/map.c"
+#line 255 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 255 "sample/map.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=1172 dst=r7 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1166 dst=r7 src=r0 offset=0 imm=0
+#line 255 "sample/map.c"
     r7 = r0;
-    // EBPF_OP_MOV64_REG pc=1173 dst=r1 src=r7 offset=0 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1167 dst=r1 src=r7 offset=0 imm=0
+#line 255 "sample/map.c"
     r1 = r7;
-    // EBPF_OP_LSH64_IMM pc=1174 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_LSH64_IMM pc=1168 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
     r1 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1175 dst=r1 src=r0 offset=0 imm=32
-#line 186 "sample/map.c"
+    // EBPF_OP_RSH64_IMM pc=1169 dst=r1 src=r0 offset=0 imm=32
+#line 255 "sample/map.c"
     r1 >>= IMMEDIATE(32);
-    // EBPF_OP_JNE_IMM pc=1176 dst=r1 src=r0 offset=-302 imm=0
-#line 186 "sample/map.c"
+    // EBPF_OP_JNE_IMM pc=1170 dst=r1 src=r0 offset=291 imm=0
+#line 255 "sample/map.c"
     if (r1 != IMMEDIATE(0))
-#line 186 "sample/map.c"
-        goto label_40;
-        // EBPF_OP_LDXW pc=1177 dst=r1 src=r10 offset=-4 imm=0
-#line 186 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_LDDW pc=1178 dst=r7 src=r0 offset=0 imm=-1
-#line 186 "sample/map.c"
-    r7 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=1180 dst=r1 src=r0 offset=-431 imm=1
-#line 186 "sample/map.c"
-    if (r1 != IMMEDIATE(1))
-#line 186 "sample/map.c"
-        goto label_28;
-        // EBPF_OP_MOV64_IMM pc=1181 dst=r1 src=r0 offset=0 imm=0
-#line 186 "sample/map.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1182 dst=r10 src=r1 offset=-4 imm=0
-#line 189 "sample/map.c"
+#line 255 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1171 dst=r1 src=r0 offset=0 imm=5
+#line 255 "sample/map.c"
+    r1 = IMMEDIATE(5);
+    // EBPF_OP_STXW pc=1172 dst=r10 src=r1 offset=-4 imm=0
+#line 256 "sample/map.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=1183 dst=r2 src=r10 offset=0 imm=0
-#line 189 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1173 dst=r2 src=r10 offset=0 imm=0
+#line 256 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1184 dst=r2 src=r0 offset=0 imm=-4
-#line 189 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1174 dst=r2 src=r0 offset=0 imm=-4
+#line 256 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1185 dst=r1 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
+    // EBPF_OP_LDDW pc=1175 dst=r1 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1187 dst=r0 src=r0 offset=0 imm=18
-#line 189 "sample/map.c"
-    r0 = test_maps_helpers[4].address
-#line 189 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1177 dst=r3 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1178 dst=r0 src=r0 offset=0 imm=16
+#line 256 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 256 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 189 "sample/map.c"
-    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
-#line 189 "sample/map.c"
+#line 256 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 256 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=1188 dst=r1 src=r10 offset=-4 imm=0
-#line 189 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_MOV64_REG pc=1189 dst=r7 src=r6 offset=0 imm=0
-#line 189 "sample/map.c"
-    r7 = r6;
-    // EBPF_OP_JEQ_IMM pc=1190 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_48;
-        // EBPF_OP_MOV64_IMM pc=1191 dst=r7 src=r0 offset=0 imm=-1
-#line 189 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_48:
-    // EBPF_OP_MOV64_REG pc=1192 dst=r2 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1193 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1194 dst=r2 src=r0 offset=0 imm=32
-#line 189 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1195 dst=r3 src=r0 offset=0 imm=-7
-#line 189 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1197 dst=r2 src=r3 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r2 == r3)
-#line 189 "sample/map.c"
-        goto label_49;
-        // EBPF_OP_MOV64_REG pc=1198 dst=r7 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
+        // EBPF_OP_MOV64_REG pc=1179 dst=r7 src=r0 offset=0 imm=0
+#line 256 "sample/map.c"
     r7 = r0;
-label_49:
-    // EBPF_OP_JNE_REG pc=1199 dst=r2 src=r3 offset=-455 imm=0
-#line 189 "sample/map.c"
-    if (r2 != r3)
-#line 189 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_JEQ_IMM pc=1200 dst=r1 src=r0 offset=1 imm=0
-#line 189 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 189 "sample/map.c"
-        goto label_50;
-        // EBPF_OP_JA pc=1201 dst=r0 src=r0 offset=-457 imm=0
-#line 189 "sample/map.c"
-    goto label_27;
-label_50:
-    // EBPF_OP_MOV64_IMM pc=1202 dst=r6 src=r0 offset=0 imm=0
-#line 189 "sample/map.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=1203 dst=r10 src=r6 offset=-4 imm=0
-#line 190 "sample/map.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
-    // EBPF_OP_MOV64_REG pc=1204 dst=r2 src=r10 offset=0 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1180 dst=r1 src=r7 offset=0 imm=0
+#line 256 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1181 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1182 dst=r1 src=r0 offset=0 imm=32
+#line 256 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1183 dst=r1 src=r0 offset=278 imm=0
+#line 256 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 256 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1184 dst=r1 src=r0 offset=0 imm=6
+#line 256 "sample/map.c"
+    r1 = IMMEDIATE(6);
+    // EBPF_OP_STXW pc=1185 dst=r10 src=r1 offset=-4 imm=0
+#line 257 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1186 dst=r2 src=r10 offset=0 imm=0
+#line 257 "sample/map.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=1205 dst=r2 src=r0 offset=0 imm=-4
-#line 190 "sample/map.c"
+    // EBPF_OP_ADD64_IMM pc=1187 dst=r2 src=r0 offset=0 imm=-4
+#line 257 "sample/map.c"
     r2 += IMMEDIATE(-4);
-    // EBPF_OP_LDDW pc=1206 dst=r1 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_LDDW pc=1188 dst=r1 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
     r1 = POINTER(_maps[7].address);
-    // EBPF_OP_CALL pc=1208 dst=r0 src=r0 offset=0 imm=17
-#line 190 "sample/map.c"
-    r0 = test_maps_helpers[5].address
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_IMM pc=1190 dst=r3 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1191 dst=r0 src=r0 offset=0 imm=16
+#line 257 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 257 "sample/map.c"
          (r1, r2, r3, r4, r5);
-#line 190 "sample/map.c"
-    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
-#line 190 "sample/map.c"
+#line 257 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 257 "sample/map.c"
         return 0;
-        // EBPF_OP_LDXW pc=1209 dst=r1 src=r10 offset=-4 imm=0
-#line 190 "sample/map.c"
-    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
-    // EBPF_OP_JEQ_IMM pc=1210 dst=r1 src=r0 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
-        goto label_51;
-        // EBPF_OP_MOV64_IMM pc=1211 dst=r7 src=r0 offset=0 imm=-1
-#line 190 "sample/map.c"
-    r7 = IMMEDIATE(-1);
-label_51:
-    // EBPF_OP_MOV64_REG pc=1212 dst=r2 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
-    r2 = r0;
-    // EBPF_OP_LSH64_IMM pc=1213 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 <<= IMMEDIATE(32);
-    // EBPF_OP_RSH64_IMM pc=1214 dst=r2 src=r0 offset=0 imm=32
-#line 190 "sample/map.c"
-    r2 >>= IMMEDIATE(32);
-    // EBPF_OP_LDDW pc=1215 dst=r3 src=r0 offset=0 imm=-7
-#line 190 "sample/map.c"
-    r3 = (uint64_t)4294967289;
-    // EBPF_OP_JEQ_REG pc=1217 dst=r2 src=r3 offset=1 imm=0
-#line 190 "sample/map.c"
-    if (r2 == r3)
-#line 190 "sample/map.c"
-        goto label_52;
+        // EBPF_OP_MOV64_REG pc=1192 dst=r7 src=r0 offset=0 imm=0
+#line 257 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1193 dst=r1 src=r7 offset=0 imm=0
+#line 257 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1194 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1195 dst=r1 src=r0 offset=0 imm=32
+#line 257 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1196 dst=r1 src=r0 offset=265 imm=0
+#line 257 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 257 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1197 dst=r1 src=r0 offset=0 imm=7
+#line 257 "sample/map.c"
+    r1 = IMMEDIATE(7);
+    // EBPF_OP_STXW pc=1198 dst=r10 src=r1 offset=-4 imm=0
+#line 258 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1199 dst=r2 src=r10 offset=0 imm=0
+#line 258 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1200 dst=r2 src=r0 offset=0 imm=-4
+#line 258 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1201 dst=r1 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1203 dst=r3 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1204 dst=r0 src=r0 offset=0 imm=16
+#line 258 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 258 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 258 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 258 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1205 dst=r7 src=r0 offset=0 imm=0
+#line 258 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1206 dst=r1 src=r7 offset=0 imm=0
+#line 258 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1207 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1208 dst=r1 src=r0 offset=0 imm=32
+#line 258 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1209 dst=r1 src=r0 offset=252 imm=0
+#line 258 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 258 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1210 dst=r1 src=r0 offset=0 imm=8
+#line 258 "sample/map.c"
+    r1 = IMMEDIATE(8);
+    // EBPF_OP_STXW pc=1211 dst=r10 src=r1 offset=-4 imm=0
+#line 259 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1212 dst=r2 src=r10 offset=0 imm=0
+#line 259 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1213 dst=r2 src=r0 offset=0 imm=-4
+#line 259 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1214 dst=r1 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1216 dst=r3 src=r0 offset=0 imm=0
+#line 259 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1217 dst=r0 src=r0 offset=0 imm=16
+#line 259 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 259 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 259 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 259 "sample/map.c"
+        return 0;
         // EBPF_OP_MOV64_REG pc=1218 dst=r7 src=r0 offset=0 imm=0
-#line 190 "sample/map.c"
+#line 259 "sample/map.c"
     r7 = r0;
-label_52:
-    // EBPF_OP_JNE_REG pc=1219 dst=r2 src=r3 offset=-475 imm=0
-#line 190 "sample/map.c"
-    if (r2 != r3)
-#line 190 "sample/map.c"
-        goto label_27;
-        // EBPF_OP_JEQ_IMM pc=1220 dst=r1 src=r0 offset=-1175 imm=0
-#line 190 "sample/map.c"
+    // EBPF_OP_MOV64_REG pc=1219 dst=r1 src=r7 offset=0 imm=0
+#line 259 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1220 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1221 dst=r1 src=r0 offset=0 imm=32
+#line 259 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1222 dst=r1 src=r0 offset=239 imm=0
+#line 259 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 259 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1223 dst=r1 src=r0 offset=0 imm=9
+#line 259 "sample/map.c"
+    r1 = IMMEDIATE(9);
+    // EBPF_OP_STXW pc=1224 dst=r10 src=r1 offset=-4 imm=0
+#line 260 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1225 dst=r2 src=r10 offset=0 imm=0
+#line 260 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1226 dst=r2 src=r0 offset=0 imm=-4
+#line 260 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1227 dst=r1 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1229 dst=r3 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1230 dst=r0 src=r0 offset=0 imm=16
+#line 260 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 260 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 260 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 260 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1231 dst=r7 src=r0 offset=0 imm=0
+#line 260 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1232 dst=r1 src=r7 offset=0 imm=0
+#line 260 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1233 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1234 dst=r1 src=r0 offset=0 imm=32
+#line 260 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JNE_IMM pc=1235 dst=r1 src=r0 offset=226 imm=0
+#line 260 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 260 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1236 dst=r8 src=r0 offset=0 imm=10
+#line 260 "sample/map.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_STXW pc=1237 dst=r10 src=r8 offset=-4 imm=0
+#line 263 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=1238 dst=r2 src=r10 offset=0 imm=0
+#line 263 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1239 dst=r2 src=r0 offset=0 imm=-4
+#line 263 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1240 dst=r1 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1242 dst=r3 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=1243 dst=r0 src=r0 offset=0 imm=16
+#line 263 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 263 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 263 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 263 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1244 dst=r7 src=r0 offset=0 imm=0
+#line 263 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1245 dst=r1 src=r7 offset=0 imm=0
+#line 263 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1246 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1247 dst=r1 src=r0 offset=0 imm=32
+#line 263 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1248 dst=r2 src=r0 offset=0 imm=-29
+#line 263 "sample/map.c"
+    r2 = (uint64_t)4294967267;
+    // EBPF_OP_JNE_REG pc=1250 dst=r1 src=r2 offset=211 imm=0
+#line 263 "sample/map.c"
+    if (r1 != r2)
+#line 263 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_STXW pc=1251 dst=r10 src=r8 offset=-4 imm=0
+#line 264 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r8;
+    // EBPF_OP_MOV64_REG pc=1252 dst=r2 src=r10 offset=0 imm=0
+#line 264 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1253 dst=r2 src=r0 offset=0 imm=-4
+#line 264 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1254 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_MOV64_IMM pc=1256 dst=r3 src=r0 offset=0 imm=2
+#line 264 "sample/map.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=1257 dst=r0 src=r0 offset=0 imm=16
+#line 264 "sample/map.c"
+    r0 = test_maps_helpers[6].address
+#line 264 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 264 "sample/map.c"
+    if ((test_maps_helpers[6].tail_call) && (r0 == 0))
+#line 264 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1258 dst=r7 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1259 dst=r1 src=r7 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1260 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1261 dst=r1 src=r0 offset=0 imm=32
+#line 264 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1262 dst=r1 src=r0 offset=1 imm=0
+#line 264 "sample/map.c"
     if (r1 == IMMEDIATE(0))
-#line 190 "sample/map.c"
+#line 264 "sample/map.c"
+        goto label_41;
+        // EBPF_OP_MOV64_REG pc=1263 dst=r6 src=r7 offset=0 imm=0
+#line 264 "sample/map.c"
+    r6 = r7;
+label_41:
+    // EBPF_OP_JNE_IMM pc=1264 dst=r1 src=r0 offset=197 imm=0
+#line 264 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 264 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1265 dst=r1 src=r0 offset=0 imm=0
+#line 264 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1266 dst=r10 src=r1 offset=-4 imm=0
+#line 266 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1267 dst=r2 src=r10 offset=0 imm=0
+#line 266 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1268 dst=r2 src=r0 offset=0 imm=-4
+#line 266 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1269 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1271 dst=r0 src=r0 offset=0 imm=18
+#line 266 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 266 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 266 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 266 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1272 dst=r7 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_MOV64_REG pc=1273 dst=r1 src=r7 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1274 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1275 dst=r1 src=r0 offset=0 imm=32
+#line 266 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1276 dst=r1 src=r0 offset=1 imm=0
+#line 266 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 266 "sample/map.c"
+        goto label_42;
+        // EBPF_OP_JA pc=1277 dst=r0 src=r0 offset=184 imm=0
+#line 266 "sample/map.c"
+    goto label_58;
+label_42:
+    // EBPF_OP_LDDW pc=1278 dst=r7 src=r0 offset=0 imm=-1
+#line 266 "sample/map.c"
+    r7 = (uint64_t)4294967295;
+    // EBPF_OP_LDXW pc=1280 dst=r1 src=r10 offset=-4 imm=0
+#line 266 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1281 dst=r1 src=r0 offset=185 imm=10
+#line 266 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 266 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1282 dst=r1 src=r0 offset=0 imm=0
+#line 266 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1283 dst=r10 src=r1 offset=-4 imm=0
+#line 274 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1284 dst=r2 src=r10 offset=0 imm=0
+#line 274 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1285 dst=r2 src=r0 offset=0 imm=-4
+#line 274 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1286 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1288 dst=r0 src=r0 offset=0 imm=17
+#line 274 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 274 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 274 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 274 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1289 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1290 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1291 dst=r1 src=r0 offset=0 imm=32
+#line 274 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1292 dst=r1 src=r0 offset=2 imm=0
+#line 274 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 274 "sample/map.c"
+        goto label_44;
+label_43:
+    // EBPF_OP_MOV64_REG pc=1293 dst=r7 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r7 = r0;
+    // EBPF_OP_JA pc=1294 dst=r0 src=r0 offset=167 imm=0
+#line 274 "sample/map.c"
+    goto label_58;
+label_44:
+    // EBPF_OP_LDXW pc=1295 dst=r1 src=r10 offset=-4 imm=0
+#line 274 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1296 dst=r1 src=r0 offset=170 imm=10
+#line 274 "sample/map.c"
+    if (r1 != IMMEDIATE(10))
+#line 274 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1297 dst=r1 src=r0 offset=0 imm=0
+#line 274 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1298 dst=r10 src=r1 offset=-4 imm=0
+#line 275 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1299 dst=r2 src=r10 offset=0 imm=0
+#line 275 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1300 dst=r2 src=r0 offset=0 imm=-4
+#line 275 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1301 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1303 dst=r0 src=r0 offset=0 imm=17
+#line 275 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 275 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 275 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 275 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1304 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1305 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1306 dst=r1 src=r0 offset=0 imm=32
+#line 275 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1307 dst=r1 src=r0 offset=1 imm=0
+#line 275 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 275 "sample/map.c"
+        goto label_45;
+        // EBPF_OP_JA pc=1308 dst=r0 src=r0 offset=-16 imm=0
+#line 275 "sample/map.c"
+    goto label_43;
+label_45:
+    // EBPF_OP_LDXW pc=1309 dst=r1 src=r10 offset=-4 imm=0
+#line 275 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1310 dst=r1 src=r0 offset=156 imm=9
+#line 275 "sample/map.c"
+    if (r1 != IMMEDIATE(9))
+#line 275 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1311 dst=r1 src=r0 offset=0 imm=0
+#line 275 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1312 dst=r10 src=r1 offset=-4 imm=0
+#line 276 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1313 dst=r2 src=r10 offset=0 imm=0
+#line 276 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1314 dst=r2 src=r0 offset=0 imm=-4
+#line 276 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1315 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1317 dst=r0 src=r0 offset=0 imm=17
+#line 276 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 276 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 276 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 276 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1318 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1319 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1320 dst=r1 src=r0 offset=0 imm=32
+#line 276 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1321 dst=r1 src=r0 offset=1 imm=0
+#line 276 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 276 "sample/map.c"
+        goto label_46;
+        // EBPF_OP_JA pc=1322 dst=r0 src=r0 offset=-30 imm=0
+#line 276 "sample/map.c"
+    goto label_43;
+label_46:
+    // EBPF_OP_LDXW pc=1323 dst=r1 src=r10 offset=-4 imm=0
+#line 276 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1324 dst=r1 src=r0 offset=142 imm=8
+#line 276 "sample/map.c"
+    if (r1 != IMMEDIATE(8))
+#line 276 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1325 dst=r1 src=r0 offset=0 imm=0
+#line 276 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1326 dst=r10 src=r1 offset=-4 imm=0
+#line 277 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1327 dst=r2 src=r10 offset=0 imm=0
+#line 277 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1328 dst=r2 src=r0 offset=0 imm=-4
+#line 277 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1329 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1331 dst=r0 src=r0 offset=0 imm=17
+#line 277 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 277 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 277 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 277 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1332 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1333 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1334 dst=r1 src=r0 offset=0 imm=32
+#line 277 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1335 dst=r1 src=r0 offset=1 imm=0
+#line 277 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 277 "sample/map.c"
+        goto label_47;
+        // EBPF_OP_JA pc=1336 dst=r0 src=r0 offset=-44 imm=0
+#line 277 "sample/map.c"
+    goto label_43;
+label_47:
+    // EBPF_OP_LDXW pc=1337 dst=r1 src=r10 offset=-4 imm=0
+#line 277 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1338 dst=r1 src=r0 offset=128 imm=7
+#line 277 "sample/map.c"
+    if (r1 != IMMEDIATE(7))
+#line 277 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1339 dst=r1 src=r0 offset=0 imm=0
+#line 277 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1340 dst=r10 src=r1 offset=-4 imm=0
+#line 278 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1341 dst=r2 src=r10 offset=0 imm=0
+#line 278 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1342 dst=r2 src=r0 offset=0 imm=-4
+#line 278 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1343 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1345 dst=r0 src=r0 offset=0 imm=17
+#line 278 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 278 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 278 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 278 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1346 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1347 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1348 dst=r1 src=r0 offset=0 imm=32
+#line 278 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1349 dst=r1 src=r0 offset=1 imm=0
+#line 278 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 278 "sample/map.c"
+        goto label_48;
+        // EBPF_OP_JA pc=1350 dst=r0 src=r0 offset=-58 imm=0
+#line 278 "sample/map.c"
+    goto label_43;
+label_48:
+    // EBPF_OP_LDXW pc=1351 dst=r1 src=r10 offset=-4 imm=0
+#line 278 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1352 dst=r1 src=r0 offset=114 imm=6
+#line 278 "sample/map.c"
+    if (r1 != IMMEDIATE(6))
+#line 278 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1353 dst=r1 src=r0 offset=0 imm=0
+#line 278 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1354 dst=r10 src=r1 offset=-4 imm=0
+#line 279 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1355 dst=r2 src=r10 offset=0 imm=0
+#line 279 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1356 dst=r2 src=r0 offset=0 imm=-4
+#line 279 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1357 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1359 dst=r0 src=r0 offset=0 imm=17
+#line 279 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 279 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 279 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 279 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1360 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1361 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1362 dst=r1 src=r0 offset=0 imm=32
+#line 279 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1363 dst=r1 src=r0 offset=1 imm=0
+#line 279 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 279 "sample/map.c"
+        goto label_49;
+        // EBPF_OP_JA pc=1364 dst=r0 src=r0 offset=-72 imm=0
+#line 279 "sample/map.c"
+    goto label_43;
+label_49:
+    // EBPF_OP_LDXW pc=1365 dst=r1 src=r10 offset=-4 imm=0
+#line 279 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1366 dst=r1 src=r0 offset=100 imm=5
+#line 279 "sample/map.c"
+    if (r1 != IMMEDIATE(5))
+#line 279 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1367 dst=r1 src=r0 offset=0 imm=0
+#line 279 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1368 dst=r10 src=r1 offset=-4 imm=0
+#line 280 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1369 dst=r2 src=r10 offset=0 imm=0
+#line 280 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1370 dst=r2 src=r0 offset=0 imm=-4
+#line 280 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1371 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1373 dst=r0 src=r0 offset=0 imm=17
+#line 280 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 280 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 280 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 280 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1374 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1375 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1376 dst=r1 src=r0 offset=0 imm=32
+#line 280 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1377 dst=r1 src=r0 offset=1 imm=0
+#line 280 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 280 "sample/map.c"
+        goto label_50;
+        // EBPF_OP_JA pc=1378 dst=r0 src=r0 offset=-86 imm=0
+#line 280 "sample/map.c"
+    goto label_43;
+label_50:
+    // EBPF_OP_LDXW pc=1379 dst=r1 src=r10 offset=-4 imm=0
+#line 280 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1380 dst=r1 src=r0 offset=86 imm=4
+#line 280 "sample/map.c"
+    if (r1 != IMMEDIATE(4))
+#line 280 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1381 dst=r1 src=r0 offset=0 imm=0
+#line 280 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1382 dst=r10 src=r1 offset=-4 imm=0
+#line 281 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1383 dst=r2 src=r10 offset=0 imm=0
+#line 281 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1384 dst=r2 src=r0 offset=0 imm=-4
+#line 281 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1385 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1387 dst=r0 src=r0 offset=0 imm=17
+#line 281 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 281 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 281 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 281 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1388 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1389 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1390 dst=r1 src=r0 offset=0 imm=32
+#line 281 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1391 dst=r1 src=r0 offset=1 imm=0
+#line 281 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 281 "sample/map.c"
+        goto label_51;
+        // EBPF_OP_JA pc=1392 dst=r0 src=r0 offset=-100 imm=0
+#line 281 "sample/map.c"
+    goto label_43;
+label_51:
+    // EBPF_OP_LDXW pc=1393 dst=r1 src=r10 offset=-4 imm=0
+#line 281 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1394 dst=r1 src=r0 offset=72 imm=3
+#line 281 "sample/map.c"
+    if (r1 != IMMEDIATE(3))
+#line 281 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1395 dst=r1 src=r0 offset=0 imm=0
+#line 281 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1396 dst=r10 src=r1 offset=-4 imm=0
+#line 282 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1397 dst=r2 src=r10 offset=0 imm=0
+#line 282 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1398 dst=r2 src=r0 offset=0 imm=-4
+#line 282 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1399 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1401 dst=r0 src=r0 offset=0 imm=17
+#line 282 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 282 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 282 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 282 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1402 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1403 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1404 dst=r1 src=r0 offset=0 imm=32
+#line 282 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1405 dst=r1 src=r0 offset=1 imm=0
+#line 282 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 282 "sample/map.c"
+        goto label_52;
+        // EBPF_OP_JA pc=1406 dst=r0 src=r0 offset=-114 imm=0
+#line 282 "sample/map.c"
+    goto label_43;
+label_52:
+    // EBPF_OP_LDXW pc=1407 dst=r1 src=r10 offset=-4 imm=0
+#line 282 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1408 dst=r1 src=r0 offset=58 imm=2
+#line 282 "sample/map.c"
+    if (r1 != IMMEDIATE(2))
+#line 282 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1409 dst=r1 src=r0 offset=0 imm=0
+#line 282 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1410 dst=r10 src=r1 offset=-4 imm=0
+#line 283 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1411 dst=r2 src=r10 offset=0 imm=0
+#line 283 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1412 dst=r2 src=r0 offset=0 imm=-4
+#line 283 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1413 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1415 dst=r0 src=r0 offset=0 imm=17
+#line 283 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 283 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 283 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 283 "sample/map.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=1416 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = r0;
+    // EBPF_OP_LSH64_IMM pc=1417 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1418 dst=r1 src=r0 offset=0 imm=32
+#line 283 "sample/map.c"
+    r1 >>= IMMEDIATE(32);
+    // EBPF_OP_JEQ_IMM pc=1419 dst=r1 src=r0 offset=1 imm=0
+#line 283 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 283 "sample/map.c"
+        goto label_53;
+        // EBPF_OP_JA pc=1420 dst=r0 src=r0 offset=-128 imm=0
+#line 283 "sample/map.c"
+    goto label_43;
+label_53:
+    // EBPF_OP_LDXW pc=1421 dst=r1 src=r10 offset=-4 imm=0
+#line 283 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JNE_IMM pc=1422 dst=r1 src=r0 offset=44 imm=1
+#line 283 "sample/map.c"
+    if (r1 != IMMEDIATE(1))
+#line 283 "sample/map.c"
+        goto label_59;
+        // EBPF_OP_MOV64_IMM pc=1423 dst=r1 src=r0 offset=0 imm=0
+#line 283 "sample/map.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1424 dst=r10 src=r1 offset=-4 imm=0
+#line 286 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=1425 dst=r2 src=r10 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1426 dst=r2 src=r0 offset=0 imm=-4
+#line 286 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1427 dst=r1 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1429 dst=r0 src=r0 offset=0 imm=18
+#line 286 "sample/map.c"
+    r0 = test_maps_helpers[4].address
+#line 286 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 286 "sample/map.c"
+    if ((test_maps_helpers[4].tail_call) && (r0 == 0))
+#line 286 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1430 dst=r1 src=r10 offset=-4 imm=0
+#line 286 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_MOV64_REG pc=1431 dst=r7 src=r6 offset=0 imm=0
+#line 286 "sample/map.c"
+    r7 = r6;
+    // EBPF_OP_JEQ_IMM pc=1432 dst=r1 src=r0 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_54;
+        // EBPF_OP_MOV64_IMM pc=1433 dst=r7 src=r0 offset=0 imm=-1
+#line 286 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_54:
+    // EBPF_OP_MOV64_REG pc=1434 dst=r2 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1435 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1436 dst=r2 src=r0 offset=0 imm=32
+#line 286 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1437 dst=r3 src=r0 offset=0 imm=-7
+#line 286 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1439 dst=r2 src=r3 offset=1 imm=0
+#line 286 "sample/map.c"
+    if (r2 == r3)
+#line 286 "sample/map.c"
+        goto label_55;
+        // EBPF_OP_MOV64_REG pc=1440 dst=r7 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r7 = r0;
+label_55:
+    // EBPF_OP_JNE_REG pc=1441 dst=r2 src=r3 offset=20 imm=0
+#line 286 "sample/map.c"
+    if (r2 != r3)
+#line 286 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_JNE_IMM pc=1442 dst=r1 src=r0 offset=19 imm=0
+#line 286 "sample/map.c"
+    if (r1 != IMMEDIATE(0))
+#line 286 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_MOV64_IMM pc=1443 dst=r6 src=r0 offset=0 imm=0
+#line 286 "sample/map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=1444 dst=r10 src=r6 offset=-4 imm=0
+#line 287 "sample/map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint32_t)r6;
+    // EBPF_OP_MOV64_REG pc=1445 dst=r2 src=r10 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=1446 dst=r2 src=r0 offset=0 imm=-4
+#line 287 "sample/map.c"
+    r2 += IMMEDIATE(-4);
+    // EBPF_OP_LDDW pc=1447 dst=r1 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r1 = POINTER(_maps[7].address);
+    // EBPF_OP_CALL pc=1449 dst=r0 src=r0 offset=0 imm=17
+#line 287 "sample/map.c"
+    r0 = test_maps_helpers[5].address
+#line 287 "sample/map.c"
+         (r1, r2, r3, r4, r5);
+#line 287 "sample/map.c"
+    if ((test_maps_helpers[5].tail_call) && (r0 == 0))
+#line 287 "sample/map.c"
+        return 0;
+        // EBPF_OP_LDXW pc=1450 dst=r1 src=r10 offset=-4 imm=0
+#line 287 "sample/map.c"
+    r1 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
+    // EBPF_OP_JEQ_IMM pc=1451 dst=r1 src=r0 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
+        goto label_56;
+        // EBPF_OP_MOV64_IMM pc=1452 dst=r7 src=r0 offset=0 imm=-1
+#line 287 "sample/map.c"
+    r7 = IMMEDIATE(-1);
+label_56:
+    // EBPF_OP_MOV64_REG pc=1453 dst=r2 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r2 = r0;
+    // EBPF_OP_LSH64_IMM pc=1454 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 <<= IMMEDIATE(32);
+    // EBPF_OP_RSH64_IMM pc=1455 dst=r2 src=r0 offset=0 imm=32
+#line 287 "sample/map.c"
+    r2 >>= IMMEDIATE(32);
+    // EBPF_OP_LDDW pc=1456 dst=r3 src=r0 offset=0 imm=-7
+#line 287 "sample/map.c"
+    r3 = (uint64_t)4294967289;
+    // EBPF_OP_JEQ_REG pc=1458 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 == r3)
+#line 287 "sample/map.c"
+        goto label_57;
+        // EBPF_OP_MOV64_REG pc=1459 dst=r7 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r7 = r0;
+label_57:
+    // EBPF_OP_JNE_REG pc=1460 dst=r2 src=r3 offset=1 imm=0
+#line 287 "sample/map.c"
+    if (r2 != r3)
+#line 287 "sample/map.c"
+        goto label_58;
+        // EBPF_OP_JEQ_IMM pc=1461 dst=r1 src=r0 offset=-1416 imm=0
+#line 287 "sample/map.c"
+    if (r1 == IMMEDIATE(0))
+#line 287 "sample/map.c"
         goto label_1;
-        // EBPF_OP_JA pc=1221 dst=r0 src=r0 offset=-477 imm=0
-#line 190 "sample/map.c"
-    goto label_27;
-#line 190 "sample/map.c"
+label_58:
+    // EBPF_OP_MOV64_IMM pc=1462 dst=r6 src=r0 offset=0 imm=0
+#line 287 "sample/map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_REG pc=1463 dst=r1 src=r7 offset=0 imm=0
+#line 306 "sample/map.c"
+    r1 = r7;
+    // EBPF_OP_LSH64_IMM pc=1464 dst=r1 src=r0 offset=0 imm=32
+#line 306 "sample/map.c"
+    r1 <<= IMMEDIATE(32);
+    // EBPF_OP_ARSH64_IMM pc=1465 dst=r1 src=r0 offset=0 imm=32
+#line 306 "sample/map.c"
+    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    // EBPF_OP_JSGT_IMM pc=1466 dst=r1 src=r0 offset=-1421 imm=-1
+#line 306 "sample/map.c"
+    if ((int64_t)r1 > IMMEDIATE(-1))
+#line 306 "sample/map.c"
+        goto label_1;
+label_59:
+    // EBPF_OP_MOV64_REG pc=1467 dst=r6 src=r7 offset=0 imm=0
+#line 306 "sample/map.c"
+    r6 = r7;
+    // EBPF_OP_JA pc=1468 dst=r0 src=r0 offset=-1423 imm=0
+#line 306 "sample/map.c"
+    goto label_1;
+#line 306 "sample/map.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -4475,7 +5349,7 @@ static program_entry_t _programs[] = {
         8,
         test_maps_helpers,
         7,
-        1222,
+        1469,
         &test_maps_program_type_guid,
         &test_maps_attach_type_guid,
     },

--- a/tests/sample/bindmonitor.c
+++ b/tests/sample/bindmonitor.c
@@ -58,7 +58,7 @@ update_audit_entry(bind_md_t* ctx)
     bpf_map_update_elem(&audit_map, &process_id, &audit_entry, 0);
 }
 
-inline process_entry_t*
+__attribute__((always_inline)) process_entry_t*
 find_or_create_process_entry(bind_md_t* ctx)
 {
     uint64_t key = ctx->process_id;
@@ -81,12 +81,208 @@ find_or_create_process_entry(bind_md_t* ctx)
     if (!entry)
         return entry;
 
+#if 0
     for (index = 0; index < 64; index++) {
         if ((ctx->app_id_start + index) >= ctx->app_id_end)
             break;
 
         entry->name[index] = ctx->app_id_start[index];
     }
+#else
+    // Work around temporary verifier limitation.
+    if (ctx->app_id_end - ctx->app_id_start > 0) {
+        entry->name[0] = ctx->app_id_start[0];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 1) {
+        entry->name[1] = ctx->app_id_start[1];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 2) {
+        entry->name[2] = ctx->app_id_start[2];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 3) {
+        entry->name[3] = ctx->app_id_start[3];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 4) {
+        entry->name[4] = ctx->app_id_start[4];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 5) {
+        entry->name[5] = ctx->app_id_start[5];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 6) {
+        entry->name[6] = ctx->app_id_start[6];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 7) {
+        entry->name[7] = ctx->app_id_start[7];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 8) {
+        entry->name[8] = ctx->app_id_start[8];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 9) {
+        entry->name[9] = ctx->app_id_start[9];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 10) {
+        entry->name[10] = ctx->app_id_start[10];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 11) {
+        entry->name[11] = ctx->app_id_start[11];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 12) {
+        entry->name[12] = ctx->app_id_start[12];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 13) {
+        entry->name[13] = ctx->app_id_start[13];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 14) {
+        entry->name[14] = ctx->app_id_start[14];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 15) {
+        entry->name[15] = ctx->app_id_start[15];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 16) {
+        entry->name[16] = ctx->app_id_start[16];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 17) {
+        entry->name[17] = ctx->app_id_start[17];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 18) {
+        entry->name[18] = ctx->app_id_start[18];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 19) {
+        entry->name[19] = ctx->app_id_start[19];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 20) {
+        entry->name[20] = ctx->app_id_start[20];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 21) {
+        entry->name[21] = ctx->app_id_start[21];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 22) {
+        entry->name[22] = ctx->app_id_start[22];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 23) {
+        entry->name[23] = ctx->app_id_start[23];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 24) {
+        entry->name[24] = ctx->app_id_start[24];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 25) {
+        entry->name[25] = ctx->app_id_start[25];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 26) {
+        entry->name[26] = ctx->app_id_start[26];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 27) {
+        entry->name[27] = ctx->app_id_start[27];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 28) {
+        entry->name[28] = ctx->app_id_start[28];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 29) {
+        entry->name[29] = ctx->app_id_start[29];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 30) {
+        entry->name[30] = ctx->app_id_start[30];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 31) {
+        entry->name[31] = ctx->app_id_start[31];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 32) {
+        entry->name[32] = ctx->app_id_start[32];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 33) {
+        entry->name[33] = ctx->app_id_start[33];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 34) {
+        entry->name[34] = ctx->app_id_start[34];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 35) {
+        entry->name[35] = ctx->app_id_start[35];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 36) {
+        entry->name[36] = ctx->app_id_start[36];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 37) {
+        entry->name[37] = ctx->app_id_start[37];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 38) {
+        entry->name[38] = ctx->app_id_start[38];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 39) {
+        entry->name[39] = ctx->app_id_start[39];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 40) {
+        entry->name[40] = ctx->app_id_start[40];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 41) {
+        entry->name[41] = ctx->app_id_start[41];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 42) {
+        entry->name[42] = ctx->app_id_start[42];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 43) {
+        entry->name[43] = ctx->app_id_start[43];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 44) {
+        entry->name[44] = ctx->app_id_start[44];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 45) {
+        entry->name[45] = ctx->app_id_start[45];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 46) {
+        entry->name[46] = ctx->app_id_start[46];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 47) {
+        entry->name[47] = ctx->app_id_start[47];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 48) {
+        entry->name[48] = ctx->app_id_start[48];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 49) {
+        entry->name[49] = ctx->app_id_start[49];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 50) {
+        entry->name[50] = ctx->app_id_start[50];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 51) {
+        entry->name[51] = ctx->app_id_start[51];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 52) {
+        entry->name[52] = ctx->app_id_start[52];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 53) {
+        entry->name[53] = ctx->app_id_start[53];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 54) {
+        entry->name[54] = ctx->app_id_start[54];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 55) {
+        entry->name[55] = ctx->app_id_start[55];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 56) {
+        entry->name[56] = ctx->app_id_start[56];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 57) {
+        entry->name[57] = ctx->app_id_start[57];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 58) {
+        entry->name[58] = ctx->app_id_start[58];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 59) {
+        entry->name[59] = ctx->app_id_start[59];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 60) {
+        entry->name[60] = ctx->app_id_start[60];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 61) {
+        entry->name[61] = ctx->app_id_start[61];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 62) {
+        entry->name[62] = ctx->app_id_start[62];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 63) {
+        entry->name[63] = ctx->app_id_start[63];
+    }
+#endif
     return entry;
 }
 

--- a/tests/sample/bindmonitor_tailcall.c
+++ b/tests/sample/bindmonitor_tailcall.c
@@ -72,7 +72,7 @@ struct _ebpf_map_definition_in_file dummy_inner_map = {
     .max_entries = 1,
     .id = INNER_MAP_ID};
 
-inline process_entry_t*
+__attribute__((always_inline)) process_entry_t*
 find_or_create_process_entry(bind_md_t* ctx)
 {
     uint64_t key = ctx->process_id;
@@ -95,12 +95,208 @@ find_or_create_process_entry(bind_md_t* ctx)
     if (!entry)
         return entry;
 
+#if 0
     for (index = 0; index < 64; index++) {
         if ((ctx->app_id_start + index) >= ctx->app_id_end)
             break;
 
         entry->name[index] = ctx->app_id_start[index];
     }
+#else
+    // Work around temporary verifier limitation.
+    if (ctx->app_id_end - ctx->app_id_start > 0) {
+        entry->name[0] = ctx->app_id_start[0];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 1) {
+        entry->name[1] = ctx->app_id_start[1];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 2) {
+        entry->name[2] = ctx->app_id_start[2];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 3) {
+        entry->name[3] = ctx->app_id_start[3];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 4) {
+        entry->name[4] = ctx->app_id_start[4];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 5) {
+        entry->name[5] = ctx->app_id_start[5];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 6) {
+        entry->name[6] = ctx->app_id_start[6];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 7) {
+        entry->name[7] = ctx->app_id_start[7];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 8) {
+        entry->name[8] = ctx->app_id_start[8];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 9) {
+        entry->name[9] = ctx->app_id_start[9];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 10) {
+        entry->name[10] = ctx->app_id_start[10];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 11) {
+        entry->name[11] = ctx->app_id_start[11];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 12) {
+        entry->name[12] = ctx->app_id_start[12];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 13) {
+        entry->name[13] = ctx->app_id_start[13];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 14) {
+        entry->name[14] = ctx->app_id_start[14];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 15) {
+        entry->name[15] = ctx->app_id_start[15];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 16) {
+        entry->name[16] = ctx->app_id_start[16];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 17) {
+        entry->name[17] = ctx->app_id_start[17];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 18) {
+        entry->name[18] = ctx->app_id_start[18];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 19) {
+        entry->name[19] = ctx->app_id_start[19];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 20) {
+        entry->name[20] = ctx->app_id_start[20];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 21) {
+        entry->name[21] = ctx->app_id_start[21];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 22) {
+        entry->name[22] = ctx->app_id_start[22];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 23) {
+        entry->name[23] = ctx->app_id_start[23];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 24) {
+        entry->name[24] = ctx->app_id_start[24];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 25) {
+        entry->name[25] = ctx->app_id_start[25];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 26) {
+        entry->name[26] = ctx->app_id_start[26];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 27) {
+        entry->name[27] = ctx->app_id_start[27];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 28) {
+        entry->name[28] = ctx->app_id_start[28];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 29) {
+        entry->name[29] = ctx->app_id_start[29];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 30) {
+        entry->name[30] = ctx->app_id_start[30];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 31) {
+        entry->name[31] = ctx->app_id_start[31];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 32) {
+        entry->name[32] = ctx->app_id_start[32];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 33) {
+        entry->name[33] = ctx->app_id_start[33];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 34) {
+        entry->name[34] = ctx->app_id_start[34];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 35) {
+        entry->name[35] = ctx->app_id_start[35];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 36) {
+        entry->name[36] = ctx->app_id_start[36];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 37) {
+        entry->name[37] = ctx->app_id_start[37];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 38) {
+        entry->name[38] = ctx->app_id_start[38];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 39) {
+        entry->name[39] = ctx->app_id_start[39];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 40) {
+        entry->name[40] = ctx->app_id_start[40];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 41) {
+        entry->name[41] = ctx->app_id_start[41];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 42) {
+        entry->name[42] = ctx->app_id_start[42];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 43) {
+        entry->name[43] = ctx->app_id_start[43];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 44) {
+        entry->name[44] = ctx->app_id_start[44];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 45) {
+        entry->name[45] = ctx->app_id_start[45];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 46) {
+        entry->name[46] = ctx->app_id_start[46];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 47) {
+        entry->name[47] = ctx->app_id_start[47];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 48) {
+        entry->name[48] = ctx->app_id_start[48];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 49) {
+        entry->name[49] = ctx->app_id_start[49];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 50) {
+        entry->name[50] = ctx->app_id_start[50];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 51) {
+        entry->name[51] = ctx->app_id_start[51];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 52) {
+        entry->name[52] = ctx->app_id_start[52];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 53) {
+        entry->name[53] = ctx->app_id_start[53];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 54) {
+        entry->name[54] = ctx->app_id_start[54];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 55) {
+        entry->name[55] = ctx->app_id_start[55];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 56) {
+        entry->name[56] = ctx->app_id_start[56];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 57) {
+        entry->name[57] = ctx->app_id_start[57];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 58) {
+        entry->name[58] = ctx->app_id_start[58];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 59) {
+        entry->name[59] = ctx->app_id_start[59];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 60) {
+        entry->name[60] = ctx->app_id_start[60];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 61) {
+        entry->name[61] = ctx->app_id_start[61];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 62) {
+        entry->name[62] = ctx->app_id_start[62];
+    }
+    if (ctx->app_id_end - ctx->app_id_start > 63) {
+        entry->name[63] = ctx->app_id_start[63];
+    }
+#endif
     return entry;
 }
 

--- a/tests/sample/map.c
+++ b/tests/sample/map.c
@@ -110,7 +110,7 @@ test_GENERAL_map(struct _ebpf_map_definition_in_file* map)
     return 0;
 }
 
-inline int
+__attribute__((always_inline)) int
 test_LRU_map(struct _ebpf_map_definition_in_file* map)
 {
     uint32_t key = 0;
@@ -118,6 +118,7 @@ test_LRU_map(struct _ebpf_map_definition_in_file* map)
     int result;
 
     // Insert capacity + 1 entries
+#if 0
     for (key = 0; key < 11; key++) {
         result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
         if (result < 0) {
@@ -125,6 +126,74 @@ test_LRU_map(struct _ebpf_map_definition_in_file* map)
             return result;
         }
     }
+#else
+    // Work around temporary compiler limitation.
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 1;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 2;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 3;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 4;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 5;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 6;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 7;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 8;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 9;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+    key = 10;
+    result = bpf_map_update_elem(map, &key, &value, BPF_ANY);
+    if (result < 0) {
+        bpf_printk("bpf_map_update_elem returned %d", result);
+        return result;
+    }
+#endif
     return 0;
 }
 
@@ -173,18 +242,46 @@ test_PUSH_POP_map(struct _ebpf_map_definition_in_file* map)
     PEEK_VALUE(map, 0, -7);
     POP_VALUE(map, 0, -7);
 
+#if 0
     for (i = 0; i < 10; i++) {
         PUSH_VALUE(map, i, FALSE, 0);
     }
+#else
+    // Work around current verifier limitation.
+    PUSH_VALUE(map, 0, FALSE, 0);
+    PUSH_VALUE(map, 1, FALSE, 0);
+    PUSH_VALUE(map, 2, FALSE, 0);
+    PUSH_VALUE(map, 3, FALSE, 0);
+    PUSH_VALUE(map, 4, FALSE, 0);
+    PUSH_VALUE(map, 5, FALSE, 0);
+    PUSH_VALUE(map, 6, FALSE, 0);
+    PUSH_VALUE(map, 7, FALSE, 0);
+    PUSH_VALUE(map, 8, FALSE, 0);
+    PUSH_VALUE(map, 9, FALSE, 0);
+#endif
 
     PUSH_VALUE(map, 10, FALSE, -29);
     PUSH_VALUE(map, 10, TRUE, 0);
 
     PEEK_VALUE(map, (map == &STACK_map) ? 10 : 1, 0);
 
+#if 0
     for (i = 0; i < 10; i++) {
         POP_VALUE(map, (map == &STACK_map) ? 10 - i : i + 1, 0);
     }
+#else
+    // Work around current verifier limitation.
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 0 : 0 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 1 : 1 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 2 : 2 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 3 : 3 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 4 : 4 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 5 : 5 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 6 : 6 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 7 : 7 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 8 : 8 + 1, 0);
+    POP_VALUE(map, (map == &STACK_map) ? 10 - 9 : 9 + 1, 0);
+#endif
 
     PEEK_VALUE(map, 0, -7);
     POP_VALUE(map, 0, -7);


### PR DESCRIPTION
Signed-off-by: Dave Thaler <dthaler@microsoft.com>

## Description

* Update verifier to latest and accept that some programs will fail verification until functionality is added to PREVAIL.
* Also fix a compiler warning in ebpf_program.c about passing a const pointer to a function that requires non-const.
* Update 3 samples with workaround for temporary verifier limitation (tracked by https://github.com/vbpf/ebpf-verifier/issues/441), by unrolling loops

Fixes #1451
Fixes #1756

## Testing

Existing tests cover.  The following samples fail to verify with the latest verifier and required updating with workarounds to remove `for` loops:
* bindmonitor.c
* bindmonitor_tailcall.c
* map.c

## Documentation

No impact.
