### PR TITLE
Add support for deploying eBPF to arbitrary filesystem locations

### DIFF
--- a/docs/InstallEbpf.md
+++ b/docs/InstallEbpf.md
@@ -71,6 +71,10 @@ has already built the binaries for `x64/Debug` or `x64/Release`.
         ```ps
         .\x64\debug\deploy-ebpf --vm="<test-vm-name>" -t
         ```
+        or, to copy files to a specific directory, including file shares, run:
+        ```ps
+        .\x64\debug\deploy-ebpf -l="c:\some\path"
+        ```
 
 2. From within the VM, install the binaries by starting an administrator Command Prompt shell (cmd.exe)
 , and running the following commands:

--- a/scripts/deploy-ebpf.ps1.in
+++ b/scripts/deploy-ebpf.ps1.in
@@ -186,7 +186,7 @@ OPTIONS:
     -h, --help     Print this help message.
     -m, --msi      Copies MSI instead of individual files
     -l, --local    Copies files to the local temp directory instead of into a VM
-\    -t, --test     Includes files needed only for testing and debugging
+    -t, --test     Includes files needed only for testing and debugging
     --vm           Specifies the VM name, which defaults to "Windows 10 dev environment"
 
 '@

--- a/scripts/deploy-ebpf.ps1.in
+++ b/scripts/deploy-ebpf.ps1.in
@@ -179,14 +179,14 @@ OVERVIEW:
 
 Copies eBPF framework files into a temp directory on the local machine or into a VM
 
-    $ deploy-ebpf [--dir="..."] [-h] [-l] [-m] [-t] [--vm="..."]
+    $ deploy-ebpf [--dir="..."] [-h] [-l[=path]] [-m] [-t] [--vm="..."]
 
 OPTIONS:
     --dir          Specifies the source directory path, which defaults to "."
     -h, --help     Print this help message.
     -m, --msi      Copies MSI instead of individual files
     -l, --local    Copies files to the local temp directory instead of into a VM
-    -t, --test     Includes files needed only for testing and debugging
+\    -t, --test     Includes files needed only for testing and debugging
     --vm           Specifies the VM name, which defaults to "Windows 10 dev environment"
 
 '@
@@ -202,8 +202,11 @@ OPTIONS:
             $vm=($arg -split "=")[1];
             break
         }
-    { @("-l", "--local") -contains $_ }
+    "^(?:-l|--list)(?:=(.+))?$"
         {
+            if ($matches[1]) {
+                $destination_directory = $matches[1]
+            }
             Clear-Variable -name vm
             break
         }
@@ -234,22 +237,24 @@ if ($vm -eq $null) {
    foreach ( $file in $built_files ) {
       $source_path = "$build_directory\$file"
       $destination_path = "$destination_directory\$file"
+      $destination_full_dir = Split-Path $destination_path
       Write-Host " $source_path -> $destination_path"
-      Copy-Item "$source_path" -Destination "$destination_path"
-      if (! $?) {
-         exit 1
+      if (! (Test-Path $destination_full_dir)) {
+         New-Item -Type Directory $destination_full_dir -ErrorAction Stop | Write-Verbose
       }
+      Copy-Item "$source_path" -Destination "$destination_path" -ErrorAction Stop
    }
 
    Write-Host "Copying files from `"$source_directory`" to `"$destination_directory`""
    foreach ( $file in $source_files ) {
       $source_path = "$source_directory\$file"
       $destination_path = "$destination_directory\$file"
+      $destination_full_dir = Split-Path $destination_path
       Write-Host " $source_path -> $destination_path"
-      Copy-Item "$source_path" -Destination "$destination_path"
-      if (! $?) {
-         exit 1
+      if (! (Test-Path $destination_full_dir)) {
+         New-Item -Type Directory $destination_full_dir -ErrorAction Stop | Write-Verbose
       }
+      Copy-Item "$source_path" -Destination "$destination_path" -ErrorAction Stop
    }
    exit 0
 }

--- a/scripts/deploy-ebpf.ps1.in
+++ b/scripts/deploy-ebpf.ps1.in
@@ -237,10 +237,10 @@ if ($vm -eq $null) {
    foreach ( $file in $built_files ) {
       $source_path = "$build_directory\$file"
       $destination_path = "$destination_directory\$file"
-      $destination_full_dir = Split-Path $destination_path
+      $destination_full_directory = Split-Path $destination_path
       Write-Host " $source_path -> $destination_path"
-      if (! (Test-Path $destination_full_dir)) {
-         New-Item -Type Directory $destination_full_dir -ErrorAction Stop | Write-Verbose
+      if (! (Test-Path $destination_full_directory)) {
+         New-Item -Type Directory $destination_full_directory -ErrorAction Stop | Write-Verbose
       }
       Copy-Item "$source_path" -Destination "$destination_path" -ErrorAction Stop
    }
@@ -249,10 +249,10 @@ if ($vm -eq $null) {
    foreach ( $file in $source_files ) {
       $source_path = "$source_directory\$file"
       $destination_path = "$destination_directory\$file"
-      $destination_full_dir = Split-Path $destination_path
+      $destination_full_directory = Split-Path $destination_path
       Write-Host " $source_path -> $destination_path"
-      if (! (Test-Path $destination_full_dir)) {
-         New-Item -Type Directory $destination_full_dir -ErrorAction Stop | Write-Verbose
+      if (! (Test-Path $destination_full_directory)) {
+         New-Item -Type Directory $destination_full_directory -ErrorAction Stop | Write-Verbose
       }
       Copy-Item "$source_path" -Destination "$destination_path" -ErrorAction Stop
    }


### PR DESCRIPTION
## Description

Add support for deploying eBPF to arbitrary filesystem locations, removing the local admin + local VM requirement.
Resolves #1994 

## Testing

Tested locally, targeting both the local system and remote filesystems over SMB.

## Documentation

Updated [InstallEbpf.md](https://github.com/mtfriesen/ebpf-for-windows/blob/mtfriesen/deploy_script/docs/InstallEbpf.md).
