### PR TITLE
Handle re-auth case.

### DIFF
--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -44,6 +44,7 @@ typedef struct _wfp_ale_layer_fields
     uint16_t compartment_id_field;
     uint16_t interface_luid_field;
     uint16_t user_id_field;
+    uint16_t flags_field;
 } wfp_ale_layer_fields_t;
 
 typedef struct _net_ebpf_extension_wfp_filter_parameters

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -1173,9 +1173,11 @@ net_ebpf_extension_sock_addr_authorize_connection_classify(
     _net_ebpf_extension_sock_addr_copy_wfp_connection_fields(
         incoming_fixed_values, incoming_metadata_values, &net_ebpf_sock_addr_ctx);
 
-    // eBPF programs will not be invoked on connection re-auth.
-    if (net_ebpf_sock_addr_ctx.flags & FWP_CONDITION_FLAG_IS_REAUTHORIZE)
+    if (net_ebpf_sock_addr_ctx.flags & FWP_CONDITION_FLAG_IS_REAUTHORIZE) {
+        // This is a re-auth of a connection that was previously authorized by the eBPF programs. Permit it.
+        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
         goto Exit;
+    }
 
     compartment_id = filter_context->compartment_id;
     ASSERT((compartment_id == UNSPECIFIED_COMPARTMENT_ID) || (compartment_id == sock_addr_ctx->compartment_id));


### PR DESCRIPTION
## Description

WFP may invoke a callout for the same connection for [re-authorization](https://learn.microsoft.com/en-us/windows/win32/fwp/ale-re-authorization). eBPF extension should not invoke the eBPF program upon reauthorization. This fix is related to the issue #2059.

Also, this PR takes into account if a callout with higher weight already redirected the connection to a local proxy. In that case, the expected thing to do would be to permit the connection un-modified. When the proxy sends a new outbound request to the original destination, the eBPF callout would get another look at the connection.

## Testing

CI.

## Documentation

No.
