### PR TITLE
Add build_msi flag, build nuget on regular build only.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -42,6 +42,7 @@ jobs:
     with:
       build_artifact: Build-x64
       generate_release_package: true
+      build_msi: true
       build_nuget: true
       build_options: /p:ReleaseJIT='True'
 
@@ -52,8 +53,6 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       build_artifact: Build-x64-native-only
-      generate_release_package: true
-      build_nuget: true
       build_options: /p:DisableJIT='True' /p:DisableInterpreter='True'
 
   cmake:

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -22,6 +22,9 @@ on:
       build_codeql:
         required: false
         type: boolean
+      build_msi:
+        required: false
+        type: boolean
       build_nuget:
         required: false
         type: boolean
@@ -189,29 +192,29 @@ jobs:
         retention-days: 5
 
     - name: Upload the MSI package (Debug)
-      if: inputs.build_artifact == 'Build-x64' && matrix.configurations == 'Debug'
+      if: inputs.build_msi == true && matrix.configurations == 'Debug'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows MSI installer (Debug)
+        name: ebpf-for-windows - MSI installer (Debug)
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/ebpf-for-windows.msi
 
     - name: Upload the MSI package (Release)
-      if: inputs.build_artifact == 'Build-x64' && matrix.configurations == 'Release'
+      if: inputs.build_msi == true && matrix.configurations == 'Release'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows MSI installer (Release)
+        name: ebpf-for-windows - MSI installer (Release)
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/ebpf-for-windows.msi
 
-    - name: Build nuget package
-      if: matrix.configurations == 'Release' && inputs.build_nuget == true && steps.skip_check.outputs.should_skip != 'true'
+    - name: Build the NuGet package
+      if: inputs.build_nuget == true && matrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} ${{env.BUILD_OPTIONS}} /t:tools\nuget
 
-    - name: Upload the nuget package
-      if: matrix.configurations == 'Release' && inputs.build_nuget == true && steps.skip_check.outputs.should_skip != 'true'
+    - name: Upload the NuGet package
+      if: minputs.build_nuget == true && atrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows nuget
+        name: ebpf-for-windows - NuGet package (Release)
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/*.nupkg
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -195,14 +195,14 @@ jobs:
       if: inputs.build_msi == true && matrix.configurations == 'Debug'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows - MSI installer (${{inputs.build_artifact}}/Debug)
+        name: ebpf-for-windows - MSI installer (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/ebpf-for-windows.msi
 
     - name: Upload the MSI package (Release)
       if: inputs.build_msi == true && matrix.configurations == 'Release'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows - MSI installer (${{inputs.build_artifact}}/Release)
+        name: ebpf-for-windows - MSI installer (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/ebpf-for-windows.msi
 
     - name: Build the NuGet package
@@ -214,7 +214,7 @@ jobs:
       if: inputs.build_nuget == true && matrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows - NuGet package (${{inputs.build_artifact}}/Release)
+        name: ebpf-for-windows - NuGet package (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/*.nupkg
 
     - name: Perform CodeQL Analysis

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -195,14 +195,14 @@ jobs:
       if: inputs.build_msi == true && matrix.configurations == 'Debug'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows - MSI installer (Debug)
+        name: ebpf-for-windows - MSI installer (${{inputs.build_artifact}}/Debug)
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/ebpf-for-windows.msi
 
     - name: Upload the MSI package (Release)
       if: inputs.build_msi == true && matrix.configurations == 'Release'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows - MSI installer (Release)
+        name: ebpf-for-windows - MSI installer (${{inputs.build_artifact}}/Release)
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/ebpf-for-windows.msi
 
     - name: Build the NuGet package
@@ -211,10 +211,10 @@ jobs:
       run: msbuild /m /p:Configuration=${{env.BUILD_CONFIGURATION}} /p:Platform=${{env.BUILD_PLATFORM}} ${{env.SOLUTION_FILE_PATH}} ${{env.BUILD_OPTIONS}} /t:tools\nuget
 
     - name: Upload the NuGet package
-      if: minputs.build_nuget == true && atrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
+      if: inputs.build_nuget == true && matrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
-        name: ebpf-for-windows - NuGet package (Release)
+        name: ebpf-for-windows - NuGet package (${{inputs.build_artifact}}/Release)
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/*.nupkg
 
     - name: Perform CodeQL Analysis

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -23,7 +23,7 @@ eBPF for Windows:
 1. Commit all the changes in the release branch into your forked repo.
 1. Create a **Draft** pull-request for the release branch into the main `ebpf-for-windows` repo, and title the PR as *"Release v`X.Y.Z`"* (replace "`X.Y.Z`" with the version number being released).
 1. Once the CI/CD pipeline for the PR completes, download the
-   "`ebpf-for-windows - MSI installer (Release)`" and "`ebpf-for-windows - NuGet package (Release)`" build artifacts
+   "`ebpf-for-windows - MSI installer (Build-x64_Release)`" and "`ebpf-for-windows - NuGet package (Build-x64_Release)`" build artifacts
    (accessible via the "`Actions`" tab on GitHub).
 1. Extract the `*.msi` and `*.nupkg` files, respectively, out of them, and rename them in the following format (replace "`X.Y.Z`" with the version number being released):
 

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -23,7 +23,7 @@ eBPF for Windows:
 1. Commit all the changes in the release branch into your forked repo.
 1. Create a **Draft** pull-request for the release branch into the main `ebpf-for-windows` repo, and title the PR as *"Release v`X.Y.Z`"* (replace "`X.Y.Z`" with the version number being released).
 1. Once the CI/CD pipeline for the PR completes, download the
-   "`ebpf-for-windows MSI installer (Release)`" and "`ebpf-for-windows nuget`" build artifacts
+   "`ebpf-for-windows - MSI installer (Release)`" and "`ebpf-for-windows - NuGet package (Release)`" build artifacts
    (accessible via the "`Actions`" tab on GitHub).
 1. Extract the `*.msi` and `*.nupkg` files, respectively, out of them, and rename them in the following format (replace "`X.Y.Z`" with the version number being released):
 


### PR DESCRIPTION
## Description

- Add new `build_msi` flag in `reusable-build.yml` and embed automatic artifact name/configuration in the output name, for more flexibility in adding multiple msi/nuget packages for multiple ci/cd builds.
- Build the nuget package & msi on the `regular` build only.
- Uniform artifact name and task descriptions.

## Testing

CI/CD.

## Documentation

`ReleaseProcess.md`
