### PR TITLE
_initialize_ebpf_object_native: only clean up locally-created objects

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1674,7 +1674,9 @@ _initialize_ebpf_object_native(
 
 Exit:
     if (result != EBPF_SUCCESS) {
-        _clean_up_ebpf_object(&object);
+        clean_up_ebpf_programs(object.programs);
+        clean_up_ebpf_maps(object.maps);
+        object.native_module_fd = ebpf_fd_invalid;
     }
     EBPF_RETURN_RESULT(result);
 }


### PR DESCRIPTION
## Description

`_initialize_ebpf_object_native` calls `_clean_up_ebpf_object` in its failure path, which releases all resources in the object. This leads to all kinds of errors, including double frees of memory and closures of OS handles.

This usage of `_clean_up_ebpf_object` is unlike the other `_initialize_ebpf_object*` routines, which release only locally-created resources. Fix this misbehavior by aligning with the clean-up-what-you-created pattern.

Resolves #2122 

## Testing

Tested in XDP stress test, plus any coverage in eBPF CI/CD.

## Documentation

N/A.
