### PR TITLE
Workaround to avoid race between attach failing and unregister

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -130,7 +130,7 @@ To build with the specific compile time options for disabling JIT compiler and/o
    *  `CONFIG_BPF_JIT_DISABLED` - Compile eBPF's *Execution Context* without support for the eBPF JIT compiler.
    *  `CONFIG_BPF_INTERPRETER_DISABLED` - Compile eBPF's *Execution Context* without support for the eBPF interpreter.
 
-      >*Note for Linux users*: this option is similar to the `CONFIG_BPF_JIT_ALWAYS_ON` which, as documented 
+      >*Note for Linux users*: this option is similar to the `CONFIG_BPF_JIT_ALWAYS_ON` which, as documented
 [here](https://googleprojectzero.blogspot.com/2018/01/reading-privileged-memory-with-side.html), is used to disable support for the interpreter.
 
 >Note: do the above steps for the following projects within the `ebpf-for-windows.sln` solution:

--- a/libs/platform/user/nmr_impl.cpp
+++ b/libs/platform/user/nmr_impl.cpp
@@ -186,6 +186,10 @@ _nmr::bind(_Inout_ client_registration& client, _Inout_ provider_registration& p
         // Clean up the binding on a failure.
         if (!NT_SUCCESS(status)) {
             unbind_complete(*binding_ptr);
+        } else {
+            std::unique_lock l(lock);
+            binding_ptr->client_binding_status = binding_status::Ready;
+            binding_ptr->provider_binding_status = binding_status::Ready;
         }
     }};
 }

--- a/libs/platform/user/nmr_impl.h
+++ b/libs/platform/user/nmr_impl.h
@@ -140,10 +140,13 @@ typedef class _nmr
 
     enum binding_status
     {
-        Ready = 0,
-        BeginUnbind,
-        UnbindPending,
-        UnbindComplete
+        Start = 0,   ///< Initial state. Binding has been created but ClientAttachProvider has not been called.
+        Ready,       ///< ClientAttachProvider has been called and returned STATUS_SUCCESS.
+        BeginUnbind, ///< Client or provider has called NmrDeregisterClient or NmrDeregisterProvider but detach has not
+                     ///< yet been called.
+        UnbindPending, ///< Client or provider detach returned STATUS_PENDING.
+        UnbindComplete ///< Client or provider detach returned STATUS_SUCCESS or called NmrBindingDetachClientComplete
+                       ///< or NmrBindingDetachProviderComplete.
     };
 
     struct binding
@@ -152,10 +155,10 @@ typedef class _nmr
         client_registration& client;
         const void* provider_binding_context = nullptr;
         const void* provider_dispatch = nullptr;
-        binding_status provider_binding_status = Ready;
+        binding_status provider_binding_status = Start;
         const void* client_binding_context = nullptr;
         const void* client_dispatch = nullptr;
-        binding_status client_binding_status = Ready;
+        binding_status client_binding_status = Start;
     };
     typedef std::function<void()> pending_action_t;
 


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #2045

## Description

Handle concurrent attach failure with deregistration of a provider or client.

## Testing

CI/Cd

## Documentation

No.
