### PR TITLE
Store leaked stacks in memory

### DIFF
--- a/libs/platform/user/ebpf_leak_detector.h
+++ b/libs/platform/user/ebpf_leak_detector.h
@@ -35,6 +35,7 @@ typedef class _ebpf_leak_detector
     std::unordered_map<uintptr_t, allocation_t> _allocations;
     std::mutex _mutex;
     const size_t _stack_depth = 32;
+    std::vector<std::string> _in_memory_log;
 } ebpf_leak_detector_t;
 
 typedef std::unique_ptr<ebpf_leak_detector_t> ebpf_leak_detector_ptr;


### PR DESCRIPTION
## Description

Debugging asserts from _ebpf_leak_detector::dump_leaks due to leaked memory is hard as the log is written to the console which is not always captured. To make it easier to debug, this change also writes the log to an in memory buffer.

## Testing

CI/CD

## Documentation

No.
