### PR TITLE
Require hooks to call eBPF programs at correct IRQL

### DIFF
--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -401,6 +401,14 @@ extern "C"
     ebpf_is_preemptible();
 
     /**
+     * @brief Get the current IRQL.
+     *
+     * @return The current IRQL.
+     */
+    uint8_t
+    ebpf_get_current_irql();
+
+    /**
      * @brief Query the platform to determine which CPU this execution is
      *   running on. Only valid if ebpf_is_preemptible() == true.
      * @retval Zero based index of CPUs.

--- a/libs/platform/ebpf_state.h
+++ b/libs/platform/ebpf_state.h
@@ -51,6 +51,18 @@ extern "C"
     ebpf_state_store(size_t index, uintptr_t value);
 
     /**
+     * @brief Store a value in the state tracker.
+     *
+     * @param[in] index Assigned for storing state.
+     * @param[in] value Value to be stored.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  operation.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_state_store_with_irql(uint8_t current_irql, size_t index, uintptr_t value);
+
+    /**
      * @brief Load a value in the state tracker.
      *
      * @param[in] index Assigned for storing state.
@@ -61,6 +73,19 @@ extern "C"
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_state_load(size_t index, _Out_ uintptr_t* value);
+
+    /**
+     * @brief Load a value in the state tracker.
+     *
+     * @param[in] current_irql Current IRQL.
+     * @param[in] index Assigned for storing state.
+     * @param[out] value Value to be loaded.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  operation.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_state_load_with_irql(uint8_t current_irql, size_t index, _Out_ uintptr_t* value);
 
 #ifdef __cplusplus
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -411,6 +411,12 @@ ebpf_is_preemptible()
     return irql < DISPATCH_LEVEL;
 }
 
+uint8_t
+ebpf_get_current_irql()
+{
+    return KeGetCurrentIrql();
+}
+
 bool
 ebpf_is_non_preemptible_work_item_supported()
 {

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -793,6 +793,12 @@ ebpf_is_preemptible()
     return !ebpf_non_preemptible;
 }
 
+uint8_t
+ebpf_get_current_irql()
+{
+    return ebpf_non_preemptible ? DISPATCH_LEVEL : PASSIVE_LEVEL;
+}
+
 bool
 ebpf_is_non_preemptible_work_item_supported()
 {


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

## Description

Some helper functions can only be called at specific IRQL. Add check on debug builds to catch extensions that are declaring the incorrect IRQL.
Use the declared IRQL to skip calling KeGetCurrentIrql.

## Testing

CI/CD

## Documentation

No
