### PR TITLE
Simplify connect-redirect classify function.

### DIFF
--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -42,12 +42,12 @@ typedef struct _net_ebpf_ext_connect_context_address_info
 
 typedef struct _net_ebpf_extension_connection_context
 {
-    LIST_ENTRY list_entry;
     uint64_t transport_endpoint_handle;
     net_ebpf_ext_connect_context_address_info_t address_info;
     uint32_t compartment_id;
     uint16_t protocol;
     uint64_t timestamp;
+    LIST_ENTRY list_entry;
 } net_ebpf_extension_connection_context_t;
 
 typedef struct _net_ebpf_extension_redirect_handle_entry
@@ -1402,8 +1402,11 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
     if (!_net_ebpf_extension_sock_addr_should_invoke_ebpf_program(filter_context, sock_addr_ctx, v4_mapped))
         goto Exit;
 
+#pragma warning(push)
+#pragma warning(suppress : 6387)
     // Acquire classify handle.
     status = FwpsAcquireClassifyHandle((void*)classify_context, 0, &classify_handle);
+#pragma warning(pop)
     if (!NT_SUCCESS(status)) {
         NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -40,23 +40,13 @@ typedef struct _net_ebpf_ext_connect_context_address_info
     uint16_t source_port;
 } net_ebpf_ext_connect_context_address_info_t;
 
-typedef struct _net_ebpf_ext_connection_context_key
+typedef struct _net_ebpf_extension_connection_context
 {
+    LIST_ENTRY list_entry;
     uint64_t transport_endpoint_handle;
     net_ebpf_ext_connect_context_address_info_t address_info;
     uint32_t compartment_id;
     uint16_t protocol;
-} net_ebpf_ext_connection_context_key_t;
-
-typedef struct _net_ebpf_extension_connection_context
-{
-    LIST_ENTRY list_entry;
-    net_ebpf_ext_connection_context_key_t key;
-    struct
-    {
-        uint8_t verdict : 2;
-        uint8_t redirected : 1;
-    } value;
     uint64_t timestamp;
 } net_ebpf_extension_connection_context_t;
 
@@ -635,15 +625,6 @@ _net_ebpf_ext_sock_addr_get_redirect_handle(uint64_t filter_id, _Out_ HANDLE* re
     NET_EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
-static void
-_net_ebpf_ext_connection_context_initialize_value(
-    BOOLEAN redirected, uint32_t verdict, _Out_ net_ebpf_extension_connection_context_t* connection_context)
-{
-    connection_context->value.redirected = redirected;
-    connection_context->value.verdict = (uint8_t)verdict;
-    connection_context->timestamp = CONVERT_100NS_UNITS_TO_MS(KeQueryInterruptTime());
-}
-
 /**
  * @brief Compare the destination address in the two provided bpf_sock_addr_t structs.
  *
@@ -665,57 +646,50 @@ _net_ebpf_ext_compare_destination_address(_In_ const bpf_sock_addr_t* addr1, _In
 }
 
 static void
-_net_ebpf_ext_connection_context_initialize_key(
+_net_ebpf_extension_connection_context_initialize(
     _In_ const bpf_sock_addr_t* sock_addr_ctx,
     uint64_t transport_endpoint_handle,
-    BOOLEAN original,
-    BOOLEAN v4_mapped,
-    _Out_ net_ebpf_ext_connection_context_key_t* context_key)
+    bool set_timestamp,
+    _Out_ net_ebpf_extension_connection_context_t* connection_context)
 {
-    // In case of original connection context, the destination IP classifiable field for classify
-    // callback at the AUTH_CONNECT_V4 layer is not populated for v4-mapped v6 address case.
-    // So for v4-mapped case, do not fill the destination IP in the key, to be able to match
-    // the context with the incoming values in AUTH callout.
-    if (!(original && v4_mapped)) {
-        RtlCopyMemory(
-            context_key->address_info.destination_ip.ipv6,
-            sock_addr_ctx->user_ip6,
-            sizeof(context_key->address_info.destination_ip));
-    }
+    RtlCopyMemory(
+        connection_context->address_info.destination_ip.ipv6,
+        sock_addr_ctx->user_ip6,
+        sizeof(connection_context->address_info.destination_ip));
 
-    context_key->address_info.destination_port = sock_addr_ctx->user_port;
-    context_key->address_info.family = sock_addr_ctx->family;
-    context_key->address_info.source_port = sock_addr_ctx->msg_src_port;
-    context_key->transport_endpoint_handle = transport_endpoint_handle;
-    context_key->protocol = (uint16_t)sock_addr_ctx->protocol;
-    context_key->compartment_id = sock_addr_ctx->compartment_id;
+    connection_context->address_info.destination_port = sock_addr_ctx->user_port;
+    connection_context->address_info.family = sock_addr_ctx->family;
+    connection_context->address_info.source_port = sock_addr_ctx->msg_src_port;
+    connection_context->transport_endpoint_handle = transport_endpoint_handle;
+    connection_context->protocol = (uint16_t)sock_addr_ctx->protocol;
+    connection_context->compartment_id = sock_addr_ctx->compartment_id;
+    if (set_timestamp)
+        connection_context->timestamp = CONVERT_100NS_UNITS_TO_MS(KeQueryInterruptTime());
 }
 
-static NTSTATUS
-_net_ebpf_ext_get_connection_context(
-    uint64_t transport_endpoint_handle,
-    _In_ const bpf_sock_addr_t* sock_addr_ctx,
-    _Outptr_ net_ebpf_extension_connection_context_t** connection_context)
+static net_ebpf_extension_connection_context_t*
+_net_ebpf_ext_get_connection_context(uint64_t transport_endpoint_handle, _In_ const bpf_sock_addr_t* sock_addr_ctx)
 {
     NTSTATUS status = STATUS_NOT_FOUND;
     KIRQL old_irql;
-    net_ebpf_ext_connection_context_key_t key = {0};
+    net_ebpf_extension_connection_context_t local_connection_context = {0};
+    net_ebpf_extension_connection_context_t* connection_context = NULL;
 
-    *connection_context = NULL;
-    _net_ebpf_ext_connection_context_initialize_key(sock_addr_ctx, transport_endpoint_handle, TRUE, FALSE, &key);
+    _net_ebpf_extension_connection_context_initialize(
+        sock_addr_ctx, transport_endpoint_handle, FALSE /*do not set timestamp*/, &local_connection_context);
     old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock);
 
     LIST_ENTRY* list_entry = _net_ebpf_ext_connect_context_list.Flink;
     while (list_entry != &_net_ebpf_ext_connect_context_list) {
         net_ebpf_extension_connection_context_t* entry =
             CONTAINING_RECORD(list_entry, net_ebpf_extension_connection_context_t, list_entry);
-        if (memcmp(&key, &entry->key, sizeof(net_ebpf_ext_connection_context_key_t)) == 0) {
-            // Found matching entry. Update timestamp and move to front of the queue.
-            entry->timestamp = CONVERT_100NS_UNITS_TO_MS(KeQueryInterruptTime());
+        if (memcmp(
+                &local_connection_context, entry, EBPF_OFFSET_OF(net_ebpf_extension_connection_context_t, timestamp)) ==
+            0) {
+            // Found matching entry. Remove it from the list and return.
             RemoveEntryList(&entry->list_entry);
-            InsertHeadList(&_net_ebpf_ext_connect_context_list, &entry->list_entry);
-
-            *connection_context = entry;
+            _net_ebpf_ext_connect_context_count--;
+            connection_context = entry;
             status = STATUS_SUCCESS;
             break;
         }
@@ -724,19 +698,7 @@ _net_ebpf_ext_get_connection_context(
 
     ExReleaseSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock, old_irql);
 
-    NET_EBPF_EXT_RETURN_NTSTATUS(status);
-}
-
-static void
-_net_ebpf_ext_delete_connection_context(_In_ _Post_invalid_ net_ebpf_extension_connection_context_t* context)
-{
-    KIRQL old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock);
-
-    RemoveEntryList(&context->list_entry);
-    ExFreePool(context);
-    _net_ebpf_ext_connect_context_count--;
-
-    ExReleaseSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock, old_irql);
+    NET_EBPF_EXT_RETURN_POINTER(net_ebpf_extension_connection_context_t*, connection_context);
 }
 
 _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_lock) static void _net_ebpf_ext_purge_lru_contexts_under_lock(
@@ -760,7 +722,7 @@ _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_lock) static void _net_eb
             NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "_net_ebpf_ext_purge_lru_contexts_under_lock: Delete",
-            entry->key.transport_endpoint_handle);
+            entry->transport_endpoint_handle);
 
         ExFreePool(entry);
     }
@@ -1139,7 +1101,6 @@ net_ebpf_extension_sock_addr_authorize_connection_classify(
     _Inout_ FWPS_CLASSIFY_OUT* classify_output)
 {
     uint32_t verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
-    NTSTATUS status;
     net_ebpf_extension_sock_addr_wfp_filter_context_t* filter_context = NULL;
     net_ebpf_sock_addr_t net_ebpf_sock_addr_ctx = {0};
     bpf_sock_addr_t* sock_addr_ctx = &net_ebpf_sock_addr_ctx.base;
@@ -1174,24 +1135,22 @@ net_ebpf_extension_sock_addr_authorize_connection_classify(
     }
 
     // Get the connection context for this connection.
-    status = _net_ebpf_ext_get_connection_context(
-        incoming_metadata_values->transportEndpointHandle, sock_addr_ctx, &connection_context);
-    if (!NT_SUCCESS(status)) {
-        // We did not find any connection context for this AUTH request. Block.
-        verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
+    connection_context =
+        _net_ebpf_ext_get_connection_context(incoming_metadata_values->transportEndpointHandle, sock_addr_ctx);
+    if (connection_context == NULL) {
+        // No blocked connection context was found for this AUTH request. Se the connection is allowed.
+        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
         goto Exit;
     }
-    verdict = connection_context->value.verdict;
-
-    _net_ebpf_ext_delete_connection_context(connection_context);
+    verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
+    ExFreePool(connection_context);
     connection_context = NULL;
 
 Exit:
     classify_output->actionType = (verdict == BPF_SOCK_ADDR_VERDICT_PROCEED) ? FWP_ACTION_PERMIT : FWP_ACTION_BLOCK;
-    // Clear FWPS_RIGHT_ACTION_WRITE only when it is a hard block.
-    if (classify_output->actionType == FWP_ACTION_BLOCK) {
+    // Clear FWPS_RIGHT_ACTION_WRITE for block action.
+    if (classify_output->actionType == FWP_ACTION_BLOCK)
         classify_output->rights &= ~FWPS_RIGHT_ACTION_WRITE;
-    }
 
     NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(
         NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
@@ -1212,7 +1171,7 @@ _net_ebpf_ext_process_redirect_verdict(
     _In_ const FWPS_FILTER* filter,
     uint64_t classify_handle,
     HANDLE redirect_handle,
-    _Out_ BOOLEAN* redirected,
+    _Out_ bool* redirected,
     _Inout_ FWPS_CLASSIFY_OUT* classify_output)
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -1262,6 +1221,8 @@ _net_ebpf_ext_process_redirect_verdict(
             InterlockedIncrement(&_net_ebpf_ext_statistics.permit_connection_count);
         }
     } else {
+        // If the eBPF program turned in a REJECT verdict, there is no need to process
+        // connection redirection, even if the program modified the destination.
         InterlockedIncrement(&_net_ebpf_ext_statistics.block_connection_count);
     }
 
@@ -1273,13 +1234,70 @@ Exit:
     NET_EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
-/*
- * Default action is BLOCK. If this callout is being invoked, it means at least one
- * eBPF program is attached. Hence no connection should be allowed unless allowed by
- * the eBPF program.
+/**
+ * @brief This function determines if the sock_addr eBPF program should be invoked as part of processing the classify
+ * callback at CONNECT_REDIRECT layer.
  *
- * If the eBPF program verdict is BLOCK, no context is created and AUTH classify will
- * block the connection by default.
+ * @param[in] filter_context Pointer to net_ebpf_extension_sock_addr_wfp_filter_context_t associated with WFP filter.
+ * @param[in] sock_addr_ctx Pointer to bpf_sock_addr_t struct to be passed to eBPF program.
+ * @param[in] v4_mapped Boolean indicating if the IP address in sock_addr is v4 mapped v6 address or not.
+ *
+ * @returns True if eBPF program should be invoked, False otherwise.
+ */
+
+bool
+_net_ebpf_extension_sock_addr_should_invoke_ebpf_program(
+    _In_ const net_ebpf_extension_sock_addr_wfp_filter_context_t* filter_context,
+    _In_ const bpf_sock_addr_t* sock_addr_ctx,
+    bool v4_mapped)
+{
+    bool process_classify = TRUE;
+
+    //  If the callout is invoked for v4, then it is safe to invoke the eBPF program.
+    if (sock_addr_ctx->family == AF_INET)
+        goto Exit;
+
+    //  If the callout is invoked for v6:
+    //  1. Check if the destination is v4-mapped v6 address or pure v6 address.
+    //  2. If it is v4-mapped v6 address, then we should proceed only if this callout
+    //     is invoked for v4 attach type.
+    //  3. If it is pure v6 address, then we should proceed only if this callout is
+    //     invoked for v6 attach type.
+
+    if (v4_mapped) {
+        if (!filter_context->v4_attach_type) {
+            // This filter is for v6 attach type, but address is v4-mapped v6 address.
+            NET_EBPF_EXT_LOG_MESSAGE(
+                NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
+                NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
+                "net_ebpf_extension_sock_addr_redirect_connection_classify: v6 attach type, v4mapped address, "
+                "ignoring");
+            process_classify = FALSE;
+            goto Exit;
+        }
+    } else if (filter_context->v4_attach_type) {
+        // This filter is for v4 attach type, but address is a pure v6 address.
+        NET_EBPF_EXT_LOG_MESSAGE(
+            NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
+            "net_ebpf_extension_sock_addr_redirect_connection_classify: v4 attach type, IPv6 address, ignoring");
+        process_classify = FALSE;
+        goto Exit;
+    }
+
+Exit:
+    NET_EBPF_EXT_RETURN_BOOL(process_classify);
+}
+
+/*
+ * For every eBPF sock_addr program attached to INET_CONNECT attach point (for a given compartment), a WFP filter
+ * is added to the WFP CONNECT_REDIRECT (with the compartment Id as filter condition). So, this classify callback
+ * function will be invoked for every new connection in the compartment. And so, the eBPF program attached
+ * to the compartment will get invoked for every new connection.
+ * If the program returns a PROCEED verdict, the connection is permitted by the callout.
+ * If the program modifies the destination IP of the connection, connection redirection will be performed by this
+ * callout. If the If on the other hand, the program returns a REJECT verdict, that decision will be cached and enforced
+ * later by a corresponding callout at WFP AUTH_CONNECT layer.
  */
 void
 net_ebpf_extension_sock_addr_redirect_connection_classify(
@@ -1295,50 +1313,26 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
     NTSTATUS status = STATUS_SUCCESS;
     net_ebpf_extension_sock_addr_wfp_filter_context_t* filter_context = NULL;
     net_ebpf_extension_hook_client_t* attached_client = NULL;
-    net_ebpf_sock_addr_t* net_ebpf_sock_addr_ctx = NULL;
-    bpf_sock_addr_t* sock_addr_ctx = NULL;
-    bpf_sock_addr_t* sock_addr_ctx_original = NULL;
+    net_ebpf_sock_addr_t net_ebpf_sock_addr_ctx = {0};
+    bpf_sock_addr_t* sock_addr_ctx = (bpf_sock_addr_t*)&net_ebpf_sock_addr_ctx.base;
+    bpf_sock_addr_t sock_addr_ctx_original = {0};
     uint32_t compartment_id = UNSPECIFIED_COMPARTMENT_ID;
+    bool v4_mapped = FALSE;
     FWPS_CONNECTION_REDIRECT_STATE redirect_state;
     HANDLE redirect_handle;
     uint64_t classify_handle = 0;
-    net_ebpf_extension_connection_context_t* connection_context_original = NULL;
-    net_ebpf_extension_connection_context_t* connection_context_redirected = NULL;
-    BOOLEAN redirected = FALSE;
-    FWP_ACTION_TYPE action = FWP_ACTION_BLOCK;
-    BOOLEAN classify_handle_acquired = FALSE;
-    BOOLEAN v4_mapped = FALSE;
-    BOOLEAN is_original_connection;
+    bool classify_handle_acquired = FALSE;
+    bool redirected = FALSE;
+    net_ebpf_extension_connection_context_t* blocked_connection_context = NULL;
 
     UNREFERENCED_PARAMETER(layer_data);
     UNREFERENCED_PARAMETER(flow_context);
 
     if ((classify_output->rights & FWPS_RIGHT_ACTION_WRITE) == 0) {
-        // Do not modify anything and bail.
+        // A callout with higher weight has revoked the write permission. Bail out.
         return;
     }
 
-    net_ebpf_sock_addr_ctx = (net_ebpf_sock_addr_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(net_ebpf_sock_addr_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (net_ebpf_sock_addr_ctx == NULL) {
-        status = STATUS_INSUFFICIENT_RESOURCES;
-        goto Exit;
-    }
-    sock_addr_ctx = &net_ebpf_sock_addr_ctx->base;
-    sock_addr_ctx_original = (bpf_sock_addr_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(bpf_sock_addr_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (sock_addr_ctx_original == NULL) {
-        status = STATUS_INSUFFICIENT_RESOURCES;
-        goto Exit;
-    }
-    memset(net_ebpf_sock_addr_ctx, 0, sizeof(bpf_sock_addr_t));
-    memset(sock_addr_ctx_original, 0, sizeof(bpf_sock_addr_t));
-
-    _net_ebpf_extension_sock_addr_copy_wfp_connection_fields(
-        incoming_fixed_values, incoming_metadata_values, net_ebpf_sock_addr_ctx);
-    *sock_addr_ctx_original = *sock_addr_ctx;
-
-    // Check if this call is intended for us.
     filter_context = (net_ebpf_extension_sock_addr_wfp_filter_context_t*)filter->context;
     ASSERT(filter_context != NULL);
     if (filter_context == NULL) {
@@ -1346,52 +1340,16 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
         goto Exit;
     }
 
-    // If the callout is invoked for v4, then it is safe to simply invoke the eBPF
-    // program from the filter context.
-    // If the callout is invoked for v6:
-    // 1. Check if the destination is v4-mapped v6 address or pure v6 address.
-    // 2. If it is v4-mapped v6 address, then we should proceed only if this callout
-    //    is invoked for v4 attach type.
-    // 3. If it is pure v6 address, then we should proceed only if this callout is
-    //    invoked for v6 attach type.
-    if (sock_addr_ctx->family == AF_INET6) {
-        if (IN6_IS_ADDR_V4MAPPED((IN6_ADDR*)sock_addr_ctx->user_ip6)) {
-            v4_mapped = TRUE;
-        }
-        if (v4_mapped) {
-            if (!filter_context->v4_attach_type) {
-                // This callout is for v6 attach type, but address is v4-mapped v6 address.
-                // Change action to permit and return.
-                NET_EBPF_EXT_LOG_MESSAGE(
-                    NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
-                    "net_ebpf_extension_sock_addr_redirect_connection_classify: v6 attach type, v4mapped, ignoring");
-                action = FWP_ACTION_PERMIT;
-                goto Exit;
-            }
-        } else if (filter_context->v4_attach_type) {
-            // This callout is for v4 attach type, but address is a pure v6 address.
-            // Change action to permit and return.
-            NET_EBPF_EXT_LOG_MESSAGE(
-                NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
-                NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
-                "net_ebpf_extension_sock_addr_redirect_connection_classify: v4 attach type, purev6, ignoring");
-            action = FWP_ACTION_PERMIT;
-            goto Exit;
-        }
-    }
-
     compartment_id = filter_context->compartment_id;
     ASSERT((compartment_id == UNSPECIFIED_COMPARTMENT_ID) || (compartment_id == sock_addr_ctx->compartment_id));
     if (compartment_id != UNSPECIFIED_COMPARTMENT_ID && compartment_id != sock_addr_ctx->compartment_id) {
-        // The client is not interested in this compartment Id. Change action to PERMIT.
+        // The client is not interested in this compartment Id.
         NET_EBPF_EXT_LOG_MESSAGE_UINT32(
             NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "The cgroup_sock_addr eBPF program is not interested in this compartment ID",
             sock_addr_ctx->compartment_id);
 
-        action = FWP_ACTION_PERMIT;
         goto Exit;
     }
 
@@ -1402,8 +1360,7 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
     }
     if (!net_ebpf_extension_hook_client_enter_rundown(attached_client)) {
         attached_client = NULL;
-        // Client is detaching, change action to permit.
-        action = FWP_ACTION_PERMIT;
+        // Client is detaching.
         goto Exit;
     }
 
@@ -1419,22 +1376,6 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
         goto Exit;
     }
 
-    connection_context_original = (net_ebpf_extension_connection_context_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(net_ebpf_extension_connection_context_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (connection_context_original == NULL) {
-        status = STATUS_INSUFFICIENT_RESOURCES;
-        goto Exit;
-    }
-    memset(connection_context_original, 0, sizeof(net_ebpf_extension_connection_context_t));
-
-    connection_context_redirected = (net_ebpf_extension_connection_context_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(net_ebpf_extension_connection_context_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (connection_context_redirected == NULL) {
-        status = STATUS_INSUFFICIENT_RESOURCES;
-        goto Exit;
-    }
-    memset(connection_context_redirected, 0, sizeof(net_ebpf_extension_connection_context_t));
-
     // Fetch redirect state.
     redirect_state = FwpsQueryConnectionRedirectState(incoming_metadata_values->redirectRecords, redirect_handle, NULL);
     if (redirect_state == FWPS_CONNECTION_REDIRECTED_BY_SELF ||
@@ -1446,26 +1387,20 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
             filter->filterId,
             (uint64_t)sock_addr_ctx->compartment_id);
 
-        // We have already looked at this connection. Permit and exit. Populate connection
-        // contexts for this new connection, so that AUTH classify can permit this connection.
-        _net_ebpf_ext_connection_context_initialize_key(
-            sock_addr_ctx,
-            incoming_metadata_values->transportEndpointHandle,
-            TRUE, /* original */
-            v4_mapped,
-            &connection_context_original->key);
-        _net_ebpf_ext_connection_context_initialize_key(
-            sock_addr_ctx,
-            incoming_metadata_values->transportEndpointHandle,
-            FALSE, /* original */
-            v4_mapped,
-            &connection_context_redirected->key);
-
-        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
-        redirected = TRUE;
-
-        goto CreateContext;
+        // This connection was previously redirected.
+        goto Exit;
     }
+
+    // Populate the sock_addr context with WFP classify input fields.
+    _net_ebpf_extension_sock_addr_copy_wfp_connection_fields(
+        incoming_fixed_values, incoming_metadata_values, &net_ebpf_sock_addr_ctx);
+    memcpy(&sock_addr_ctx_original, sock_addr_ctx, sizeof(sock_addr_ctx_original));
+
+    v4_mapped = (sock_addr_ctx->family == AF_INET6) && IN6_IS_ADDR_V4MAPPED((IN6_ADDR*)sock_addr_ctx->user_ip6);
+
+    // Check if the eBPF program should be invoked based on the IP address family and the hook attach type.
+    if (!_net_ebpf_extension_sock_addr_should_invoke_ebpf_program(filter_context, sock_addr_ctx, v4_mapped))
+        goto Exit;
 
     // Acquire classify handle.
     status = FwpsAcquireClassifyHandle((void*)classify_context, 0, &classify_handle);
@@ -1489,27 +1424,10 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
         sock_addr_ctx->user_ip4 = local_v4_ip;
     }
 
-    is_original_connection = TRUE;
-    _net_ebpf_ext_connection_context_initialize_key(
-        sock_addr_ctx,
-        incoming_metadata_values->transportEndpointHandle,
-        is_original_connection,
-        v4_mapped,
-        &connection_context_original->key);
-
     if (net_ebpf_extension_hook_invoke_program(attached_client, sock_addr_ctx, &verdict) != EBPF_SUCCESS) {
         status = STATUS_UNSUCCESSFUL;
         goto Exit;
     }
-
-    // Initialize connection_context_redirected destination with the redirected address.
-    is_original_connection = FALSE;
-    _net_ebpf_ext_connection_context_initialize_key(
-        sock_addr_ctx,
-        incoming_metadata_values->transportEndpointHandle,
-        is_original_connection,
-        v4_mapped,
-        &connection_context_redirected->key);
 
     if (v4_mapped) {
         sock_addr_ctx->family = AF_INET6;
@@ -1519,7 +1437,7 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
 
     status = _net_ebpf_ext_process_redirect_verdict(
         verdict,
-        sock_addr_ctx_original,
+        &sock_addr_ctx_original,
         sock_addr_ctx,
         filter,
         classify_handle,
@@ -1528,27 +1446,24 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
         classify_output);
     NET_EBPF_EXT_BAIL_ON_ERROR_STATUS(status);
 
-CreateContext:
-    if (verdict == BPF_SOCK_ADDR_VERDICT_PROCEED) {
-        _net_ebpf_ext_connection_context_initialize_value(redirected, verdict, connection_context_redirected);
-
-        _net_ebpf_ext_insert_connection_context_to_list(connection_context_redirected);
-
-        if (redirected) {
-            // If the connection has been redirected, then initialize connection context
-            // with original destination also.
-            _net_ebpf_ext_connection_context_initialize_value(redirected, verdict, connection_context_original);
-
-            _net_ebpf_ext_insert_connection_context_to_list(connection_context_original);
-        } else {
-            ExFreePool(connection_context_original);
-            connection_context_original = NULL;
+    if (verdict == BPF_SOCK_ADDR_VERDICT_REJECT) {
+        // Create a blocked connection context and add it to list for the AUTH_CONNECT layer callout to enforce the
+        // verdict of the program.
+        blocked_connection_context = (net_ebpf_extension_connection_context_t*)ExAllocatePoolUninitialized(
+            NonPagedPoolNx, sizeof(net_ebpf_extension_connection_context_t), NET_EBPF_EXTENSION_POOL_TAG);
+        if (blocked_connection_context == NULL) {
+            status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Exit;
         }
-    } else {
-        ExFreePool(connection_context_original);
-        connection_context_original = NULL;
-        ExFreePool(connection_context_redirected);
-        connection_context_redirected = NULL;
+        memset(blocked_connection_context, 0, sizeof(net_ebpf_extension_connection_context_t));
+
+        _net_ebpf_extension_connection_context_initialize(
+            sock_addr_ctx,
+            incoming_metadata_values->transportEndpointHandle,
+            TRUE, /*set timestamp*/
+            blocked_connection_context);
+
+        _net_ebpf_ext_insert_connection_context_to_list(blocked_connection_context);
     }
 
     NET_EBPF_EXT_LOG_SOCK_ADDR_CLASSIFY(
@@ -1560,32 +1475,16 @@ CreateContext:
         redirected,
         verdict);
 
-    action = FWP_ACTION_PERMIT;
-
 Exit:
-    classify_output->actionType = action;
-    // Clear FWPS_RIGHT_ACTION_WRITE only when it is a hard block.
-    if (action == FWP_ACTION_BLOCK) {
-        classify_output->rights &= ~FWPS_RIGHT_ACTION_WRITE;
-    }
-    if (classify_handle_acquired) {
+    // Callout at CONNECT_REDIRECT layer always returns WFP action PERMIT.
+    // If the eBPF program was invoked and it returned a REJECT verdict, it would be enforced by the callout at
+    // AUTH_CONNECT layer further downstream.
+
+    classify_output->actionType = FWP_ACTION_PERMIT;
+
+    if (classify_handle_acquired)
         FwpsReleaseClassifyHandle(classify_handle);
-    }
-    if (net_ebpf_sock_addr_ctx) {
-        ExFreePool(net_ebpf_sock_addr_ctx);
-        sock_addr_ctx = NULL;
-    }
-    if (sock_addr_ctx_original) {
-        ExFreePool(sock_addr_ctx_original);
-    }
-    if (!NT_SUCCESS(status)) {
-        if (connection_context_original) {
-            ExFreePool(connection_context_original);
-        }
-        if (connection_context_redirected) {
-            ExFreePool(connection_context_redirected);
-        }
-    }
+
     if (attached_client)
         net_ebpf_extension_hook_client_leave_rundown(attached_client);
 }

--- a/netebpfext/net_ebpf_ext_tracelog.h
+++ b/netebpfext/net_ebpf_ext_tracelog.h
@@ -10,6 +10,7 @@ void
 net_ebpf_ext_trace_terminate();
 
 #define NET_EBPF_EXT_TRACELOG_EVENT_SUCCESS "NetEbpfExtSuccess"
+#define NET_EBPF_EXT_TRACELOG_EVENT_RETURN "NetEbpfExtReturn"
 #define NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_ERROR "NetEbpfExtGenericError"
 #define NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE "NetEbpfExtGenericMessage"
 #define NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR "NetEbpfExtApiError"
@@ -70,7 +71,7 @@ net_ebpf_ext_trace_terminate();
     TraceLoggingWrite(                                              \
         net_ebpf_ext_tracelog_provider,                             \
         NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                      \
-        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),               \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                    \
         TraceLoggingKeyword((keyword)),                             \
         TraceLoggingString(#api, "api"),                            \
         TraceLoggingNTStatus(status));
@@ -79,7 +80,7 @@ net_ebpf_ext_trace_terminate();
     TraceLoggingWrite(                                                                             \
         net_ebpf_ext_tracelog_provider,                                                            \
         NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                                                     \
-        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                              \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                                   \
         TraceLoggingKeyword((keyword)),                                                            \
         TraceLoggingString(#api, "api"),                                                           \
         TraceLoggingNTStatus(status),                                                              \
@@ -152,11 +153,37 @@ net_ebpf_ext_trace_terminate();
         return local_result;                               \
     } while (false);
 
+#define NET_EBPF_EXT_RETURN_POINTER(type, pointer)                   \
+    do {                                                             \
+        type local_result = (type)(pointer);                         \
+        TraceLoggingWrite(                                           \
+            net_ebpf_ext_tracelog_provider,                          \
+            NET_EBPF_EXT_TRACELOG_EVENT_RETURN,                      \
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),               \
+            TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_BASE), \
+            TraceLoggingString(__FUNCTION__ " returned"),            \
+            TraceLoggingPointer(local_result, #pointer));            \
+        return local_result;                                         \
+    } while (false);
+
+#define NET_EBPF_EXT_RETURN_BOOL(flag)                               \
+    do {                                                             \
+        bool local_result = (flag);                                  \
+        TraceLoggingWrite(                                           \
+            net_ebpf_ext_tracelog_provider,                          \
+            NET_EBPF_EXT_TRACELOG_EVENT_RETURN,                      \
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),               \
+            TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_BASE), \
+            TraceLoggingString(__FUNCTION__ " returned"),            \
+            TraceLoggingBool(!!local_result, #flag));                \
+        return local_result;                                         \
+    } while (false);
+
 #define NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(keyword, api, status, value1, value2) \
     TraceLoggingWrite(                                                                            \
         net_ebpf_ext_tracelog_provider,                                                           \
         NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                                                    \
-        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                             \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                                  \
         TraceLoggingKeyword((keyword)),                                                           \
         TraceLoggingString(#api, "api"),                                                          \
         TraceLoggingNTStatus(status),                                                             \


### PR DESCRIPTION
## Description

This PR aims to simplify the classify callback function for WFP CONNECT_REDIRECT layer callout. It modifies the logic to cache blocked connections instead of permitted connections. It is assumed, that a sock_addr eBPF program will block far fewer connections than it permits. So the goal is to optimize the permitted connections case.

## Testing

CI.

## Documentation

No.