### PR TITLE
Export new sock_addr specific helper function (windows only)

### DIFF
--- a/docs/SelfHostedRunnerSetup.md
+++ b/docs/SelfHostedRunnerSetup.md
@@ -24,9 +24,11 @@ This document discusses the steps to set up such a self-hosted actions-runner th
 8) Edit test configuration JSON files.
    1) Edit `test_execution.json` file. Add the name of the one of the VMs in `BasicTest` section. Add the names of both the VMs in `MultiVMTest` section along with the "Interfaces" section that must contain information about the network interfaces created in step 7.2 Above. This section must contain the interface alias, and IPv4 and IPv6 addresses. The CICD test automation would apply these IP addresses on the NICs of the test VM.
    2) Edit `vm_list.json` with the names of the two test VMs.
-9) Store the VM administrator credential:
+9) Store the VM administrator and standard user credentials:
    1) `Install-Module CredentialManager -force`
    2) `New-StoredCredential -Target `**`TEST_VM`**` -Username <VM Administrator> -Password <VM Administrator account password> -Persist LocalMachine`
+   3) `New-StoredCredential -Target `**`TEST_VM_STANDARD`**` -Username <VM Standard User Name> -Password <VM Standard User account password> -Persist LocalMachine`
+
 10) Modify the environment of the VM as needed. Create new checkpoints using **Hyper-V**. Rename the new checkpoint as `baseline`, and remove the old baseline. 
 11) Set up Windows Error Reporting [Local Dump Collection](https://docs.microsoft.com/en-us/windows/win32/wer/collecting-user-mode-dumps) on the VMs with the following commands.
     ```New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -ErrorAction SilentlyContinue```

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -1,40 +1,48 @@
 # eBPF extensions
 
 ## 1 Overview
-An "eBPF extension" is a Windows kernel driver or component that implements eBPF hooks or helper functions. The design of eBPF for Windows is
-such that an extension providing an implementation for hooks and helper functions can be developed and deployed
-without the need to modify either the eBPF execution context or the eBPF verifier.
+An "eBPF extension" is a Windows kernel driver or component that implements eBPF hooks or helper functions. The design
+of eBPF for Windows is such that an extension providing an implementation for hooks and helper functions can be
+developed and deployed without the need to modify either the eBPF execution context or the eBPF verifier.
 
 ## 1.1 Windows Network Module Registrar
 The eBPF for Windows project uses the
 [Network Module Registrar (NMR)](https://docs.microsoft.com/en-us/windows-hardware/drivers/network/introduction-to-the-network-module-registrar)
-feature in Windows to develop eBPF extensions that are decoupled from the core eBPF for Windows framework.  NMR facilitates attaching software
-modules to each other. The
+feature in Windows to develop eBPF extensions that are decoupled from the core eBPF for Windows framework.  NMR
+facilitates attaching software modules to each other. The
 [Network Programming Interface (NPI)](https://docs.microsoft.com/en-us/windows-hardware/drivers/network/network-programming-interface)
 defines the contract between the modules.  The eBPF extensions would implement the
-[Provider Modules](https://docs.microsoft.com/en-us/windows-hardware/drivers/network/provider-module) for two types of NPIs as discussed in detail below.
-Even though the NMR component and the relevant APIs have the word "Network" in them, these software modules
-are completely agnostic of Windows Networking stack and non-networking eBPF extensions can be developed using these.
+[Provider Modules](https://docs.microsoft.com/en-us/windows-hardware/drivers/network/provider-module) for two types of
+NPIs as discussed in detail below. Even though the NMR component and the relevant APIs have the word "Network" in them,
+these software modules are completely agnostic of Windows Networking stack and non-networking eBPF extensions can be
+developed using these.
 
 ## 1.2 Prerequisites
-The audience is assumed to be familiar with [NMR Architecture](https://docs.microsoft.com/en-us/windows-hardware/drivers/network/architecture-overview) and
-the various aspects of developing NMR modules as described in [NMR documentation](https://docs.microsoft.com/en-us/windows-hardware/drivers/network/network-module-registrar2).
+The audience is assumed to be familiar with
+[NMR Architecture](https://docs.microsoft.com/en-us/windows-hardware/drivers/network/architecture-overview)
+and the various aspects of developing NMR modules as described in
+[NMR documentation](https://docs.microsoft.com/en-us/windows-hardware/drivers/network/network-module-registrar2).
 
 ## 1.3 NPI Contracts for eBPF Extensions
-eBPF Extensions need to implement *provider modules* for two types of NPIs. They are the **Program Information NPI** provider and the **Hook NPI** provider. The following section explains when an extension must implement these providers.
+eBPF Extensions need to implement *provider modules* for two types of NPIs. They are the **Program Information NPI**
+provider and the **Hook NPI** provider. The following section explains when an extension must implement these
+providers.
 
 ### 1.3.1 eBPF Program Information NPI Provider
 The eBPF Program Information NPI contract is used to provide information about an eBPF program type. Program types
 are defined as the ABI contracts that eBPF programs are written to conform to.
-This information is consumed by the eBPF verifier to ensure that any eBPF programs of a given type are safe to load
+This information is consumed by the eBPF verifier to ensure that any eBPF programs of a given type is safe to load
 and execute. The ABI contract includes both a description of the &quot;context&quot; parameter passed to the eBPF
 program as well as the list of specific helper functions that are available to such eBPF programs.
 
-eBPF extensions must implement a different Program Information NPI provider module for each program type for which it provides
-implementation of hooks or helper functions specific to that program type.
+eBPF extensions must implement a different Program Information NPI provider module for each program type for which it
+provides implementation of hooks or helper functions specific to that program type.
 
 ### 1.3.2 eBPF Hook NPI Provider
-The Hook NPI contracts are used by extension to invoke eBPF programs when OS events occur. A given eBPF hook may have several attach types. The eBPF extension must register a separate Hook NPI provider module for each attach type it supports for an eBPF hook. Note that, there can be more than one attach types for a given program type. If an extension is adding a new attach type for an existing program type, then it only needs to implement the Hook NPI Provider.
+The Hook NPI contracts are used by extension to invoke eBPF programs when OS events occur. A given eBPF hook may have
+several attach types. The eBPF extension must register a separate Hook NPI provider module for each attach type it
+supports for an eBPF hook. Note that, there can be more than one attach types for a given program type. If an extension
+is adding a new attach type for an existing program type, then it only needs to implement the Hook NPI Provider.
 
 ## 2 Authoring an eBPF Extension
 The steps for authoring an eBPF extension are:
@@ -46,7 +54,9 @@ The steps for authoring an eBPF extension are:
 The following sections describe these steps in detail.
 
 ### 2.1 Program Information NPI Provider Registration
-When registering itself to the NMR, the Program Information NPI Provider should have the [`NPI_REGISTRATION_INSTANCE`](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/ns-netioddk-_npi_registration_instance) initialized as follows:
+When registering itself to the NMR, the Program Information NPI Provider should have the
+[`NPI_REGISTRATION_INSTANCE`](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/ns-netioddk-_npi_registration_instance)
+initialized as follows:
 * `NpiId`: This should be set to `EBPF_PROGRAM_INFO_EXTENSION_IID` defined in `ebpf_extension_uuids.h`.
 * `ModuleId`: This should be set to the eBPF program type GUID.
 * `NpiSpecificCharacteristics`: Pointer to structure of type `ebpf_extension_data_t`.
@@ -55,10 +65,14 @@ When registering itself to the NMR, the Program Information NPI Provider should 
 #### `ebpf_program_data_t` Struct
 The various fields of this structure should be set as follows:
 * `program_info`: Pointer to `ebpf_program_info_t`.
-* `program_type_specific_helper_function_addresses`: Pointer to `ebpf_helper_function_addresses_t`. This structure provides the helper functions that are exclusive to this program type.
-* `global_helper_function_addresses`:  Pointer to `ebpf_helper_function_addresses_t`. This structure provides helper functions that override the global helper functions provided by the eBPF runtime.
-* `context_create`: Pointer to `ebpf_program_context_create_t` function that creates a program type specific context structure from provided data and context buffers.
-* `context_destroy`: Pointer to `ebpf_program_context_destroy_t` function that destroys a program type specific context structure and populates the returned data and context buffers.
+* `program_type_specific_helper_function_addresses`: Pointer to `ebpf_helper_function_addresses_t`. This structure
+provides the helper functions that are exclusive to this program type.
+* `global_helper_function_addresses`:  Pointer to `ebpf_helper_function_addresses_t`. This structure provides helper
+functions that override the global helper functions provided by the eBPF runtime.
+* `context_create`: Pointer to `ebpf_program_context_create_t` function that creates a program type specific context
+structure from provided data and context buffers.
+* `context_destroy`: Pointer to `ebpf_program_context_destroy_t` function that destroys a program type specific
+context structure and populates the returned data and context buffers.
 * `required_irql`: IRQL that the eBPF program runs at.
 
 #### `ebpf_program_info_t` Struct
@@ -71,8 +85,10 @@ The various fields of this structure should be set as follows:
 The various fields of this structure should be set as follows:
 * `name`: Friendly name of the program type.
 * `context_descriptor`: Pointer of type `ebpf_context_descriptor_t`.
-* `program_type`: GUID for the program type. This should be the same as the `NpiId` in `NPI_REGISTRATION_INSTANCE` as noted above.
-* `bpf_prog_type`: Set to the equivalent bpf program type integer. If there is no equivalent bpf program type, this field should be set to `0 (BPF_PROG_TYPE_UNSPEC)`.
+* `program_type`: GUID for the program type. This should be the same as the `NpiId` in `NPI_REGISTRATION_INSTANCE` as
+noted above.
+* `bpf_prog_type`: Set to the equivalent bpf program type integer. If there is no equivalent bpf program type, this
+field should be set to `0 (BPF_PROG_TYPE_UNSPEC)`.
 * `is_privileged`: Set to `FALSE`.
 
 #### `ebpf_context_descriptor_t` Struct
@@ -103,18 +119,21 @@ const ebpf_context_descriptor_t g_xdp_context_descriptor = {sizeof(xdp_md_t),
                                                             EBPF_OFFSET_OF(xdp_md_t, data_end),
                                                             EBPF_OFFSET_OF(xdp_md_t, data_meta)};
 ```
-If any of the data or metadata pointer fields are not present on the context structure, the offset value is set to -1 in the context descriptor.
+If any of the data or metadata pointer fields are not present on the context structure, the offset value is set to -1
+in the context descriptor.
 
 #### `ebpf_helper_function_prototype_t` Struct
 This structure is used to describe the prototypes of the various helper functions implemented by the extension.
 * `helper_id`: Integer signifying the helper function ID. (See section 2.6).
 Helper function IDs for different program types need not be unique.
 * `name`: Helper function name.
-* `return_type`: Set the appropriate value for the `ebpf_return_type_t` enum that represents the return type of the helper function.
+* `return_type`: Set the appropriate value for the `ebpf_return_type_t` enum that represents the return type of the
+helper function.
 * `arguments`: Array of (at most) five helper function arguments of type `ebpf_argument_type_t`.
 
 #### `ebpf_argument_type_t` Enum
-This enum describes the various argument types that can be passed to an eBPF helper function. This is defined in the [PREVAIL Verifier](https://github.com/vbpf/ebpf-verifier) project.
+This enum describes the various argument types that can be passed to an eBPF helper function. This is defined in the
+[PREVAIL Verifier](https://github.com/vbpf/ebpf-verifier) project.
 ```
 typedef enum _ebpf_argument_type {
     EBPF_ARGUMENT_TYPE_DONTCARE = 0,
@@ -133,7 +152,8 @@ typedef enum _ebpf_argument_type {
 ```
 
 #### `ebpf_return_type` Enum
-This enum describes the various return types from an eBPF helper function. This is defined in the [PREVAIL Verifier](https://github.com/vbpf/ebpf-verifier) project.
+This enum describes the various return types from an eBPF helper function. This is defined in the
+[PREVAIL Verifier](https://github.com/vbpf/ebpf-verifier) project.
 ```
 typedef enum _ebpf_return_type {
     EBPF_RETURN_TYPE_INTEGER = 0,
@@ -143,42 +163,78 @@ typedef enum _ebpf_return_type {
 ```
 
 #### `ebpf_helper_function_addresses_t` Struct
-This structure is used to specify the address at which the various helper functions implemented by the extension reside. If an eBPF program is JIT compiled, then the generated machine code will have `call` instructions to these addresses. For interpreted mode, the eBPF Execution Engine will invoke the functions at these addresses. The fields of this struct should be set as follows:
+This structure is used to specify the address at which the various helper functions implemented by the extension
+reside. If an eBPF program is JIT compiled, then the generated machine code will have `call` instructions to these
+addresses. For interpreted mode, the eBPF Execution Engine will invoke the functions at these addresses. The fields of
+this struct should be set as follows:
 * `helper_function_count`: Number of helper functions implemented by the extension for the given program type.
-* `helper_function_address`: Array of addresses (64-bit unsigned integer) for the helper functions. The addresses must be arranged in the array in the *same order* as the array of helper function prototypes denoted by the `helper_prototype` field in `ebpf_program_info_t` struct.  For the correct execution of eBPF programs, the helper function addresses cannot change while a loaded eBPF program is executing.
+* `helper_function_address`: Array of addresses (64-bit unsigned integer) for the helper functions. The addresses must
+be arranged in the array in the *same order* as the array of helper function prototypes denoted by the
+`helper_prototype` field in `ebpf_program_info_t` struct.  For the correct execution of eBPF programs, the helper
+function addresses cannot change while a loaded eBPF program is executing.
 
-There are two sets of helper function addresses that the extension can return. The first are helper functions that are only callable during execution of an eBPF program that matches this program type. The second are helper function implementations that override the global helper function implementations provided by the eBPF runtime.
+There are two sets of helper function addresses that the extension can return. The first are helper functions that are
+only callable during execution of an eBPF program that matches this program type. The second are helper function
+implementations that override the global helper function implementations provided by the eBPF runtime.
 
 ### `ebpf_program_context_create_t` Function
-This optional function is used to build a program type specific context structure that is used when an application calls `bpf_prog_test_run_opts`. The application optionally passes in flat buffers representing the data and the context structure to be passed to the eBPF program. The extension then constructs a context structure to be passed to the eBPF program. Note: If `ebpf_program_context_create_t` is present, then `ebpf_program_context_destroy_t` and `required_irql` must be set.
+This optional function is used to build a program type specific context structure that is used when an application
+calls `bpf_prog_test_run_opts`. The application optionally passes in flat buffers representing the data and the context
+structure to be passed to the eBPF program. The extension then constructs a context structure to be passed to the eBPF
+program. Note: If `ebpf_program_context_create_t` is present, then `ebpf_program_context_destroy_t` and `required_irql`
+must be set.
 
 ### `ebpf_program_context_destroy_t` Function
-This optional function is used to populate the flat buffers representing the data and context structures that are returned to the application when the `bpf_prog_test_run_opts` call completes. In addition, the function frees any resources allocated in the `ebpf_program_context_create_t` call.
+This optional function is used to populate the flat buffers representing the data and context structures that are
+returned to the application when the `bpf_prog_test_run_opts` call completes. In addition, the function frees any
+resources allocated in the `ebpf_program_context_create_t` call.
 
 ### 2.2 Program Information NPI Client Attach and Detach Callbacks
-The eBPF Execution Context registers a Program Information NPI client module with the NMR for every eBPF program that gets loaded. The Execution Context will use the program type GUID of the program as the NPI ID of the client module. And as a result, upon eBPF program load, the associated Program Information NPI client module will attach with the corresponding Program Information NPI provider module in the extension. The Program Information NPI does not have any client or provider dispatch tables. Neither does the client's `NpiSpecificCharacteristics` have any data. So, no special processing is required in the client attach and detach callback handler on the provider module. An extension must not unload until there are no more attached Program Information NPI clients.
+The eBPF Execution Context registers a Program Information NPI client module with the NMR for every eBPF program that
+gets loaded. The Execution Context will use the program type GUID of the program as the NPI ID of the client module.
+And as a result, upon eBPF program load, the associated Program Information NPI client module will attach with the
+corresponding Program Information NPI provider module in the extension. The Program Information NPI does not have any
+client or provider dispatch tables. Neither does the client's `NpiSpecificCharacteristics` have any data. So, no
+special processing is required in the client attach and detach callback handler on the provider module. An extension
+must not unload until there are no more attached Program Information NPI clients.
 
 ### 2.3 Hook NPI Provider Registration
-When registering itself to the NMR, the Hook NPI provider should have the [`NPI_REGISTRATION_INSTANCE`](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/ns-netioddk-_npi_registration_instance) initialized as follows:
+When registering itself to the NMR, the Hook NPI provider should have the
+[`NPI_REGISTRATION_INSTANCE`](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/ns-netioddk-_npi_registration_instance)
+initialized as follows:
 * `NpiId`: This should be set to `EBPF_HOOK_EXTENSION_IID` defined in `ebpf_extension_uuids.h`.
 * `ModuleId`: This should be set to the attach type GUID.
 * `NpiSpecificCharacteristics`: Pointer to structure of type `ebpf_extension_data_t`.
   * The `data` field of this structure should point to a structure of type `ebpf_attach_provider_data_t`.
 
 #### `ebpf_attach_provider_data_t` Struct
-This structure is used to specify the attach type supported by the extension for the given Hook NPI provider. It contains the following fields:
+This structure is used to specify the attach type supported by the extension for the given Hook NPI provider. It
+contains the following fields:
 * `supported_program_type`
 * `bpf_attach_type`
 
-The `supported_program_type` field of the struct should be filled with the `ebpf_program_type_t` (GUID) of the supported program type. While attaching an eBPF program to a hook instance, the Execution Context enforces that the requested attach type is supported by the Hook NPI provider. If not, the eBPF program fails to attach to the hook.
+The `supported_program_type` field of the struct should be filled with the `ebpf_program_type_t` (GUID) of the
+supported program type. While attaching an eBPF program to a hook instance, the Execution Context enforces that the
+requested attach type is supported by the Hook NPI provider. If not, the eBPF program fails to attach to the hook.
 
-The `bpf_attach_type` field should contain the equivalent bpf attach type integer. If there is no equivalent bpf attach type, this field should be set to `0 (BPF_ATTACH_TYPE_UNSPEC)`.
+The `bpf_attach_type` field should contain the equivalent bpf attach type integer. If there is no equivalent bpf
+attach type, this field should be set to `0 (BPF_ATTACH_TYPE_UNSPEC)`.
 
 ### 2.4 Hook NPI Client Attach and Detach Callbacks
-The eBPF Execution Context registers a Hook NPI client module with the NMR for each program that is attached to a hook. The attach type GUID is used as the NPI of the client module. And as a result, when an eBPF program gets attached to a hook, the associated Hook NPI client module will attach to the corresponding Hook NPI provider module in the extension. The [client attach callback](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nc-netioddk-npi_provider_attach_client_fn) function is invoked when the NPI client is being attached. The provider must store the following in a per-client data structure from the passed in parameters:
+The eBPF Execution Context registers a Hook NPI client module with the NMR for each program that is attached to a hook.
+The attach type GUID is used as the NPI of the client module. And as a result, when an eBPF program gets attached to
+a hook, the associated Hook NPI client module will attach to the corresponding Hook NPI provider module in the
+extension. The
+[client attach callback](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nc-netioddk-npi_provider_attach_client_fn)
+function is invoked when the NPI client is being attached. The provider must store the following in a per-client data
+structure from the passed in parameters:
 * `ClientBindingContext`: Client binding context.
 * `ClientDispatch`: Client dispatch table (see section 2.5 below).
-* `NpiSpecificCharacteristics`: Obtained from `ClientRegistrationInstance` parameter. This contains attach-type specific data that may be used by an extension for attaching an eBPF program. For example, when an eBPF program is being attached to an XDP hook, the network interface index can be passed via this parameter. This tells the extension to invoke the eBPF program whenever there are any inbound packets on that network interface. The attach parameter can be obtained as follows:
+* `NpiSpecificCharacteristics`: Obtained from `ClientRegistrationInstance` parameter. This contains attach-type
+specific data that may be used by an extension for attaching an eBPF program. For example, when an eBPF program is
+being attached to an XDP hook, the network interface index can be passed via this parameter. This tells the extension
+to invoke the eBPF program whenever there are any inbound packets on that network interface. The attach parameter can
+be obtained as follows:
 ```
 ebpf_extension_data_t* extension_data = (ebpf_extension_data_t*)ClientRegistrationInstance->NpiSpecificCharacteristics;
 attach_parameter = extension_data->data;
@@ -186,10 +242,13 @@ attach_parameter = extension_data->data;
 
 The per-client data structure should be returned as the `ProviderBindingContext` output parameter.
 
-Upon [client detach callback](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nc-netioddk-npi_provider_detach_client_fn) the provider must free the per-client context passed in via `ProviderBindingContext` parameter.
+Upon
+[client detach callback](https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nc-netioddk-npi_provider_detach_client_fn)
+the provider must free the per-client context passed in via `ProviderBindingContext` parameter.
 
 ### 2.5 Invoking an eBPF program from Hook NPI Provider
-To invoke an eBPF program, the extension uses the dispatch table supplied by the Hook NPI client during attaching. There is only one function in the client dispatch table, which is of the following type:
+To invoke an eBPF program, the extension uses the dispatch table supplied by the Hook NPI client during attaching.
+There is only one function in the client dispatch table, which is of the following type:
 
 ```
 /**
@@ -203,13 +262,28 @@ The function pointer can be obtained from the client dispatch table as follows:
 ```
 invoke_program = (ebpf_invoke_program_function_t)client_dispatch_table->function[0];
 ```
-When an extension invokes this function pointer, then the call flows through the eBPF Execution Context and eventually invokes the eBPF program.
-When invoking an eBPF program, the extension must supply the client binding context it obtained from the Hook NPI client as the `client_binding_context` parameter. For the second parameter `context`, it must pass the program type specific context data structure. Note that the Program Information NPI provider supplies the context descriptor (using the `ebpf_context_descriptor_t` type) to the eBPF verifier and JIT-compiler via the NPI client hosted by the Execution Context. The `result` output parameter holds the return value from the eBPF program post execution.
+When an extension invokes this function pointer, then the call flows through the eBPF Execution Context and eventually
+invokes the eBPF program.  When invoking an eBPF program, the extension must supply the client binding context it
+obtained from the Hook NPI client as the `client_binding_context` parameter. For the second parameter `context`, it
+must pass the program type specific context data structure. Note that the Program Information NPI provider supplies
+the context descriptor (using the `ebpf_context_descriptor_t` type) to the eBPF verifier and JIT-compiler via the NPI
+client hosted by the Execution Context. The `result` output parameter holds the return value from the eBPF program
+post execution.
 
 ### 2.6 Authoring Helper Functions
-An extension can provide an implementation of helper functions that can be invoked by the eBPF programs. The helper functions can be of two types:
-1. Program-Type specific: These helper functions can only be invoked by eBPF programs of a given program type. Usually, an extension may provide implementations for hooks of certain program types and provide helper functions that are associated with those helper functions. The Program Information NPI provider must then provide the prototypes and addresses for those functions. For these type of helpers, the helper function Id must be greater that 65535 (0xFFFF) for program type specific helper functions.
-2. General: The general helper functions can be invoked by eBPF programs of all types. Examples of this type of helper functions are the eBPF Map helper functions. These helper functions are implemented by the eBPF Execution Context itself. However, if a program type so chooses, it may provide implementations for general helper functions. For that the extension would have to provide another Program Information NPI provider, which *does not* provide any program context descriptor. Instead, it only supplies the prototypes and addresses of the general helper functions. The NPI ID of this module defined as:
+An extension can provide an implementation of helper functions that can be invoked by the eBPF programs. The helper
+functions can be of two types:
+1. Program-Type specific: These helper functions can only be invoked by eBPF programs of a given program type. Usually,
+an extension may provide implementations for hooks of certain program types and provide helper functions that are
+associated with those helper functions. The Program Information NPI provider must then provide the prototypes and
+addresses for those functions. For these type of helpers, the helper function Id must be greater that 65535 (0xFFFF)
+for program type specific helper functions.
+2. General: The general helper functions can be invoked by eBPF programs of all types. Examples of this type of helper
+functions are the eBPF Map helper functions. These helper functions are implemented by the eBPF Execution Context
+itself. However, if a program type so chooses, it may provide implementations for general helper functions. For that
+the extension would have to provide another Program Information NPI provider, which *does not* provide any program
+context descriptor. Instead, it only supplies the prototypes and addresses of the general helper functions. The NPI ID
+of this module defined as:
 ```
 GUID ebpf_general_helper_function_module_id = {/* 8d2a1d3f-9ce6-473d-b48e-17aa5c5581fe */
                                                   0x8d2a1d3f,
@@ -219,11 +293,21 @@ GUID ebpf_general_helper_function_module_id = {/* 8d2a1d3f-9ce6-473d-b48e-17aa5c
 ```
 The helper function ID for a general helper function must be in the range 0 - 65535 and must be globally unique.
 
-The parameter and return types for these helper functions must adhere to the `ebpf_argument_type_t` and `ebpf_return_type_t` enums.
+The parameter and return types for these helper functions must adhere to the `ebpf_argument_type_t` and
+`ebpf_return_type_t` enums.
 
 ### 2.7 Registering Program Types and Attach Types
-The eBPF Execution Context loads an eBPF program from an ELF file that has program section(s) with section names. The prefix to these names determines the program type. For example, the section name `"xdp"` implies that the corresponding program type is `EBPF_PROGRAM_TYPE_XDP`. The Execution Context discovers the program type associated with a section prefix by reading the data from Windows registry. When an eBPF extension is installed, it must update the registry with the program types it implements along with the associated section prefixes.
-Note: The registry location and data format are TBD. This is currently tracked by issue #223.
+The eBPF Execution Context loads an eBPF program from an ELF file that has program section(s) with section names. The
+prefix to these names determines the program type. For example, the section name `"xdp"` implies that the corresponding
+program type is `EBPF_PROGRAM_TYPE_XDP`. The Execution Context discovers the program type associated with a section
+prefix by reading the data from Windows registry. When an eBPF extension is installed, it must update the registry with
+the program types it implements along with the associated section prefixes.
+
+_Note: The registry location and data format are TBD. This is currently tracked by issue #223._
 
 ### 2.8 eBPF Sample Driver
-The eBPF for Windows project provides a [sample extension driver](https://github.com/microsoft/ebpf-for-windows/tree/8f46b4020f79c32f994d3a59671ce8782e4b4cf0/tests/sample/ext) as an example for how to implement an extension. This simple extension exposes a new program type, and implements a hook for it with a single attach type. It implements simple NPI provider modules for the two NPIs. It also implements three program-type specific helper functions.
+The eBPF for Windows project provides a
+[sample extension driver](https://github.com/microsoft/ebpf-for-windows/tree/8f46b4020f79c32f994d3a59671ce8782e4b4cf0/tests/sample/ext)
+as an example for how to implement an extension. This simple extension exposes a new program type, and implements a
+hook for it with a single attach type. It implements simple NPI provider modules for the two NPIs. It also implements
+three program-type specific helper functions.

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -161,11 +161,10 @@ typedef enum
 /**
  * @brief Get current pid and tgid (sock_addr specific only).
  *
- * @param[in] ctx pointer to bpf_sock_addr_t context.
+ * @param[in] ctx Pointer to bpf_sock_addr_t context.
  *
- *
- * @retval A 64-bit integer containing the current tgid and pid,
- *  and created as such:
+ * returns a 64-bit integer containing the current tgid
+ *  and pid, and created as such:
  *
  * 	*current_task*\ **->tgid << 32 \|**
  * 	*current_task*\ **->pid**.

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -163,7 +163,7 @@ typedef enum
  *
  * @param[in] ctx Pointer to bpf_sock_addr_t context.
  *
- * returns a 64-bit integer containing the current tgid
+ * @returns a 64-bit integer containing the current tgid
  *  and pid, and created as such:
  *
  * 	*current_task*\ **->tgid << 32 \|**

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -151,6 +151,31 @@ typedef struct bpf_sock_addr
     uint64_t interface_luid; ///< Interface LUID.
 } bpf_sock_addr_t;
 
+#define SOCK_ADDR_EXT_HELPER_FN_BASE 0xFFFF
+
+typedef enum
+{
+    BPF_FUNC_sock_addr_get_current_pid_tgid = SOCK_ADDR_EXT_HELPER_FN_BASE + 1,
+} ebpf_sock_addr_helper_id_t;
+
+/**
+ * @brief Get current pid and tgid (sock_addr specific only).
+ *
+ * @param[in] ctx pointer to bpf_sock_addr_t context.
+ *
+ *
+ * @retval A 64-bit integer containing the current tgid and pid,
+ *  and created as such:
+ *
+ * 	*current_task*\ **->tgid << 32 \|**
+ * 	*current_task*\ **->pid**.
+ */
+EBPF_HELPER(uint64_t, bpf_sock_addr_get_current_pid_tgid, (bpf_sock_addr_t * ctx));
+#ifndef __doxygen
+#define bpf_sock_addr_get_current_pid_tgid \
+    ((bpf_sock_addr_get_current_pid_tgid_t)BPF_FUNC_sock_addr_get_current_pid_tgid)
+#endif
+
 /**
  * @brief Handle socket operation. Currently supports ingress/egress connection initialization.
  *

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -83,15 +83,6 @@ typedef struct _ebpf_program
 } ebpf_program_t;
 
 static ebpf_result_t
-_ebpf_program_get_context(_Outptr_ void** context);
-
-static struct
-{
-    size_t size;
-    _ebpf_extension_dispatch_function function[1];
-} _ebpf_program_dispatch_table = {1, {_ebpf_program_get_context}};
-
-static ebpf_result_t
 _ebpf_program_update_helpers(_Inout_ ebpf_program_t* program);
 
 static ebpf_result_t
@@ -99,6 +90,9 @@ _ebpf_program_update_interpret_helpers(_Inout_ ebpf_program_t* program, _Inout_ 
 
 static ebpf_result_t
 _ebpf_program_update_jit_helpers(_Inout_ ebpf_program_t* program, _Inout_ void* context);
+
+static ebpf_result_t
+_ebpf_program_register_helpers(_In_ const ebpf_program_t* program);
 
 static ebpf_result_t
 _ebpf_program_get_helper_function_address(
@@ -402,7 +396,7 @@ ebpf_program_load_providers(_Inout_ ebpf_program_t* program)
         &module_id,
         program,
         NULL,
-        (ebpf_extension_dispatch_table_t*)&_ebpf_program_dispatch_table,
+        NULL,
         (void**)&program->info_extension_provider_binding_context,
         &program->info_extension_provider_data,
         NULL,
@@ -995,7 +989,6 @@ typedef struct _ebpf_program_tail_call_state
 {
     const ebpf_program_t* next_program;
     uint32_t count;
-    void* context;
 } ebpf_program_tail_call_state_t;
 
 _Must_inspect_result_ ebpf_result_t
@@ -1048,7 +1041,6 @@ ebpf_program_invoke(
 
     bool program_state_stored = false;
 
-    state.context = context;
     if (!ebpf_state_store(_ebpf_program_state_index, (uintptr_t)&state, execution_state) == EBPF_SUCCESS) {
         *result = 0;
         goto Done;
@@ -1674,23 +1666,6 @@ Exit:
     ebpf_program_free_program_info((ebpf_program_info_t*)program_info);
 
     EBPF_RETURN_RESULT(result);
-}
-
-static ebpf_result_t
-_ebpf_program_get_context(_Outptr_ void** context)
-{
-    ebpf_result_t result;
-    ebpf_program_tail_call_state_t* state = NULL;
-    *context = NULL;
-    result = ebpf_state_load(_ebpf_program_state_index, (uintptr_t*)&state);
-    if (result != EBPF_SUCCESS) {
-        goto Exit;
-    }
-
-    *context = state->context;
-
-Exit:
-    return result;
 }
 
 typedef struct _ebpf_program_test_run_context

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -185,7 +185,7 @@ net_ebpf_ext_bind_register_providers()
     // Set the program type as the provider module id.
     _ebpf_bind_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_BIND;
     status = net_ebpf_extension_program_info_provider_register(
-        &program_info_provider_parameters, NULL, NULL, &_ebpf_bind_program_info_provider_context);
+        &program_info_provider_parameters, &_ebpf_bind_program_info_provider_context);
     if (status != STATUS_SUCCESS)
         goto Exit;
 

--- a/netebpfext/net_ebpf_ext_prog_info_provider.c
+++ b/netebpfext/net_ebpf_ext_prog_info_provider.c
@@ -12,10 +12,8 @@
  */
 typedef struct _net_ebpf_extension_program_info_client
 {
-    HANDLE nmr_binding_handle;                                    ///< NMR binding handle.
-    GUID client_module_id;                                        ///< NMR module ID.
-    ebpf_get_program_context_t get_program_context;               ///< Pointer to function to get the program context.
-    net_ebpf_extension_program_info_provider_t* provider_context; ///< Pointer to the hook NPI provider context.
+    HANDLE nmr_binding_handle; ///< NMR binding handle.
+    GUID client_module_id;     ///< NMR module Id.
 } net_ebpf_extension_program_info_client_t;
 
 /**
@@ -25,10 +23,6 @@ typedef struct _net_ebpf_extension_program_info_provider
 {
     NPI_PROVIDER_CHARACTERISTICS characteristics; ///< NPI Provider characteristics.
     HANDLE nmr_provider_handle;                   ///< NMR binding handle.
-    net_ebpf_extension_program_info_on_client_attach
-        attach_callback; ///< Pointer to program info provider specific callback to be invoked when a client attaches.
-    net_ebpf_extension_program_info_on_client_detach
-        detach_callback; ///< Pointer to program info provider specific callback to be invoked when a client detaches.
 } net_ebpf_extension_program_info_provider_t;
 
 /**
@@ -57,17 +51,15 @@ _net_ebpf_extension_program_info_provider_attach_client(
     _Outptr_result_maybenull_ const void** provider_dispatch)
 {
     NTSTATUS status = STATUS_SUCCESS;
-    ebpf_result_t result;
-    net_ebpf_extension_program_info_provider_t* local_provider_context =
-        (net_ebpf_extension_program_info_provider_t*)provider_context;
     net_ebpf_extension_program_info_client_t* program_info_client = NULL;
-    ebpf_extension_dispatch_table_t* client_dispatch_table;
 
     NET_EBPF_EXT_LOG_ENTRY();
 
+    UNREFERENCED_PARAMETER(provider_context);
+    UNREFERENCED_PARAMETER(client_dispatch);
     UNREFERENCED_PARAMETER(client_binding_context);
 
-    if ((provider_binding_context == NULL) || (provider_dispatch == NULL) || (local_provider_context == NULL)) {
+    if ((provider_binding_context == NULL) || (provider_dispatch == NULL)) {
         status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }
@@ -75,11 +67,6 @@ _net_ebpf_extension_program_info_provider_attach_client(
     *provider_binding_context = NULL;
     *provider_dispatch = NULL;
 
-    client_dispatch_table = (ebpf_extension_dispatch_table_t*)client_dispatch;
-    if (client_dispatch_table == NULL) {
-        status = STATUS_INVALID_PARAMETER;
-        goto Exit;
-    }
     program_info_client = (net_ebpf_extension_program_info_client_t*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, sizeof(net_ebpf_extension_program_info_client_t), NET_EBPF_EXTENSION_POOL_TAG);
     if (program_info_client == NULL) {
@@ -88,17 +75,8 @@ _net_ebpf_extension_program_info_provider_attach_client(
     }
     memset(program_info_client, 0, sizeof(net_ebpf_extension_program_info_client_t));
 
-    program_info_client->get_program_context = (ebpf_get_program_context_t)client_dispatch_table->function[0];
     program_info_client->nmr_binding_handle = nmr_binding_handle;
     program_info_client->client_module_id = client_registration_instance->ModuleId->Guid;
-    program_info_client->provider_context = local_provider_context;
-
-    if (local_provider_context->attach_callback) {
-        result = local_provider_context->attach_callback(program_info_client, local_provider_context);
-        if (result != EBPF_SUCCESS) {
-            status = STATUS_ACCESS_DENIED;
-        }
-    }
 
 Exit:
     if (NT_SUCCESS(status)) {
@@ -121,19 +99,11 @@ Exit:
 static NTSTATUS
 _net_ebpf_extension_program_info_provider_detach_client(_In_ const void* provider_binding_context)
 {
-    net_ebpf_extension_program_info_client_t* local_client_context =
-        (net_ebpf_extension_program_info_client_t*)provider_binding_context;
+    NTSTATUS status = STATUS_SUCCESS;
 
-    if (local_client_context == NULL) {
-        return STATUS_INVALID_PARAMETER;
-    }
+    UNREFERENCED_PARAMETER(provider_binding_context);
 
-    net_ebpf_extension_program_info_provider_t* local_provider_context = local_client_context->provider_context;
-    if (local_provider_context->detach_callback) {
-        local_provider_context->detach_callback(local_client_context);
-    }
-
-    return STATUS_SUCCESS;
+    return status;
 }
 
 static void
@@ -157,8 +127,6 @@ net_ebpf_extension_program_info_provider_unregister(
 NTSTATUS
 net_ebpf_extension_program_info_provider_register(
     _In_ const net_ebpf_extension_program_info_provider_parameters_t* parameters,
-    _In_opt_ net_ebpf_extension_program_info_on_client_attach attach_callback,
-    _In_opt_ net_ebpf_extension_program_info_on_client_detach detach_callback,
     _Outptr_ net_ebpf_extension_program_info_provider_t** provider_context)
 {
     net_ebpf_extension_program_info_provider_t* local_provider_context = NULL;
@@ -187,9 +155,6 @@ net_ebpf_extension_program_info_provider_register(
     characteristics->ProviderRegistrationInstance.NpiSpecificCharacteristics = parameters->provider_data;
     characteristics->ProviderRegistrationInstance.ModuleId = parameters->provider_module_id;
 
-    local_provider_context->attach_callback = attach_callback;
-    local_provider_context->detach_callback = detach_callback;
-
     status = NmrRegisterProvider(characteristics, local_provider_context, &local_provider_context->nmr_provider_handle);
     if (!NT_SUCCESS(status))
         goto Exit;
@@ -202,11 +167,4 @@ Exit:
         net_ebpf_extension_program_info_provider_unregister(local_provider_context);
 
     NET_EBPF_EXT_RETURN_NTSTATUS(status);
-}
-
-const ebpf_get_program_context_t
-net_ebpf_extension_get_program_context_function(
-    _In_ const net_ebpf_extension_program_info_client_t* program_info_client)
-{
-    return program_info_client->get_program_context;
 }

--- a/netebpfext/net_ebpf_ext_prog_info_provider.h
+++ b/netebpfext/net_ebpf_ext_prog_info_provider.h
@@ -6,13 +6,6 @@
 #include "net_ebpf_ext.h"
 
 typedef struct _net_ebpf_extension_program_info_provider net_ebpf_extension_program_info_provider_t;
-typedef struct _net_ebpf_extension_program_info_client net_ebpf_extension_program_info_client_t;
-
-/**
- * @brief Pointer to function to get the context for the current invocation of the eBPF program.
- * This is the only function in the client's dispatch table.
- */
-typedef ebpf_result_t (*ebpf_get_program_context_t)(_Outptr_ void** context);
 
 /**
  * @brief Data structure for program info NPI provider registration parameters.
@@ -24,43 +17,9 @@ typedef struct _net_ebpf_extension_program_info_provider_parameters
 } net_ebpf_extension_program_info_provider_parameters_t;
 
 /**
- * @brief Unregister the program information NPI provider.
- *
- * @param[in] provider_context Pointer to the provider context being un-registered.
- */
-void
-net_ebpf_extension_program_info_provider_unregister(
-    _Frees_ptr_opt_ net_ebpf_extension_program_info_provider_t* provider_context);
-
-/**
- * @brief This callback function should be implemented by program info provider modules. This callback is invoked when
- * a program info NPI client is attempting to attach to the program info NPI provider.
- * @param[in] attaching_client Pointer to context of the hook NPI client that is requesting to be attached.
- * @param[in] provider_context Pointer to the hook NPI provider context to which the client is being attached.
- *
- * @retval EBPF_SUCCESS The operation succeeded.
- * @retval EBPF_ACCESS_DENIED Request to attach client is denied by the provider.
- * @retval EBPF_INVALID_ARGUMENT One or more parameters are incorrect.
- */
-typedef ebpf_result_t (*net_ebpf_extension_program_info_on_client_attach)(
-    _In_ const net_ebpf_extension_program_info_client_t* attaching_client,
-    _In_ const net_ebpf_extension_program_info_provider_t* provider_context);
-
-/**
- * @brief This callback function should be implemented by program info provider modules. This callback is invoked when
- * a program info NPI client is attempting to detach from the program info NPI provider.
- * @param[in] detaching_client Pointer to context of the hook NPI client that is requesting to be detached.
- *
- */
-typedef void (*net_ebpf_extension_program_info_on_client_detach)(
-    _In_ const net_ebpf_extension_program_info_client_t* detaching_client);
-
-/**
  * @brief Register the program information NPI provider.
  *
  * @param[in] provider_characteristics Pointer to the NPI provider characteristics struct.
- * @param[in] attach_callback Optionally, pointer to callback function to be invoked when a client attaches.
- * @param[in] detach_callback Optionally, pointer to callback function to be invoked when a client detaches.
  * @param[in, out] provider_context Pointer to the provider context being registered.
  *
  * @retval STATUS_SUCCESS Operation succeeded.
@@ -69,17 +28,13 @@ typedef void (*net_ebpf_extension_program_info_on_client_detach)(
 NTSTATUS
 net_ebpf_extension_program_info_provider_register(
     _In_ const net_ebpf_extension_program_info_provider_parameters_t* parameters,
-    _In_opt_ net_ebpf_extension_program_info_on_client_attach attach_callback,
-    _In_opt_ net_ebpf_extension_program_info_on_client_detach detach_callback,
     _Outptr_ net_ebpf_extension_program_info_provider_t** provider_context);
 
 /**
- * @brief Get the ebpf_get_program_context_t function pointer.
+ * @brief Unregister the program information NPI provider.
  *
- * @param[in] program_info_client Pointer to program info NPI client.
- *
- * @returns ebpf_get_program_context_t function pointer.
+ * @param[in] provider_context Pointer to the provider context being un-registered.
  */
-const ebpf_get_program_context_t
-net_ebpf_extension_get_program_context_function(
-    _In_ const net_ebpf_extension_program_info_client_t* program_info_client);
+void
+net_ebpf_extension_program_info_provider_unregister(
+    _Frees_ptr_opt_ net_ebpf_extension_program_info_provider_t* provider_context);

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -21,24 +21,33 @@ static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {
     EBPF_OFFSET_OF(xdp_md_t, data),
     EBPF_OFFSET_OF(xdp_md_t, data_end),
     EBPF_OFFSET_OF(xdp_md_t, data_meta)};
+
 static ebpf_program_info_t _ebpf_xdp_program_info = {
     {"xdp", &_ebpf_xdp_context_descriptor, {0}, BPF_PROG_TYPE_XDP},
     EBPF_COUNT_OF(_xdp_ebpf_extension_helper_function_prototype),
     _xdp_ebpf_extension_helper_function_prototype};
+
 static ebpf_program_section_info_t _ebpf_xdp_section_info[] = {
     {(const wchar_t*)L"xdp", &EBPF_PROGRAM_TYPE_XDP, &EBPF_ATTACH_TYPE_XDP, BPF_PROG_TYPE_XDP, BPF_XDP}};
 
 // Bind program information.
 static ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
     sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
+
 static ebpf_program_info_t _ebpf_bind_program_info = {
     {"bind", &_ebpf_bind_context_descriptor, {0}, BPF_PROG_TYPE_BIND}, 0, NULL};
+
 static ebpf_program_section_info_t _ebpf_bind_section_info[] = {
     {L"bind", &EBPF_PROGRAM_TYPE_BIND, &EBPF_ATTACH_TYPE_BIND, BPF_PROG_TYPE_BIND, BPF_ATTACH_TYPE_BIND}};
 
 // CGROUP_SOCK_ADDR global helper function prototypes.
+static ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_function_prototype[] = {
+    {BPF_FUNC_sock_addr_get_current_pid_tgid,
+     "bpf_sock_addr_get_current_pid_tgid",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}}};
+
 static ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_function_prototype[] = {
-    {BPF_FUNC_get_current_pid_tgid, "bpf_get_current_pid_tgid", EBPF_RETURN_TYPE_INTEGER, {0}},
     {BPF_FUNC_get_current_logon_id,
      "bpf_get_current_logon_id",
      EBPF_RETURN_TYPE_INTEGER,
@@ -52,12 +61,14 @@ static ebpf_context_descriptor_t _ebpf_sock_addr_context_descriptor = {
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
     -1, // Offset into ctx struct for pointer to metadata, or -1 if none.
 };
+
 static ebpf_program_info_t _ebpf_sock_addr_program_info = {
     {"sock_addr", &_ebpf_sock_addr_context_descriptor, {0}, BPF_PROG_TYPE_CGROUP_SOCK_ADDR},
-    0,
-    NULL,
+    EBPF_COUNT_OF(_sock_addr_ebpf_extension_helper_function_prototype),
+    _sock_addr_ebpf_extension_helper_function_prototype,
     EBPF_COUNT_OF(_ebpf_sock_addr_global_helper_function_prototype),
     _ebpf_sock_addr_global_helper_function_prototype};
+
 static ebpf_program_section_info_t _ebpf_sock_addr_section_info[] = {
     {L"cgroup/connect4",
      &EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR,
@@ -87,8 +98,10 @@ static ebpf_context_descriptor_t _ebpf_sock_ops_context_descriptor = {
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
     -1, // Offset into ctx struct for pointer to metadata, or -1 if none.
 };
+
 static ebpf_program_info_t _ebpf_sock_ops_program_info = {
     {"sockops", &_ebpf_sock_ops_context_descriptor, {0}, BPF_PROG_TYPE_SOCK_OPS}, 0, NULL};
+
 static ebpf_program_section_info_t _ebpf_sock_ops_section_info[] = {
     {L"sockops",
      &EBPF_PROGRAM_TYPE_SOCK_OPS,

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -40,13 +40,14 @@ static ebpf_program_info_t _ebpf_bind_program_info = {
 static ebpf_program_section_info_t _ebpf_bind_section_info[] = {
     {L"bind", &EBPF_PROGRAM_TYPE_BIND, &EBPF_ATTACH_TYPE_BIND, BPF_PROG_TYPE_BIND, BPF_ATTACH_TYPE_BIND}};
 
-// CGROUP_SOCK_ADDR global helper function prototypes.
+// CGROUP_SOCK_ADDR extension specific helper function prototypes.
 static ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_function_prototype[] = {
     {BPF_FUNC_sock_addr_get_current_pid_tgid,
      "bpf_sock_addr_get_current_pid_tgid",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}}};
 
+// CGROUP_SOCK_ADDR global helper function prototypes.
 static ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_function_prototype[] = {
     {BPF_FUNC_get_current_logon_id,
      "bpf_get_current_logon_id",

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -21,8 +21,6 @@ typedef struct _net_ebpf_bpf_sock_addr
     uint64_t process_id;
 } net_ebpf_sock_addr_t;
 
-static ebpf_get_program_context_t _net_ebpf_sock_addr_get_program_context = NULL;
-
 /**
  * Connection context info does not contain the source IP address because
  * the source IP address is not always available at connect_redirect layer.
@@ -306,29 +304,6 @@ static net_ebpf_extension_hook_provider_t*
 //
 // NMR Registration Helper Routines.
 //
-
-static ebpf_result_t
-_net_ebpf_extension_sock_addr_program_info_on_client_attach(
-    _In_ const net_ebpf_extension_program_info_client_t* attaching_client,
-    _In_ const net_ebpf_extension_program_info_provider_t* provider_context)
-{
-    UNREFERENCED_PARAMETER(provider_context);
-
-    _net_ebpf_sock_addr_get_program_context = net_ebpf_extension_get_program_context_function(attaching_client);
-    if (_net_ebpf_sock_addr_get_program_context == NULL) {
-        NET_EBPF_EXT_RETURN_RESULT(EBPF_INVALID_ARGUMENT);
-    }
-
-    NET_EBPF_EXT_RETURN_RESULT(EBPF_SUCCESS);
-}
-
-static void
-_net_ebpf_extension_sock_addr_program_info_on_client_detach(
-    _In_ const net_ebpf_extension_program_info_client_t* detaching_client)
-{
-    UNREFERENCED_PARAMETER(detaching_client);
-    _net_ebpf_sock_addr_get_program_context = NULL;
-}
 
 static ebpf_result_t
 _net_ebpf_extension_sock_addr_on_client_attach(
@@ -798,11 +773,9 @@ net_ebpf_ext_sock_addr_register_providers()
     // Set the program type as the provider module id.
     _ebpf_sock_addr_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR;
     status = net_ebpf_extension_program_info_provider_register(
-        &program_info_provider_parameters,
-        _net_ebpf_extension_sock_addr_program_info_on_client_attach,
-        _net_ebpf_extension_sock_addr_program_info_on_client_detach,
-        &_ebpf_sock_addr_program_info_provider_context);
-    NET_EBPF_EXT_BAIL_ON_ERROR_STATUS(status);
+        &program_info_provider_parameters, &_ebpf_sock_addr_program_info_provider_context);
+    if (status != STATUS_SUCCESS)
+        goto Exit;
 
     for (int i = 0; i < NET_EBPF_SOCK_ADDR_HOOK_PROVIDER_COUNT; i++) {
         const net_ebpf_extension_hook_provider_parameters_t hook_provider_parameters = {

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -102,23 +102,9 @@ _get_thread_id()
 }
 
 static uint64_t
-_ebpf_sock_addr_get_current_pid_tgid()
+_ebpf_sock_addr_get_current_pid_tgid(_In_ const bpf_sock_addr_t* ctx)
 {
-    net_ebpf_sock_addr_t* sock_addr_ctx = NULL;
-    ASSERT(_net_ebpf_sock_addr_get_program_context != NULL);
-    _net_ebpf_sock_addr_get_program_context((void**)&sock_addr_ctx);
-    ASSERT(sock_addr_ctx != NULL);
-    if (sock_addr_ctx == NULL) {
-        NET_EBPF_EXT_LOG_MESSAGE(
-            NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,
-            NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
-            "_ebpf_sock_addr_get_current_pid_tgid: get_program_context failed.");
-    }
-
-    if (sock_addr_ctx == NULL) {
-        return (((uint64_t)_get_process_id() << 32) | _get_thread_id());
-    }
-
+    net_ebpf_sock_addr_t* sock_addr_ctx = CONTAINING_RECORD(ctx, net_ebpf_sock_addr_t, base);
     return (sock_addr_ctx->process_id << 32 | _get_thread_id());
 }
 
@@ -280,18 +266,22 @@ _ebpf_sock_addr_context_destroy(
 //
 // SOCK_ADDR Program Information NPI Provider.
 //
-static const void* _ebpf_sock_addr_helper_functions[] = {
-    (void*)_ebpf_sock_addr_get_current_pid_tgid,
-    (void*)_ebpf_sock_addr_get_current_logon_id,
-    (void*)_ebpf_sock_addr_is_current_admin};
 
-static ebpf_helper_function_addresses_t _ebpf_sock_addr_helper_function_address_table = {
-    EBPF_COUNT_OF(_ebpf_sock_addr_helper_functions), (uint64_t*)_ebpf_sock_addr_helper_functions};
+static const void* _ebpf_sock_addr_specific_helper_functions[] = {(void*)_ebpf_sock_addr_get_current_pid_tgid};
+
+static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function_address_table = {
+    EBPF_COUNT_OF(_ebpf_sock_addr_specific_helper_functions), (uint64_t*)_ebpf_sock_addr_specific_helper_functions};
+
+static const void* _ebpf_sock_addr_global_helper_functions[] = {
+    (void*)_ebpf_sock_addr_get_current_logon_id, (void*)_ebpf_sock_addr_is_current_admin};
+
+static ebpf_helper_function_addresses_t _ebpf_sock_addr_global_helper_function_address_table = {
+    EBPF_COUNT_OF(_ebpf_sock_addr_global_helper_functions), (uint64_t*)_ebpf_sock_addr_global_helper_functions};
 
 static ebpf_program_data_t _ebpf_sock_addr_program_data = {
     .program_info = &_ebpf_sock_addr_program_info,
-    .program_type_specific_helper_function_addresses = NULL,
-    .global_helper_function_addresses = &_ebpf_sock_addr_helper_function_address_table,
+    .program_type_specific_helper_function_addresses = &_ebpf_sock_addr_specific_helper_function_address_table,
+    .global_helper_function_addresses = &_ebpf_sock_addr_global_helper_function_address_table,
     .context_create = &_ebpf_sock_addr_context_create,
     .context_destroy = &_ebpf_sock_addr_context_destroy};
 

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -301,7 +301,7 @@ net_ebpf_ext_sock_ops_register_providers()
     // Set the program type as the provider module id.
     _ebpf_sock_ops_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_SOCK_OPS;
     status = net_ebpf_extension_program_info_provider_register(
-        &program_info_provider_parameters, NULL, NULL, &_ebpf_sock_ops_program_info_provider_context);
+        &program_info_provider_parameters, &_ebpf_sock_ops_program_info_provider_context);
     if (status != STATUS_SUCCESS)
         goto Exit;
 

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -257,7 +257,7 @@ net_ebpf_ext_xdp_register_providers()
     // Set the program type as the provider module id.
     _ebpf_xdp_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_XDP;
     status = net_ebpf_extension_program_info_provider_register(
-        &program_info_provider_parameters, NULL, NULL, &_ebpf_xdp_program_info_provider_context);
+        &program_info_provider_parameters, &_ebpf_xdp_program_info_provider_context);
     if (status != STATUS_SUCCESS)
         goto Exit;
 

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -77,7 +77,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
-    {NULL, 19, "helper_id_19"},
+    {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 2, "helper_id_2"},
@@ -170,7 +170,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 59 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=59 imm=6
+        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=60 imm=6
 #line 59 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 59 "sample/cgroup_sock_addr2.c"
@@ -179,7 +179,7 @@ label_1:
     // EBPF_OP_LDXW pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 63 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=57 imm=2
+    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=58 imm=2
 #line 63 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 63 "sample/cgroup_sock_addr2.c"
@@ -301,7 +301,10 @@ label_2:
     // EBPF_OP_STXDW pc=54 dst=r10 src=r9 offset=-72 imm=0
 #line 41 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r9;
-    // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=19
+    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 42 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
 #line 42 "sample/cgroup_sock_addr2.c"
@@ -310,16 +313,16 @@ label_2:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=56 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=57 dst=r10 src=r8 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=59 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=20
 #line 43 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 43 "sample/cgroup_sock_addr2.c"
@@ -328,13 +331,13 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=60 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=61 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=21
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -343,31 +346,31 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=63 dst=r10 src=r0 offset=-56 imm=0
+        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=65 dst=r10 src=r8 offset=-8 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=66 dst=r2 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=67 dst=r2 src=r0 offset=0 imm=-8
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=68 dst=r3 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=-72
+    // EBPF_OP_ADD64_IMM pc=69 dst=r3 src=r0 offset=0 imm=-72
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-72);
-    // EBPF_OP_LDDW pc=69 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=71 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=72 dst=r4 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=2
 #line 47 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 47 "sample/cgroup_sock_addr2.c"
@@ -377,10 +380,10 @@ label_2:
 #line 47 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=73 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r0 src=r7 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=74 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=75 dst=r0 src=r0 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 122 "sample/cgroup_sock_addr2.c"
@@ -391,7 +394,7 @@ label_3:
 static helper_function_entry_t connect_redirect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
-    {NULL, 19, "helper_id_19"},
+    {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 2, "helper_id_2"},
@@ -466,7 +469,7 @@ connect_redirect6(void* context)
     if (r1 == IMMEDIATE(17))
 #line 88 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=75 imm=6
+        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=76 imm=6
 #line 88 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 88 "sample/cgroup_sock_addr2.c"
@@ -475,7 +478,7 @@ label_1:
     // EBPF_OP_LDXW pc=8 dst=r2 src=r6 offset=0 imm=0
 #line 92 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=73 imm=23
+    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=74 imm=23
 #line 92 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(23))
 #line 92 "sample/cgroup_sock_addr2.c"
@@ -648,7 +651,10 @@ label_2:
     // EBPF_OP_STXDW pc=64 dst=r10 src=r9 offset=-64 imm=0
 #line 41 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=19
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=66 dst=r0 src=r0 offset=0 imm=65536
 #line 42 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
 #line 42 "sample/cgroup_sock_addr2.c"
@@ -657,16 +663,16 @@ label_2:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=66 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=67 dst=r10 src=r8 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=70 dst=r0 src=r0 offset=0 imm=20
 #line 43 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 43 "sample/cgroup_sock_addr2.c"
@@ -675,13 +681,13 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=70 dst=r10 src=r0 offset=-64 imm=0
+        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=21
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -690,31 +696,31 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=73 dst=r10 src=r0 offset=-48 imm=0
+        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-8 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=75 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r2 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=76 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=77 dst=r2 src=r0 offset=0 imm=-8
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=77 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=78 dst=r3 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r3 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=79 dst=r3 src=r0 offset=0 imm=-64
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=79 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=80 dst=r1 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=81 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=82 dst=r4 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=2
 #line 47 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 47 "sample/cgroup_sock_addr2.c"
@@ -724,10 +730,10 @@ label_2:
 #line 47 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=83 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r0 src=r7 offset=0 imm=0
 #line 129 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=84 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=85 dst=r0 src=r0 offset=0 imm=0
 #line 129 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 129 "sample/cgroup_sock_addr2.c"
@@ -747,7 +753,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         6,
-        75,
+        76,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -761,7 +767,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         6,
-        85,
+        86,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -51,7 +51,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
-    {NULL, 19, "helper_id_19"},
+    {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 2, "helper_id_2"},
@@ -144,7 +144,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 59 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=59 imm=6
+        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=60 imm=6
 #line 59 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 59 "sample/cgroup_sock_addr2.c"
@@ -153,7 +153,7 @@ label_1:
     // EBPF_OP_LDXW pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 63 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=57 imm=2
+    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=58 imm=2
 #line 63 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 63 "sample/cgroup_sock_addr2.c"
@@ -275,7 +275,10 @@ label_2:
     // EBPF_OP_STXDW pc=54 dst=r10 src=r9 offset=-72 imm=0
 #line 41 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r9;
-    // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=19
+    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 42 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
 #line 42 "sample/cgroup_sock_addr2.c"
@@ -284,16 +287,16 @@ label_2:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=56 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=57 dst=r10 src=r8 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=59 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=20
 #line 43 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 43 "sample/cgroup_sock_addr2.c"
@@ -302,13 +305,13 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=60 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=61 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=21
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -317,31 +320,31 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=63 dst=r10 src=r0 offset=-56 imm=0
+        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=65 dst=r10 src=r8 offset=-8 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=66 dst=r2 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=67 dst=r2 src=r0 offset=0 imm=-8
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=68 dst=r3 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=-72
+    // EBPF_OP_ADD64_IMM pc=69 dst=r3 src=r0 offset=0 imm=-72
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-72);
-    // EBPF_OP_LDDW pc=69 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=71 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=72 dst=r4 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=2
 #line 47 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 47 "sample/cgroup_sock_addr2.c"
@@ -351,10 +354,10 @@ label_2:
 #line 47 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=73 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r0 src=r7 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=74 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=75 dst=r0 src=r0 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 122 "sample/cgroup_sock_addr2.c"
@@ -365,7 +368,7 @@ label_3:
 static helper_function_entry_t connect_redirect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
-    {NULL, 19, "helper_id_19"},
+    {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 2, "helper_id_2"},
@@ -440,7 +443,7 @@ connect_redirect6(void* context)
     if (r1 == IMMEDIATE(17))
 #line 88 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=75 imm=6
+        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=76 imm=6
 #line 88 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 88 "sample/cgroup_sock_addr2.c"
@@ -449,7 +452,7 @@ label_1:
     // EBPF_OP_LDXW pc=8 dst=r2 src=r6 offset=0 imm=0
 #line 92 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=73 imm=23
+    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=74 imm=23
 #line 92 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(23))
 #line 92 "sample/cgroup_sock_addr2.c"
@@ -622,7 +625,10 @@ label_2:
     // EBPF_OP_STXDW pc=64 dst=r10 src=r9 offset=-64 imm=0
 #line 41 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=19
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=66 dst=r0 src=r0 offset=0 imm=65536
 #line 42 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
 #line 42 "sample/cgroup_sock_addr2.c"
@@ -631,16 +637,16 @@ label_2:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=66 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=67 dst=r10 src=r8 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=70 dst=r0 src=r0 offset=0 imm=20
 #line 43 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 43 "sample/cgroup_sock_addr2.c"
@@ -649,13 +655,13 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=70 dst=r10 src=r0 offset=-64 imm=0
+        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=21
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -664,31 +670,31 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=73 dst=r10 src=r0 offset=-48 imm=0
+        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-8 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=75 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r2 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=76 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=77 dst=r2 src=r0 offset=0 imm=-8
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=77 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=78 dst=r3 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r3 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=79 dst=r3 src=r0 offset=0 imm=-64
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=79 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=80 dst=r1 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=81 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=82 dst=r4 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=2
 #line 47 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 47 "sample/cgroup_sock_addr2.c"
@@ -698,10 +704,10 @@ label_2:
 #line 47 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=83 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r0 src=r7 offset=0 imm=0
 #line 129 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=84 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=85 dst=r0 src=r0 offset=0 imm=0
 #line 129 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 129 "sample/cgroup_sock_addr2.c"
@@ -721,7 +727,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         6,
-        75,
+        76,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -735,7 +741,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         6,
-        85,
+        86,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -212,7 +212,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
-    {NULL, 19, "helper_id_19"},
+    {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 2, "helper_id_2"},
@@ -305,7 +305,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 59 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=59 imm=6
+        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=60 imm=6
 #line 59 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 59 "sample/cgroup_sock_addr2.c"
@@ -314,7 +314,7 @@ label_1:
     // EBPF_OP_LDXW pc=14 dst=r1 src=r6 offset=0 imm=0
 #line 63 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=57 imm=2
+    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=58 imm=2
 #line 63 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 63 "sample/cgroup_sock_addr2.c"
@@ -436,7 +436,10 @@ label_2:
     // EBPF_OP_STXDW pc=54 dst=r10 src=r9 offset=-72 imm=0
 #line 41 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r9;
-    // EBPF_OP_CALL pc=55 dst=r0 src=r0 offset=0 imm=19
+    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
 #line 42 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
 #line 42 "sample/cgroup_sock_addr2.c"
@@ -445,16 +448,16 @@ label_2:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=56 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=57 dst=r10 src=r8 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=59 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=20
 #line 43 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 43 "sample/cgroup_sock_addr2.c"
@@ -463,13 +466,13 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=60 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=61 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=21
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -478,31 +481,31 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=63 dst=r10 src=r0 offset=-56 imm=0
+        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=65 dst=r10 src=r8 offset=-8 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=66 dst=r2 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=67 dst=r2 src=r0 offset=0 imm=-8
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=68 dst=r3 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=-72
+    // EBPF_OP_ADD64_IMM pc=69 dst=r3 src=r0 offset=0 imm=-72
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-72);
-    // EBPF_OP_LDDW pc=69 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=71 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=72 dst=r4 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=2
 #line 47 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 47 "sample/cgroup_sock_addr2.c"
@@ -512,10 +515,10 @@ label_2:
 #line 47 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=73 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r0 src=r7 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=74 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=75 dst=r0 src=r0 offset=0 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 122 "sample/cgroup_sock_addr2.c"
@@ -526,7 +529,7 @@ label_3:
 static helper_function_entry_t connect_redirect6_helpers[] = {
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
-    {NULL, 19, "helper_id_19"},
+    {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
     {NULL, 2, "helper_id_2"},
@@ -601,7 +604,7 @@ connect_redirect6(void* context)
     if (r1 == IMMEDIATE(17))
 #line 88 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=75 imm=6
+        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=76 imm=6
 #line 88 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 88 "sample/cgroup_sock_addr2.c"
@@ -610,7 +613,7 @@ label_1:
     // EBPF_OP_LDXW pc=8 dst=r2 src=r6 offset=0 imm=0
 #line 92 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=73 imm=23
+    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=74 imm=23
 #line 92 "sample/cgroup_sock_addr2.c"
     if (r2 != IMMEDIATE(23))
 #line 92 "sample/cgroup_sock_addr2.c"
@@ -783,7 +786,10 @@ label_2:
     // EBPF_OP_STXDW pc=64 dst=r10 src=r9 offset=-64 imm=0
 #line 41 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=19
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 42 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=66 dst=r0 src=r0 offset=0 imm=65536
 #line 42 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
 #line 42 "sample/cgroup_sock_addr2.c"
@@ -792,16 +798,16 @@ label_2:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=66 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=67 dst=r10 src=r8 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=68 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=70 dst=r0 src=r0 offset=0 imm=20
 #line 43 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 43 "sample/cgroup_sock_addr2.c"
@@ -810,13 +816,13 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=70 dst=r10 src=r0 offset=-64 imm=0
+        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=21
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -825,31 +831,31 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=73 dst=r10 src=r0 offset=-48 imm=0
+        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-8 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=75 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r2 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=76 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=77 dst=r2 src=r0 offset=0 imm=-8
 #line 46 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=77 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=78 dst=r3 src=r10 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r3 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=79 dst=r3 src=r0 offset=0 imm=-64
 #line 46 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=79 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=80 dst=r1 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=81 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=82 dst=r4 src=r0 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=2
 #line 47 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 47 "sample/cgroup_sock_addr2.c"
@@ -859,10 +865,10 @@ label_2:
 #line 47 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=83 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r0 src=r7 offset=0 imm=0
 #line 129 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=84 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=85 dst=r0 src=r0 offset=0 imm=0
 #line 129 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 129 "sample/cgroup_sock_addr2.c"
@@ -882,7 +888,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         6,
-        75,
+        76,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -896,7 +902,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         6,
-        85,
+        86,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -6,15 +6,6 @@
 ebpf_registry_key_t ebpf_root_registry_key = HKEY_CURRENT_USER;
 DEVICE_OBJECT* _net_ebpf_ext_driver_device_object;
 
-static ebpf_result_t
-_get_program_context(_Outptr_ void** context)
-{
-    *context = nullptr;
-    return EBPF_KEY_NOT_FOUND;
-}
-
-ebpf_extension_dispatch_table_t dispatch_table = {0, 1, {(_ebpf_extension_dispatch_function)_get_program_context}};
-
 _netebpf_ext_helper::_netebpf_ext_helper(
     _In_opt_ const void* npi_specific_characteristics,
     _In_opt_ _ebpf_extension_dispatch_function dispatch_function,
@@ -122,7 +113,7 @@ _netebpf_ext_helper::_program_info_client_attach_provider(
     NTSTATUS status = NmrClientAttachProvider(
         nmr_binding_handle,
         client_binding_context.get(),
-        &dispatch_table,
+        &client_binding_context,
         &client_binding_context->context,
         &client_binding_context->dispatch);
 

--- a/tests/sample/cgroup_sock_addr2.c
+++ b/tests/sample/cgroup_sock_addr2.c
@@ -39,7 +39,7 @@ update_audit_map_entry(bpf_sock_addr_t* ctx)
 {
     uint64_t key = 0;
     sock_addr_audit_entry_t entry = {0};
-    entry.process_id = bpf_get_current_pid_tgid();
+    entry.process_id = bpf_sock_addr_get_current_pid_tgid(ctx);
     entry.logon_id = bpf_get_current_logon_id(ctx);
     entry.is_admin = bpf_is_current_admin(ctx);
 

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -19,11 +19,10 @@
 
 #define SAMPLE_EBPF_EXTENSION_NPI_PROVIDER_VERSION 0
 
+#define SAMPLE_PID_TGID_VALUE 9999
+
 // f788ef4a-207d-4dc3-85cf-0f2ea107213c
 DEFINE_GUID(EBPF_PROGRAM_TYPE_SAMPLE, 0xf788ef4a, 0x207d, 0x4dc3, 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c);
-
-typedef ebpf_result_t (*ebpf_get_program_context_t)(_Outptr_ void** context);
-static ebpf_get_program_context_t _sample_ebpf_ext_get_program_context = NULL;
 
 // Sample Extension helper function addresses table.
 static uint64_t
@@ -256,9 +255,9 @@ _sample_ebpf_extension_program_info_provider_attach_client(
 {
     NTSTATUS status = STATUS_SUCCESS;
     sample_ebpf_extension_program_info_client_t* program_info_client = NULL;
-    ebpf_extension_dispatch_table_t* client_dispatch_table;
 
     UNREFERENCED_PARAMETER(provider_context);
+    UNREFERENCED_PARAMETER(client_dispatch);
     UNREFERENCED_PARAMETER(client_binding_context);
 
     if ((provider_binding_context == NULL) || (provider_dispatch == NULL)) {
@@ -268,12 +267,6 @@ _sample_ebpf_extension_program_info_provider_attach_client(
 
     *provider_binding_context = NULL;
     *provider_dispatch = NULL;
-
-    client_dispatch_table = (ebpf_extension_dispatch_table_t*)client_dispatch;
-    if (client_dispatch_table == NULL) {
-        status = STATUS_INVALID_PARAMETER;
-        goto Exit;
-    }
 
     program_info_client = (sample_ebpf_extension_program_info_client_t*)ebpf_allocate(
         sizeof(sample_ebpf_extension_program_info_client_t));
@@ -285,8 +278,6 @@ _sample_ebpf_extension_program_info_provider_attach_client(
 
     program_info_client->nmr_binding_handle = nmr_binding_handle;
     program_info_client->client_module_id = client_registration_instance->ModuleId->Guid;
-
-    _sample_ebpf_ext_get_program_context = (ebpf_get_program_context_t)client_dispatch_table->function[0];
 
 Exit:
     if (NT_SUCCESS(status)) {
@@ -303,7 +294,6 @@ _sample_ebpf_extension_program_info_provider_detach_client(_In_ const void* prov
     NTSTATUS status = STATUS_SUCCESS;
 
     UNREFERENCED_PARAMETER(provider_binding_context);
-    _sample_ebpf_ext_get_program_context = NULL;
 
     return status;
 }
@@ -591,11 +581,7 @@ Exit:
 static uint64_t
 _sample_get_pid_tgid()
 {
-    sample_program_context_t* context = NULL;
-    _sample_ebpf_ext_get_program_context((void**)&context);
-    ASSERT(context != NULL);
-
-    return context->pid_tgid;
+    return SAMPLE_PID_TGID_VALUE;
 }
 
 // Helper Function Definitions.

--- a/tests/sample/ext/drv/sample_ext_drv.c
+++ b/tests/sample/ext/drv/sample_ext_drv.c
@@ -17,8 +17,6 @@
 #define SAMPLE_EBPF_EXT_DEVICE_NAME L"\\Device\\" SAMPLE_EBPF_EXT_NAME_W
 #define SAMPLE_EBPF_EXT_SYMBOLIC_DEVICE_NAME L"\\GLOBAL??\\" SAMPLE_EBPF_EXT_DEVICE_BASE_NAME
 
-#define SAMPLE_PID_TGID_VALUE 9999
-
 // Driver global variables
 static DEVICE_OBJECT* _sample_ebpf_ext_driver_device_object;
 static BOOLEAN _sample_ebpf_ext_driver_unloading_flag = FALSE;
@@ -286,7 +284,6 @@ _sample_ebpf_ext_driver_io_device_control(
                 // Invoke the eBPF program. Pass the output buffer as program context data.
                 program_context.data_start = output_buffer;
                 program_context.data_end = (uint8_t*)output_buffer + output_buffer_length;
-                program_context.pid_tgid = SAMPLE_PID_TGID_VALUE;
                 result = sample_ebpf_extension_invoke_program(&program_context, &program_result);
             }
         } else {

--- a/tests/sample/ext/inc/sample_ext_helpers.h
+++ b/tests/sample/ext/inc/sample_ext_helpers.h
@@ -17,7 +17,6 @@ typedef struct _sample_program_context
     uint8_t* data_end;
     uint32_t uint32_data;
     uint16_t uint16_data;
-    uint64_t pid_tgid;
 } sample_program_context_t;
 
 #define SAMPLE_EXT_HELPER_FN_BASE 0xFFFF


### PR DESCRIPTION
## Description

This PR provides a new (temporary) 'program type specific' helper function ```bpf_sock_addr_get_current_pid_tgid(void *ctx)```.

This helper function is a _Windows_ _Only_ (stopgap) feature and is provided as a work-around for an existing edge-case implementation design bug in the currently supported 'global' ```bpf_get_current_pid_tgid()``` helper function.

This 'program type specific' helper function _may_ be removed once the implementation design issues for the global version are resolved.


## Testing

Ensure single and multi-(VM) machine unit tests pass successfully.

## Documentation

Added documentation for the new call.
