### PR TITLE
Fix local_service_name leak in ebpf_native_load

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1176,6 +1176,7 @@ ebpf_native_load(
 
     result = ebpf_allocate_preemptible_work_item(&cleanup_workitem, _ebpf_native_unload_work_item, local_service_name);
     if (result != EBPF_SUCCESS) {
+        ebpf_free(local_service_name);
         goto Done;
     }
 


### PR DESCRIPTION
## Description
ebpf_native_load allocates local_service_name, which eventually gets freed by the cleanup_workitem. However, if we fail to allocate the cleanup_workitem, then local_service_name leaks.

Manually free local_service_name if we fail before the cleanup_workitem can be allocated.

Resolves #2092 

## Testing
Tested in XDP stress test. Other eBPF issues are still being hit, but this one seems fixed.

## Documentation
N/A.