### PR TITLE
Resolve circular references using id entry references

### DIFF
--- a/include/ebpf_result.h
+++ b/include/ebpf_result.h
@@ -112,6 +112,9 @@ extern "C"
 
         /// Operation timed out.
         EBPF_TIMEOUT,
+
+        /// Key is valid, but the object has been deleted.
+        EBPF_STALE_KEY,
     } ebpf_result_t;
 
 #define EBPF_RESULT_COUNT (EBPF_INVALID_POINTER + 1)

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -23,7 +23,7 @@ typedef struct _ebpf_core_object_map
 {
     ebpf_core_map_t core_map;
     ebpf_lock_t lock;
-    struct _ebpf_core_map* inner_map_template;
+    ebpf_map_definition_in_memory_t inner_template_map_definition;
     bool is_program_type_set;
     ebpf_program_type_t program_type;
 } ebpf_core_object_map_t;
@@ -431,10 +431,12 @@ _associate_inner_map(_Inout_ ebpf_core_object_map_t* object_map, ebpf_handle_t i
     ebpf_core_object_t* inner_map_template_object = NULL;
 
     if (local_map_definition.type != BPF_MAP_TYPE_ARRAY_OF_MAPS &&
-        local_map_definition.type != BPF_MAP_TYPE_HASH_OF_MAPS)
+        local_map_definition.type != BPF_MAP_TYPE_HASH_OF_MAPS) {
         goto Exit;
+    }
 
     if (inner_map_handle == ebpf_handle_invalid) {
+
         // Must have a valid inner_map_handle.
         EBPF_LOG_MESSAGE(
             EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Map in map must have a valid inner_map_handle");
@@ -444,31 +446,35 @@ _associate_inner_map(_Inout_ ebpf_core_object_map_t* object_map, ebpf_handle_t i
 
     // Convert value handle to an object pointer.
     result = ebpf_object_reference_by_handle(inner_map_handle, EBPF_OBJECT_MAP, &inner_map_template_object);
-    if (result != EBPF_SUCCESS)
+    if (result != EBPF_SUCCESS) {
+        EBPF_LOG_MESSAGE_NTSTATUS(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Get object ref by handle failed.", result);
         goto Exit;
+    }
 
-    object_map->inner_map_template = (ebpf_map_t*)inner_map_template_object;
-    object_map->core_map.ebpf_map_definition.inner_map_id = object_map->inner_map_template->object.id;
+    ebpf_core_map_t* template_core_map = (ebpf_core_map_t*)inner_map_template_object;
+    template_core_map = EBPF_FROM_FIELD(ebpf_core_map_t, object, inner_map_template_object);
+
+    object_map->inner_template_map_definition = template_core_map->ebpf_map_definition;
+    object_map->core_map.ebpf_map_definition.inner_map_id = template_core_map->object.id;
 
 Exit:
+    if (inner_map_template_object) {
+        ebpf_object_release_reference(inner_map_template_object);
+    }
+
     return result;
 }
 
 static void
 _delete_object_array_map(_Inout_ _Post_invalid_ ebpf_core_map_t* map, ebpf_object_type_t value_type)
 {
-    ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
-
     // Release all entry references.
     for (uint32_t i = 0; i < map->ebpf_map_definition.max_entries; i++) {
         ebpf_id_t id = *(ebpf_id_t*)&map->data[i * map->ebpf_map_definition.value_size];
         if (id) {
-            ebpf_assert_success(ebpf_object_dereference_by_id(id, value_type));
+            ebpf_assert_success(ebpf_object_release_id_reference(id, value_type));
         }
-    }
-
-    if (object_map->inner_map_template != NULL) {
-        ebpf_object_release_reference(&object_map->inner_map_template->object);
     }
 
     _delete_array_map(map);
@@ -559,14 +565,13 @@ _check_value_type(_In_ const ebpf_core_map_t* outer_map, _In_ const ebpf_core_ob
     }
 
     ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, outer_map);
-
-    ebpf_core_map_t* template = object_map->inner_map_template;
     const ebpf_map_t* value_map = (ebpf_map_t*)value_object;
 
-    bool allowed = (template != NULL) && (value_map->ebpf_map_definition.type == template->ebpf_map_definition.type) &&
-                   (value_map->ebpf_map_definition.key_size == template->ebpf_map_definition.key_size) &&
-                   (value_map->ebpf_map_definition.value_size == template->ebpf_map_definition.value_size) &&
-                   (value_map->ebpf_map_definition.max_entries == template->ebpf_map_definition.max_entries);
+    bool allowed =
+        (value_map->ebpf_map_definition.type == object_map->inner_template_map_definition.type) &&
+        (value_map->ebpf_map_definition.key_size == object_map->inner_template_map_definition.key_size) &&
+        (value_map->ebpf_map_definition.value_size == object_map->inner_template_map_definition.value_size) &&
+        (value_map->ebpf_map_definition.max_entries == object_map->inner_template_map_definition.max_entries);
 
     return allowed;
 }
@@ -618,52 +623,97 @@ _update_array_map_entry_with_handle(
     uintptr_t value_handle,
     ebpf_map_option_t option)
 {
-    if (!map || !key || (option == EBPF_NOEXIST))
-        return EBPF_INVALID_ARGUMENT;
-
-    uint32_t index = *(uint32_t*)key;
-
-    if (index >= map->ebpf_map_definition.max_entries)
-        return EBPF_INVALID_ARGUMENT;
-
     ebpf_result_t result = EBPF_SUCCESS;
 
-    ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
-    ebpf_core_object_t* value_object = NULL;
+    // The 'map' and 'key' arguments cannot be NULL due to caller's prior validations.
+    ebpf_assert(map != NULL && key != NULL);
 
+    if (option == EBPF_NOEXIST) {
+        EBPF_LOG_MESSAGE_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Invalid map option rejected", option);
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    uint32_t index = *(uint32_t*)key;
+    if (index >= map->ebpf_map_definition.max_entries) {
+        EBPF_LOG_MESSAGE_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Index larger than max entries rejected", index);
+        return EBPF_INVALID_ARGUMENT;
+    }
+
+    ebpf_core_object_t* value_object = NULL;
     if (value_handle != (uintptr_t)ebpf_handle_invalid) {
         result = ebpf_object_reference_by_handle(value_handle, value_type, &value_object);
         if (result != EBPF_SUCCESS) {
+            EBPF_LOG_MESSAGE_UINT64_UINT64(
+                EBPF_TRACELOG_LEVEL_ERROR,
+                EBPF_TRACELOG_KEYWORD_MAP,
+                "Invalid object handle rejected",
+                value_handle,
+                result);
             return result;
         }
     }
 
+    ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
+    bool locked = FALSE;
+
     ebpf_lock_state_t lock_state = ebpf_lock_lock(&object_map->lock);
+    locked = TRUE;
 
     if (value_handle != (uintptr_t)ebpf_handle_invalid) {
         result = _validate_map_value_object(object_map, value_type, value_object);
         if (result != EBPF_SUCCESS) {
+            EBPF_LOG_MESSAGE_UINT64_UINT64(
+                EBPF_TRACELOG_LEVEL_ERROR,
+                EBPF_TRACELOG_KEYWORD_MAP,
+                "Object validation failed",
+                value_object->id,
+                result);
             goto Done;
         }
     }
 
-    // Release the reference on the old ID stored here, if any.
     uint8_t* entry = &map->data[*key * map->ebpf_map_definition.value_size];
     ebpf_id_t old_id = *(ebpf_id_t*)entry;
     if (old_id) {
-        ebpf_assert_success(ebpf_object_dereference_by_id(old_id, value_type));
+
+        // Release the reference on the old ID's id table entry. The object may have been already deleted, so an
+        // error return value of 'not found' is ok.
+        result = ebpf_object_release_id_reference(old_id, value_type);
+        ebpf_assert(result == EBPF_SUCCESS || result == EBPF_STALE_KEY);
+        if (result == EBPF_STALE_KEY) {
+            result = EBPF_SUCCESS;
+        }
     }
 
-    ebpf_id_t id = value_object ? value_object->id : 0;
+    if (value_object) {
 
-    // Store the object ID as the value.
+        // Acquire a reference to the id table entry for the new incoming id. This operation _cannot_ fail as we
+        // already have a valid pointer to the object.  A failure here is indicative of a fatal internal error.
+        ebpf_assert_success(ebpf_object_acquire_id_reference(value_object->id, value_type));
+    }
+
+    // Note that this could be an 'update to erase' operation where we don't have a valid (incoming) object.  In this
+    // case, the 'id' value in the map entry is 'updated' to zero.
+    ebpf_id_t id = value_object ? value_object->id : 0;
     memcpy(entry, &id, map->ebpf_map_definition.value_size);
+    result = EBPF_SUCCESS;
 
 Done:
-    if (result != EBPF_SUCCESS && value_object != NULL) {
+
+    if (value_object != NULL) {
+
+        // We have stored the id of the object, so let go of our reference on the object itself.  Going forward, we'll
+        // use the id to get to the object, as and when required.  Note that this is with the explicit understanding
+        // that the object may well have been since destroyed by the time we actually need to use this id. This is
+        // perfectly valid and something we need to be prepared for.
         ebpf_object_release_reference((ebpf_core_object_t*)value_object);
     }
-    ebpf_lock_unlock(&object_map->lock, lock_state);
+
+    if (locked) {
+        ebpf_lock_unlock(&object_map->lock, lock_state);
+    }
 
     return result;
 }
@@ -686,8 +736,8 @@ static ebpf_result_t
 _delete_array_map_entry_with_reference(
     _Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key, ebpf_object_type_t value_type)
 {
-    if (value_type == EBPF_OBJECT_UNKNOWN)
-        return EBPF_INVALID_ARGUMENT;
+    ebpf_assert(value_type == EBPF_OBJECT_PROGRAM || value_type == EBPF_OBJECT_MAP);
+
     ebpf_result_t result;
     uint8_t* entry;
     ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
@@ -696,7 +746,13 @@ _delete_array_map_entry_with_reference(
     if (result == EBPF_SUCCESS) {
         ebpf_id_t id = *(ebpf_id_t*)entry;
         if (id) {
-            ebpf_assert_success(ebpf_object_dereference_by_id(id, value_type));
+
+            // The object may have been already deleted, so an error return value of 'stale key' is ok.
+            result = ebpf_object_release_id_reference(id, value_type);
+            ebpf_assert(result == EBPF_SUCCESS || result == EBPF_STALE_KEY);
+            if (result == EBPF_STALE_KEY) {
+                result = EBPF_SUCCESS;
+            }
         }
         _delete_array_map_entry(map, key);
     }
@@ -731,9 +787,8 @@ _get_object_from_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_
 {
     uint32_t index = *(uint32_t*)key;
 
-    // We need to take a lock here to make sure we can
-    // safely reference the object when another thread
-    // might be trying to delete the entry we find.
+    // We need to take a lock here to make sure we can safely reference the object when another thread might be trying
+    // to delete the entry we find.
     ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
 
     ebpf_lock_state_t lock_state = ebpf_lock_lock(&object_map->lock);
@@ -745,7 +800,10 @@ _get_object_from_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_
         ebpf_object_type_t value_type =
             (map->ebpf_map_definition.type == BPF_MAP_TYPE_PROG_ARRAY) ? EBPF_OBJECT_PROGRAM : EBPF_OBJECT_MAP;
         if (id != 0) {
-            ebpf_assert_success(ebpf_object_reference_by_id(id, value_type, &object));
+
+            // Note that this call might fail and that's fine.  The id might be valid, but the object might have been
+            // since deleted.
+            (void)ebpf_object_reference_by_id(id, value_type, &object);
         }
     }
 
@@ -833,8 +891,6 @@ _delete_hash_map(_In_ _Post_invalid_ ebpf_core_map_t* map)
 static void
 _delete_object_hash_map(_In_ _Post_invalid_ ebpf_core_map_t* map)
 {
-    ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
-
     // Release all entry references.
     uint8_t* next_key;
     for (uint8_t* previous_key = NULL;; previous_key = next_key) {
@@ -846,12 +902,14 @@ _delete_object_hash_map(_In_ _Post_invalid_ ebpf_core_map_t* map)
         }
         ebpf_id_t id = *(ebpf_id_t*)value;
         if (id) {
-            ebpf_assert_success(ebpf_object_dereference_by_id(id, EBPF_OBJECT_MAP));
-        }
-    }
 
-    if (object_map->inner_map_template != NULL) {
-        ebpf_object_release_reference(&object_map->inner_map_template->object);
+            // The object may have been already deleted, so an error return value of 'stale key' is ok.
+            result = ebpf_object_release_id_reference(id, EBPF_OBJECT_MAP);
+            ebpf_assert(result == EBPF_SUCCESS || result == EBPF_STALE_KEY);
+            if (result == EBPF_STALE_KEY) {
+                result = EBPF_SUCCESS;
+            }
+        }
     }
 
     _delete_hash_map(map);
@@ -1286,8 +1344,9 @@ _update_hash_map_entry_with_handle(
 {
     ebpf_result_t result = EBPF_SUCCESS;
     size_t entry_count = 0;
-    if (!map || !key)
-        return EBPF_INVALID_ARGUMENT;
+
+    // The 'map' and 'key' arguments cannot be NULL due to caller's prior validations.
+    ebpf_assert(map != NULL && key != NULL);
 
     ebpf_hash_table_operations_t hash_table_operation;
     switch (option) {
@@ -1301,6 +1360,8 @@ _update_hash_map_entry_with_handle(
         hash_table_operation = EBPF_HASH_TABLE_OPERATION_REPLACE;
         break;
     default:
+        EBPF_LOG_MESSAGE_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Invalid map option rejected", option);
         return EBPF_INVALID_ARGUMENT;
     }
 
@@ -1308,6 +1369,12 @@ _update_hash_map_entry_with_handle(
     ebpf_core_object_t* value_object = NULL;
     result = ebpf_object_reference_by_handle(value_handle, value_type, &value_object);
     if (result != EBPF_SUCCESS) {
+        EBPF_LOG_MESSAGE_UINT64_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_MAP,
+            "Invalid Object handle rejected",
+            value_handle,
+            result);
         return result;
     }
 
@@ -1317,33 +1384,49 @@ _update_hash_map_entry_with_handle(
 
     uint8_t* old_value = NULL;
     ebpf_result_t found_result = ebpf_hash_table_find((ebpf_hash_table_t*)map->data, key, &old_value);
-    ebpf_id_t old_id = (old_value) ? *(ebpf_id_t*)old_value : 0;
-
     if ((found_result != EBPF_SUCCESS) && (entry_count == map->ebpf_map_definition.max_entries)) {
+
         // The hash table is already full.
+        EBPF_LOG_MESSAGE(EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Hash table full");
         result = EBPF_OUT_OF_SPACE;
         goto Done;
     }
 
     result = _validate_map_value_object(object_map, value_type, value_object);
     if (result != EBPF_SUCCESS) {
+        EBPF_LOG_MESSAGE_UINT64_UINT64(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Object validation failed", value_object->id, result);
         goto Done;
+    }
+
+    // Release the reference on the old ID stored here, if any.
+    ebpf_id_t old_id = (old_value) ? *(ebpf_id_t*)old_value : 0;
+    if (old_id) {
+
+        // Release the reference on the old ID's id table entry. The object may already have been deleted, so an
+        // error return value of 'not found' is ok.
+        result = ebpf_object_release_id_reference(old_id, value_type);
+        ebpf_assert(result == EBPF_SUCCESS || result == EBPF_STALE_KEY);
+        if (result == EBPF_STALE_KEY) {
+            result = EBPF_SUCCESS;
+        }
     }
 
     // Store the new object ID as the value.
     result =
         ebpf_hash_table_update((ebpf_hash_table_t*)map->data, key, (uint8_t*)&value_object->id, hash_table_operation);
     if (result != EBPF_SUCCESS) {
+        EBPF_LOG_MESSAGE_NTSTATUS(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_MAP, "Hash table update failed.", result);
         goto Done;
     }
 
-    // Release the reference on the old ID stored here, if any.
-    if (old_id) {
-        ebpf_assert_success(ebpf_object_dereference_by_id(old_id, value_type));
-    }
+    // Acquire a reference to the id table entry for the new incoming id. This operation _cannot_ fail as we already
+    // have a valid pointer to the object.  A failure here is indicative of a fatal internal error.
+    ebpf_assert_success(ebpf_object_acquire_id_reference(value_object->id, value_type));
 
 Done:
-    if ((result != EBPF_SUCCESS) && (value_object != NULL)) {
+    if (value_object != NULL) {
         ebpf_object_release_reference((ebpf_core_object_t*)value_object);
     }
     ebpf_lock_unlock(&object_map->lock, lock_state);
@@ -1360,20 +1443,25 @@ _update_map_hash_map_entry_with_handle(
 static ebpf_result_t
 _delete_map_hash_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_t* key)
 {
-    ebpf_result_t result;
-    if (!map || !key)
-        return EBPF_INVALID_ARGUMENT;
+    // The 'map' and 'key' arguments cannot be NULL due to caller's prior validations.
+    ebpf_assert(map != NULL && key != NULL);
 
     ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
 
     ebpf_lock_state_t lock_state = ebpf_lock_lock(&object_map->lock);
 
     uint8_t* value = NULL;
-    result = _find_hash_map_entry(map, key, true, &value);
+    ebpf_result_t result = _find_hash_map_entry(map, key, true, &value);
     if (result == EBPF_SUCCESS) {
         ebpf_id_t id = *(ebpf_id_t*)value;
         if (id) {
-            ebpf_assert_success(ebpf_object_dereference_by_id(id, EBPF_OBJECT_MAP));
+
+            // The object may have been already deleted, so an error return value of 'stale key' is ok.
+            result = ebpf_object_release_id_reference(id, EBPF_OBJECT_MAP);
+            ebpf_assert(result == EBPF_SUCCESS || result == EBPF_STALE_KEY);
+            if (result == EBPF_STALE_KEY) {
+                result = EBPF_SUCCESS;
+            }
         }
     }
 
@@ -2469,8 +2557,9 @@ ebpf_map_get_info(
     info->map_flags = 0;
     if (info->type == BPF_MAP_TYPE_ARRAY_OF_MAPS || info->type == BPF_MAP_TYPE_HASH_OF_MAPS) {
         ebpf_core_object_map_t* object_map = EBPF_FROM_FIELD(ebpf_core_object_map_t, core_map, map);
-        info->inner_map_id =
-            (object_map->inner_map_template) ? object_map->inner_map_template->object.id : EBPF_ID_NONE;
+        info->inner_map_id = object_map->core_map.ebpf_map_definition.inner_map_id
+                                 ? object_map->core_map.ebpf_map_definition.inner_map_id
+                                 : EBPF_ID_NONE;
     } else {
         info->inner_map_id = EBPF_ID_NONE;
     }

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -9,14 +9,25 @@ static const uint32_t _ebpf_object_marker = 'eobj';
 static ebpf_lock_t _ebpf_object_tracking_list_lock = {0};
 
 /**
- * @brief Objects are added to the ID table when they are initialized and removed
- * from the table when they are freed. Objects in the table always have a
- *  ref-count > 0.
+ * @brief Objects are allocated an entry in the the ID
+ * table when they are initialized.  Along with a pointer to
+ *  the object, each id table entry maintains its own ref-count
+ *  that starts off at 1 when it is assigned to a new object.
+ *  The entry ref-count indicates the number of other objects
+ *  holding a reference to the corresponding object's id.  On
+ *  the destruction of an object, the object pointer in the
+ *  corresponding id table entry is reset to NULL and the entry
+ *  ref-count is also decremented. Note that the entry will
+ *  continue to be considered 'in use' until all other objects
+ *  are done with the associated object (they let go of their
+ *  references to this entry).  When the entry ref-count goes
+ *  down to 0 _and_ the object pointer is NULL, it is eligible
+ *  for re-use. Note that either of these events can occur
+ *  first.
  *
  * Map objects can have references due to one of the following:
  * 1) An open handle holds a reference on it.
  * 2) A pinning table entry holds a reference on it.
- * 3) Program holds a reference on the map when it is associated with it.
  *
  * Program objects can have references due to one of the following:
  * 1) An open handle holds a reference on it.
@@ -36,6 +47,20 @@ typedef struct _ebpf_id_entry
 {
     // Counter incremented each time a new object is stored here.
     uint16_t counter;
+
+    // Reference count for this entry itself. This will be 1 when the pointed-to object (below) is created and
+    // incremented for every other object that holds a reference to this entry.
+    //
+    // If the pointed-to object gets destroyed first:
+    // - the object pointer will be nulled out and the id entry ref count will be decremented. After this point,
+    //   other objects that continue to hold a reference to this id entry, will fail to acquire a reference to the
+    //   pointed-to object (via its id) and will need to handle the failure gracefully.
+    //
+    // If the id references get dropped first:
+    // - the id entry count gets decremented.  Even after all the other objects holding a reference to this id entry
+    //   drop their references, the final ref-count will be 1 as the object is still around.  When the object is
+    //   finally destroyed, the entry id ref count goes to zero and and the entry can now be re-used.
+    int64_t reference_count;
 
     // Pointer to object.
     ebpf_core_object_t* object;
@@ -83,7 +108,7 @@ _ebpf_object_tracking_list_insert(_Inout_ ebpf_core_object_t* object)
     ebpf_lock_state_t state;
     state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);
     for (new_index = 1; new_index < EBPF_COUNT_OF(_ebpf_id_table); new_index++) {
-        if (_ebpf_id_table[new_index].object == NULL) {
+        if (_ebpf_id_table[new_index].object == NULL && _ebpf_id_table[new_index].reference_count == 0) {
             break;
         }
     }
@@ -94,6 +119,7 @@ _ebpf_object_tracking_list_insert(_Inout_ ebpf_core_object_t* object)
 
     // Generate a new ID.
     _ebpf_id_table[new_index].counter++;
+    _ebpf_id_table[new_index].reference_count = 1;
     _ebpf_id_table[new_index].object = object;
     object->id = _get_id_from_index(new_index);
 
@@ -112,10 +138,12 @@ _Requires_lock_held_(&_ebpf_object_tracking_list_lock) static void _ebpf_object_
     ebpf_result_t return_value = _get_index_from_id(object->id, &index);
     ebpf_assert(return_value == EBPF_SUCCESS);
 
-    // In a release build, ebpf_assert is a no-op so we
-    // need to avoid an unreferenced variable warning.
+    // In a release build, ebpf_assert is a no-op so we need to avoid an unreferenced variable warning.
     UNREFERENCED_PARAMETER(return_value);
 
+    // Under lock, so un-protected access is ok.
+    _ebpf_id_table[index].reference_count--;
+    ebpf_assert(_ebpf_id_table[index].reference_count >= 0);
     _ebpf_id_table[index].object = NULL;
 }
 
@@ -244,6 +272,9 @@ _Requires_lock_held_(&_ebpf_object_tracking_list_lock) static ebpf_core_object_t
     while (index < EBPF_COUNT_OF(_ebpf_id_table)) {
         ebpf_core_object_t* object = _ebpf_id_table[index].object;
         if ((object != NULL) && (object->type == object_type)) {
+
+            // Under lock, so un-protected access is ok.
+            _ebpf_id_table[index].reference_count++;
             return object;
         }
         index++;
@@ -367,4 +398,108 @@ ebpf_duplicate_string(_In_z_ const char* source)
     }
     memcpy(destination, source, length);
     return destination;
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_object_acquire_id_reference(ebpf_id_t id, ebpf_object_type_t object_type)
+{
+    ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);
+
+    uint32_t index;
+    ebpf_result_t result = _get_index_from_id(id, &index);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    ebpf_id_entry_t* entry = &_ebpf_id_table[index];
+    ebpf_assert(entry->reference_count);
+    if (entry->reference_count == 0) {
+        if (entry->object == NULL) {
+
+            // Do not allow access to entries that are not in use.
+            result = EBPF_INVALID_ARGUMENT;
+        } else {
+
+            // This can _never_ happen.  If the object pointer is not null, the ref-count HAS TO BE _at_ _least_ 1.
+            // This conditon is indicative of a severe internal error.
+            ebpf_assert(0);
+            result = EBPF_FAILED;
+        }
+        goto Done;
+    }
+
+    // ref count is non-zero
+    if (entry->object == NULL) {
+
+        // The object at this entry has been deleted and all that remains are (the now stale) references to this entry
+        // held by other objects.  This is a non-reversible situation and there's no point in giving out references
+        // for such entries, so deny with a suitable error code.
+        result = EBPF_STALE_KEY;
+        goto Done;
+    }
+
+    ebpf_assert(entry->object->type == object_type);
+    if (entry->object->type != object_type) {
+        result = EBPF_INVALID_OBJECT;
+        goto Done;
+    }
+
+    // We have a live object of the matching type and with an existing non-zero ref count, so we're good.
+    // We're under lock so un-protected access is ok.
+    entry->reference_count++;
+    result = EBPF_SUCCESS;
+
+Done:
+    ebpf_lock_unlock(&_ebpf_object_tracking_list_lock, state);
+    return result;
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_object_release_id_reference(ebpf_id_t id, ebpf_object_type_t object_type)
+{
+    ebpf_lock_state_t state = ebpf_lock_lock(&_ebpf_object_tracking_list_lock);
+
+    uint32_t index;
+    ebpf_result_t result = _get_index_from_id(id, &index);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    ebpf_id_entry_t* entry = &_ebpf_id_table[index];
+    ebpf_assert(entry->reference_count);
+    if (entry->reference_count == 0) {
+        if (entry->object == NULL) {
+
+            // Do not allow access to entries that are not in use.
+            result = EBPF_INVALID_ARGUMENT;
+        } else {
+
+            // This can _never_ happen.  If the object pointer is not null, the ref-count HAS TO BE _at_ _least_ 1.
+            // This conditon is indicative of a severe internal error.
+            result = EBPF_FAILED;
+        }
+        goto Done;
+    }
+
+    // ref count is non-zero
+    if (entry->object != NULL) {
+
+        // If the object is still around, it needs to be of the expected type.
+        ebpf_assert(entry->object->type == object_type);
+        if (entry->object->type != object_type) {
+            result = EBPF_INVALID_OBJECT;
+            goto Done;
+        }
+    }
+
+    // Either we don't have an object or we have one of the matching type.  In either case, the existing entry
+    // ref count is non-zero, so we're ok to decrement it.
+    // We're also still under lock so un-protected updates are ok.
+    entry->reference_count--;
+    ebpf_assert(entry->reference_count >= 0);
+    result = EBPF_SUCCESS;
+
+Done:
+    ebpf_lock_unlock(&_ebpf_object_tracking_list_lock, state);
+    return result;
 }

--- a/libs/platform/ebpf_object.h
+++ b/libs/platform/ebpf_object.h
@@ -174,6 +174,45 @@ extern "C"
     ebpf_object_reference_by_handle(
         ebpf_handle_t handle, ebpf_object_type_t object_type, _Outptr_ struct _ebpf_core_object** object);
 
+    /**
+     * @brief Find an ID in the ID table, verify the type matches,
+     *  and release a reference previously acquired via
+     *  ebpf_object_reference_id.
+     *
+     * @param[in] id ID to find in table.
+     * @param[in] object_type Object type to match.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_KEY_NOT_FOUND The provided ID is not valid.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_object_dereference_by_id(ebpf_id_t id, ebpf_object_type_t object_type);
+
+    /**
+     * @brief Find an ID in the ID table, verify the type matches,
+     *  and acquire a reference on the id table entry for this
+     *  id
+     *
+     * @param[in] id ID to find in table.
+     * @param[in] object_type Object type to match.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_KEY_NOT_FOUND The provided ID is not valid.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_object_acquire_id_reference(ebpf_id_t start_id, ebpf_object_type_t object_type);
+
+    /**
+     * @brief Find an ID in the ID table, verify the type matches,
+     *  and release the id table entry reference previously acquired
+     *  via ebpf_object_reference_by_id.
+     *
+     * @param[in] id ID to find in table.
+     * @param[in] object_type Object type to match.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_KEY_NOT_FOUND The provided ID is not valid.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_object_release_id_reference(ebpf_id_t start_id, ebpf_object_type_t object_type);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -419,44 +419,69 @@ void
 _test_nested_maps(bpf_map_type type)
 {
     // Create first inner map.
-    fd_t inner1 = bpf_map_create(BPF_MAP_TYPE_ARRAY, nullptr, sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
-    REQUIRE(inner1 > 0);
+    fd_t inner_map_fd1 =
+        bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map1", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(inner_map_fd1 > 0);
 
     // Create outer map.
-    bpf_map_create_opts opts = {.inner_map_fd = (uint32_t)inner1};
+    bpf_map_create_opts opts = {.inner_map_fd = (uint32_t)inner_map_fd1};
     fd_t outer_map_fd = bpf_map_create(type, "outer_map", sizeof(uint32_t), sizeof(fd_t), 10, &opts);
-
     REQUIRE(outer_map_fd > 0);
 
     // Create second inner map.
-    fd_t inner2 = bpf_map_create(BPF_MAP_TYPE_ARRAY, nullptr, sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
-    REQUIRE(inner2 > 0);
+    fd_t inner_map_fd2 =
+        bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map2", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(inner_map_fd2 > 0);
 
     // Insert both inner maps in outer map.
     uint32_t key = 1;
-    uint32_t result = bpf_map_update_elem(outer_map_fd, &key, &inner1, 0);
+    uint32_t result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd1, 0);
     REQUIRE(result == ERROR_SUCCESS);
 
     key = 2;
-    result = bpf_map_update_elem(outer_map_fd, &key, &inner1, 0);
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
     REQUIRE(result == ERROR_SUCCESS);
 
-    // Remove the inner maps from outer map.
+    // Add inner map (1) multiple times.
+    key = 3;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd1, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 4;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd1, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    // Add inner map (2) multiple times.
+    key = 5;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 6;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 7;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    // Remove some inner maps from outer map.
     key = 1;
     result = bpf_map_delete_elem(outer_map_fd, &key);
     REQUIRE(result == ERROR_SUCCESS);
+
     key = 2;
     result = bpf_map_delete_elem(outer_map_fd, &key);
     REQUIRE(result == ERROR_SUCCESS);
 
-    _close(inner1);
-    _close(inner2);
+    // Leave the other instances of 'map inserts' as-is, the post-app-termination clean-up should take care of these.
+
+    _close(inner_map_fd1);
+    _close(inner_map_fd2);
     _close(outer_map_fd);
 }
 
-TEST_CASE("array_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
-
-TEST_CASE("hash_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }
+TEST_CASE("array_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
+TEST_CASE("hash_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }
 
 TEST_CASE("tailcall_load_test", "[tailcall_load_test]")
 {
@@ -759,3 +784,95 @@ bpf_user_helpers_test(ebpf_execution_type_t execution_type)
 
 TEST_CASE("bpf_user_helpers_test_jit", "[api_test]") { bpf_user_helpers_test(EBPF_EXECUTION_JIT); }
 TEST_CASE("bpf_user_helpers_test_native", "[api_test]") { bpf_user_helpers_test(EBPF_EXECUTION_NATIVE); }
+
+// This test tests resource reclamation and clean-up after a premature/abnormal user mode application exit.
+TEST_CASE("close_unload_test", "[native_tests][native_close_cleanup_tests]")
+{
+    struct bpf_object* object = nullptr;
+    hook_helper_t hook(EBPF_ATTACH_TYPE_BIND);
+    program_load_attach_helper_t _helper(
+        "bindmonitor_tailcall.sys", BPF_PROG_TYPE_BIND, "BindMonitor", EBPF_EXECUTION_NATIVE, nullptr, 0, hook);
+    object = _helper.get_object();
+
+    // Set up tail calls.
+    struct bpf_program* callee0 = bpf_object__find_program_by_name(object, "BindMonitor_Callee0");
+    REQUIRE(callee0 != nullptr);
+    fd_t callee0_fd = bpf_program__fd(callee0);
+    REQUIRE(callee0_fd > 0);
+
+    struct bpf_program* callee1 = bpf_object__find_program_by_name(object, "BindMonitor_Callee1");
+    REQUIRE(callee1 != nullptr);
+    fd_t callee1_fd = bpf_program__fd(callee1);
+    REQUIRE(callee1_fd > 0);
+
+    fd_t prog_map_fd = bpf_object__find_map_fd_by_name(object, "prog_array_map");
+    REQUIRE(prog_map_fd > 0);
+
+    uint32_t index = 0;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee0_fd, 0) == 0);
+
+    index = 1;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    // Now insert the same program for multiple keys in the same map.
+    index = 2;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    index = 4;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    index = 7;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    bindmonitor_test(object);
+
+    // The block of commented code after this comment is for documentation purposes only.
+    //
+    // A well-behaved user mode application _should_ call these calls to correctly free the allocated objects. In case
+    // of careless applications that do not do so (or even well behaved applications, when they crash or terminate for
+    // some reason before getting to this point), the 'premature application close' event handling _should_ take care
+    // of reclaiming and free'ing such objects. All unit tests belonging to the '[native_close_cleanup_tests]'
+    // unit-test class simulate this behavior by _not_ calling the clean-up api calls.
+    //
+    // For native tests (meant for execution on the kernel mode ebpf-for-windows driver), this event will be handled
+    // by the ebpf-core kernel mode driver on test application termination.
+    //
+    // The success/failure of the [native_close_cleanup_tests] tests can only be (indirectly) checked by attempting to
+    // stop the ebpf-core driver after executing this class of tests.  If the clean-up by the ebpf-core driver is not
+    // successful, it cannot be stopped/unloaded.  This step is performed automatically by the CI/CD test pass runs and
+    // will need to be perfomed as an explicit manual step after a manually initiated test-run.
+    //
+    // On a final note, each test in the [native_close_cleanup_tests] set _must_ load a .sys driver (if it needs one)
+    // that either has not been loaded yet, or was loaded but has since been unloaded (before start of the test). Given
+    // that we deliberately skip the clean-up API calls, the drivers stay loaded at the end of the individual test. An
+    // attempt to (re)load the same driver again (by the next test) will fail (as it should), but leads to spurious
+    // test failures (by way of an assert due to an error returned by bpf_object__load() in the
+    // program_load_attach_helper_t constructor).
+
+    /*
+        --- DO NOT REMOVE OR UN-COMMENT ---
+
+    auto cleanup = [prog_map_fd, &index]() {
+        index = 0;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+        index = 1;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+        index = 2;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+        index = 4;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+
+        index = 7;
+        REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+    };
+
+    // Clean up tail calls.
+    cleanup();
+
+    // Free the program as well.
+    bpf_object__close(object);
+    */
+}

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -77,7 +77,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         2,                       // Maximum number of entries allowed in the map.
+         8,                       // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -43,7 +43,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         2,                       // Maximum number of entries allowed in the map.
+         8,                       // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -210,7 +210,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         2,                       // Maximum number of entries allowed in the map.
+         8,                       // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2843,3 +2843,157 @@ extension_reload_test(ebpf_execution_type_t execution_type)
 }
 
 DECLARE_ALL_TEST_CASES("extension_reload_test", "[end_to_end]", extension_reload_test);
+
+// This test tests resource reclamation and clean-up after a premature/abnormal user mode application exit.
+TEST_CASE("close_unload_test", "[close_cleanup]")
+{
+    _test_helper_end_to_end test_helper;
+
+    const char* error_message = nullptr;
+    int result;
+    bpf_object* object = nullptr;
+    bpf_link* link = nullptr;
+    fd_t program_fd;
+
+    program_info_provider_t bind_program_info(EBPF_PROGRAM_TYPE_BIND);
+
+    const char* file_name = "bindmonitor_tailcall_um.dll";
+    result =
+        ebpf_program_load(file_name, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object, &program_fd, &error_message);
+
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        free((void*)error_message);
+    }
+    REQUIRE(result == 0);
+
+    // Set up tail calls.
+    struct bpf_program* callee0 = bpf_object__find_program_by_name(object, "BindMonitor_Callee0");
+    REQUIRE(callee0 != nullptr);
+    fd_t callee0_fd = bpf_program__fd(callee0);
+    REQUIRE(callee0_fd > 0);
+
+    struct bpf_program* callee1 = bpf_object__find_program_by_name(object, "BindMonitor_Callee1");
+    REQUIRE(callee1 != nullptr);
+    fd_t callee1_fd = bpf_program__fd(callee1);
+    REQUIRE(callee1_fd > 0);
+
+    fd_t prog_map_fd = bpf_object__find_map_fd_by_name(object, "prog_array_map");
+    REQUIRE(prog_map_fd > 0);
+
+    uint32_t index = 0;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee0_fd, 0) == 0);
+    index = 1;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    uint32_t ifindex = 0;
+    REQUIRE(hook.attach_link(program_fd, &ifindex, sizeof(ifindex), &link) == EBPF_SUCCESS);
+
+    // These are needed to prevent the memory leak detector from flagging a memory leak.
+    hook.detach_link(link);
+    hook.close_link(link);
+
+    // The block of commented code after this comment is for documentation purposes only.
+    //
+    // A well-behaved user mode application _should_ call these calls to correctly free the allocated objects. In case
+    // of careless applications that do not do so (or even well behaved applications, when they crash or terminate for
+    // some reason before getting to this point), the 'premature application close' event handling _should_ take care
+    // of reclaiming and free'ing such objects.
+    //
+    // In a user-mode unit test case such as this one, the 'premature application close' event is simulated/handled in
+    // the context of the bpf_object__close() api, so a call to that api is mandatory for such tests.  All unit tests
+    // belonging to the '[close_cleanup]' unit-test class will show this behavior.
+    //
+    // For an identical test meant for execution on the native (kernel mode ebpf-for-windows driver), this event will
+    // be handled by the kernel mode driver on test application termination.  Such a test application _should_ _not_
+    // call bpf_object__close() api either.
+    //
+
+    /*
+       --- DO NOT REMOVE OR UN-COMMENT ---
+    //
+    // index = 0;
+    // REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+    //
+    // index = 1;
+    // REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+    */
+
+    bpf_object__close(object);
+}
+
+// This test tests the case where a program is inserted multiple times with different keys into the same map.
+TEST_CASE("multiple_map_insert", "[close_cleanup]")
+{
+    _test_helper_end_to_end test_helper;
+
+    const char* error_message = nullptr;
+    int result;
+    bpf_object* object = nullptr;
+    bpf_link* link = nullptr;
+    fd_t program_fd;
+
+    program_info_provider_t bind_program_info(EBPF_PROGRAM_TYPE_BIND);
+
+    const char* file_name = "bindmonitor_tailcall_um.dll";
+    result =
+        ebpf_program_load(file_name, BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object, &program_fd, &error_message);
+
+    if (error_message) {
+        printf("ebpf_program_load failed with %s\n", error_message);
+        free((void*)error_message);
+    }
+    REQUIRE(result == 0);
+
+    // Set up tail calls.
+    struct bpf_program* callee0 = bpf_object__find_program_by_name(object, "BindMonitor_Callee0");
+    REQUIRE(callee0 != nullptr);
+    fd_t callee0_fd = bpf_program__fd(callee0);
+    REQUIRE(callee0_fd > 0);
+
+    struct bpf_program* callee1 = bpf_object__find_program_by_name(object, "BindMonitor_Callee1");
+    REQUIRE(callee1 != nullptr);
+    fd_t callee1_fd = bpf_program__fd(callee1);
+    REQUIRE(callee1_fd > 0);
+
+    fd_t prog_map_fd = bpf_object__find_map_fd_by_name(object, "prog_array_map");
+    REQUIRE(prog_map_fd > 0);
+
+    uint32_t index = 0;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee0_fd, 0) == 0);
+
+    index = 1;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    // Insert the same program for multiple keys in the same map.
+    index = 2;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    index = 4;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    index = 7;
+    REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
+
+    single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    uint32_t ifindex = 0;
+    REQUIRE(hook.attach_link(program_fd, &ifindex, sizeof(ifindex), &link) == EBPF_SUCCESS);
+
+    // These are needed to prevent the memory leak detector from flagging a memory leak.
+    hook.detach_link(link);
+    hook.close_link(link);
+
+    /*
+       --- DO NOT REMOVE OR UN-COMMENT ---
+    // Please refer to the detailed comment in the 'close_unload_test' test for explanation.
+    //
+    // index = 0;
+    // REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+    //
+    // index = 1;
+    // REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &ebpf_fd_invalid, 0) == 0);
+    */
+
+    bpf_object__close(object);
+}

--- a/tests/sample/bindmonitor_tailcall.c
+++ b/tests/sample/bindmonitor_tailcall.c
@@ -40,7 +40,7 @@ struct bpf_map_def limits_map = {
 
 SEC("maps")
 struct bpf_map_def prog_array_map = {
-    .type = BPF_MAP_TYPE_PROG_ARRAY, .key_size = sizeof(uint32_t), .value_size = sizeof(uint32_t), .max_entries = 2};
+    .type = BPF_MAP_TYPE_PROG_ARRAY, .key_size = sizeof(uint32_t), .value_size = sizeof(uint32_t), .max_entries = 8};
 
 SEC("maps")
 // Dummy map. Should not be populated by UM.

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1504,20 +1504,21 @@ _ebpf_test_map_in_map(ebpf_map_type_t type)
     _test_helper_end_to_end test_helper;
 
     // Create an inner map that we'll use both as a template and as an actual entry.
-    int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_ARRAY, nullptr, sizeof(__u32), sizeof(__u32), 1, nullptr);
+    int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map", sizeof(__u32), sizeof(__u32), 1, nullptr);
     REQUIRE(inner_map_fd > 0);
 
     // Verify that we cannot simply create an outer map without a template.
-    REQUIRE(bpf_map_create(type, nullptr, sizeof(__u32), sizeof(__u32), 2, nullptr) < 0);
+    REQUIRE(bpf_map_create(type, "array_map_of_maps", sizeof(__u32), sizeof(__u32), 2, nullptr) < 0);
     REQUIRE(errno == EBADF);
 
+    // Verify that we cannot create an outer map with an invalid fd for the inner map.
     bpf_map_create_opts opts = {.inner_map_fd = (uint32_t)ebpf_fd_invalid};
-    REQUIRE(bpf_map_create(type, nullptr, sizeof(__u32), sizeof(fd_t), 2, &opts) < 0);
+    REQUIRE(bpf_map_create(type, "array_map_of_maps", sizeof(__u32), sizeof(fd_t), 2, &opts) < 0);
     REQUIRE(errno == EBADF);
 
     // Verify we can create an outer map with a template.
     opts.inner_map_fd = inner_map_fd;
-    int outer_map_fd = bpf_map_create(type, nullptr, sizeof(__u32), sizeof(fd_t), 2, &opts);
+    int outer_map_fd = bpf_map_create(type, "array_map_of_maps", sizeof(__u32), sizeof(fd_t), 2, &opts);
     REQUIRE(outer_map_fd > 0);
 
     // Verify we can insert the inner map into the outer map.
@@ -2650,3 +2651,49 @@ TEST_CASE("libbpf_num_possible_cpus", "[libbpf]")
     int cpu_count = libbpf_num_possible_cpus();
     REQUIRE(cpu_count > 0);
 }
+
+void
+_test_nested_maps(bpf_map_type map_type)
+{
+    _test_helper_end_to_end test_helper;
+
+    // First, create an inner map.
+    fd_t inner_map_fd1 =
+        bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map1", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(inner_map_fd1 > 0);
+
+    // Create outer map with the inner map handle in options.
+    bpf_map_create_opts opts = {.inner_map_fd = (uint32_t)inner_map_fd1};
+    fd_t outer_map_fd = bpf_map_create(map_type, "outer_map", sizeof(uint32_t), sizeof(fd_t), 10, &opts);
+    REQUIRE(outer_map_fd > 0);
+
+    // Create second inner map.
+    fd_t inner_map_fd2 =
+        bpf_map_create(BPF_MAP_TYPE_ARRAY, "inner_map2", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+    REQUIRE(inner_map_fd2 > 0);
+
+    // Insert both inner maps in outer map.
+    uint32_t key = 1;
+    uint32_t result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd1, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 2;
+    result = bpf_map_update_elem(outer_map_fd, &key, &inner_map_fd2, 0);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    // Remove the inner maps from outer map.
+    key = 1;
+    result = bpf_map_delete_elem(outer_map_fd, &key);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    key = 2;
+    result = bpf_map_delete_elem(outer_map_fd, &key);
+    REQUIRE(result == ERROR_SUCCESS);
+
+    Platform::_close(inner_map_fd2);
+    Platform::_close(inner_map_fd1);
+    Platform::_close(outer_map_fd);
+}
+
+TEST_CASE("array_map_of_maps", "[libbpf]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
+TEST_CASE("hash_map_of_maps", "[libbpf]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }


### PR DESCRIPTION
The current 'map <--> contained-objects' relationship uses strong circular references maintained between object-maps (map-of-maps, hash-map-of-maps) and objects (programs and maps).

While this design works for well-behaved user mode applications, it breaks down if the user mode applications do not perform explicit clean-up via the provided clean-up APIs, leading to leaked resources by the way of programs and maps orphaned in memory. This typically happens with user programs that either exit prematurely, do not call the clean-up API calls or crash before they can do so.

This PR proposes a new design solution where we use references to the id table entry for object instead of the object itself. 

**Testing**


_User mode:_

Ensure that the ```unit_tests.exe``` test suite passes successfully.

_Kernel Mode:_

- Ensure that the ```api_test.exe``` test suite passes successfully, multiple times back-to-back.
- The ```epbfcore.sys``` driver can be unloaded and re-loaded successfully after a multiple pass test run.

_Testing Notes:_

Some edge cases were not covered by the existing tests, so new tests (user and kernel-mode) were added.
I'm seeing some inconsistencies in API behavior across different map types. My plan is to verify API functionality on linux for these scenarios and create new issues where required.

**Documentation**

No new documentation required.

Fixes: #1509 #1510