### PR TITLE
Move extension definitions to their own file

### DIFF
--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "ebpf_result.h"
+#include "ebpf_structs.h"
+#include "ebpf_windows.h"
+
+typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
+    _In_ const void* extension_client_binding_context, _Inout_ void* program_context, _Out_ uint32_t* result);
+
+typedef ebpf_result_t (*ebpf_program_batch_begin_invoke_function_t)(
+    _In_ const void* extension_client_binding_context, size_t state_size, _Out_writes_(state_size) void* state);
+
+typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
+    _In_ const void* extension_client_binding_context,
+    _Inout_ void* program_context,
+    _Out_ uint32_t* result,
+    _In_ const void* state);
+
+typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(_In_ const void* extension_client_binding_context);
+
+typedef ebpf_result_t (*_ebpf_extension_dispatch_function)();
+
+typedef struct _ebpf_extension_dispatch_table
+{
+    uint16_t version; ///< Version of the dispatch table.
+    uint16_t count;   ///< Number of entries in the dispatch table.
+    _Field_size_(count) _ebpf_extension_dispatch_function function[1];
+} ebpf_extension_dispatch_table_t;
+
+typedef struct _ebpf_extension_data
+{
+    uint16_t version;
+    size_t size;
+    void* data;
+} ebpf_extension_data_t;
+
+typedef struct _ebpf_attach_provider_data
+{
+    ebpf_program_type_t supported_program_type;
+    bpf_attach_type_t bpf_attach_type;
+    enum bpf_link_type link_type;
+} ebpf_attach_provider_data_t;
+
+/***
+ * The state of the execution context when the eBPF program was invoked.
+ * This is used to cache state that won't change during the execution of
+ * the eBPF program and is expensive to query.
+ */
+typedef struct _ebpf_execution_context_state
+{
+    union
+    {
+        uint64_t thread;
+        uint32_t cpu;
+    } id;
+    uint8_t current_irql;
+} ebpf_execution_context_state_t;
+
+#define EBPF_ATTACH_CLIENT_DATA_VERSION 0
+#define EBPF_ATTACH_PROVIDER_DATA_VERSION 1
+#define EBPF_MAX_GENERAL_HELPER_FUNCTION 0xFFFF

--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -386,6 +386,9 @@ SPDX-License-Identifier: MIT
 			<Component Id="EBPF_BASE.H" DiskId="1" Guid="{FC47A44E-7747-4E98-AD55-09D9671C01C1}">
 				<File Id="EBPF_BASE.H" Name="ebpf_base.h" Source="$(var.SolutionDir)external\ebpf-verifier\src\ebpf_base.h" />
 			</Component>
+			<Component Id="EBPF_EXTENSION.H" DiskId="1" Guid="{F5F5F5F5-7747-4E98-AD55-09D9671C01C1}">
+				<File Id="EBPF_EXTENSION.H" Name="ebpf_extension.h" Source="$(var.SolutionDir)include\ebpf_extension.h" />
+			</Component>
 		</ComponentGroup>
 		<ComponentGroup Id="eBPF_Development_include_asm" Directory="dir_include_asm">
 			<Component Id="ERRNO.H" DiskId="1" Guid="{DF63C9C1-FA9C-44E3-94EB-F77B7072E4BE}">

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 #pragma once
 
+#include "ebpf_extension.h"
 #include "ebpf_result.h"
 #include "ebpf_structs.h"
 #include "ebpf_windows.h"
@@ -24,8 +25,6 @@ extern "C"
 #define EBPF_DEVICE_NAME L"\\Device\\EbpfIoDevice"
 #define EBPF_SYMBOLIC_DEVICE_NAME L"\\GLOBAL??\\EbpfIoDevice"
 #define EBPF_DEVICE_WIN32_NAME L"\\\\.\\EbpfIoDevice"
-
-#define EBPF_MAX_GENERAL_HELPER_FUNCTION 0xFFFF
 
 #define EBPF_UTF8_STRING_FROM_CONST_STRING(x) \
     {                                         \
@@ -92,45 +91,6 @@ extern "C"
     typedef struct _ebpf_extension_client ebpf_extension_client_t;
     typedef struct _ebpf_extension_provider ebpf_extension_provider_t;
     typedef struct _ebpf_helper_function_prototype ebpf_helper_function_prototype_t;
-    typedef ebpf_result_t (*_ebpf_extension_dispatch_function)();
-    typedef struct _ebpf_extension_dispatch_table
-    {
-        uint16_t version; ///< Version of the dispatch table.
-        uint16_t count;   ///< Number of entries in the dispatch table.
-        _Field_size_(count) _ebpf_extension_dispatch_function function[1];
-    } ebpf_extension_dispatch_table_t;
-
-    typedef struct _ebpf_extension_data
-    {
-        uint16_t version;
-        size_t size;
-        void* data;
-    } ebpf_extension_data_t;
-
-    typedef struct _ebpf_attach_provider_data
-    {
-        ebpf_program_type_t supported_program_type;
-        bpf_attach_type_t bpf_attach_type;
-        enum bpf_link_type link_type;
-    } ebpf_attach_provider_data_t;
-
-    /***
-     * The state of the execution context when the eBPF program was invoked.
-     * This is used to cache state that won't change during the execution of
-     * the eBPF program and is expensive to query.
-     */
-    typedef struct _ebpf_execution_context_state
-    {
-        union
-        {
-            uint64_t thread;
-            uint32_t cpu;
-        } id;
-        uint8_t current_irql;
-    } ebpf_execution_context_state_t;
-
-#define EBPF_ATTACH_CLIENT_DATA_VERSION 0
-#define EBPF_ATTACH_PROVIDER_DATA_VERSION 1
 
     typedef struct _ebpf_trampoline_table ebpf_trampoline_table_t;
 
@@ -1539,7 +1499,7 @@ extern "C"
 
 #define EBPF_LOG_WIN32_API_FAILURE(keyword, api)          \
     do {                                                  \
-        unsigned long last_error = GetLastError();                \
+        unsigned long last_error = GetLastError();        \
         TraceLoggingWrite(                                \
             ebpf_tracelog_provider,                       \
             EBPF_TRACELOG_EVENT_API_ERROR,                \
@@ -1551,7 +1511,7 @@ extern "C"
 
 #define EBPF_LOG_WIN32_STRING_API_FAILURE(keyword, message, api) \
     do {                                                         \
-        unsigned long last_error = GetLastError();                       \
+        unsigned long last_error = GetLastError();               \
         TraceLoggingWrite(                                       \
             ebpf_tracelog_provider,                              \
             EBPF_TRACELOG_EVENT_API_ERROR,                       \
@@ -1564,7 +1524,7 @@ extern "C"
 
 #define EBPF_LOG_WIN32_WSTRING_API_FAILURE(keyword, wstring, api) \
     do {                                                          \
-        unsigned long last_error = GetLastError();                        \
+        unsigned long last_error = GetLastError();                \
         TraceLoggingWrite(                                        \
             ebpf_tracelog_provider,                               \
             EBPF_TRACELOG_EVENT_API_ERROR,                        \
@@ -1577,7 +1537,7 @@ extern "C"
 
 #define EBPF_LOG_WIN32_GUID_API_FAILURE(keyword, guid, api) \
     do {                                                    \
-        unsigned long last_error = GetLastError();                  \
+        unsigned long last_error = GetLastError();          \
         TraceLoggingWrite(                                  \
             ebpf_tracelog_provider,                         \
             EBPF_TRACELOG_EVENT_API_ERROR,                  \


### PR DESCRIPTION
Resolves: #2146
Resolves: #2147

## Description

Extension writes need access to certain structures and types. Moving these types from ebpf_platform.h to ebpf_extension.h allows developers to more easily implement extensions.

## Testing

None needed. No impact to existing code.

## Documentation

No.
