### PR TITLE
Add a connection reauth test in sock_add tests

### DIFF
--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -188,7 +188,7 @@ _fwp_engine::test_cgroup_inet6_recv_accept(_In_ fwp_classify_parameters_t* param
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->reauthorization_flage;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->reauthorization_flag;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value);

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -166,7 +166,7 @@ _fwp_engine::test_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* param
         const_cast<FWP_BYTE_BLOB*>(&parameters->app_id);
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_USER_ID].value.byteBlob =
         const_cast<FWP_BYTE_BLOB*>(&parameters->user_id);
-    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->reauth_flag;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->flag_reauthorize;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -188,7 +188,7 @@ _fwp_engine::test_cgroup_inet6_recv_accept(_In_ fwp_classify_parameters_t* param
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->reauth_flag;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->flag_reauthorize;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -287,7 +287,7 @@ _fwp_engine::test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_ALE_USER_ID].value.byteBlob = &parameters->user_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
-    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->reauth_flag;
+    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->flag_reauthorize;
 
     action = test_callout(
         FWPS_LAYER_ALE_AUTH_CONNECT_V4, FWPM_LAYER_ALE_AUTH_CONNECT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value2);
@@ -356,7 +356,7 @@ _fwp_engine::test_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
-    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->reauth_flag;
+    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->flag_reauthorize;
     
     action = test_callout(
         FWPS_LAYER_ALE_AUTH_CONNECT_V6, FWPM_LAYER_ALE_AUTH_CONNECT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value2);

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -166,6 +166,7 @@ _fwp_engine::test_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* param
         const_cast<FWP_BYTE_BLOB*>(&parameters->app_id);
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_USER_ID].value.byteBlob =
         const_cast<FWP_BYTE_BLOB*>(&parameters->user_id);
+        incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_FLAGS].value.uint32=  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -187,6 +188,7 @@ _fwp_engine::test_cgroup_inet6_recv_accept(_In_ fwp_classify_parameters_t* param
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_FLAGS].value.uint32=  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -264,6 +266,7 @@ _fwp_engine::test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_ALE_USER_ID].value.byteBlob = &parameters->user_id;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_FLAGS].value.uint32=  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     action = test_callout(
         FWPS_LAYER_ALE_CONNECT_REDIRECT_V4, FWPM_LAYER_ALE_CONNECT_REDIRECT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -328,6 +331,7 @@ _fwp_engine::test_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
+    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_FLAGS].value.uint32=  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     action = test_callout(
         FWPS_LAYER_ALE_CONNECT_REDIRECT_V6,

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -166,7 +166,7 @@ _fwp_engine::test_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* param
         const_cast<FWP_BYTE_BLOB*>(&parameters->app_id);
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_USER_ID].value.byteBlob =
         const_cast<FWP_BYTE_BLOB*>(&parameters->user_id);
-        incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->reauth_flag;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -188,7 +188,7 @@ _fwp_engine::test_cgroup_inet6_recv_accept(_In_ fwp_classify_parameters_t* param
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->reauth_flag;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -266,7 +266,6 @@ _fwp_engine::test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     action = test_callout(
         FWPS_LAYER_ALE_CONNECT_REDIRECT_V4, FWPM_LAYER_ALE_CONNECT_REDIRECT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -288,6 +287,7 @@ _fwp_engine::test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_ALE_USER_ID].value.byteBlob = &parameters->user_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
+    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->reauth_flag;
 
     action = test_callout(
         FWPS_LAYER_ALE_AUTH_CONNECT_V4, FWPM_LAYER_ALE_AUTH_CONNECT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value2);
@@ -331,7 +331,6 @@ _fwp_engine::test_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     action = test_callout(
         FWPS_LAYER_ALE_CONNECT_REDIRECT_V6,
@@ -357,7 +356,8 @@ _fwp_engine::test_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
-
+    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->reauth_flag;
+    
     action = test_callout(
         FWPS_LAYER_ALE_AUTH_CONNECT_V6, FWPM_LAYER_ALE_AUTH_CONNECT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value2);
 

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -166,7 +166,7 @@ _fwp_engine::test_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* param
         const_cast<FWP_BYTE_BLOB*>(&parameters->app_id);
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_USER_ID].value.byteBlob =
         const_cast<FWP_BYTE_BLOB*>(&parameters->user_id);
-    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->flag_reauthorize;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->reauthorization_flag;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -188,7 +188,7 @@ _fwp_engine::test_cgroup_inet6_recv_accept(_In_ fwp_classify_parameters_t* param
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->flag_reauthorize;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->reauthorization_flage;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -287,7 +287,7 @@ _fwp_engine::test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_ALE_USER_ID].value.byteBlob = &parameters->user_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
-    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->flag_reauthorize;
+    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 = parameters->reauthorization_flag;
 
     action = test_callout(
         FWPS_LAYER_ALE_AUTH_CONNECT_V4, FWPM_LAYER_ALE_AUTH_CONNECT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value2);
@@ -356,7 +356,7 @@ _fwp_engine::test_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
     incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
-    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->flag_reauthorize;
+    incoming_value2[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 = parameters->reauthorization_flag;
     
     action = test_callout(
         FWPS_LAYER_ALE_AUTH_CONNECT_V6, FWPM_LAYER_ALE_AUTH_CONNECT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value2);

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -166,7 +166,7 @@ _fwp_engine::test_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* param
         const_cast<FWP_BYTE_BLOB*>(&parameters->app_id);
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_USER_ID].value.byteBlob =
         const_cast<FWP_BYTE_BLOB*>(&parameters->user_id);
-        incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_FLAGS].value.uint32=  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+        incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -166,7 +166,7 @@ _fwp_engine::test_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* param
         const_cast<FWP_BYTE_BLOB*>(&parameters->app_id);
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V4_ALE_USER_ID].value.byteBlob =
         const_cast<FWP_BYTE_BLOB*>(&parameters->user_id);
-        incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+        incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V4, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -188,7 +188,7 @@ _fwp_engine::test_cgroup_inet6_recv_accept(_In_ fwp_classify_parameters_t* param
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_IP_LOCAL_INTERFACE].value.uint64 = &parameters->interface_luid;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_AUTH_RECV_ACCEPT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_FLAGS].value.uint32=  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     return test_callout(
         FWPS_LAYER_ALE_AUTH_RECV_ACCEPT_V6, FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -266,7 +266,7 @@ _fwp_engine::test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V4_FLAGS].value.uint32=  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V4_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     action = test_callout(
         FWPS_LAYER_ALE_CONNECT_REDIRECT_V4, FWPM_LAYER_ALE_CONNECT_REDIRECT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
@@ -331,7 +331,7 @@ _fwp_engine::test_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameter
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_COMPARTMENT_ID].value.uint32 = parameters->compartment_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_ALE_APP_ID].value.byteBlob = &parameters->app_id;
     incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_ALE_USER_ID].value.byteBlob = &parameters->user_id;
-    incoming_value[FWPS_FIELD_ALE_CONNECT_REDIRECT_V6_FLAGS].value.uint32=  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    incoming_value[FWPS_FIELD_ALE_AUTH_CONNECT_V6_FLAGS].value.uint32 =  FWP_CONDITION_FLAG_IS_REAUTHORIZE;
 
     action = test_callout(
         FWPS_LAYER_ALE_CONNECT_REDIRECT_V6,

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -25,6 +25,7 @@ typedef struct _fwp_classify_parameters
     uint64_t interface_luid;
     TOKEN_ACCESS_INFORMATION token_access_information;
     FWP_BYTE_BLOB user_id;
+    uint32_t reauth_flag;
 } fwp_classify_parameters_t;
 
 typedef class _fwp_engine

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -25,7 +25,7 @@ typedef struct _fwp_classify_parameters
     uint64_t interface_luid;
     TOKEN_ACCESS_INFORMATION token_access_information;
     FWP_BYTE_BLOB user_id;
-    uint32_t reauth_flag;
+    uint32_t flag_reauthorize;
 } fwp_classify_parameters_t;
 
 typedef class _fwp_engine

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -25,7 +25,7 @@ typedef struct _fwp_classify_parameters
     uint64_t interface_luid;
     TOKEN_ACCESS_INFORMATION token_access_information;
     FWP_BYTE_BLOB user_id;
-    uint32_t flag_reauthorize;
+    uint32_t reauthorization_flag;
 } fwp_classify_parameters_t;
 
 typedef class _fwp_engine

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -467,7 +467,7 @@ TEST_CASE("sock_addr_invoke", "[netebpfext]")
     result = helper.test_cgroup_inet6_connect(&parameters);
     REQUIRE(result == FWP_ACTION_BLOCK);
 
-    // Test reauth flags.
+    // Test reauth flag.
     // Classify operations that should be allowed.
     client_context.sock_addr_action = SOCK_ADDR_TEST_ACTION_PERMIT;
     client_context.validate_sock_addr_entries = true;

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -468,46 +468,13 @@ TEST_CASE("sock_addr_invoke", "[netebpfext]")
     REQUIRE(result == FWP_ACTION_BLOCK);
 
     // Test reauth flags.
-    //  Classify operations that should be allowed.
+    // Classify operations that should be allowed.
     client_context.sock_addr_action = SOCK_ADDR_TEST_ACTION_PERMIT;
     client_context.validate_sock_addr_entries = true;
     
     parameters.reauth_flag = FWP_CONDITION_FLAG_IS_REAUTHORIZE;
     
     result = helper.test_cgroup_inet4_recv_accept(&parameters);
-    REQUIRE(result == FWP_ACTION_PERMIT);
-
-    result = helper.test_cgroup_inet6_recv_accept(&parameters);
-    REQUIRE(result == FWP_ACTION_PERMIT);
-
-    result = helper.test_cgroup_inet4_connect(&parameters);
-    REQUIRE(result == FWP_ACTION_PERMIT);
-
-    result = helper.test_cgroup_inet6_connect(&parameters);
-    REQUIRE(result == FWP_ACTION_PERMIT);
-
-}
-
-
-TEST_CASE("reauth_invoke", "[netebpfext]")
-{
-    ebpf_extension_data_t npi_specific_characteristics = {};
-    test_sock_addr_client_context_t client_context = {};
-    fwp_classify_parameters_t parameters = {};
-
-    netebpf_ext_helper_t helper(
-        &npi_specific_characteristics,
-        (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_sock_addr_program,
-        (netebpfext_helper_base_client_context_t*)&client_context);
-
-    netebpfext_initialize_fwp_classify_parameters(&parameters);
-
-    // Classify operations that should be allowed.
-    client_context.sock_addr_action = SOCK_ADDR_TEST_ACTION_PERMIT;
-    client_context.validate_sock_addr_entries = true;
-    parameters.reauth_flag = FWP_CONDITION_FLAG_IS_REAUTHORIZE;
-    FWP_ACTION_TYPE result = helper.test_cgroup_inet4_recv_accept(&parameters);
-    
     REQUIRE(result == FWP_ACTION_PERMIT);
 
     result = helper.test_cgroup_inet6_recv_accept(&parameters);

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -467,7 +467,7 @@ TEST_CASE("sock_addr_invoke", "[netebpfext]")
     result = helper.test_cgroup_inet6_connect(&parameters);
     REQUIRE(result == FWP_ACTION_BLOCK);
 
-    // Test reauth flag.
+    // Test reauthorization flag.
     // Classify operations that should be allowed.
     client_context.sock_addr_action = SOCK_ADDR_TEST_ACTION_PERMIT;
     client_context.validate_sock_addr_entries = true;

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -472,7 +472,7 @@ TEST_CASE("sock_addr_invoke", "[netebpfext]")
     client_context.sock_addr_action = SOCK_ADDR_TEST_ACTION_PERMIT;
     client_context.validate_sock_addr_entries = true;
     
-    parameters.reauth_flag = FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    parameters.flag_reauthorize = FWP_CONDITION_FLAG_IS_REAUTHORIZE;
     
     result = helper.test_cgroup_inet4_recv_accept(&parameters);
     REQUIRE(result == FWP_ACTION_PERMIT);

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -472,7 +472,7 @@ TEST_CASE("sock_addr_invoke", "[netebpfext]")
     client_context.sock_addr_action = SOCK_ADDR_TEST_ACTION_PERMIT;
     client_context.validate_sock_addr_entries = true;
     
-    parameters.flag_reauthorize = FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    parameters.reauthorization_flag = FWP_CONDITION_FLAG_IS_REAUTHORIZE;
     
     result = helper.test_cgroup_inet4_recv_accept(&parameters);
     REQUIRE(result == FWP_ACTION_PERMIT);

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -466,6 +466,58 @@ TEST_CASE("sock_addr_invoke", "[netebpfext]")
 
     result = helper.test_cgroup_inet6_connect(&parameters);
     REQUIRE(result == FWP_ACTION_BLOCK);
+
+    // Test reauth flags.
+    //  Classify operations that should be allowed.
+    client_context.sock_addr_action = SOCK_ADDR_TEST_ACTION_PERMIT;
+    client_context.validate_sock_addr_entries = true;
+    
+    parameters.reauth_flag = FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    
+    result = helper.test_cgroup_inet4_recv_accept(&parameters);
+    REQUIRE(result == FWP_ACTION_PERMIT);
+
+    result = helper.test_cgroup_inet6_recv_accept(&parameters);
+    REQUIRE(result == FWP_ACTION_PERMIT);
+
+    result = helper.test_cgroup_inet4_connect(&parameters);
+    REQUIRE(result == FWP_ACTION_PERMIT);
+
+    result = helper.test_cgroup_inet6_connect(&parameters);
+    REQUIRE(result == FWP_ACTION_PERMIT);
+
+}
+
+
+TEST_CASE("reauth_invoke", "[netebpfext]")
+{
+    ebpf_extension_data_t npi_specific_characteristics = {};
+    test_sock_addr_client_context_t client_context = {};
+    fwp_classify_parameters_t parameters = {};
+
+    netebpf_ext_helper_t helper(
+        &npi_specific_characteristics,
+        (_ebpf_extension_dispatch_function)netebpfext_unit_invoke_sock_addr_program,
+        (netebpfext_helper_base_client_context_t*)&client_context);
+
+    netebpfext_initialize_fwp_classify_parameters(&parameters);
+
+    // Classify operations that should be allowed.
+    client_context.sock_addr_action = SOCK_ADDR_TEST_ACTION_PERMIT;
+    client_context.validate_sock_addr_entries = true;
+    parameters.reauth_flag = FWP_CONDITION_FLAG_IS_REAUTHORIZE;
+    FWP_ACTION_TYPE result = helper.test_cgroup_inet4_recv_accept(&parameters);
+    
+    REQUIRE(result == FWP_ACTION_PERMIT);
+
+    result = helper.test_cgroup_inet6_recv_accept(&parameters);
+    REQUIRE(result == FWP_ACTION_PERMIT);
+
+    result = helper.test_cgroup_inet4_connect(&parameters);
+    REQUIRE(result == FWP_ACTION_PERMIT);
+
+    result = helper.test_cgroup_inet6_connect(&parameters);
+    REQUIRE(result == FWP_ACTION_PERMIT);
 }
 
 void


### PR DESCRIPTION
Closes #2077 
## Description

`FWP_CONDITION_FLAG_IS_REAUTHORIZE` is defined as a parameter for condition to reauthorize a connection. Missing tests for the following APIs:

- [x] test_cgroup_inet6_recv_accept
- [x] test_cgroup_inet4_recv_accept
- [x] test_cgroup_inet6_connect
- [x] test_cgroup_inet4_connect

## Testing
These tests are invoked in `netebpfext_unit.exe`, inside `sock_addr_invoke` API. 
Build the visual studio successfully without any error on local machine.

Loading and running the following tests on the VM to make sure they are passing :
```
PS C:\Debug> .\netebpfext_unit.exe -d yes
Randomness seeded to: 24456912
0.014 s: query program info
0.008 s: classify_packet
0.007 s: xdp_context
0.007 s: bind_invoke
0.009 s: bind_context
0.010 s: sock_addr_invoke
10.017 s: sock_addr_invoke_concurrent1
10.017 s: sock_addr_invoke_concurrent2
10.007 s: sock_addr_invoke_concurrent3
0.004 s: sock_addr_context
0.006 s: sock_ops_invoke
0.004 s: sock_ops_context
===============================================================================
All tests passed (9471384 assertions in 12 test cases)

```

CICD build pipeline is not failing.
