### PR TITLE
Enable scorecards to run in merge queue

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -127,6 +127,7 @@ jobs:
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
 
     - name: Create generated artifact folder
+      if: (steps.skip_check.outputs.should_skip != 'true')
       run: |
         mkdir ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\Artifacts
 

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -5,11 +5,11 @@ name: Scorecards
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, 'gh-readonly-queue/main/**' ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, 'gh-readonly-queue/main/**' ]
   merge_group:
-    branches: [ main ]
+    branches: [ main, 'gh-readonly-queue/main/**' ]
 
 concurrency:
   # Cancel any Scorecards workflow currently in progress for the same PR.


### PR DESCRIPTION
## Description

More of issue #2076.  Without this, the scorecards workflow doesn't run on queued merge requests.

Also fixes #2116

## Testing

In CI/CD, since this only affects github CICD.

## Documentation

No impact
