### PR TITLE
libs\platform\user\nmr_impl.cpp should implement complete NMR state machine

### DIFF
--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -442,7 +442,7 @@ test_provider_attach_client(
 };
 
 static NTSTATUS
-test_denied_client_attach_provider(
+test_denied_provider_attach_client(
     HANDLE nmr_binding_handle,
     _Inout_ void* client_context,
     _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance,
@@ -551,7 +551,7 @@ TEST_CASE("extension_test", "[platform]")
             &provider_data,
             &test_provider_dispatch_table,
             &callback_context,
-            (NPI_PROVIDER_ATTACH_CLIENT_FN*)test_denied_client_attach_provider,
+            (NPI_PROVIDER_ATTACH_CLIENT_FN*)test_denied_provider_attach_client,
             (NPI_PROVIDER_DETACH_CLIENT_FN*)test_provider_detach_client,
             nullptr) == EBPF_SUCCESS);
     REQUIRE(test_denied_attach_called == true);

--- a/libs/platform/user/nmr_impl.cpp
+++ b/libs/platform/user/nmr_impl.cpp
@@ -185,6 +185,16 @@ _nmr::bind(_Inout_ client_registration& client, _Inout_ provider_registration& p
 
         // Clean up the binding on a failure.
         if (!NT_SUCCESS(status)) {
+            if (binding_ptr->client_binding_status != binding_status::Ready ||
+                binding_ptr->provider_binding_status != binding_status::Ready) {
+                
+                // Unbind already started.
+                status = STATUS_SUCCESS;
+            }
+
+            status = (binding_ptr->provider_binding_context)
+                     ? binding_ptr->provider.characteristics.ProviderDetachClient(const_cast<void*>(binding_ptr->provider_binding_context))
+                     : STATUS_SUCCESS;
             unbind_complete(*binding_ptr);
         } else {
             std::unique_lock l(lock);


### PR DESCRIPTION
Closes #2048 
## Description

The code in libs\platform\user\nmr_impl.cpp currently misses several possible state transitions that client/provider could make.

Examples are:

If the client fails after calling NmrClientAttachProvider and having it return success.
Should call ProviderDetachClient if ProviderAttachClient succeeds, but client rejects the attach.
