### PR TITLE
Invoke _ebpf_extension_client_notify_change before completing binding

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -132,9 +132,7 @@ _ebpf_program_initialize_or_verify_program_info_hash(_Inout_ ebpf_program_t* pro
 
 static ebpf_result_t
 _ebpf_program_program_info_provider_changed(
-    _In_ const void* client_binding_context,
-    _In_ const void* provider_binding_context,
-    _In_opt_ const ebpf_extension_data_t* provider_data)
+    _In_ const void* client_binding_context, _In_opt_ const ebpf_extension_data_t* provider_data)
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t return_value;
@@ -143,13 +141,11 @@ _ebpf_program_program_info_provider_changed(
     if (provider_data == NULL) {
         // Detach
         // Extension is detaching. Program will get invalidated.
-        program->info_extension_provider_binding_context = NULL;
         program->info_extension_provider_data = NULL;
         return_value = EBPF_SUCCESS;
         goto Exit;
     } else {
         // Attach
-        program->info_extension_provider_binding_context = provider_binding_context;
         program->info_extension_provider_data = provider_data;
 
         ebpf_helper_function_addresses_t* helper_function_addresses = NULL;
@@ -237,7 +233,6 @@ Exit:
 
     if (return_value != EBPF_SUCCESS) {
         program->info_extension_provider_data = NULL;
-        program->info_extension_provider_binding_context = NULL;
     }
 
     EBPF_RETURN_RESULT(return_value);

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -834,9 +834,7 @@ extern "C"
     ebpf_interlocked_xor_int64(_Inout_ volatile int64_t* destination, int64_t mask);
 
     typedef ebpf_result_t (*ebpf_extension_change_callback_t)(
-        _In_ const void* client_binding_context,
-        _In_ const void* provider_binding_context,
-        _In_opt_ const ebpf_extension_data_t* provider_data);
+        _In_ const void* client_binding_context, _In_opt_ const ebpf_extension_data_t* provider_data);
 
     /**
      * @brief Load an extension and get its dispatch table.


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #2008

## Description

NMR client attach contract states that validation of the binding should occur before calling NmrClientAttachProvider. The extension wrapper was incorrectly calling NmrClientAttachProvider first.

## Testing

CI/CD

## Documentation

No.
