### PR TITLE
Code coverage report is calculated before running tests

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -4,9 +4,9 @@
 codecov:
   notify:
     wait_for_ci: yes
-    after_n_builds: 4 # (unit_tests, bpf2c) * (Debug, Release)
+    after_n_builds: 28 # (unit_tests, bpf2c) * (Debug, Release)
 comment:
-    after_n_builds: 4 # (unit_tests, bpf2c) * (Debug, Release)
+    after_n_builds: 28 # (unit_tests, bpf2c) * (Debug, Release)
 coverage:
   status:
     project:


### PR DESCRIPTION
## Description

code cov calculates the coverage of tests right before CI/CD build and even running any tests( https://github.com/microsoft/ebpf-for-windows/pull/1866#issuecomment-1379673088).
This will create confusion whether the coverage change is correct or not. In fact, it computes the numbers before all the tests are complete, which is skewing the numbers.

## Testing

Updated the number of `after_n_builds` to reflect the correct threshold. More information about this flag is listed [here](https://docs.codecov.com/changelog/release-notes-for-codecov-v449#new).
## Documentation
N/A
