### PR TITLE
Add concurrency stress-testing for loading/unloading native modules.

### DIFF
--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -484,6 +484,122 @@ droppacket_test(ebpf_execution_type_t execution_type)
     bpf_object__close(object);
 }
 
+void
+native_load_unload_thread(
+    std::stop_token token,
+    uint32_t thread_no,
+    _In_ const std::string& file_name,
+    _In_ const std::string& map_name,
+    ebpf_program_type_t prog_type,
+    ebpf_attach_type_t attach_type)
+{
+    uint64_t iteration = 0;
+    printf("native_load_unload_thread[%u] for '%s' started...\n", thread_no, file_name.c_str());
+    while (!token.stop_requested()) {
+
+        const char* error_message = nullptr;
+        bpf_object* object = nullptr;
+        bpf_link* link = nullptr;
+        fd_t program_fd;
+
+        iteration++;
+
+        single_instance_hook_t hook(prog_type, attach_type);
+        program_info_provider_t program_info(prog_type);
+
+        // Load the given program
+        int result = ebpf_program_load(
+            file_name.c_str(), BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, &object, &program_fd, &error_message);
+        if (result != 0) {
+            printf(
+                "native_load_unload_thread[%u/%llu]: ebpf_program_load() failed to load '%s' with error (%i)-'%s'\n",
+                thread_no,
+                iteration,
+                file_name.c_str(),
+                result,
+                error_message ? error_message : "(null)");
+            ebpf_free((void*)error_message);
+        }
+        REQUIRE(result == 0);
+
+        // Once loaded, we do the least amount of activity in order to maximize the jitter
+
+        // Optionally, lookup a key in the given map (as a further test)
+        if (map_name.length() > 0) {
+            uint32_t key = 0;
+            uint64_t value = 0;
+            fd_t program_map_fd = bpf_object__find_map_fd_by_name(object, map_name.c_str());
+            REQUIRE(bpf_map_lookup_elem(program_map_fd, &key, &value) == EBPF_SUCCESS);
+            REQUIRE(value == 0);
+            Platform::_close(program_map_fd);
+        }
+
+        // Attach to the test interface
+        uint32_t if_index = TEST_IFINDEX;
+        REQUIRE(hook.attach_link(program_fd, &if_index, sizeof(if_index), &link) == EBPF_SUCCESS);
+
+        // Close up all
+        hook.detach_link(link);
+        hook.close_link(link);
+        bpf_object__close(object);
+
+        // Temp-debug trace - REMOVE on final PR
+        printf("\nnative_load_unload_thread[%u/%llu] for '%s' complete.\n", thread_no, iteration, file_name.c_str());
+    }
+    printf(
+        "native_load_unload_thread[%u] for '%s' successfully completed with %llu iterations.\n",
+        thread_no,
+        file_name.c_str(),
+        iteration);
+}
+
+TEST_CASE("native_load_unload_concurrent", "[end_to_end]")
+{
+    _test_helper_end_to_end test_helper;
+
+    typedef struct
+    {
+        std::string file_name;
+        std::string map_name;
+        ebpf_program_type_t prog_type;
+        ebpf_attach_type_t attach_type;
+
+    } native_module_data_t;
+    std::vector<native_module_data_t> native_modues{
+        {"droppacket_um.dll", "dropped_packet_map", EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP},
+        {"divide_by_zero_um.dll", "", EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP}};
+    const int CONCURRENT_THREAD_RUN_TIME_IN_SECONDS = 10;
+
+    // Test all the defined native modules (simulated in user mode)
+    for (auto module : native_modues) {
+        std::vector<std::jthread> threads;
+
+        // Attempt to saturate all core threads with contention
+        for (uint32_t i = 0; i < ebpf_get_cpu_count() * 4; i++) {
+            threads.emplace_back(
+                native_load_unload_thread,
+                i,
+                std::ref(module.file_name),
+                std::ref(module.map_name),
+                module.prog_type,
+                module.attach_type);
+        }
+
+        // Wait for the defined running time.
+        std::this_thread::sleep_for(std::chrono::seconds(CONCURRENT_THREAD_RUN_TIME_IN_SECONDS));
+
+        // Stop all threads.
+        for (auto& thread : threads) {
+            thread.request_stop();
+        }
+
+        // Wait for all threads to stop.
+        for (auto& thread : threads) {
+            thread.join();
+        }
+    }
+}
+
 // See also divide_by_zero_test_km in api_test.cpp for the kernel-mode equivalent.
 void
 divide_by_zero_test_um(ebpf_execution_type_t execution_type)


### PR DESCRIPTION
Closes #2150

## Description

Add concurrency stress-testing for loading/unloading native modules.

## Testing

Local, CI/CD.

## Documentation

n.a.
