### PR TITLE
Wrap calls from ebpf_drv.c in epoch calls

### DIFF
--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -9,7 +9,6 @@
  */
 
 #include "ebpf_core.h"
-#include "ebpf_object.h"
 
 #include <wdf.h>
 
@@ -203,10 +202,7 @@ static void
 _ebpf_driver_file_close(WDFFILEOBJECT wdf_file_object)
 {
     FILE_OBJECT* file_object = WdfFileObjectWdmGetFileObject(wdf_file_object);
-    ebpf_base_object_t* base_object = file_object->FsContext2;
-    if (base_object != NULL) {
-        base_object->release_reference(base_object);
-    }
+    ebpf_core_close_context(file_object->FsContext2);
 }
 
 static void

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2391,8 +2391,9 @@ ebpf_core_cancel_protocol_handler(_Inout_ void* async_context)
 void
 ebpf_core_close_context(_In_opt_ void* context)
 {
-    if (!context)
+    if (!context) {
         return;
+    }
 
     ebpf_epoch_enter();
 

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2310,10 +2310,8 @@ ebpf_core_invoke_protocol_handler(
         goto Done;
     }
 
-    retval = ebpf_epoch_enter();
-    if (retval != EBPF_SUCCESS) {
-        goto Done;
-    }
+    ebpf_epoch_enter();
+    retval = EBPF_SUCCESS;
     epoch_entered = true;
 
     switch (handler->call_type) {
@@ -2384,5 +2382,22 @@ Done:
 bool
 ebpf_core_cancel_protocol_handler(_Inout_ void* async_context)
 {
-    return ebpf_async_cancel(async_context);
+    ebpf_epoch_enter();
+    bool return_value = ebpf_async_cancel(async_context);
+    ebpf_epoch_exit();
+    return return_value;
+}
+
+void
+ebpf_core_close_context(_In_opt_ void* context)
+{
+    if (!context)
+        return;
+
+    ebpf_epoch_enter();
+
+    ebpf_core_object_t* object = (ebpf_core_object_t*)context;
+    object->base.release_reference(object);
+
+    ebpf_epoch_exit();
 }

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -239,6 +239,14 @@ extern "C"
         _In_reads_(count_of_helpers) const uint32_t* helper_function_ids,
         _Out_writes_(count_of_helpers) uint64_t* helper_function_addresses);
 
+    /**
+     * @brief Close the FsContext2 from a file object.
+     *
+     * @param[in] context The FsContext2 from a fileobject to close.
+     */
+    void
+    ebpf_core_close_context(_In_opt_ void* context);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -387,10 +387,7 @@ _ebpf_link_instance_invoke_batch_begin(
         goto Done;
     }
 
-    return_value = ebpf_epoch_enter();
-    if (return_value != EBPF_SUCCESS) {
-        goto Done;
-    }
+    ebpf_epoch_enter();
     epoch_entered = true;
 
     return_value = ebpf_program_reference_providers(link->program);

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1710,10 +1710,7 @@ _ebpf_program_test_run_work_item(_Inout_opt_ void* work_item_context)
     old_irql = ebpf_raise_irql(context->required_irql);
     irql_raised = true;
 
-    result = ebpf_epoch_enter();
-    if (result != EBPF_SUCCESS) {
-        goto Done;
-    }
+    ebpf_epoch_enter();
     epoch_entered = true;
 
     ebpf_get_execution_context_state(&execution_context_state);
@@ -1727,10 +1724,7 @@ _ebpf_program_test_run_work_item(_Inout_opt_ void* work_item_context)
         // Start a new epoch every batch_size iterations.
         if ((i % batch_size == (batch_size - 1))) {
             ebpf_epoch_exit();
-            result = ebpf_epoch_enter();
-            if (result != EBPF_SUCCESS) {
-                break;
-            }
+            ebpf_epoch_enter();
         }
         ebpf_program_invoke(context->program, context->context, &return_value, &execution_context_state);
         if (ebpf_should_yield_processor()) {

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -42,7 +42,7 @@
 // If the stale flag is already set, then the per-CPU stale_worker is scheduled.
 //
 // Thread entry table:
-// The thread entry is a fixed size per-CPU hash table for tracking per-thread ebpf_epoch_state_t. The hash is
+// The thread entry table is a fixed size per-CPU hash table for tracking per-thread ebpf_epoch_state_t. The hash is
 // based on the thread ID. The thread entry table is protected by a semaphore that limits the number of threads
 // that can be active in the epoch at any one time. If a thread attempts to enter the epoch and the semaphore
 // count is 0, then the thread blocks until a thread exits the epoch, which ensures that the thread entry table
@@ -58,8 +58,6 @@
 #define EBPF_EPOCH_THREAD_TABLE_TIMEOUT_IN_NANO_SECONDS 1000000000 // 1 second
 
 #define EBPF_NANO_SECONDS_PER_FILETIME_TICK 100
-
-#define EBPF_EPOCH_RESERVED_THREAD_ENTRY_COUNT 1
 
 typedef struct _ebpf_epoch_state
 {

--- a/libs/platform/ebpf_epoch.c
+++ b/libs/platform/ebpf_epoch.c
@@ -336,7 +336,7 @@ ebpf_epoch_enter()
     if (is_preemptible) {
         // Find the first available thread entry.
         ebpf_epoch_thread_entry_t* thread_entry = _ebpf_epoch_get_thread_entry(&_ebpf_epoch_cpu_table[current_cpu], 0);
-        ebpf_assert(thread_entry != NULL);
+        _Analysis_assume_(thread_entry != NULL);
         ebpf_assert(thread_entry->thread_id == 0);
 
         // Mark thread entry as in use.
@@ -382,7 +382,7 @@ ebpf_epoch_exit()
             _ebpf_epoch_get_thread_entry(&_ebpf_epoch_cpu_table[current_cpu], thread_id);
 
         // Having a thread entry is a precondition for calling ebpf_epoch_exit().
-        ebpf_assert(thread_entry != NULL);
+        _Analysis_assume_(thread_entry != NULL);
         ebpf_assert(thread_entry->thread_id == thread_id);
 
         // Mark thread entry as free.

--- a/libs/platform/ebpf_epoch.h
+++ b/libs/platform/ebpf_epoch.h
@@ -31,11 +31,8 @@ extern "C"
 
     /**
      * @brief Called prior to touching memory with lifetime under epoch control.
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MEMORY Unable to allocate per-thread
-     *   tracking state.
      */
-    _Must_inspect_result_ ebpf_result_t
+    void
     ebpf_epoch_enter();
 
     /**

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -1267,6 +1267,44 @@ extern "C"
     void
     ebpf_get_execution_context_state(_Out_ ebpf_execution_context_state_t* state);
 
+    typedef struct _ebpf_semaphore ebpf_semaphore_t;
+
+    /**
+     * @brief Create a semaphore.
+     *
+     * @param[out] semaphore Pointer to the memory that contains the semaphore.
+     * @param[in] initial_count Initial count of the semaphore.
+     * @param[in] maximum_count Maximum count of the semaphore.
+     * @retval EBPF_SUCCESS The hash object was created.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for the semaphore.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_semaphore_create(_Outptr_ ebpf_semaphore_t** semaphore, int initial_count, int maximum_count);
+
+    /**
+     * @brief Destroy a semaphore.
+     *
+     * @param[in] semaphore Semaphore to destroy.
+     */
+    void
+    ebpf_semaphore_destroy(_Frees_ptr_opt_ ebpf_semaphore_t* semaphore);
+
+    /**
+     * @brief Wait on a semaphore.
+     *
+     * @param[in] semaphore Semaphore to wait on.
+     */
+    void
+    ebpf_semaphore_wait(_In_ ebpf_semaphore_t* semaphore);
+
+    /**
+     * @brief Release a semaphore.
+     *
+     * @param[in] semaphore Semaphore to release.
+     */
+    void
+    ebpf_semaphore_release(_In_ ebpf_semaphore_t* semaphore);
+
 #define EBPF_TRACELOG_EVENT_SUCCESS "EbpfSuccess"
 #define EBPF_TRACELOG_EVENT_RETURN "EbpfReturn"
 #define EBPF_TRACELOG_EVENT_GENERIC_ERROR "EbpfGenericError"

--- a/libs/platform/ebpf_state.c
+++ b/libs/platform/ebpf_state.c
@@ -92,7 +92,7 @@ _ebpf_state_get_entry(
     // High frequency call, don't log entry/exit.
     ebpf_state_entry_t* local_entry = NULL;
 
-    if (execution_context_state->current_irql == PASSIVE_LEVEL) {
+    if (execution_context_state->current_irql < DISPATCH_LEVEL) {
         ebpf_result_t return_value;
         uint64_t current_thread_id = execution_context_state->id.thread;
 

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -835,8 +835,9 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_semaphore_create(_Outptr_ ebpf_semaphore_t** semaphore, int initial_count, int maximum_count)
 {
     *semaphore = ebpf_allocate(sizeof(KSEMAPHORE));
-    if (*semaphore == NULL)
+    if (*semaphore == NULL) {
         return EBPF_NO_MEMORY;
+    }
 
     KeInitializeSemaphore(&(*semaphore)->semaphore, initial_count, maximum_count);
     return EBPF_SUCCESS;

--- a/tests/performance/ExecutionContext.cpp
+++ b/tests/performance/ExecutionContext.cpp
@@ -76,7 +76,7 @@ typedef class _ebpf_program_test_state
     {
         uint32_t result;
         ebpf_execution_context_state_t state = {0};
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         ebpf_get_execution_context_state(&state);
         ebpf_program_invoke(program, context, &result, &state);
         ebpf_epoch_exit();
@@ -121,7 +121,7 @@ typedef class _ebpf_map_test_state
         uint32_t key = cpu_id;
         volatile uint64_t* value = nullptr;
 
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         (void)ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
         uint64_t local = *value;
         UNREFERENCED_PARAMETER(local);
@@ -133,7 +133,7 @@ typedef class _ebpf_map_test_state
     {
         uint32_t key = cpu_id;
         uint64_t* value = nullptr;
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         (void)ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
         (*value)++;
         ebpf_epoch_exit();
@@ -144,7 +144,7 @@ typedef class _ebpf_map_test_state
     {
         uint32_t key = cpu_id;
         uint64_t value = 0;
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         (void)ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
         ebpf_epoch_exit();
     }
@@ -154,7 +154,7 @@ typedef class _ebpf_map_test_state
     {
         uint32_t key = ebpf_random_uint32();
         uint64_t value = 0;
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         (void)ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
         ebpf_epoch_exit();
     }
@@ -172,7 +172,7 @@ typedef class _ebpf_map_test_state
             }
         }
         uint32_t key = lru_key_base + (ebpf_random_uint32() % lru_key_range);
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         // Check if the current key is present.
         if (ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER) == EBPF_SUCCESS) {
             // Cache hit.
@@ -232,7 +232,7 @@ typedef class _ebpf_map_lpm_trie_test_state
         std::vector<uint8_t> key(prefix.size() + sizeof(length));
         memcpy(key.data(), &length, sizeof(length));
         std::copy(prefix.begin(), prefix.end(), key.begin() + sizeof(length));
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         REQUIRE(
             ebpf_map_update_entry(map, key.size(), key.data(), value.size(), value.data(), EBPF_ANY, 0) ==
             EBPF_SUCCESS);
@@ -249,7 +249,7 @@ typedef class _ebpf_map_lpm_trie_test_state
         } ipv4_key = {32, ipv4_routes[ebpf_random_uint32() % ipv4_routes.size()].second};
         volatile uint64_t* value = nullptr;
 
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         (void)ebpf_map_find_entry(map, sizeof(ipv4_key), (uint8_t*)&ipv4_key, sizeof(value), (uint8_t*)&value, 0);
         UNREFERENCED_PARAMETER(value);
         ebpf_epoch_exit();

--- a/tests/performance/platform.cpp
+++ b/tests/performance/platform.cpp
@@ -7,14 +7,14 @@
 static void
 _perf_epoch_enter_exit()
 {
-    REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+    ebpf_epoch_enter();
     ebpf_epoch_exit();
 }
 
 static void
 _perf_epoch_enter_alloc_free_exit()
 {
-    REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+    ebpf_epoch_enter();
     void* p = ebpf_epoch_allocate(10);
     if (p != NULL) {
         ebpf_epoch_free(p);
@@ -31,7 +31,7 @@ _perf_epoch_enter_alloc_free_exit()
 static void
 _perf_bpf_get_prandom_u32()
 {
-    REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+    ebpf_epoch_enter();
     ebpf_random_uint32();
     ebpf_epoch_exit();
 }
@@ -40,7 +40,7 @@ static void
 _perf_bpf_ktime_get_boot_ns()
 {
     uint64_t time;
-    REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+    ebpf_epoch_enter();
     time = ebpf_query_time_since_boot(true) * EBPF_NS_PER_FILETIME;
     ebpf_epoch_exit();
 }
@@ -49,7 +49,7 @@ static void
 _perf_bpf_ktime_get_ns()
 {
     uint64_t time;
-    REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+    ebpf_epoch_enter();
     time = ebpf_query_time_since_boot(false) * EBPF_NS_PER_FILETIME;
     ebpf_epoch_exit();
 }
@@ -57,7 +57,7 @@ _perf_bpf_ktime_get_ns()
 static void
 _perf_bpf_get_smp_processor_id()
 {
-    REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+    ebpf_epoch_enter();
     ebpf_get_current_cpu();
     ebpf_epoch_exit();
 }
@@ -77,7 +77,7 @@ typedef class _ebpf_hash_table_test_state
         REQUIRE(ebpf_epoch_initiate() == EBPF_SUCCESS);
         epoch_initiated = true;
 
-        REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+        ebpf_epoch_enter();
         keys.resize(static_cast<size_t>(cpu_count) * 4ull);
         const ebpf_hash_table_creation_options_t options = {
             .key_size = sizeof(uint32_t),
@@ -113,7 +113,7 @@ typedef class _ebpf_hash_table_test_state
     {
         uint8_t* value;
         for (auto& key : keys) {
-            REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+            ebpf_epoch_enter();
             // Expected to fail.
             (void)ebpf_hash_table_find(table, reinterpret_cast<uint8_t*>(&key), &value);
             ebpf_epoch_exit();
@@ -125,7 +125,7 @@ typedef class _ebpf_hash_table_test_state
     {
         uint32_t next_key;
         for (auto& key : keys) {
-            REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+            ebpf_epoch_enter();
             // Expected to fail.
             (void)ebpf_hash_table_next_key(
                 table, reinterpret_cast<uint8_t*>(&key), reinterpret_cast<uint8_t*>(&next_key));
@@ -142,7 +142,7 @@ typedef class _ebpf_hash_table_test_state
             uint32_t start = current_cpu * 4;
             uint32_t end = start + 4;
             for (uint32_t index = start; index < end; index++) {
-                REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+                ebpf_epoch_enter();
                 // Expected to fail.
                 (void)ebpf_hash_table_update(
                     table,
@@ -160,7 +160,7 @@ typedef class _ebpf_hash_table_test_state
         uint64_t value = 12345678;
         // Update conflicting keys
         for (auto& key : keys) {
-            REQUIRE(ebpf_epoch_enter() == EBPF_SUCCESS);
+            ebpf_epoch_enter();
             // Expected to fail.
             (void)ebpf_hash_table_update(
                 table,


### PR DESCRIPTION
## Description

Ensure that all calls from ebpf_drv.c are to API's that call epoch enter/exit as appropriate.
Replace dynamically sized thread entry table with fixed capacity thread entry table with block on full semantics.

Resolves: #2164
Resolves: #2165

## Testing

CI/CD

## Documentation

No.
