### PR TITLE
Add assert to verify that caller is within an epoch when freeing memory

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -237,6 +237,7 @@ ebpf_core_terminate()
     ebpf_provider_unload(_ebpf_global_helper_function_provider_context);
     _ebpf_global_helper_function_provider_context = NULL;
 
+    ebpf_epoch_enter();
     ebpf_program_terminate();
 
     ebpf_handle_table_terminate();
@@ -247,6 +248,7 @@ ebpf_core_terminate()
     _ebpf_core_map_pinning_table = NULL;
 
     ebpf_state_terminate();
+    ebpf_epoch_exit();
 
     // Shut down the epoch tracker and free any remaining memory or work items.
     // Note: Some objects may only be released on epoch termination.
@@ -927,6 +929,7 @@ _ebpf_core_protocol_program_test_run_complete(
     _Inout_ void* completion_context,
     _Inout_ void* async_context)
 {
+    ebpf_epoch_enter();
     ebpf_operation_program_test_run_reply_t* reply = (ebpf_operation_program_test_run_reply_t*)completion_context;
     if (result == EBPF_SUCCESS) {
         reply->header.length = (uint16_t)(
@@ -940,6 +943,7 @@ _ebpf_core_protocol_program_test_run_complete(
     ebpf_async_complete(async_context, reply->header.length, result);
     ebpf_object_release_reference((ebpf_core_object_t*)program);
     ebpf_free((void*)options);
+    ebpf_epoch_exit();
 }
 
 static ebpf_result_t

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -113,6 +113,7 @@ static void
 _test_crud_operations(ebpf_map_type_t map_type)
 {
     _ebpf_core_initializer core;
+    ebpf_epoch_scope_t epoch_scope;
     bool is_array;
     bool supports_find_and_delete;
     bool replace_on_full;
@@ -322,6 +323,7 @@ MAP_TEST(BPF_MAP_TYPE_LRU_PERCPU_HASH);
 TEST_CASE("map_crud_operations_lpm_trie_32", "[execution_context]")
 {
     _ebpf_core_initializer core;
+    _ebpf_epoch_scope epoch_scope;
     const size_t max_string = 16;
     typedef struct _lpm_trie_key
     {
@@ -404,6 +406,7 @@ generate_prefix(size_t length, uint8_t value, uint8_t prefix[16])
 TEST_CASE("map_crud_operations_lpm_trie_128", "[execution_context]")
 {
     _ebpf_core_initializer core;
+    _ebpf_epoch_scope epoch_scope;
 
     const size_t max_string = 20;
     typedef struct _lpm_trie_key
@@ -507,6 +510,7 @@ TEST_CASE("map_crud_operations_lpm_trie_128", "[execution_context]")
 TEST_CASE("map_crud_operations_queue", "[execution_context]")
 {
     _ebpf_core_initializer core;
+    _ebpf_epoch_scope epoch_scope;
     ebpf_map_definition_in_memory_t map_definition{BPF_MAP_TYPE_QUEUE, 0, sizeof(uint32_t), 10};
     map_ptr map;
     {
@@ -591,6 +595,7 @@ TEST_CASE("map_crud_operations_queue", "[execution_context]")
 TEST_CASE("map_crud_operations_stack", "[execution_context]")
 {
     _ebpf_core_initializer core;
+    _ebpf_epoch_scope epoch_scope;
     ebpf_map_definition_in_memory_t map_definition{BPF_MAP_TYPE_STACK, 0, sizeof(uint32_t), 10};
     map_ptr map;
     {
@@ -651,6 +656,7 @@ test_function()
 TEST_CASE("program", "[execution_context]")
 {
     _ebpf_core_initializer core;
+    _ebpf_epoch_scope epoch_scope;
 
     program_ptr program;
     {
@@ -751,10 +757,14 @@ TEST_CASE("program", "[execution_context]")
                _In_ const ebpf_program_test_run_options_t* options,
                _Inout_ void* completion_context,
                _Inout_ void* async_context) {
+                UNREFERENCED_PARAMETER(program);
+                UNREFERENCED_PARAMETER(options);
+                UNREFERENCED_PARAMETER(completion_context);
                 ebpf_assert(program != nullptr);
                 ebpf_assert(options != nullptr);
                 ebpf_assert(completion_context != nullptr);
                 ebpf_assert(async_context != nullptr);
+                _ebpf_epoch_scope epoch_scope;
                 ebpf_async_complete(async_context, options->data_size_out, result);
             }) == EBPF_PENDING);
 
@@ -825,6 +835,7 @@ TEST_CASE("program", "[execution_context]")
 TEST_CASE("name size", "[execution_context]")
 {
     _ebpf_core_initializer core;
+    _ebpf_epoch_scope epoch_scope;
     program_info_provider_t program_info_provider(EBPF_PROGRAM_TYPE_BIND);
 
     program_ptr program;
@@ -873,6 +884,7 @@ TEST_CASE("test-csum-diff", "[execution_context]")
 TEST_CASE("ring_buffer_async_query", "[execution_context]")
 {
     _ebpf_core_initializer core;
+    _ebpf_epoch_scope epoch_scope;
     ebpf_map_definition_in_memory_t map_definition{BPF_MAP_TYPE_RINGBUF, 0, 0, 64 * 1024};
     map_ptr map;
     {

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -187,6 +187,7 @@ ebpf_object_acquire_reference(ebpf_core_object_t* object)
 {
     ebpf_assert(object->base.marker == _ebpf_object_marker);
     int32_t new_ref_count = ebpf_interlocked_increment_int32(&object->base.reference_count);
+    UNREFERENCED_PARAMETER(new_ref_count);
     ebpf_assert(new_ref_count != 1);
 }
 

--- a/libs/platform/kernel/framework.h
+++ b/libs/platform/kernel/framework.h
@@ -18,11 +18,7 @@
 #define true 1
 #define false 0
 
-#ifdef _DEBUG
 #define ebpf_assert(x) ASSERT(x)
-#else
-#define ebpf_assert(x) (void)(x)
-#endif // !_DEBUG
 
 #define ebpf_list_entry_t LIST_ENTRY
 

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -807,6 +807,7 @@ ebpf_set_current_thread_affinity(uintptr_t new_thread_affinity_mask, _Out_ uintp
     if (old_mask == 0) {
         unsigned long error = GetLastError();
         ebpf_assert(error != ERROR_SUCCESS);
+        UNREFERENCED_PARAMETER(error);
         return EBPF_OPERATION_NOT_SUPPORTED;
     } else {
         *old_thread_affinity_mask = old_mask;

--- a/libs/platform/user/framework.h
+++ b/libs/platform/user/framework.h
@@ -21,11 +21,7 @@ typedef _Return_type_success_(return >= 0) long NTSTATUS;
 
 #pragma comment(lib, "rpcrt4")
 
-#ifdef _DEBUG
 #define ebpf_assert(x) assert(x)
-#else
-#define ebpf_assert(x) (void)(x)
-#endif //!_DEBUG
 
 #if !defined(UNREFERENCED_PARAMETER)
 #define UNREFERENCED_PARAMETER(X) (X)

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -770,6 +770,7 @@ _IRQL_requires_max_(DISPATCH_LEVEL) void NTAPI
 {
     UNREFERENCED_PARAMETER(classifyHandle);
     UNREFERENCED_PARAMETER(flags);
+    UNREFERENCED_PARAMETER(modifiedLayerData);
 
     ebpf_assert(modifiedLayerData != nullptr);
 }

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "ebpf_api.h"
+#include "ebpf_epoch.h"
 #include "ebpf_nethooks.h"
 #include "ebpf_platform.h"
 #include "ebpf_program_types.h"
@@ -599,3 +600,9 @@ typedef class _program_info_provider
 #define ETHERNET_TYPE_IPV4 0x0800
 std::vector<uint8_t>
 prepare_udp_packet(uint16_t udp_length, uint16_t ethertype);
+
+typedef struct _ebpf_epoch_scope
+{
+    _ebpf_epoch_scope() { ebpf_epoch_enter(); }
+    ~_ebpf_epoch_scope() { ebpf_epoch_exit(); }
+} ebpf_epoch_scope_t;

--- a/tests/performance/ExecutionContext.cpp
+++ b/tests/performance/ExecutionContext.cpp
@@ -32,8 +32,10 @@ typedef class _ebpf_program_test_state
     }
     ~_ebpf_program_test_state()
     {
+        ebpf_epoch_enter();
         ebpf_object_release_reference(reinterpret_cast<ebpf_core_object_t*>(program));
         delete program_info_provider;
+        ebpf_epoch_exit();
         ebpf_core_terminate();
     }
 
@@ -98,6 +100,7 @@ typedef class _ebpf_map_test_state
         ebpf_map_definition_in_memory_t definition{
             type, sizeof(uint32_t), sizeof(uint64_t), map_size.has_value() ? map_size.value() : ebpf_get_cpu_count()};
 
+        _ebpf_epoch_scope epoch_scope;
         REQUIRE(ebpf_map_create(&name, &definition, ebpf_handle_invalid, &map) == EBPF_SUCCESS);
 
         for (uint32_t i = 0; i < definition.max_entries; i++) {
@@ -111,7 +114,10 @@ typedef class _ebpf_map_test_state
     }
     ~_ebpf_map_test_state()
     {
-        ebpf_object_release_reference((ebpf_core_object_t*)map);
+        {
+            _ebpf_epoch_scope epoch_scope;
+            ebpf_object_release_reference((ebpf_core_object_t*)map);
+        }
         ebpf_core_terminate();
     }
 
@@ -257,7 +263,10 @@ typedef class _ebpf_map_lpm_trie_test_state
 
     ~_ebpf_map_lpm_trie_test_state()
     {
-        ebpf_object_release_reference((ebpf_core_object_t*)map);
+        {
+            _ebpf_epoch_scope epoch_scope;
+            ebpf_object_release_reference((ebpf_core_object_t*)map);
+        }
         ebpf_core_terminate();
     }
 


### PR DESCRIPTION
## Description

The API's ebpf_epoch_free and ebpf_epoch_schedule_work_item should only be called during an epoch. This change adds a check to enforce that.

## Testing

CI/CD

## Documentation

No.
