### PR TITLE
Fix memory leaks in netebpfext

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -89,20 +89,6 @@ jobs:
       code_coverage: true
       gather_dumps: true
       capture_etw: true
-
-  unit_tests_leak_detection:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests_with_leak_detection
-      test_command: .\unit_tests.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
       leak_detection: true
 
   # Run the netebpfext unit tests in GitHub.
@@ -114,20 +100,6 @@ jobs:
     with:
       name: netebpf_ext_unit_tests
       pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      test_command: .\netebpfext_unit.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-
-  netebpfext_unit_leak_detection:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpfext_unit_leak_detection
       test_command: .\netebpfext_unit.exe -d yes
       build_artifact: Build-x64
       environment: windows-2022
@@ -376,6 +348,7 @@ jobs:
       code_coverage: true
       gather_dumps: true
       fault_injection: true
+      leak_detection: true
 
   # Additional jobs to run on a schedule only (skip push and pull request).
   # ---------------------------------------------------------------------------

--- a/libs/platform/user/kernel_um.h
+++ b/libs/platform/user/kernel_um.h
@@ -478,6 +478,17 @@ extern "C"
         return entry;
     }
 
+    FORCEINLINE
+    void
+    AppendTailList(_Inout_ LIST_ENTRY* list_head, _Inout_ LIST_ENTRY* list_to_append)
+    {
+        LIST_ENTRY* list_end = list_head->Blink;
+        list_head->Blink->Flink = list_to_append;
+        list_head->Blink = list_to_append->Blink;
+        list_to_append->Blink->Flink = list_head;
+        list_to_append->Blink = list_end;
+    }
+
     PGENERIC_MAPPING
     IoGetFileObjectGenericMapping();
 

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -126,6 +126,11 @@ _net_ebpf_extension_bind_on_client_attach(
         (net_ebpf_extension_hook_client_t*)attaching_client, filter_context);
 
 Exit:
+    if (result != EBPF_SUCCESS) {
+        if (filter_context != NULL) {
+            ExFreePool(filter_context);
+        }
+    }
     NET_EBPF_EXT_RETURN_RESULT(result);
 }
 

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -368,8 +368,10 @@ Exit:
         *provider_binding_context = hook_client;
         hook_client = NULL;
     } else {
-        if (hook_client)
+        if (hook_client) {
+            IoFreeWorkItem(hook_client->detach_work_item);
             ExFreePool(hook_client);
+        }
     }
 
     NET_EBPF_EXT_RETURN_NTSTATUS(status);

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -284,6 +284,18 @@ Exit:
     NET_EBPF_EXT_RETURN_RESULT(result);
 }
 
+void
+_net_ebpf_extension_hook_client_cleanup(_Frees_ptr_opt_ net_ebpf_extension_hook_client_t* hook_client)
+{
+    if (hook_client != NULL) {
+        if (hook_client->detach_work_item) {
+            IoFreeWorkItem(hook_client->detach_work_item);
+        }
+        ExFreePool(hook_client);
+        ;
+    }
+}
+
 /**
  * @brief Callback invoked when an eBPF hook NPI client (a.k.a eBPF link object) attaches.
  *
@@ -368,10 +380,7 @@ Exit:
         *provider_binding_context = hook_client;
         hook_client = NULL;
     } else {
-        if (hook_client) {
-            IoFreeWorkItem(hook_client->detach_work_item);
-            ExFreePool(hook_client);
-        }
+        _net_ebpf_extension_hook_client_cleanup(hook_client);
     }
 
     NET_EBPF_EXT_RETURN_NTSTATUS(status);

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -285,17 +285,14 @@ Exit:
 }
 
 void
-_net_ebpf_extension_hook_client_cleanup(_Frees_ptr_opt_ net_ebpf_extension_hook_client_t* hook_client)
+_net_ebpf_extension_hook_client_cleanup(_In_opt_ _Frees_ptr_opt_ net_ebpf_extension_hook_client_t* hook_client)
 {
-#pragma warning(push)
-#pragma warning(disable : 6001) // Using uninitialized memory '*hook_client'.
     if (hook_client != NULL) {
         if (hook_client->detach_work_item != NULL) {
             IoFreeWorkItem(hook_client->detach_work_item);
         }
         ExFreePool(hook_client);
     }
-#pragma warning(pop)
 }
 
 /**

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -287,13 +287,15 @@ Exit:
 void
 _net_ebpf_extension_hook_client_cleanup(_Frees_ptr_opt_ net_ebpf_extension_hook_client_t* hook_client)
 {
+#pragma warning(push)
+#pragma warning(disable : 6001) // Using uninitialized memory '*hook_client'.
     if (hook_client != NULL) {
-        if (hook_client->detach_work_item) {
+        if (hook_client->detach_work_item != NULL) {
             IoFreeWorkItem(hook_client->detach_work_item);
         }
         ExFreePool(hook_client);
-        ;
     }
+#pragma warning(pop)
 }
 
 /**
@@ -345,6 +347,7 @@ _net_ebpf_extension_hook_provider_attach_client(
     }
     memset(hook_client, 0, sizeof(net_ebpf_extension_hook_client_t));
 
+    hook_client->detach_work_item = NULL;
     hook_client->nmr_binding_handle = nmr_binding_handle;
     hook_client->client_module_id = client_registration_instance->ModuleId->Guid;
     hook_client->client_binding_context = client_binding_context;


### PR DESCRIPTION
## Description

This PR does the following:
1. Enable memory leak detection for `fault_injection_netebpfext` tests.
2. Fix memory leaks discovered by the test.
3. Remove `unit_tests_leak_detection`, `netebpfext_unit_leak_detection` and enable `leak_detection` in `unit_tests`, `netebpf_ext_unit_tests`.

## Testing

This PR adds the memory leak detection test.

## Documentation

NA
