### PR TITLE
Update api_common to first read eBPF store values from HKLM path.

### DIFF
--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -27,7 +27,8 @@
 static thread_local ebpf_handle_t _program_under_verification = ebpf_handle_invalid;
 
 // TODO: Issue #1231 Change to using HKEY_LOCAL_MACHINE
-ebpf_registry_key_t root_registry_key = HKEY_CURRENT_USER;
+ebpf_registry_key_t root_registry_key_current_user = HKEY_CURRENT_USER;
+ebpf_registry_key_t root_registry_key_local_machine = HKEY_LOCAL_MACHINE;
 
 extern bool use_ebpf_store;
 

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -118,18 +118,6 @@ function Start-eBPFComponents
     }
 }
 
-#
-# Update eBPF store.
-#
-function Update-eBPFStore
-{
-    Write-Log "Clearing eBPF store"
-    .\export_program_info.exe --clear
-
-    Write-Log "Populating eBPF store"
-    .\export_program_info.exe
-}
-
 function Install-eBPFComponents
 {
     param([parameter(Mandatory=$false)] [bool] $Tracing = $false,
@@ -159,10 +147,6 @@ function Install-eBPFComponents
 
     # Start all components.
     Start-eBPFComponents -Tracing $Tracing
-
-    ## TODO: Issue 1231, remove this step when this issue is fixed.
-    # Update eBPF store.
-    Update-eBPFStore
 }
 
 function Stop-eBPFComponents
@@ -180,7 +164,6 @@ function Uninstall-eBPFComponents
 {
     Stop-eBPFComponents
     Unregister-eBPFComponents
-    .\export_program_info.exe --clear
     Remove-Item "$Env:systemroot\system32\drivers\*bpf*" -Force -ErrorAction Stop 2>&1 | Write-Log
     Remove-Item "$Env:systemroot\system32\*bpf*" -Force -ErrorAction Stop 2>&1 | Write-Log
     wpr.exe -cancel


### PR DESCRIPTION
## Description

Currently, the extension driver (netebpfext) already populates HKLM. But the user mode reads from HKCU (which is populated by executing `export_program_info.exe`. This all works normally, but if the user mode app is running as a LocalSystem service, it is not able to read HKCU ebpf store, and program load fails. 

This PR makes changes in `api_common` to first read the eBPF store from HKLM and then from HKCU. This allows user mode app running as localsystem to be able to load programs.

## Testing

Updated kernel CICD test scripts to _not_ call `export_program_info.exe`, so that user mode ends up reading the store values from HKLM path.

## Documentation

No.
