### PR TITLE
Sync msi's libbpf directory tree to nuget

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -28,7 +28,8 @@ The following must be installed in order to build this project:
    - `"MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs (latest)"`
 
 1. [Visual Studio Build Tools 2022](https://aka.ms/vs/17/release/vs_buildtools.exe) (version **17.4.2 or later**).
-1. The *WiX Toolset* has a dependency on the **.NET 3.5 Framework**: you can either enable from the Start menu -> "*Turn Windows features on or off*" and then select "*.NET Framework 3.5 (includes .NET 2.0 and 3.0)*" (recommended), *or*
+1. [The WiX Toolset v3.11.2 build tools](https://github.com/wixtoolset/wix3/releases)
+    > Note: The *WiX Toolset* has a dependency on the **.NET 3.5 Framework**: you can either enable from the Start menu -> "*Turn Windows features on or off*" and then select "*.NET Framework 3.5 (includes .NET 2.0 and 3.0)*" (recommended), *or*
 install it directly from [here](https://www.microsoft.com/en-us/download/details.aspx?id=21).
 1. [WiX Toolset v3 - Visual Studio 2022 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2022Extension).
 1. [SDK for Windows 11, version 22H2](https://go.microsoft.com/fwlink/p/?linkid=2196241) (version **10.0.22621.x**).

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -7,6 +7,7 @@ Note: Currently releases are not production signed.
 
 1. Update the version number, making sure to follow [Semantic Versioning 2.0](https://semver.org), in the following files:
     * resource\ebpf_version.h
+    * installer\Product.wxs (in the XML attribute `<Wix... <Product... Version="x.y.z" ...>...>`)
     * docs\tutorial.md
 2. Regenerate the expected bpf2c output:
     ``` .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\```

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -59,10 +59,6 @@ SPDX-License-Identifier: MIT
 				<ComponentGroupRef Id="eBPF_Development_include_libbpf_include_uapi" />
 				<ComponentGroupRef Id="eBPF_Development_include_libbpf_include_uapi_linux" />
 				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src" />
-				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src_kernel" />
-				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src_kernel_bpf" />
-				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src_skeleton" />
-				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src_windows" />
 				<ComponentGroupRef Id="eBPF_Development_include_linux" />
 				<ComponentGroupRef Id="eBPF_Development_include_net" />
 				<ComponentGroupRef Id="eBPF_Development_include_uapi" />
@@ -155,13 +151,7 @@ SPDX-License-Identifier: MIT
 									<Directory Id="dir_include_libbpf_include_uapi_linux" Name="linux" />
 								</Directory>
 							</Directory>
-							<Directory Id="dir_include_libbpf_src" Name="src">
-								<Directory Id="dir_include_libbpf_src_kernel" Name="kernel">
-									<Directory Id="dir_include_libbpf_src_kernel_bpf" Name="bpf" />
-								</Directory>
-								<Directory Id="dir_include_libbpf_src_skeleton" Name="skeleton" />
-								<Directory Id="dir_include_libbpf_src_windows" Name="windows" />
-							</Directory>
+							<Directory Id="dir_include_libbpf_src" Name="src" />
 						</Directory>
 						<Directory Id="dir_include_linux" Name="linux" />
 						<Directory Id="dir_include_net" Name="net" />
@@ -394,7 +384,7 @@ SPDX-License-Identifier: MIT
 				<File Id="GIT_COMMIT_ID.H" Name="git_commit_id.h" Source="$(var.SolutionDir)include\git_commit_id.h" />
 			</Component>
 			<Component Id="EBPF_BASE.H" DiskId="1" Guid="{FC47A44E-7747-4E98-AD55-09D9671C01C1}">
-				<File Id="EBPF_BASE.H" Name="git_commit_id.h" Source="$(var.SolutionDir)external\ebpf-verifier\src\ebpf_base.h" />
+				<File Id="EBPF_BASE.H" Name="ebpf_base.h" Source="$(var.SolutionDir)external\ebpf-verifier\src\ebpf_base.h" />
 			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="eBPF_Development_include_asm" Directory="dir_include_asm">
@@ -517,36 +507,65 @@ SPDX-License-Identifier: MIT
 			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="eBPF_Development_include_libbpf_src" Directory="dir_include_libbpf_src">
-			<Component Id="CFG.H" DiskId="1" Guid="{EC69B227-F8C9-4178-AEFB-8744A1C08D7F}">
-				<File Id="CFG.H" Name="cfg.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\cfg.h" />
+			<Component Id="BPF_1.H" DiskId="1" Guid="{F08F4178-620F-4919-8F97-0A988EE22E6A}">
+				<File Id="BPF_1.H" Name="bpf.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\bpf.h" />
 			</Component>
-			<Component Id="JSON_WRITER.H" DiskId="1" Guid="{1475A491-ADEB-468C-8B3D-4EF2FA70C859}">
-				<File Id="JSON_WRITER.H" Name="json_writer.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\json_writer.h" />
+			<Component Id="BPF_CORE_READ.H" DiskId="1" Guid="{421BC497-8EB2-460C-ACC0-39510D66C8B1}">
+				<File Id="BPF_CORE_READ.H" Name="bpf_core_read.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\bpf_core_read.h" />
 			</Component>
-			<Component Id="MAIN.H" DiskId="1" Guid="{403E5308-CCEA-47BC-A310-AB94C2600FC3}">
-				<File Id="MAIN.H" Name="main.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\main.h" />
+			<Component Id="BPF_ENDIAN_1.H" DiskId="1" Guid="{2C17136B-4451-4412-9764-E903B8AC1F06}">
+				<File Id="BPF_ENDIAN_1.H" Name="bpf_endian.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\bpf_endian.h" />
 			</Component>
-			<Component Id="NETLINK_DUMPER.H" DiskId="1" Guid="{463A308F-02FA-4D6A-9E61-D1493CD32D45}">
-				<File Id="NETLINK_DUMPER.H" Name="netlink_dumper.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\netlink_dumper.h" />
+			<Component Id="BPF_GEN_INTERNAL.H" DiskId="1" Guid="{C0F686E9-F086-41FD-9D3D-E23B84B942F9}">
+				<File Id="BPF_GEN_INTERNAL.H" Name="bpf_gen_internal.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\bpf_gen_internal.h" />
 			</Component>
-			<Component Id="XLATED_DUMPER.H" DiskId="1" Guid="{EF8C3AB4-76BD-4C18-9F8E-8F7DCC2E9841}">
-				<File Id="XLATED_DUMPER.H" Name="xlated_dumper.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\xlated_dumper.h" />
+			<Component Id="BPF_HELPERS_1.H" DiskId="1" Guid="{FF2CDD1A-BB03-4580-AC2B-5EC477E32ACE}">
+				<File Id="BPF_HELPERS_1.H" Name="bpf_helpers.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\bpf_helpers.h" />
 			</Component>
-		</ComponentGroup>
-		<ComponentGroup Id="eBPF_Development_include_libbpf_src_kernel" Directory="dir_include_libbpf_src_kernel" />
-		<ComponentGroup Id="eBPF_Development_include_libbpf_src_kernel_bpf" Directory="dir_include_libbpf_src_kernel_bpf">
-			<Component Id="DISASM.H" DiskId="1" Guid="{5ABA3B9C-8F62-4009-B6DC-710327011BD3}">
-				<File Id="DISASM.H" Name="disasm.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\kernel\bpf\disasm.h" />
+			<Component Id="BPF_HELPER_DEFS_1.H" DiskId="1" Guid="{9FD016D9-D5D3-4A11-BAC7-64BD68F1F61C}">
+				<File Id="BPF_HELPER_DEFS_1.H" Name="bpf_helper_defs.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\bpf_helper_defs.h" />
 			</Component>
-		</ComponentGroup>
-		<ComponentGroup Id="eBPF_Development_include_libbpf_src_skeleton" Directory="dir_include_libbpf_src_skeleton">
-			<Component Id="PID_ITER.H" DiskId="1" Guid="{2F0497D2-9D2A-4788-B188-DA27CDA94D98}">
-				<File Id="PID_ITER.H" Name="pid_iter.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\skeleton\pid_iter.h" />
+			<Component Id="BPF_TRACING.H" DiskId="1" Guid="{DD88A4DF-C36D-4D48-B191-9C2E3C8768E8}">
+				<File Id="BPF_TRACING.H" Name="bpf_tracing.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\bpf_tracing.h" />
 			</Component>
-		</ComponentGroup>
-		<ComponentGroup Id="eBPF_Development_include_libbpf_src_windows" Directory="dir_include_libbpf_src_windows">
-			<Component Id="PLATFORM.H" DiskId="1" Guid="{594B90B0-BFF4-470A-B706-EA76CEC6F4DA}">
-				<File Id="PLATFORM.H" Name="platform.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\windows\platform.h" />
+			<Component Id="BTF_1.H" DiskId="1" Guid="{1D54C166-3E43-41A0-ABAC-941237C12A7E}">
+				<File Id="BTF_1.H" Name="btf.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\btf.h" />
+			</Component>
+			<Component Id="HASHMAP_1.H" DiskId="1" Guid="{C51AD9E3-9DF4-483B-844F-05B5F723330C}">
+				<File Id="HASHMAP_1.H" Name="hashmap.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\hashmap.h" />
+			</Component>
+			<Component Id="LIBBPF_1.H" DiskId="1" Guid="{77100F8C-A601-45B8-AD07-3C2B0F31FCF4}">
+				<File Id="LIBBPF_1.H" Name="libbpf.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\libbpf.h" />
+			</Component>
+			<Component Id="LIBBPF_COMMON.H" DiskId="1" Guid="{46E4A472-4975-40F4-B825-1C26D5D71A15}">
+				<File Id="LIBBPF_COMMON.H" Name="libbpf_common.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\libbpf_common.h" />
+			</Component>
+			<Component Id="LIBBPF_INTERNAL.H" DiskId="1" Guid="{EE258EDC-DDF9-44DB-92D1-93D33B45CF4D}">
+				<File Id="LIBBPF_INTERNAL.H" Name="libbpf_internal.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\libbpf_internal.h" />
+			</Component>
+			<Component Id="LIBBPF_LEGACY_1.H" DiskId="1" Guid="{4C687F08-30C6-4298-9632-2CD91566669B}">
+				<File Id="LIBBPF_LEGACY_1.H" Name="libbpf_legacy.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\libbpf_legacy.h" />
+			</Component>
+			<Component Id="LIBBPF_VERSION.H" DiskId="1" Guid="{763C6514-9295-436B-87DF-54789F444685}">
+				<File Id="LIBBPF_VERSION.H" Name="libbpf_version.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\libbpf_version.h" />
+			</Component>
+			<Component Id="NLATTR.H" DiskId="1" Guid="{1624501C-4523-4E99-A594-274FDE8C1128}">
+				<File Id="NLATTR.H" Name="nlattr.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\nlattr.h" />
+			</Component>
+			<Component Id="RELO_CORE.H" DiskId="1" Guid="{B911127B-3702-49F2-A97F-15268F905EE3}">
+				<File Id="RELO_CORE.H" Name="relo_core.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\relo_core.h" />
+			</Component>
+			<Component Id="SKEL_INTERNAL.H" DiskId="1" Guid="{674B4B4C-968B-4593-948D-4BD623EC4E13}">
+				<File Id="SKEL_INTERNAL.H" Name="skel_internal.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\skel_internal.h" />
+			</Component>
+			<Component Id="STRSET.H" DiskId="1" Guid="{00A310E8-6886-4C45-8BEA-F5121B2AAD0A}">
+				<File Id="STRSET.H" Name="strset.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\strset.h" />
+			</Component>
+			<Component Id="STR_ERROR.H" DiskId="1" Guid="{E9AC241C-5A14-4C3B-96F4-AB79211DB9F4}">
+				<File Id="STR_ERROR.H" Name="str_error.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\str_error.h" />
+			</Component>
+			<Component Id="USDT.BPF.H" DiskId="1" Guid="{7E29208F-3B05-4F1E-A425-1BD8759CD659}">
+				<File Id="USDT.BPF.H" Name="usdt.bpf.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\src\usdt.bpf.h" />
 			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="eBPF_Development_include_uapi_linux" Directory="dir_include_uapi_linux">

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -594,9 +594,6 @@ SPDX-License-Identifier: MIT
 			<Component Id="eBPFApi_lib" Guid="{A164197B-3C57-4ECA-B138-CBF558DA4401}">
 				<File Id="EbpfApi.lib" Name="EbpfApi.lib" DiskId="1" Source="$(var.api.TargetDir)EbpfApi.lib" />
 			</Component>
-			<Component Id="eBPFApi_lib_pdb" Guid="{197589BB-4A27-4313-9A70-BB455A58C987}">
-				<File Id="eBPFApi_lib.pdb" Name="EbpfApi.pdb" DiskId="1" Source="$(var.api.TargetDir)EbpfApi.pdb" />
-			</Component>
 		</ComponentGroup>
 	</Fragment>
 

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -53,10 +53,16 @@ SPDX-License-Identifier: MIT
 				<ComponentGroupRef Id="eBPF_Development_include_bpf" />
 				<ComponentGroupRef Id="eBPF_Development_include_kernel" />
 				<ComponentGroupRef Id="eBPF_Development_include_libbpf" />
-				<ComponentGroupRef Id="eBPF_Development_include_libbpf_asm" />
-				<ComponentGroupRef Id="eBPF_Development_include_libbpf_linux" />
-				<ComponentGroupRef Id="eBPF_Development_include_libbpf_uapi" />
-				<ComponentGroupRef Id="eBPF_Development_include_libbpf_uapi_linux" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_include" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_include_asm" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_include_linux" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_include_uapi" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_include_uapi_linux" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src_kernel" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src_kernel_bpf" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src_skeleton" />
+				<ComponentGroupRef Id="eBPF_Development_include_libbpf_src_windows" />
 				<ComponentGroupRef Id="eBPF_Development_include_linux" />
 				<ComponentGroupRef Id="eBPF_Development_include_net" />
 				<ComponentGroupRef Id="eBPF_Development_include_uapi" />
@@ -142,10 +148,19 @@ SPDX-License-Identifier: MIT
 						<Directory Id="dir_include_bpf" Name="bpf" />
 						<Directory Id="dir_include_kernel" Name="kernel" />
 						<Directory Id="dir_include_libbpf" Name="libbpf">
-							<Directory Id="dir_include_libbpf_asm" Name="asm" />
-							<Directory Id="dir_include_libbpf_linux" Name="linux" />
-							<Directory Id="dir_include_libbpf_uapi" Name="uapi">
-								<Directory Id="dir_include_libbpf_uapi_linux" Name="linux" />
+							<Directory Id="dir_include_libbpf_include" Name="include">
+								<Directory Id="dir_include_libbpf_include_asm" Name="asm" />
+								<Directory Id="dir_include_libbpf_include_linux" Name="linux" />
+								<Directory Id="dir_include_libbpf_include_uapi" Name="uapi">
+									<Directory Id="dir_include_libbpf_include_uapi_linux" Name="linux" />
+								</Directory>
+							</Directory>
+							<Directory Id="dir_include_libbpf_src" Name="src">
+								<Directory Id="dir_include_libbpf_src_kernel" Name="kernel">
+									<Directory Id="dir_include_libbpf_src_kernel_bpf" Name="bpf" />
+								</Directory>
+								<Directory Id="dir_include_libbpf_src_skeleton" Name="skeleton" />
+								<Directory Id="dir_include_libbpf_src_windows" Name="windows" />
 							</Directory>
 						</Directory>
 						<Directory Id="dir_include_linux" Name="linux" />
@@ -378,6 +393,9 @@ SPDX-License-Identifier: MIT
 			<Component Id="GIT_COMMIT_ID.H" DiskId="1" Guid="{0AB71C9D-68E6-4892-A45D-306BA921CC07}">
 				<File Id="GIT_COMMIT_ID.H" Name="git_commit_id.h" Source="$(var.SolutionDir)include\git_commit_id.h" />
 			</Component>
+			<Component Id="EBPF_BASE.H" DiskId="1" Guid="{FC47A44E-7747-4E98-AD55-09D9671C01C1}">
+				<File Id="EBPF_BASE.H" Name="git_commit_id.h" Source="$(var.SolutionDir)external\ebpf-verifier\src\ebpf_base.h" />
+			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="eBPF_Development_include_asm" Directory="dir_include_asm">
 			<Component Id="ERRNO.H" DiskId="1" Guid="{DF63C9C1-FA9C-44E3-94EB-F77B7072E4BE}">
@@ -436,12 +454,13 @@ SPDX-License-Identifier: MIT
 		</ComponentGroup>
 		<ComponentGroup Id="eBPF_Development_include_uapi" Directory="dir_include_uapi" />
 		<ComponentGroup Id="eBPF_Development_include_libbpf" Directory="dir_include_libbpf" />
-		<ComponentGroup Id="eBPF_Development_include_libbpf_asm" Directory="dir_include_libbpf_asm">
-			<Component Id="BARRIER.H" DiskId="1" Guid="{BE2698A4-4865-4F24-BA81-9A23555D99F4}">
+		<ComponentGroup Id="eBPF_Development_include_libbpf_include" Directory="dir_include_libbpf_include" />
+		<ComponentGroup Id="eBPF_Development_include_libbpf_include_asm" Directory="dir_include_libbpf_include_asm">
+			<Component Id="BARRIER.H" DiskId="1" Guid="{999F024F-ECC5-4CD1-AAAA-39E185AFAB08}">
 				<File Id="BARRIER.H" Name="barrier.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\include\asm\barrier.h" />
 			</Component>
 		</ComponentGroup>
-		<ComponentGroup Id="eBPF_Development_include_libbpf_linux" Directory="dir_include_libbpf_linux">
+		<ComponentGroup Id="eBPF_Development_include_libbpf_include_linux" Directory="dir_include_libbpf_include_linux">
 			<Component Id="COMPILER.H" DiskId="1" Guid="{417DA64B-E685-4EF6-8D96-18E9A41B003F}">
 				<File Id="COMPILER.H" Name="compiler.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\include\linux\compiler.h" />
 			</Component>
@@ -467,8 +486,8 @@ SPDX-License-Identifier: MIT
 				<File Id="TYPES_1.H" Name="types.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\include\linux\types.h" />
 			</Component>
 		</ComponentGroup>
-		<ComponentGroup Id="eBPF_Development_include_libbpf_uapi" Directory="dir_include_libbpf_uapi"/>
-		<ComponentGroup Id="eBPF_Development_include_libbpf_uapi_linux" Directory="dir_include_libbpf_uapi_linux">
+		<ComponentGroup Id="eBPF_Development_include_libbpf_include_uapi" Directory="dir_include_libbpf_include_uapi" />
+		<ComponentGroup Id="eBPF_Development_include_libbpf_include_uapi_linux" Directory="dir_include_libbpf_include_uapi_linux">
 			<Component Id="BPF.H_3" DiskId="1" Guid="{CBACC6D2-C5DC-4F47-9A10-873CFCE5900C}">
 				<File Id="BPF.H_3" Name="bpf.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\include\uapi\linux\bpf.h" />
 			</Component>
@@ -495,6 +514,39 @@ SPDX-License-Identifier: MIT
 			</Component>
 			<Component Id="PKT_SCHED.H" DiskId="1" Guid="{CC3A71B7-7E14-4AF1-9F29-980E72C19A26}">
 				<File Id="PKT_SCHED.H" Name="pkt_sched.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\libbpf\include\uapi\linux\pkt_sched.h" />
+			</Component>
+		</ComponentGroup>
+		<ComponentGroup Id="eBPF_Development_include_libbpf_src" Directory="dir_include_libbpf_src">
+			<Component Id="CFG.H" DiskId="1" Guid="{EC69B227-F8C9-4178-AEFB-8744A1C08D7F}">
+				<File Id="CFG.H" Name="cfg.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\cfg.h" />
+			</Component>
+			<Component Id="JSON_WRITER.H" DiskId="1" Guid="{1475A491-ADEB-468C-8B3D-4EF2FA70C859}">
+				<File Id="JSON_WRITER.H" Name="json_writer.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\json_writer.h" />
+			</Component>
+			<Component Id="MAIN.H" DiskId="1" Guid="{403E5308-CCEA-47BC-A310-AB94C2600FC3}">
+				<File Id="MAIN.H" Name="main.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\main.h" />
+			</Component>
+			<Component Id="NETLINK_DUMPER.H" DiskId="1" Guid="{463A308F-02FA-4D6A-9E61-D1493CD32D45}">
+				<File Id="NETLINK_DUMPER.H" Name="netlink_dumper.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\netlink_dumper.h" />
+			</Component>
+			<Component Id="XLATED_DUMPER.H" DiskId="1" Guid="{EF8C3AB4-76BD-4C18-9F8E-8F7DCC2E9841}">
+				<File Id="XLATED_DUMPER.H" Name="xlated_dumper.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\xlated_dumper.h" />
+			</Component>
+		</ComponentGroup>
+		<ComponentGroup Id="eBPF_Development_include_libbpf_src_kernel" Directory="dir_include_libbpf_src_kernel" />
+		<ComponentGroup Id="eBPF_Development_include_libbpf_src_kernel_bpf" Directory="dir_include_libbpf_src_kernel_bpf">
+			<Component Id="DISASM.H" DiskId="1" Guid="{5ABA3B9C-8F62-4009-B6DC-710327011BD3}">
+				<File Id="DISASM.H" Name="disasm.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\kernel\bpf\disasm.h" />
+			</Component>
+		</ComponentGroup>
+		<ComponentGroup Id="eBPF_Development_include_libbpf_src_skeleton" Directory="dir_include_libbpf_src_skeleton">
+			<Component Id="PID_ITER.H" DiskId="1" Guid="{2F0497D2-9D2A-4788-B188-DA27CDA94D98}">
+				<File Id="PID_ITER.H" Name="pid_iter.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\skeleton\pid_iter.h" />
+			</Component>
+		</ComponentGroup>
+		<ComponentGroup Id="eBPF_Development_include_libbpf_src_windows" Directory="dir_include_libbpf_src_windows">
+			<Component Id="PLATFORM.H" DiskId="1" Guid="{594B90B0-BFF4-470A-B706-EA76CEC6F4DA}">
+				<File Id="PLATFORM.H" Name="platform.h" KeyPath="yes" Source="$(var.SolutionDir)external\bpftool\src\windows\platform.h" />
 			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="eBPF_Development_include_uapi_linux" Directory="dir_include_uapi_linux">


### PR DESCRIPTION
Closes #2065
Closes #2160 

## Description

This PR syncs the MSI's directory tree for `/include/libbpf` to the one in the nuget package:

- Moves `/include/libbpf/*` to `/include/libbpf/include/*`.
- Adds `/include/libbpf/src/*`.

## Testing

CI/CD, local install.

## Documentation

- GettingStarted.md
- ReleaseProcess.md
