### PR TITLE
SAL annotation for several source codes

### DIFF
--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -18,7 +18,13 @@ TOKEN_VALUE g_LevelEnum[2] = {
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_show_disassembly(
-    LPCWSTR machine, LPWSTR* argv, DWORD current_index, DWORD argc, DWORD flags, LPCVOID data, BOOL* done)
+    IN LPCWSTR machine,
+    _Inout_updates_(argc) LPWSTR* argv,
+    IN DWORD current_index,
+    IN DWORD argc,
+    IN DWORD flags,
+    IN LPCVOID data,
+    OUT BOOL* done)
 {
     UNREFERENCED_PARAMETER(machine);
     UNREFERENCED_PARAMETER(flags);
@@ -83,7 +89,13 @@ _get_map_type_name(ebpf_map_type_t type)
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_show_sections(
-    LPCWSTR machine, LPWSTR* argv, DWORD current_index, DWORD argc, DWORD flags, LPCVOID data, BOOL* done)
+    IN LPCWSTR machine,
+    _Inout_updates_(argc) LPWSTR* argv,
+    IN DWORD current_index,
+    IN DWORD argc,
+    IN DWORD flags,
+    IN LPCVOID data,
+    OUT BOOL* done)
 {
     UNREFERENCED_PARAMETER(machine);
     UNREFERENCED_PARAMETER(flags);
@@ -205,7 +217,13 @@ handle_ebpf_show_sections(
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_show_verification(
-    LPCWSTR machine, LPWSTR* argv, DWORD current_index, DWORD argc, DWORD flags, LPCVOID data, BOOL* done)
+    IN LPCWSTR machine,
+    _Inout_updates_(argc) LPWSTR* argv,
+    IN DWORD current_index,
+    IN DWORD argc,
+    IN DWORD flags,
+    IN LPCVOID data,
+    OUT BOOL* done)
 {
     UNREFERENCED_PARAMETER(machine);
     UNREFERENCED_PARAMETER(flags);

--- a/libs/ebpfnetsh/links.cpp
+++ b/libs/ebpfnetsh/links.cpp
@@ -21,7 +21,13 @@
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_show_links(
-    LPCWSTR machine, LPWSTR* argv, DWORD current_index, DWORD argc, DWORD flags, LPCVOID data, BOOL* done)
+    IN LPCWSTR machine,
+    _Inout_updates_(argc) LPWSTR* argv,
+    IN DWORD current_index,
+    IN DWORD argc,
+    IN DWORD flags,
+    IN LPCVOID data,
+    OUT BOOL* done)
 {
     UNREFERENCED_PARAMETER(argv);
     UNREFERENCED_PARAMETER(current_index);

--- a/libs/ebpfnetsh/maps.cpp
+++ b/libs/ebpfnetsh/maps.cpp
@@ -18,7 +18,13 @@
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_show_maps(
-    LPCWSTR machine, LPWSTR* argv, DWORD current_index, DWORD argc, DWORD flags, LPCVOID data, BOOL* done)
+    IN LPCWSTR machine,
+    _Inout_updates_(argc) LPWSTR* argv,
+    IN DWORD current_index,
+    IN DWORD argc,
+    IN DWORD flags,
+    IN LPCVOID data,
+    OUT BOOL* done)
 {
     UNREFERENCED_PARAMETER(argv);
     UNREFERENCED_PARAMETER(current_index);

--- a/libs/ebpfnetsh/pins.cpp
+++ b/libs/ebpfnetsh/pins.cpp
@@ -18,7 +18,13 @@
 // definition of "FN_HANDLE_CMD" in public file of NetSh.h
 unsigned long
 handle_ebpf_show_pins(
-    LPCWSTR machine, LPWSTR* argv, DWORD current_index, DWORD argc, DWORD flags, LPCVOID data, BOOL* done)
+    IN LPCWSTR machine,
+    _Inout_updates_(argc) LPWSTR* argv,
+    IN DWORD current_index,
+    IN DWORD argc,
+    IN DWORD flags,
+    IN LPCVOID data,
+    OUT BOOL* done)
 {
     UNREFERENCED_PARAMETER(argv);
     UNREFERENCED_PARAMETER(current_index);


### PR DESCRIPTION
Closes #2052 
## Description
The following functions or structs in the source codes need SAL annotation. Please note that these annotations needed to match what was defined in public file of `NetSh.h`
1. `elf.cpp`
```
handle_ebpf_show_disassembly
handle_ebpf_show_sections
handle_ebpf_show_verification

```
2. `maps.cpp`
```
handle_ebpf_show_maps

```
3. `pins.cpp`
```
handle_ebpf_show_pins
``` 
4. `links.cpp`
```
handle_ebpf_show_links
```
5. ` svc_main.cpp` : Already addressed in PR #2019 
```
service_control_handler
report_service_status
service_init
service_main
```


6. Tried to remove `_In_` from pass by value types in `wer_report_test_wrapper.cpp` . However, they can't be removed to match header file. If removed, the CICD build will fail. 
```
WerReportAddDump_test
WerReportCreate_test
WerReportSubmit_test
```

## Testing

1. Build the visual studio successfully without any error on local machine. 
2. Loading and running the following tests on the VM to make sure they are passing :

- api_test.exe:
```
C:\Debug>api_test.exe
Randomness seeded to: 980087186
===============================================================================
All tests passed (431 assertions in 31 test cases)
```
- unit_tests.exe

```
===============================================================================
All tests passed (7014 assertions in 257 test cases)
```
