### PR TITLE
Skip scorecard steps in merge queue

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -37,11 +37,13 @@ jobs:
           egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
       - name: "Checkout code"
+        if: github.ref_name == 'main'
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           persist-credentials: false
 
       - name: "Run analysis"
+        if: github.ref_name == 'main'
         uses: ossf/scorecard-action@b614d455ee90608b5e36e3299cd50d457eb37d5f # Don't update this until they fix PR support
         with:
           results_file: results.sarif
@@ -57,6 +59,7 @@ jobs:
 
       # Upload the results as artifacts (optional).
       - name: "Upload artifact"
+        if: github.ref_name == 'main'
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
         with:
           name: SARIF file
@@ -65,6 +68,7 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
+        if: github.ref_name == 'main'
         uses: github/codeql-action/upload-sarif@17573ee1cc1b9d061760f3a006fc4aac4f944fd5
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Description

The scorecard step is not currently supported in the merge queue itself as documented in the github action (see #2118).  So make the scorecards workflow run and simply report success so that CI/CD runs in the merge queue don't fail as a result.

Fixes #2118

## Testing

CI/CD.  Issue #2118 references an example of a failure in CI/CD that this should fix.

## Documentation

No impact.
