### PR TITLE
Simulate NMR API failures: Fix memory leaks and segmentation fault

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1727,6 +1727,7 @@ _initialize_ebpf_object_from_native_file(
         program->handle = ebpf_handle_invalid;
         program->program_type = info->program_type;
         program->attach_type = info->expected_attach_type;
+        program->fd = ebpf_fd_invalid;
 
         program->section_name = ebpf_duplicate_string(info->section_name);
         if (program->section_name == nullptr) {
@@ -1754,16 +1755,16 @@ _initialize_ebpf_object_from_native_file(
 
 Exit:
     if (result != EBPF_SUCCESS) {
-        if (program && object.programs.size() == 0) {
-            ebpf_free(program->section_name);
-            ebpf_free(program->program_name);
+        if (program) {
+            // Deallocate program, if it was allocated but not added to
+            // the object programs vector.
+            clean_up_ebpf_program(program);
         }
 
         clean_up_ebpf_programs(object.programs);
         clean_up_ebpf_maps(object.maps);
     }
 
-    ebpf_free(program);
     ebpf_free_sections(infos);
     EBPF_RETURN_RESULT(result);
 }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1753,11 +1753,17 @@ _initialize_ebpf_object_from_native_file(
     }
 
 Exit:
-    ebpf_free(program);
     if (result != EBPF_SUCCESS) {
+        if (program && object.programs.size() == 0) {
+            ebpf_free(program->section_name);
+            ebpf_free(program->program_name);
+        }
+
         clean_up_ebpf_programs(object.programs);
         clean_up_ebpf_maps(object.maps);
     }
+
+    ebpf_free(program);
     ebpf_free_sections(infos);
     EBPF_RETURN_RESULT(result);
 }

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -374,7 +374,15 @@ ebpf_store_load_program_information(
 Exit:
     if (result != EBPF_SUCCESS) {
         ebpf_free(*program_info);
+
+        // Deallocate the dynamic memory in the program_info_array vector.
+        if (program_info_array.size() > 0) {
+            for (auto program_data : program_info_array) {
+                ebpf_program_info_free(program_data);
+            }
+        }
     }
+
     if (program_data_key) {
         close_registry_key(program_data_key);
     }
@@ -569,6 +577,15 @@ ebpf_store_load_section_information(
 Exit:
     if (result != EBPF_SUCCESS) {
         ebpf_free(*section_info);
+        // Deallocate the dynamic memory in the section_info_array vector.
+        if (section_info_array.size() > 0) {
+            for (auto section_data : section_info_array) {
+                ebpf_free(section_data->program_type);
+                ebpf_free(section_data->attach_type);
+                ebpf_free(const_cast<char*>(section_data->section_prefix));
+                ebpf_free(section_data);
+            }
+        }
     }
     if (section_data_key) {
         close_registry_key(section_data_key);

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -314,6 +314,7 @@ ebpf_native_terminate()
     // ebpf_provider_unload is blocking call until all the
     // native modules have been detached.
     ebpf_provider_unload(_ebpf_native_provider);
+    _ebpf_native_provider = NULL;
 
     // All native modules should be cleaned up by now.
     ebpf_assert(!_ebpf_native_client_table || ebpf_hash_table_key_count(_ebpf_native_client_table) == 0);

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include "ebpf_fault_injection.h"
 #include "fwp_um.h"
 #include "net_ebpf_ext_sock_addr.h"
 #include "netebpfext_platform.h"
@@ -20,6 +21,8 @@ DEFINE_GUID(
 DEFINE_GUID(EBPF_DEFAULT_SUBLAYER, 0x7c7b3fb9, 0x3331, 0x436a, 0x98, 0xe1, 0xb9, 0x01, 0xdf, 0x45, 0x7f, 0xff);
 
 std::unique_ptr<_fwp_engine> _fwp_engine::_engine;
+
+static bool fault_injection_enabled = ebpf_fault_injection_is_enabled();
 
 // Attempt to classify a test packet at a given WFP layer on a given interface index.
 // This is used to test the xdp hook.
@@ -269,7 +272,7 @@ _fwp_engine::test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameter
 
     action = test_callout(
         FWPS_LAYER_ALE_CONNECT_REDIRECT_V4, FWPM_LAYER_ALE_CONNECT_REDIRECT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
-    ebpf_assert(action == FWP_ACTION_PERMIT);
+    ebpf_assert(action == FWP_ACTION_PERMIT || !fault_injection_enabled);
 
     if (_fwp_um_connect_request != nullptr) {
         redirected =

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#include "ebpf_fault_injection.h"
 #include "fwp_um.h"
 #include "net_ebpf_ext_sock_addr.h"
 #include "netebpfext_platform.h"
@@ -21,8 +20,6 @@ DEFINE_GUID(
 DEFINE_GUID(EBPF_DEFAULT_SUBLAYER, 0x7c7b3fb9, 0x3331, 0x436a, 0x98, 0xe1, 0xb9, 0x01, 0xdf, 0x45, 0x7f, 0xff);
 
 std::unique_ptr<_fwp_engine> _fwp_engine::_engine;
-
-static bool fault_injection_enabled = ebpf_fault_injection_is_enabled();
 
 // Attempt to classify a test packet at a given WFP layer on a given interface index.
 // This is used to test the xdp hook.
@@ -272,7 +269,7 @@ _fwp_engine::test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameter
 
     action = test_callout(
         FWPS_LAYER_ALE_CONNECT_REDIRECT_V4, FWPM_LAYER_ALE_CONNECT_REDIRECT_V4, EBPF_DEFAULT_SUBLAYER, incoming_value);
-    ebpf_assert(action == FWP_ACTION_PERMIT || !fault_injection_enabled);
+    ebpf_assert(action == FWP_ACTION_PERMIT);
 
     if (_fwp_um_connect_request != nullptr) {
         redirected =


### PR DESCRIPTION
## Description
For each Memory leak call stack and SIGSEGV, please refer to the analysis attached in #2101 

This PR was tested with fault injection conditions added for the following NMR APIs.
1. NmrRegisterProvider
2. NmrDeregisterProvider
3. NmrWaitForProviderDeregisterComplete

FYI, Issue #2101 will be addressed in incremental commits.

## Testing

_Do any existing tests cover this change? Yes
 Are new tests needed?_ No

## Documentation
No

_Is there any documentation impact for this change?_
