### PR TITLE
Set github workflow egress-policy to block

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -354,7 +354,10 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@c8454efe5d0bdefd25384362fe217428ca277d57 # v2.2.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
 
       - id: skip_check
         uses: fkirc/skip-duplicate-actions@12aca0a884f6137d619d6a8a09fcc3406ced5281 # v5.3.0

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -34,7 +34,13 @@ jobs:
       - name: Harden Runner
         uses: step-security/harden-runner@c8454efe5d0bdefd25384362fe217428ca277d57 # v2.2.0
         with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            bestpractices.coreinfrastructure.org:443
+            github.com:443
 
       - name: "Checkout code"
         if: github.ref_name == 'main'

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -32,7 +32,10 @@ jobs:
     - name: Harden Runner
       uses: step-security/harden-runner@c8454efe5d0bdefd25384362fe217428ca277d57
       with:
-        egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+        egress-policy: block
+        allowed-endpoints: >
+          azure.archive.ubuntu.com:80
+          github.com:443
 
     - name: Install doxygen
       run: |


### PR DESCRIPTION
## Description

Block CICD workflow access to Internet endpoints other than those explicitly allowed, to harden workflows.
Changes come from the step-security recommendations based on the previous logging enabled:
* reusable-test.yml: https://app.stepsecurity.io/github/microsoft/ebpf-for-windows/actions/runs/4276930416
* scorecards-analysis.yml: https://app.stepsecurity.io/github/microsoft/ebpf-for-windows/actions/runs/4272794709
* update-docs.yml: https://app.stepsecurity.io/github/microsoft/ebpf-for-windows/actions/runs/4265294976 

See
https://github.com/step-security/harden-runner#restrict-egress-traffic-to-allowed-endpoints for docs on egress-policy.

Fixes #2142

## Testing

CI/CD

## Documentation

No impact.
