### PR TITLE
Fix memory leak in ebpf_ring_buffer_map_subscribe

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -3729,7 +3729,10 @@ ebpf_ring_buffer_map_subscribe(
         if (result == EBPF_PENDING)
             result = EBPF_SUCCESS;
 
-        *subscription = local_subscription.release();
+        // If the async IOCTL failed, then free the subscription object.
+        if (result == EBPF_SUCCESS) {
+            *subscription = local_subscription.release();
+        }
 
         EBPF_RETURN_RESULT(result);
     } catch (const std::bad_alloc&) {


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

Resolves: #2053

## Description

Fix leak of subscription object in ebpf_ring_buffer_map_subscribe.

## Testing

Existing low-memory tests trigger this path. Testing with annotated new/delete detects this failure.

## Documentation

No.
