### PR TITLE
Remove vestigal division by zero code

### DIFF
--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -165,9 +165,6 @@ extern "C"
         return swap32(value >> 32) | ((uint64_t)swap32(value & ((1ull << 32ull) - 1))) << 32;
     }
 
-    void
-    division_by_zero(uint32_t address);
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/bpf2c_tests/bpf_test.cpp
+++ b/tests/bpf2c_tests/bpf_test.cpp
@@ -22,12 +22,6 @@ extern "C"
 
 extern "C" metadata_table_t C_NAME;
 
-extern "C" void
-division_by_zero(uint32_t address)
-{
-    std::cerr << "BPF program hit divide by zero at PC=" << address << std::endl;
-}
-
 int
 main(int argc, char** argv)
 {

--- a/tests/bpf2c_tests/expected/bad_map_name_dll.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/bad_map_name_sys.c
+++ b/tests/bpf2c_tests/expected/bad_map_name_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_ringbuf_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/bpf_call_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_call_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/bpf_call_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_call_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/bpf_dll.c
+++ b/tests/bpf2c_tests/expected/bpf_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/bpf_sys.c
+++ b/tests/bpf2c_tests/expected/bpf_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/divide_by_zero_dll.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/divide_by_zero_sys.c
+++ b/tests/bpf2c_tests/expected/divide_by_zero_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 #define FIND_METADATA_ENTRTY(NAME, X) \
     if (std::string(NAME) == #X)      \
         return &X;

--- a/tests/bpf2c_tests/expected/droppacket_unsafe_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_unsafe_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static map_entry_t _maps[] = {

--- a/tests/bpf2c_tests/expected/empty_dll.c
+++ b/tests/bpf2c_tests/expected/empty_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/empty_sys.c
+++ b/tests/bpf2c_tests/expected/empty_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/map_in_map_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/map_in_map_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
+++ b/tests/bpf2c_tests/expected/map_in_map_v2_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/map_reuse_2_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/map_reuse_2_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_2_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/map_reuse_dll.c
+++ b/tests/bpf2c_tests/expected/map_reuse_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/map_reuse_sys.c
+++ b/tests/bpf2c_tests/expected/map_reuse_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/printk_legacy_dll.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/printk_legacy_sys.c
+++ b/tests/bpf2c_tests/expected/printk_legacy_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/printk_unsafe_dll.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 #define FIND_METADATA_ENTRTY(NAME, X) \
     if (std::string(NAME) == #X)      \
         return &X;

--- a/tests/bpf2c_tests/expected/printk_unsafe_sys.c
+++ b/tests/bpf2c_tests/expected/printk_unsafe_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_bad_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/tail_call_bad_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_bad_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/tail_call_map_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/tail_call_map_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_map_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_multiple_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/tail_call_sys.c
+++ b/tests/bpf2c_tests/expected/tail_call_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
+++ b/tests/bpf2c_tests/expected/test_sample_ebpf_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_dll.c
@@ -30,12 +30,6 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
 
 #include "bpf2c.h"

--- a/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/test_utility_helpers_sys.c
@@ -165,12 +165,6 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     return STATUS_SUCCESS;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}
-
 #include "bpf2c.h"
 
 static void

--- a/tools/bpf2c/bpf2c_dll.c
+++ b/tools/bpf2c/bpf2c_dll.c
@@ -27,10 +27,4 @@ DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpRese
     return TRUE;
 }
 
-void
-division_by_zero(uint32_t address)
-{
-    fprintf(stderr, "Divide by zero at address %d\n", address);
-}
-
 __declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }

--- a/tools/bpf2c/bpf2c_driver.c
+++ b/tools/bpf2c/bpf2c_driver.c
@@ -161,9 +161,3 @@ _bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
     UNREFERENCED_PARAMETER(client_binding_context);
     return STATUS_SUCCESS;
 }
-
-void
-division_by_zero(uint32_t address)
-{
-    UNREFERENCED_PARAMETER(address);
-}


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #1989

## Description

The bpf2c tool previously implemented the incorrect division by zero behavior. The behavior was corrected, but the division by zero handling code remained. This PR cleans up left over division by zero code.

## Testing

CI/CD

## Documentation

No.
