### PR TITLE
XDP: Invoke eBPF programs at specified IRQL

### DIFF
--- a/libs/platform/user/kernel_um.cpp
+++ b/libs/platform/user/kernel_um.cpp
@@ -578,6 +578,15 @@ SeAccessCheckFromState(
 KIRQL
 KeGetCurrentIrql() { return PASSIVE_LEVEL; }
 
+KIRQL
+KeRaiseIrqlToDpcLevel() { return KeGetCurrentIrql(); }
+
+VOID
+KeLowerIrql(_In_ KIRQL Irql)
+{
+    UNREFERENCED_PARAMETER(Irql);
+}
+
 HANDLE
 PsGetCurrentProcessId() { return (HANDLE)(uintptr_t)GetCurrentProcessId(); }
 

--- a/libs/platform/user/kernel_um.h
+++ b/libs/platform/user/kernel_um.h
@@ -519,6 +519,12 @@ extern "C"
     KIRQL
     KeGetCurrentIrql();
 
+    KIRQL
+    KeRaiseIrqlToDpcLevel();
+
+    VOID
+    KeLowerIrql(_In_ KIRQL Irql);
+
     HANDLE
     PsGetCurrentProcessId();
 


### PR DESCRIPTION
## Description

XDP requires dispatch level, but currently invokes eBPF at the caller's arbitrary IRQL. Related to #2016.

I ran `./scripts/format-code` which made some unrelated whitespace changes.

## Testing

CI/CD.

## Documentation

N/A.
