### PR TITLE
Remove preprocessor library dependencies from `libfuzzer.h`.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,15 +12,19 @@
   <PropertyGroup Condition="'$(AddressSanitizer)'=='True'">
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Release'">
+    <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MD-x86_64.lib</FuzzerLibs>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)'=='Debug'">
+    <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MDd-x86_64.lib</FuzzerLibs>
+  </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Fuzzer)'=='Release|True'">
     <EnableASAN>true</EnableASAN>
     <AdditionalOptions>/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div %(AdditionalOptions)</AdditionalOptions>
-    <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MD-x86_64.lib</FuzzerLibs>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Fuzzer)'=='Debug|True'">
     <EnableASAN>true</EnableASAN>
     <AdditionalOptions>/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div %(AdditionalOptions)</AdditionalOptions>
-    <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MDd-x86_64.lib</FuzzerLibs>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Fuzzer)'!='True'">
     <SpectreMitigation>Spectre</SpectreMitigation>

--- a/tests/libfuzzer/include/libfuzzer.h
+++ b/tests/libfuzzer/include/libfuzzer.h
@@ -1,14 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#pragma comment(lib, "libsancov.lib")
-
-#if defined(_DEBUG)
-#pragma comment(lib, "clang_rt.fuzzer_MDd-x86_64.lib")
-#else
-#pragma comment(lib, "clang_rt.fuzzer_MD-x86_64.lib")
-#endif
-
 #ifdef __cplusplus
 #define FUZZ_EXPORT extern "C" __declspec(dllexport)
 #else #define FUZZ_EXPORT __declspec(dllexport)


### PR DESCRIPTION
Closes #1934 

## Description

This PR complements #1935, by removing the preprocessor directives from `libfuzzer.h`, which were pulling in ASAN & fuzzing library dependencies. Now this is done by defining the libraries globally and referencing them locally only within the projects that actually need them.

## Testing

CI/CD, local build.

## Documentation

n.a.
