### PR TITLE
Redirect list

### DIFF
--- a/installer/ebpf-for-windows.wixproj
+++ b/installer/ebpf-for-windows.wixproj
@@ -137,6 +137,14 @@ SPDX-License-Identifier: MIT
       <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
       <RefTargetDir>INSTALLFOLDER</RefTargetDir>
     </ProjectReference>
+    <ProjectReference Include="..\tests\xdp\xdp_tests.vcxproj">
+      <Name>xdp_tests</Name>
+      <Project>{07dc6181-84a2-4a14-a806-5e9af6c929c2}</Project>
+      <Private>True</Private>
+      <DoNotHarvest>True</DoNotHarvest>
+      <RefProjectOutputGroups>Binaries;Content;Satellites</RefProjectOutputGroups>
+      <RefTargetDir>INSTALLFOLDER</RefTargetDir>
+    </ProjectReference>
     <ProjectReference Include="..\tools\bpf2c\bpf2c.vcxproj">
       <Name>bpf2c</Name>
       <Project>{69b97e52-18dc-434e-a6e4-4c0f3e88c44a}</Project>

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -1435,6 +1435,7 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
 
     // Check if the eBPF program should be invoked based on the IP address family and the hook attach type.
     if (!_net_ebpf_extension_sock_addr_should_invoke_ebpf_program(filter_context, sock_addr_ctx, v4_mapped)) {
+        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
         goto Exit;
     }
 

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -39,24 +39,14 @@ typedef struct _net_ebpf_ext_connect_context_address_info
     uint16_t source_port;
 } net_ebpf_ext_connect_context_address_info_t;
 
-typedef struct _net_ebpf_ext_connection_context_key
+typedef struct _net_ebpf_extension_connection_context
 {
     uint64_t transport_endpoint_handle;
     net_ebpf_ext_connect_context_address_info_t address_info;
     uint32_t compartment_id;
     uint16_t protocol;
-} net_ebpf_ext_connection_context_key_t;
-
-typedef struct _net_ebpf_extension_connection_context
-{
-    LIST_ENTRY list_entry;
-    net_ebpf_ext_connection_context_key_t key;
-    struct
-    {
-        uint8_t verdict : 2;
-        uint8_t redirected : 1;
-    } value;
     uint64_t timestamp;
+    LIST_ENTRY list_entry;
 } net_ebpf_extension_connection_context_t;
 
 typedef struct _net_ebpf_extension_redirect_handle_entry
@@ -603,15 +593,6 @@ _net_ebpf_ext_sock_addr_get_redirect_handle(uint64_t filter_id, _Out_ HANDLE* re
     NET_EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
-static void
-_net_ebpf_ext_connection_context_initialize_value(
-    BOOLEAN redirected, uint32_t verdict, _Out_ net_ebpf_extension_connection_context_t* connection_context)
-{
-    connection_context->value.redirected = redirected;
-    connection_context->value.verdict = (uint8_t)verdict;
-    connection_context->timestamp = CONVERT_100NS_UNITS_TO_MS(KeQueryInterruptTime());
-}
-
 /**
  * @brief Compare the destination address in the two provided bpf_sock_addr_t structs.
  *
@@ -633,56 +614,51 @@ _net_ebpf_ext_compare_destination_address(_In_ const bpf_sock_addr_t* addr1, _In
 }
 
 static void
-_net_ebpf_ext_connection_context_initialize_key(
+_net_ebpf_extension_connection_context_initialize(
     _In_ const bpf_sock_addr_t* sock_addr_ctx,
     uint64_t transport_endpoint_handle,
-    BOOLEAN original,
-    BOOLEAN v4_mapped,
-    _Out_ net_ebpf_ext_connection_context_key_t* context_key)
+    bool set_timestamp,
+    _Out_ net_ebpf_extension_connection_context_t* connection_context)
 {
-    // In case of original connection context, the destination IP classifiable field for classify
-    // callback at the AUTH_CONNECT_V4 layer is not populated for v4-mapped v6 address case.
-    // So for v4-mapped case, do not fill the destination IP in the key, to be able to match
-    // the context with the incoming values in AUTH callout.
-    if (!(original && v4_mapped)) {
-        RtlCopyMemory(
-            context_key->address_info.destination_ip.ipv6,
-            sock_addr_ctx->user_ip6,
-            sizeof(context_key->address_info.destination_ip));
-    }
+    RtlCopyMemory(
+        connection_context->address_info.destination_ip.ipv6,
+        sock_addr_ctx->user_ip6,
+        sizeof(connection_context->address_info.destination_ip));
 
-    context_key->address_info.destination_port = sock_addr_ctx->user_port;
-    context_key->address_info.family = sock_addr_ctx->family;
-    context_key->address_info.source_port = sock_addr_ctx->msg_src_port;
-    context_key->transport_endpoint_handle = transport_endpoint_handle;
-    context_key->protocol = (uint16_t)sock_addr_ctx->protocol;
-    context_key->compartment_id = sock_addr_ctx->compartment_id;
+    connection_context->address_info.destination_port = sock_addr_ctx->user_port;
+    connection_context->address_info.family = sock_addr_ctx->family;
+    connection_context->address_info.source_port = sock_addr_ctx->msg_src_port;
+    connection_context->transport_endpoint_handle = transport_endpoint_handle;
+    connection_context->protocol = (uint16_t)sock_addr_ctx->protocol;
+    connection_context->compartment_id = sock_addr_ctx->compartment_id;
+    if (set_timestamp)
+        connection_context->timestamp = CONVERT_100NS_UNITS_TO_MS(KeQueryInterruptTime());
 }
 
-static NTSTATUS
+static net_ebpf_extension_connection_context_t*
 _net_ebpf_ext_get_and_remove_connection_context(
-    uint64_t transport_endpoint_handle,
-    _In_ const bpf_sock_addr_t* sock_addr_ctx,
-    _Outptr_ net_ebpf_extension_connection_context_t** connection_context)
+    uint64_t transport_endpoint_handle, _In_ const bpf_sock_addr_t* sock_addr_ctx)
 {
     NTSTATUS status = STATUS_NOT_FOUND;
     KIRQL old_irql;
-    net_ebpf_ext_connection_context_key_t key = {0};
+    net_ebpf_extension_connection_context_t local_connection_context = {0};
+    net_ebpf_extension_connection_context_t* connection_context = NULL;
 
-    *connection_context = NULL;
-    _net_ebpf_ext_connection_context_initialize_key(sock_addr_ctx, transport_endpoint_handle, TRUE, FALSE, &key);
+    _net_ebpf_extension_connection_context_initialize(
+        sock_addr_ctx, transport_endpoint_handle, FALSE /*do not set timestamp*/, &local_connection_context);
     old_irql = ExAcquireSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock);
 
     LIST_ENTRY* list_entry = _net_ebpf_ext_connect_context_list.Flink;
     while (list_entry != &_net_ebpf_ext_connect_context_list) {
         net_ebpf_extension_connection_context_t* entry =
             CONTAINING_RECORD(list_entry, net_ebpf_extension_connection_context_t, list_entry);
-        if (memcmp(&key, &entry->key, sizeof(net_ebpf_ext_connection_context_key_t)) == 0) {
-            // Found matching entry. Delete it from the list.
+        if (memcmp(
+                &local_connection_context, entry, EBPF_OFFSET_OF(net_ebpf_extension_connection_context_t, timestamp)) ==
+            0) {
+            // Found matching entry. Remove it from the list and return.
             RemoveEntryList(&entry->list_entry);
-
-            *connection_context = entry;
             _net_ebpf_ext_connect_context_count--;
+            connection_context = entry;
             status = STATUS_SUCCESS;
             break;
         }
@@ -691,7 +667,7 @@ _net_ebpf_ext_get_and_remove_connection_context(
 
     ExReleaseSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock, old_irql);
 
-    NET_EBPF_EXT_RETURN_NTSTATUS(status);
+    NET_EBPF_EXT_RETURN_POINTER(net_ebpf_extension_connection_context_t*, connection_context);
 }
 
 _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_lock) static void _net_ebpf_ext_purge_lru_contexts_under_lock(
@@ -715,7 +691,7 @@ _Requires_exclusive_lock_held_(_net_ebpf_ext_sock_addr_lock) static void _net_eb
             NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "_net_ebpf_ext_purge_lru_contexts_under_lock: Delete",
-            entry->key.transport_endpoint_handle);
+            entry->transport_endpoint_handle);
 
         ExFreePool(entry);
     }
@@ -1120,7 +1096,6 @@ net_ebpf_extension_sock_addr_authorize_connection_classify(
     _Inout_ FWPS_CLASSIFY_OUT* classify_output)
 {
     uint32_t verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
-    NTSTATUS status;
     net_ebpf_extension_sock_addr_wfp_filter_context_t* filter_context = NULL;
     net_ebpf_sock_addr_t net_ebpf_sock_addr_ctx = {0};
     bpf_sock_addr_t* sock_addr_ctx = &net_ebpf_sock_addr_ctx.base;
@@ -1161,25 +1136,23 @@ net_ebpf_extension_sock_addr_authorize_connection_classify(
         goto Exit;
     }
 
-    // Get the connection context for this connection.
-    status = _net_ebpf_ext_get_and_remove_connection_context(
-        incoming_metadata_values->transportEndpointHandle, sock_addr_ctx, &connection_context);
-    if (!NT_SUCCESS(status)) {
-        // We did not find any connection context for this AUTH request. Block.
-        verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
+    // Find and remove the connection context for this connection.
+    connection_context = _net_ebpf_ext_get_and_remove_connection_context(
+        incoming_metadata_values->transportEndpointHandle, sock_addr_ctx);
+    if (connection_context == NULL) {
+        // No blocked connection context was found for this AUTH request. Se the connection is allowed.
+        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
         goto Exit;
     }
-    verdict = connection_context->value.verdict;
-
+    verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
     ExFreePool(connection_context);
     connection_context = NULL;
 
 Exit:
     classify_output->actionType = (verdict == BPF_SOCK_ADDR_VERDICT_PROCEED) ? FWP_ACTION_PERMIT : FWP_ACTION_BLOCK;
-    // Clear FWPS_RIGHT_ACTION_WRITE only when it is a hard block.
-    if (classify_output->actionType == FWP_ACTION_BLOCK) {
+    // Clear FWPS_RIGHT_ACTION_WRITE for block action.
+    if (classify_output->actionType == FWP_ACTION_BLOCK)
         classify_output->rights &= ~FWPS_RIGHT_ACTION_WRITE;
-    }
 
     NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(
         NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
@@ -1215,13 +1188,12 @@ _net_ebpf_ext_sock_addr_is_connection_locally_redirected_by_others(
 
 static NTSTATUS
 _net_ebpf_ext_process_redirect_verdict(
-    uint32_t verdict,
     _In_ const bpf_sock_addr_t* original_context,
     _In_ const bpf_sock_addr_t* redirected_context,
     _In_ const FWPS_FILTER* filter,
     uint64_t classify_handle,
     HANDLE redirect_handle,
-    _Out_ BOOLEAN* redirected,
+    _Out_ bool* redirected,
     _Inout_ FWPS_CLASSIFY_OUT* classify_output)
 {
     NTSTATUS status = STATUS_SUCCESS;
@@ -1230,55 +1202,47 @@ _net_ebpf_ext_process_redirect_verdict(
 
     *redirected = FALSE;
 
-    if (verdict == BPF_SOCK_ADDR_VERDICT_PROCEED) {
-        // Check if destination IP and/or port have been modified.
-        BOOLEAN address_changed = !_net_ebpf_ext_compare_destination_address(redirected_context, original_context);
-        if (redirected_context->user_port != original_context->user_port || address_changed) {
-            *redirected = TRUE;
+    // Check if destination IP and/or port have been modified.
+    BOOLEAN address_changed = !_net_ebpf_ext_compare_destination_address(redirected_context, original_context);
+    if (redirected_context->user_port != original_context->user_port || address_changed) {
+        *redirected = TRUE;
 
-            status = FwpsAcquireWritableLayerDataPointer(
-                classify_handle, filter->filterId, 0, (void**)&connect_request, classify_output);
-            if (!NT_SUCCESS(status)) {
-                NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
-                    "FwpsAcquireWritableLayerDataPointer",
-                    status,
-                    filter->filterId,
-                    (uint64_t)redirected_context->compartment_id);
+        status = FwpsAcquireWritableLayerDataPointer(
+            classify_handle, filter->filterId, 0, (PVOID*)&connect_request, classify_output);
+        if (!NT_SUCCESS(status)) {
+            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(
+                NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
+                "FwpsAcquireWritableLayerDataPointer",
+                status,
+                filter->filterId,
+                (uint64_t)redirected_context->compartment_id);
 
-                goto Exit;
-            }
-            commit_layer_data = TRUE;
-
-            if (_net_ebpf_ext_sock_addr_is_connection_locally_redirected_by_others(connect_request, filter->filterId)) {
-                // Since this connection has been redirected to a local proxy, it should not be redirected once more.
-                // Once the local proxy sends out another outbound connection to the original destination,
-                // that connection will get intercepted again and the eBPF program will be invoked again.
-                goto Exit;
-            }
-
-            InterlockedIncrement(&_net_ebpf_ext_statistics.redirect_connection_count);
-
-            if (redirected_context->user_port != original_context->user_port) {
-                INETADDR_SET_PORT((PSOCKADDR)&connect_request->remoteAddressAndPort, redirected_context->user_port);
-            }
-            if (address_changed) {
-                uint8_t* address;
-                if (redirected_context->family == AF_INET) {
-                    address = (uint8_t*)&redirected_context->user_ip4;
-                } else {
-                    address = (uint8_t*)&(redirected_context->user_ip6[0]);
-                }
-                INETADDR_SET_ADDRESS((PSOCKADDR)&connect_request->remoteAddressAndPort, address);
-            }
-
-            connect_request->localRedirectTargetPID = TARGET_PROCESS_ID;
-            connect_request->localRedirectHandle = redirect_handle;
-        } else {
-            InterlockedIncrement(&_net_ebpf_ext_statistics.permit_connection_count);
+            goto Exit;
         }
-    } else {
-        InterlockedIncrement(&_net_ebpf_ext_statistics.block_connection_count);
+        commit_layer_data = TRUE;
+
+        if (_net_ebpf_ext_sock_addr_is_connection_locally_redirected_by_others(connect_request, filter->filterId)) {
+            // Since this connection has been redirected to a local proxy, it should not be redirected once more.
+            // Once the local proxy sends out another outbound connection to the original destination,
+            // that connection will get intercepted again and the eBPF program will be invoked again.
+            goto Exit;
+        }
+
+        if (redirected_context->user_port != original_context->user_port) {
+            INETADDR_SET_PORT((PSOCKADDR)&connect_request->remoteAddressAndPort, redirected_context->user_port);
+        }
+        if (address_changed) {
+            uint8_t* address;
+            if (redirected_context->family == AF_INET) {
+                address = (uint8_t*)&redirected_context->user_ip4;
+            } else {
+                address = (uint8_t*)&(redirected_context->user_ip6[0]);
+            }
+            INETADDR_SET_ADDRESS((PSOCKADDR)&connect_request->remoteAddressAndPort, address);
+        }
+
+        connect_request->localRedirectTargetPID = TARGET_PROCESS_ID;
+        connect_request->localRedirectHandle = redirect_handle;
     }
 
 Exit:
@@ -1289,13 +1253,70 @@ Exit:
     NET_EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
-/*
- * Default action is BLOCK. If this callout is being invoked, it means at least one
- * eBPF program is attached. Hence no connection should be allowed unless allowed by
- * the eBPF program.
+/**
+ * @brief This function determines if the sock_addr eBPF program should be invoked as part of processing the classify
+ * callback at CONNECT_REDIRECT layer.
  *
- * If the eBPF program verdict is BLOCK, no context is created and AUTH classify will
- * block the connection by default.
+ * @param[in] filter_context Pointer to net_ebpf_extension_sock_addr_wfp_filter_context_t associated with WFP filter.
+ * @param[in] sock_addr_ctx Pointer to bpf_sock_addr_t struct to be passed to eBPF program.
+ * @param[in] v4_mapped Boolean indicating if the IP address in sock_addr is v4 mapped v6 address or not.
+ *
+ * @returns True if eBPF program should be invoked, False otherwise.
+ */
+
+bool
+_net_ebpf_extension_sock_addr_should_invoke_ebpf_program(
+    _In_ const net_ebpf_extension_sock_addr_wfp_filter_context_t* filter_context,
+    _In_ const bpf_sock_addr_t* sock_addr_ctx,
+    bool v4_mapped)
+{
+    bool process_classify = TRUE;
+
+    //  If the callout is invoked for v4, then it is safe to invoke the eBPF program.
+    if (sock_addr_ctx->family == AF_INET)
+        goto Exit;
+
+    //  If the callout is invoked for v6:
+    //  1. Check if the destination is v4-mapped v6 address or pure v6 address.
+    //  2. If it is v4-mapped v6 address, then we should proceed only if this callout
+    //     is invoked for v4 attach type.
+    //  3. If it is pure v6 address, then we should proceed only if this callout is
+    //     invoked for v6 attach type.
+
+    if (v4_mapped) {
+        if (!filter_context->v4_attach_type) {
+            // This filter is for v6 attach type, but address is v4-mapped v6 address.
+            NET_EBPF_EXT_LOG_MESSAGE(
+                NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
+                NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
+                "net_ebpf_extension_sock_addr_redirect_connection_classify: v6 attach type, v4mapped address, "
+                "ignoring");
+            process_classify = FALSE;
+            goto Exit;
+        }
+    } else if (filter_context->v4_attach_type) {
+        // This filter is for v4 attach type, but address is a pure v6 address.
+        NET_EBPF_EXT_LOG_MESSAGE(
+            NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
+            "net_ebpf_extension_sock_addr_redirect_connection_classify: v4 attach type, IPv6 address, ignoring");
+        process_classify = FALSE;
+        goto Exit;
+    }
+
+Exit:
+    NET_EBPF_EXT_RETURN_BOOL(process_classify);
+}
+
+/*
+ * For every eBPF sock_addr program attached to INET_CONNECT attach point (for a given compartment), a WFP filter
+ * is added to the WFP CONNECT_REDIRECT (with the compartment Id as filter condition). So, this classify callback
+ * function will be invoked for every new connection in the compartment. And so, the eBPF program attached
+ * to the compartment will get invoked for every new connection.
+ * If the program returns a PROCEED verdict, the connection is permitted by the callout.
+ * If the program modifies the destination IP of the connection, connection redirection will be performed by this
+ * callout. If the If on the other hand, the program returns a REJECT verdict, that decision will be cached and enforced
+ * later by a corresponding callout at WFP AUTH_CONNECT layer.
  */
 void
 net_ebpf_extension_sock_addr_redirect_connection_classify(
@@ -1311,50 +1332,26 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
     NTSTATUS status = STATUS_SUCCESS;
     net_ebpf_extension_sock_addr_wfp_filter_context_t* filter_context = NULL;
     net_ebpf_extension_hook_client_t* attached_client = NULL;
-    net_ebpf_sock_addr_t* net_ebpf_sock_addr_ctx = NULL;
-    bpf_sock_addr_t* sock_addr_ctx = NULL;
-    bpf_sock_addr_t* sock_addr_ctx_original = NULL;
+    net_ebpf_sock_addr_t net_ebpf_sock_addr_ctx = {0};
+    bpf_sock_addr_t* sock_addr_ctx = (bpf_sock_addr_t*)&net_ebpf_sock_addr_ctx.base;
+    bpf_sock_addr_t sock_addr_ctx_original = {0};
     uint32_t compartment_id = UNSPECIFIED_COMPARTMENT_ID;
+    bool v4_mapped = FALSE;
     FWPS_CONNECTION_REDIRECT_STATE redirect_state;
     HANDLE redirect_handle;
     uint64_t classify_handle = 0;
-    net_ebpf_extension_connection_context_t* connection_context_original = NULL;
-    net_ebpf_extension_connection_context_t* connection_context_redirected = NULL;
-    BOOLEAN redirected = FALSE;
-    FWP_ACTION_TYPE action = FWP_ACTION_PERMIT;
-    BOOLEAN classify_handle_acquired = FALSE;
-    BOOLEAN v4_mapped = FALSE;
-    BOOLEAN is_original_connection;
+    bool classify_handle_acquired = FALSE;
+    bool redirected = FALSE;
+    net_ebpf_extension_connection_context_t* blocked_connection_context = NULL;
 
     UNREFERENCED_PARAMETER(layer_data);
     UNREFERENCED_PARAMETER(flow_context);
 
     if ((classify_output->rights & FWPS_RIGHT_ACTION_WRITE) == 0) {
-        // Do not modify anything and bail.
+        // A callout with higher weight has revoked the write permission. Bail out.
         return;
     }
 
-    net_ebpf_sock_addr_ctx = (net_ebpf_sock_addr_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(net_ebpf_sock_addr_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (net_ebpf_sock_addr_ctx == NULL) {
-        status = STATUS_INSUFFICIENT_RESOURCES;
-        goto Exit;
-    }
-    sock_addr_ctx = &net_ebpf_sock_addr_ctx->base;
-    sock_addr_ctx_original = (bpf_sock_addr_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(bpf_sock_addr_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (sock_addr_ctx_original == NULL) {
-        status = STATUS_INSUFFICIENT_RESOURCES;
-        goto Exit;
-    }
-    memset(net_ebpf_sock_addr_ctx, 0, sizeof(bpf_sock_addr_t));
-    memset(sock_addr_ctx_original, 0, sizeof(bpf_sock_addr_t));
-
-    _net_ebpf_extension_sock_addr_copy_wfp_connection_fields(
-        incoming_fixed_values, incoming_metadata_values, net_ebpf_sock_addr_ctx);
-    *sock_addr_ctx_original = *sock_addr_ctx;
-
-    // Check if this call is intended for us.
     filter_context = (net_ebpf_extension_sock_addr_wfp_filter_context_t*)filter->context;
     ASSERT(filter_context != NULL);
     if (filter_context == NULL) {
@@ -1362,52 +1359,16 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
         goto Exit;
     }
 
-    // If the callout is invoked for v4, then it is safe to simply invoke the eBPF
-    // program from the filter context.
-    // If the callout is invoked for v6:
-    // 1. Check if the destination is v4-mapped v6 address or pure v6 address.
-    // 2. If it is v4-mapped v6 address, then we should proceed only if this callout
-    //    is invoked for v4 attach type.
-    // 3. If it is pure v6 address, then we should proceed only if this callout is
-    //    invoked for v6 attach type.
-    if (sock_addr_ctx->family == AF_INET6) {
-        if (IN6_IS_ADDR_V4MAPPED((IN6_ADDR*)sock_addr_ctx->user_ip6)) {
-            v4_mapped = TRUE;
-        }
-        if (v4_mapped) {
-            if (!filter_context->v4_attach_type) {
-                // This callout is for v6 attach type, but address is v4-mapped v6 address.
-                // Change action to permit and return.
-                NET_EBPF_EXT_LOG_MESSAGE(
-                    NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
-                    "net_ebpf_extension_sock_addr_redirect_connection_classify: v6 attach type, v4mapped, ignoring");
-                action = FWP_ACTION_PERMIT;
-                goto Exit;
-            }
-        } else if (filter_context->v4_attach_type) {
-            // This callout is for v4 attach type, but address is a pure v6 address.
-            // Change action to permit and return.
-            NET_EBPF_EXT_LOG_MESSAGE(
-                NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
-                NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
-                "net_ebpf_extension_sock_addr_redirect_connection_classify: v4 attach type, purev6, ignoring");
-            action = FWP_ACTION_PERMIT;
-            goto Exit;
-        }
-    }
-
     compartment_id = filter_context->compartment_id;
     ASSERT((compartment_id == UNSPECIFIED_COMPARTMENT_ID) || (compartment_id == sock_addr_ctx->compartment_id));
     if (compartment_id != UNSPECIFIED_COMPARTMENT_ID && compartment_id != sock_addr_ctx->compartment_id) {
-        // The client is not interested in this compartment Id. Change action to PERMIT.
+        // The client is not interested in this compartment Id.
         NET_EBPF_EXT_LOG_MESSAGE_UINT32(
             NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
             "The cgroup_sock_addr eBPF program is not interested in this compartment ID",
             sock_addr_ctx->compartment_id);
 
-        action = FWP_ACTION_PERMIT;
         goto Exit;
     }
 
@@ -1418,8 +1379,7 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
     }
     if (!net_ebpf_extension_hook_client_enter_rundown(attached_client)) {
         attached_client = NULL;
-        // Client is detaching, change action to permit.
-        action = FWP_ACTION_PERMIT;
+        // Client is detaching.
         goto Exit;
     }
 
@@ -1435,22 +1395,6 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
         goto Exit;
     }
 
-    connection_context_original = (net_ebpf_extension_connection_context_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(net_ebpf_extension_connection_context_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (connection_context_original == NULL) {
-        status = STATUS_INSUFFICIENT_RESOURCES;
-        goto Exit;
-    }
-    memset(connection_context_original, 0, sizeof(net_ebpf_extension_connection_context_t));
-
-    connection_context_redirected = (net_ebpf_extension_connection_context_t*)ExAllocatePoolUninitialized(
-        NonPagedPoolNx, sizeof(net_ebpf_extension_connection_context_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (connection_context_redirected == NULL) {
-        status = STATUS_INSUFFICIENT_RESOURCES;
-        goto Exit;
-    }
-    memset(connection_context_redirected, 0, sizeof(net_ebpf_extension_connection_context_t));
-
     // Fetch redirect state.
     redirect_state = FwpsQueryConnectionRedirectState(incoming_metadata_values->redirectRecords, redirect_handle, NULL);
     if (redirect_state == FWPS_CONNECTION_REDIRECTED_BY_SELF ||
@@ -1462,29 +1406,26 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
             filter->filterId,
             (uint64_t)sock_addr_ctx->compartment_id);
 
-        // We have already looked at this connection. Permit and exit. Populate connection
-        // contexts for this new connection, so that AUTH classify can permit this connection.
-        _net_ebpf_ext_connection_context_initialize_key(
-            sock_addr_ctx,
-            incoming_metadata_values->transportEndpointHandle,
-            TRUE, /* original */
-            v4_mapped,
-            &connection_context_original->key);
-        _net_ebpf_ext_connection_context_initialize_key(
-            sock_addr_ctx,
-            incoming_metadata_values->transportEndpointHandle,
-            FALSE, /* original */
-            v4_mapped,
-            &connection_context_redirected->key);
-
-        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
-        redirected = TRUE;
-
-        goto CreateContext;
+        // This connection was previously redirected.
+        goto Exit;
     }
 
+    // Populate the sock_addr context with WFP classify input fields.
+    _net_ebpf_extension_sock_addr_copy_wfp_connection_fields(
+        incoming_fixed_values, incoming_metadata_values, &net_ebpf_sock_addr_ctx);
+    memcpy(&sock_addr_ctx_original, sock_addr_ctx, sizeof(sock_addr_ctx_original));
+
+    v4_mapped = (sock_addr_ctx->family == AF_INET6) && IN6_IS_ADDR_V4MAPPED((IN6_ADDR*)sock_addr_ctx->user_ip6);
+
+    // Check if the eBPF program should be invoked based on the IP address family and the hook attach type.
+    if (!_net_ebpf_extension_sock_addr_should_invoke_ebpf_program(filter_context, sock_addr_ctx, v4_mapped))
+        goto Exit;
+
+#pragma warning(push)
+#pragma warning(suppress : 6387)
     // Acquire classify handle.
     status = FwpsAcquireClassifyHandle((void*)classify_context, 0, &classify_handle);
+#pragma warning(pop)
     if (!NT_SUCCESS(status)) {
         NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(
             NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
@@ -1498,6 +1439,7 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
     classify_handle_acquired = TRUE;
 
     if (v4_mapped) {
+        // Change sock_addr_ctx to using IPv4 address for the eBPF program.
         sock_addr_ctx->family = AF_INET;
         const uint8_t* v4_ip = IN6_GET_ADDR_V4MAPPED((IN6_ADDR*)&sock_addr_ctx->user_ip6);
         uint32_t local_v4_ip = *((uint32_t*)v4_ip);
@@ -1505,66 +1447,53 @@ net_ebpf_extension_sock_addr_redirect_connection_classify(
         sock_addr_ctx->user_ip4 = local_v4_ip;
     }
 
-    is_original_connection = TRUE;
-    _net_ebpf_ext_connection_context_initialize_key(
-        sock_addr_ctx,
-        incoming_metadata_values->transportEndpointHandle,
-        is_original_connection,
-        v4_mapped,
-        &connection_context_original->key);
-
     if (net_ebpf_extension_hook_invoke_program(attached_client, sock_addr_ctx, &verdict) != EBPF_SUCCESS) {
         status = STATUS_UNSUCCESSFUL;
         goto Exit;
     }
 
-    // Initialize connection_context_redirected destination with the redirected address.
-    is_original_connection = FALSE;
-    _net_ebpf_ext_connection_context_initialize_key(
-        sock_addr_ctx,
-        incoming_metadata_values->transportEndpointHandle,
-        is_original_connection,
-        v4_mapped,
-        &connection_context_redirected->key);
+    if (verdict == BPF_SOCK_ADDR_VERDICT_REJECT) {
+        // Create a blocked connection context and add it to list for the AUTH_CONNECT layer callout to enforce the
+        // verdict of the program.
+        // Since the eBPF program turned in a REJECT verdict, there is no need to process
+        // connection redirection, even if the program modified the destination.
 
-    if (v4_mapped) {
-        sock_addr_ctx->family = AF_INET6;
-        IN_ADDR v4_address = *((IN_ADDR*)&sock_addr_ctx->user_ip4);
-        IN6_SET_ADDR_V4MAPPED((IN6_ADDR*)&sock_addr_ctx->user_ip6, (IN_ADDR*)&v4_address);
-    }
-
-    status = _net_ebpf_ext_process_redirect_verdict(
-        verdict,
-        sock_addr_ctx_original,
-        sock_addr_ctx,
-        filter,
-        classify_handle,
-        redirect_handle,
-        &redirected,
-        classify_output);
-    NET_EBPF_EXT_BAIL_ON_ERROR_STATUS(status);
-
-CreateContext:
-    if (verdict == BPF_SOCK_ADDR_VERDICT_PROCEED) {
-        _net_ebpf_ext_connection_context_initialize_value(redirected, verdict, connection_context_redirected);
-
-        _net_ebpf_ext_insert_connection_context_to_list(connection_context_redirected);
-
-        if (redirected) {
-            // If the connection has been redirected, then initialize connection context
-            // with original destination also.
-            _net_ebpf_ext_connection_context_initialize_value(redirected, verdict, connection_context_original);
-
-            _net_ebpf_ext_insert_connection_context_to_list(connection_context_original);
-        } else {
-            ExFreePool(connection_context_original);
-            connection_context_original = NULL;
+        blocked_connection_context = (net_ebpf_extension_connection_context_t*)ExAllocatePoolUninitialized(
+            NonPagedPoolNx, sizeof(net_ebpf_extension_connection_context_t), NET_EBPF_EXTENSION_POOL_TAG);
+        if (blocked_connection_context == NULL) {
+            status = STATUS_INSUFFICIENT_RESOURCES;
+            goto Exit;
         }
+        memset(blocked_connection_context, 0, sizeof(net_ebpf_extension_connection_context_t));
+
+        _net_ebpf_extension_connection_context_initialize(
+            sock_addr_ctx,
+            incoming_metadata_values->transportEndpointHandle,
+            TRUE, /*set timestamp*/
+            blocked_connection_context);
+
+        _net_ebpf_ext_insert_connection_context_to_list(blocked_connection_context);
+
+        InterlockedIncrement(&_net_ebpf_ext_statistics.block_connection_count);
     } else {
-        ExFreePool(connection_context_original);
-        connection_context_original = NULL;
-        ExFreePool(connection_context_redirected);
-        connection_context_redirected = NULL;
+        if (v4_mapped) {
+            // Revert back the sock_addr_ctx to v4-mapped v6 address for conenction-redirection processing.
+            sock_addr_ctx->family = AF_INET6;
+            IN_ADDR v4_address = *((IN_ADDR*)&sock_addr_ctx->user_ip4);
+            IN6_SET_ADDR_V4MAPPED((IN6_ADDR*)&sock_addr_ctx->user_ip6, (IN_ADDR*)&v4_address);
+        }
+        status = _net_ebpf_ext_process_redirect_verdict(
+            &sock_addr_ctx_original,
+            sock_addr_ctx,
+            filter,
+            classify_handle,
+            redirect_handle,
+            &redirected,
+            classify_output);
+        NET_EBPF_EXT_BAIL_ON_ERROR_STATUS(status);
+
+        (redirected) ? InterlockedIncrement(&_net_ebpf_ext_statistics.redirect_connection_count)
+                     : InterlockedIncrement(&_net_ebpf_ext_statistics.permit_connection_count);
     }
 
     NET_EBPF_EXT_LOG_SOCK_ADDR_CLASSIFY(
@@ -1576,32 +1505,16 @@ CreateContext:
         redirected,
         verdict);
 
-    action = FWP_ACTION_PERMIT;
-
 Exit:
-    classify_output->actionType = action;
-    // Clear FWPS_RIGHT_ACTION_WRITE only when it is a hard block.
-    if (action == FWP_ACTION_BLOCK) {
-        classify_output->rights &= ~FWPS_RIGHT_ACTION_WRITE;
-    }
-    if (classify_handle_acquired) {
+    // Callout at CONNECT_REDIRECT layer always returns WFP action PERMIT.
+    // If the eBPF program was invoked and it returned a REJECT verdict, it would be enforced by the callout at
+    // AUTH_CONNECT layer further downstream.
+
+    classify_output->actionType = FWP_ACTION_PERMIT;
+
+    if (classify_handle_acquired)
         FwpsReleaseClassifyHandle(classify_handle);
-    }
-    if (net_ebpf_sock_addr_ctx) {
-        ExFreePool(net_ebpf_sock_addr_ctx);
-        sock_addr_ctx = NULL;
-    }
-    if (sock_addr_ctx_original) {
-        ExFreePool(sock_addr_ctx_original);
-    }
-    if (!NT_SUCCESS(status)) {
-        if (connection_context_original) {
-            ExFreePool(connection_context_original);
-        }
-        if (connection_context_redirected) {
-            ExFreePool(connection_context_redirected);
-        }
-    }
+
     if (attached_client)
         net_ebpf_extension_hook_client_leave_rundown(attached_client);
 }

--- a/netebpfext/net_ebpf_ext_tracelog.h
+++ b/netebpfext/net_ebpf_ext_tracelog.h
@@ -10,6 +10,7 @@ void
 net_ebpf_ext_trace_terminate();
 
 #define NET_EBPF_EXT_TRACELOG_EVENT_SUCCESS "NetEbpfExtSuccess"
+#define NET_EBPF_EXT_TRACELOG_EVENT_RETURN "NetEbpfExtReturn"
 #define NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_ERROR "NetEbpfExtGenericError"
 #define NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_MESSAGE "NetEbpfExtGenericMessage"
 #define NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR "NetEbpfExtApiError"
@@ -70,7 +71,7 @@ net_ebpf_ext_trace_terminate();
     TraceLoggingWrite(                                              \
         net_ebpf_ext_tracelog_provider,                             \
         NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                      \
-        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),               \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                    \
         TraceLoggingKeyword((keyword)),                             \
         TraceLoggingString(#api, "api"),                            \
         TraceLoggingNTStatus(status));
@@ -79,7 +80,7 @@ net_ebpf_ext_trace_terminate();
     TraceLoggingWrite(                                                                             \
         net_ebpf_ext_tracelog_provider,                                                            \
         NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                                                     \
-        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                              \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                                   \
         TraceLoggingKeyword((keyword)),                                                            \
         TraceLoggingString(#api, "api"),                                                           \
         TraceLoggingNTStatus(status),                                                              \
@@ -152,11 +153,37 @@ net_ebpf_ext_trace_terminate();
         return local_result;                               \
     } while (false);
 
+#define NET_EBPF_EXT_RETURN_POINTER(type, pointer)                   \
+    do {                                                             \
+        type local_result = (type)(pointer);                         \
+        TraceLoggingWrite(                                           \
+            net_ebpf_ext_tracelog_provider,                          \
+            NET_EBPF_EXT_TRACELOG_EVENT_RETURN,                      \
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),               \
+            TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_BASE), \
+            TraceLoggingString(__FUNCTION__ " returned"),            \
+            TraceLoggingPointer(local_result, #pointer));            \
+        return local_result;                                         \
+    } while (false);
+
+#define NET_EBPF_EXT_RETURN_BOOL(flag)                               \
+    do {                                                             \
+        bool local_result = (flag);                                  \
+        TraceLoggingWrite(                                           \
+            net_ebpf_ext_tracelog_provider,                          \
+            NET_EBPF_EXT_TRACELOG_EVENT_RETURN,                      \
+            TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),               \
+            TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_BASE), \
+            TraceLoggingString(__FUNCTION__ " returned"),            \
+            TraceLoggingBool(!!local_result, #flag));                \
+        return local_result;                                         \
+    } while (false);
+
 #define NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(keyword, api, status, value1, value2) \
     TraceLoggingWrite(                                                                            \
         net_ebpf_ext_tracelog_provider,                                                           \
         NET_EBPF_EXT_TRACELOG_EVENT_API_ERROR,                                                    \
-        TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                             \
+        TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                                  \
         TraceLoggingKeyword((keyword)),                                                           \
         TraceLoggingString(#api, "api"),                                                          \
         TraceLoggingNTStatus(status),                                                             \

--- a/netebpfext/sys/netebpfext.vcxproj
+++ b/netebpfext/sys/netebpfext.vcxproj
@@ -76,6 +76,8 @@
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\kernel;$(OutputPath);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)include\kernel;$(SolutionDir)netebpfext;$(SolutionDir)netebpfext\sys</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
+      <!-- Change stack depth for C6262 from 1024 to 4096 -->
+      <PREfastAdditionalOptions>stacksize4096</PREfastAdditionalOptions>
     </ClCompile>
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>

--- a/netebpfext/sys/netebpfext.vcxproj
+++ b/netebpfext/sys/netebpfext.vcxproj
@@ -76,8 +76,6 @@
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\kernel;$(OutputPath);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)include\kernel;$(SolutionDir)netebpfext;$(SolutionDir)netebpfext\sys</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
-      <ExceptionHandling>
-      </ExceptionHandling>
     </ClCompile>
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>
@@ -99,8 +97,8 @@
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\kernel;$(OutputPath);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)include\kernel;$(SolutionDir)netebpfext;$(SolutionDir)netebpfext\sys</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
-      <ExceptionHandling>
-      </ExceptionHandling>
+      <!-- Change stack depth for C6262 from 1024 to 4096 -->
+      <PREfastAdditionalOptions>stacksize4096</PREfastAdditionalOptions>
     </ClCompile>
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -210,7 +210,7 @@ function Invoke-ConnectRedirectTest
         --user-name $StandardUserName `
         --password $StandardUserPassword `
         --user-type $UserType `
-        "[connect_redirect_tests_v4]"
+        "[connect_authorize_redirect_tests_v4]"
     Out-String -InputObject $Output | Write-Log
     $ParsedOutput = $Output.Split(" ")
     if (($LASTEXITCODE -ne 0) -or ($ParsedOutput[$ParsedOutput.Length -2] -eq "failed")) { throw ("Connect-Redirect Test Failed.") }
@@ -228,7 +228,7 @@ function Invoke-ConnectRedirectTest
         --user-name $StandardUserName `
         --password $StandardUserPassword `
         --user-type $UserType `
-        "[connect_redirect_tests_v6]"
+        "[connect_authorize_redirect_tests_v6]"
     Out-String -InputObject $Output | Write-Log
     $ParsedOutput = $Output.Split(" ")
     if (($LASTEXITCODE -ne 0) -or ($ParsedOutput[$ParsedOutput.Length -2] -eq "failed")) { throw ("Connect-Redirect Test Failed.") }

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -88,7 +88,8 @@ _get_current_thread_authentication_id()
     privileges = (TOKEN_GROUPS_AND_PRIVILEGES*)malloc(size);
     REQUIRE(privileges != nullptr);
 
-    result = GetTokenInformation(thread_token_handle, TokenGroupsAndPrivileges, privileges, size, (unsigned long*)&size);
+    result =
+        GetTokenInformation(thread_token_handle, TokenGroupsAndPrivileges, privileges, size, (unsigned long*)&size);
     REQUIRE(result == true);
 
     authentication_id = *(uint64_t*)&privileges->AuthenticationId;
@@ -482,84 +483,216 @@ connect_redirect_test_wrapper(
     delete sender_socket;
 }
 
-void
-connect_redirect_tests_common(_In_ const struct bpf_object* object, bool dual_stack, _In_ test_addresses_t& addresses)
-{
-    // First category is authorize tests.
-    const char* protocol_string = (_globals.protocol == IPPROTO_TCP) ? "TCP" : "UDP";
-    const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";
-    const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";
+#define DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(destination)                                              \
+    void connection_authorization_tests_##destination##(                                                         \
+        ADDRESS_FAMILY family, IPPROTO protocol, bool dual_stack, _In_ test_addresses_t& addresses)              \
+    {                                                                                                            \
+        _initialize_test_globals();                                                                              \
+        struct bpf_object* object = nullptr;                                                                     \
+        _load_and_attach_ebpf_programs(&object);                                                                 \
+        _globals.family = family;                                                                                \
+        _globals.protocol = protocol;                                                                            \
+        const char* protocol_string = (_globals.protocol == IPPROTO_TCP) ? "TCP" : "UDP";                        \
+        const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";                              \
+        const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";                             \
+        printf("CONNECT: " #destination " | %s | %s | %s\n", protocol_string, family_string, dual_stack_string); \
+        authorize_test_wrapper(object, dual_stack, addresses.##destination##);                                   \
+        bpf_object__close(object);                                                                               \
+    }
 
-    // Loopback address.
-    printf("CONNECT: Loopback | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    authorize_test_wrapper(object, dual_stack, addresses.loopback_address);
+// Declare connection_authorization_* test functions.
 
-    // Remote address.
-    printf("CONNECT: Remote | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    authorize_test_wrapper(object, dual_stack, addresses.remote_address);
+// connect to loopback address.
+// connection_authorization_tests_loopback_address
+DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(loopback_address)
+// connect to local address.
+// connection_authorization_tests_local_address
+DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(local_address)
+// connect to remote address.
+// connection_authorization_tests_remote_address
+DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(remote_address)
 
-    // Local non-loopback address.
-    printf("CONNECT: Local | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    authorize_test_wrapper(object, dual_stack, addresses.local_address);
+#define DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                                    \
+    socket_family_name, socket_family_type, dual_stack, protocol, destination)                            \
+    TEST_CASE(socket_family_name "_" #destination "_" #protocol, "[connect_authorize_redirect_tests_v4]") \
+    {                                                                                                     \
+        connection_authorization_tests_##destination##(                                                   \
+            AF_INET, protocol, (dual_stack), _globals.addresses[##socket_family_type##]);                 \
+    }
 
-    // Second category is connection redirection tests.
+#define DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, protocol) \
+    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, loopback_address)                              \
+    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, local_address)                                 \
+    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, remote_address)
 
-    // Remote -> Remote
-    printf("REDIRECT: Remote -> Remote | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    connect_redirect_test_wrapper(object, addresses.vip_address, addresses.remote_address, dual_stack);
+#define DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                    \
+    socket_family_name, socket_family_type, dual_stack, protocol, destination)                            \
+    TEST_CASE(socket_family_name "_" #destination "_" #protocol, "[connect_authorize_redirect_tests_v6]") \
+    {                                                                                                     \
+        connection_authorization_tests_##destination##(                                                   \
+            AF_INET6, protocol, (dual_stack), _globals.addresses[##socket_family_type##]);                \
+    }
 
-    // Remote -> Loopback
-    printf("REDIRECT: Remote -> Loopback | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    connect_redirect_test_wrapper(object, addresses.vip_address, addresses.loopback_address, dual_stack);
+#define DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, protocol) \
+    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, loopback_address)                              \
+    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, local_address)                                 \
+    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, remote_address)
 
-    // Remote -> Local non-loopback
-    printf("REDIRECT: Remote -> Local | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    connect_redirect_test_wrapper(object, addresses.vip_address, addresses.local_address, dual_stack);
+// Connection Authorization test cases
 
-    // Loopback -> Remote
-    printf("REDIRECT: Loopback -> Remote | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    connect_redirect_test_wrapper(object, addresses.loopback_address, addresses.remote_address, dual_stack);
+// IPv4, TCP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, IPPROTO_TCP)
 
-    // Loopback -> Local non-loopback
-    printf("REDIRECT: Loopback -> Local | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    connect_redirect_test_wrapper(object, addresses.loopback_address, addresses.local_address, dual_stack);
+// IPv4, UDP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, IPPROTO_UDP)
 
-    // Local non-loopback -> Loopback
-    printf("REDIRECT: Local -> Loopback | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    connect_redirect_test_wrapper(object, addresses.local_address, addresses.loopback_address, dual_stack);
+// Dual stack socket, IPv4, TCP,
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, IPPROTO_TCP)
 
-    // Local non-loopback -> Remote
-    printf("REDIRECT: Local -> Remote | %s | %s | %s\n", protocol_string, family_string, dual_stack_string);
-    connect_redirect_test_wrapper(object, addresses.local_address, addresses.remote_address, dual_stack);
-}
+// Dual stack socket, IPv4, UDP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, IPPROTO_UDP)
 
-void
-test_common(ADDRESS_FAMILY family, IPPROTO protocol)
-{
-    _initialize_test_globals();
+// IPv6, TCP,
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, IPPROTO_TCP)
 
-    struct bpf_object* object = nullptr;
-    _load_and_attach_ebpf_programs(&object);
+// IPv6, UDP
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, IPPROTO_UDP)
 
-    _globals.family = family;
-    _globals.protocol = protocol;
-    socket_family_t socket_family = (family == AF_INET) ? socket_family_t::IPv4 : socket_family_t::IPv6;
-    socket_family_t dual_stack_socket_family = (family == AF_INET) ? socket_family_t::Dual : socket_family_t::IPv6;
+// Dual stack socket, IPv6, TCP,
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, IPPROTO_TCP)
 
-    connect_redirect_tests_common(object, false, _globals.addresses[socket_family]);
-    connect_redirect_tests_common(object, true, _globals.addresses[dual_stack_socket_family]);
+// Dual stack socket, IPv6, UDP
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, IPPROTO_UDP)
 
-    // This should also detach the programs as they are not pinned.
-    bpf_object__close(object);
-}
+#define DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(original_destination, new_destination)         \
+    void connection_redirection_tests_##original_destination##_##new_destination##(                 \
+        ADDRESS_FAMILY family, IPPROTO protocol, bool dual_stack, _In_ test_addresses_t& addresses) \
+    {                                                                                               \
+        _initialize_test_globals();                                                                 \
+        struct bpf_object* object = nullptr;                                                        \
+        _load_and_attach_ebpf_programs(&object);                                                    \
+        _globals.family = family;                                                                   \
+        _globals.protocol = protocol;                                                               \
+        const char* protocol_string = (_globals.protocol == IPPROTO_TCP) ? "TCP" : "UDP";           \
+        const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";                 \
+        const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";                \
+        printf(                                                                                     \
+            "REDIRECT: " #original_destination " -> " #new_destination " | %s | %s | %s\n",         \
+            protocol_string,                                                                        \
+            family_string,                                                                          \
+            dual_stack_string);                                                                     \
+        connect_redirect_test_wrapper(                                                              \
+            object, addresses.##original_destination##, addresses.##new_destination##, dual_stack); \
+        bpf_object__close(object);                                                                  \
+    }
 
-TEST_CASE("connect_redirect_tcp_v4", "[connect_redirect_tests_v4]") { test_common(AF_INET, IPPROTO_TCP); }
+// Declare connection_redirection_* test functions.
 
-TEST_CASE("connect_redirect_udp_v4", "[connect_redirect_tests_v4]") { test_common(AF_INET, IPPROTO_UDP); }
+// remote (vip) address to another remote address.
+// connection_redirection_tests_vip_address_remote_address
+DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(vip_address, remote_address)
+// remote (vip) address to loopback address.
+// connection_redirection_tests_vip_address_loopback_address
+DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(vip_address, loopback_address)
+// remote (vip) address to local address.
+// connection_redirection_tests_vip_address_local_address
+DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(vip_address, local_address)
+// loopback address to remote address.
+// connection_redirection_tests_loopback_address_remote_address
+DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(loopback_address, remote_address)
+// loopback address to local address.
+// connection_redirection_tests_loopback_address_local_address
+DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(loopback_address, local_address)
+// local address to remote address.
+// connection_redirection_tests_local_address_remote_address
+DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(local_address, remote_address)
+// local address to loopback address.
+// connection_redirection_tests_local_address_loopback_address
+DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(local_address, loopback_address)
 
-TEST_CASE("connect_redirect_tcp_v6", "[connect_redirect_tests_v6]") { test_common(AF_INET6, IPPROTO_TCP); }
+#define DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                     \
+    socket_family_name, socket_family_type, dual_stack, protocol, original_destination, new_destination) \
+    TEST_CASE(                                                                                           \
+        socket_family_name "_" #original_destination "_" #new_destination "_" #protocol,                 \
+        "[connect_authorize_redirect_tests_v4]")                                                         \
+    {                                                                                                    \
+        connection_redirection_tests_##original_destination##_##new_destination##(                       \
+            AF_INET, protocol, (dual_stack), _globals.addresses[##socket_family_type##]);                \
+    }
 
-TEST_CASE("connect_redirect_udp_v6", "[connect_redirect_tests_v6]") { test_common(AF_INET6, IPPROTO_UDP); }
+#define DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, protocol) \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, vip_address, remote_address)                 \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, vip_address, loopback_address)               \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, vip_address, local_address)                  \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, loopback_address, remote_address)            \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, loopback_address, local_address)             \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, local_address, loopback_address)             \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, local_address, remote_address)
+
+#define DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                     \
+    socket_family_name, socket_family_type, dual_stack, protocol, original_destination, new_destination) \
+    TEST_CASE(                                                                                           \
+        socket_family_name "_" #original_destination "_" #new_destination "_" #protocol,                 \
+        "[connect_authorize_redirect_tests_v6]")                                                         \
+    {                                                                                                    \
+        connection_redirection_tests_##original_destination##_##new_destination##(                       \
+            AF_INET6, protocol, (dual_stack), _globals.addresses[##socket_family_type##]);               \
+    }
+
+#define DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, protocol) \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, vip_address, remote_address)                 \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, vip_address, loopback_address)               \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, vip_address, local_address)                  \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, loopback_address, remote_address)            \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, loopback_address, local_address)             \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, local_address, loopback_address)             \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                   \
+        socket_family_name, socket_family_type, dual_stack, protocol, local_address, remote_address)
+
+// Connection redirection test cases.
+
+// IPv4, TCP
+DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, IPPROTO_TCP)
+
+// IPv4, UDP
+DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, IPPROTO_UDP)
+
+// Dual stack socket, IPv4, TCP
+DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, IPPROTO_TCP)
+
+// Dual stack socket, IPv4, UDP
+DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, IPPROTO_UDP)
+
+// IPv6, TCP
+DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, IPPROTO_TCP)
+
+// IPv6, UDP
+DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, IPPROTO_UDP)
+
+// Dual stack socket, IPv6, TCP
+DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, IPPROTO_TCP)
+
+// Dual stack socket, IPv6, UDP
+DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, IPPROTO_UDP)
 
 int
 main(int argc, char* argv[])


### PR DESCRIPTION
## Description

This PR simplifies the connect_redirect callout's logic in the sock_addr hook. The callout now stores only the connections that are blocked by the eBPF program. The auth_connect layer callout would permit all connections by default, unless they are found in the blocked connection list. This change was made with the assumption, that in a typical deployment, eBPF program will permit majority of the connections that it will inspect. This way, the frequency of allocation for connection contexts would be reduced. Plus, the overall callout logic is simplified.

Refactored connect_redirect tests to have 80 test cases instead of 4 giant test cases with 20 sub-variations each.

TraceloggingWrite seems to be increasing stack frame size which is being flagged by static analysis tool. To temporarily work around this, the stack size parameter for static analysis tool has been increased to 4K. This should be properly addressed by #1247 .

A co-incidental bug in wixproj is fixed.

## Testing

No changes in test coverage is required.

## Documentation

N/A.
