### PR TITLE
Simulate NMR API failures: Fix SIGSEGV crashes

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -361,7 +361,7 @@ _ebpf_native_provider_attach_client_callback(
         goto Done;
     }
     table = (metadata_table_t*)client_registration_instance->NpiSpecificCharacteristics;
-    if (!table->programs || !table->maps) {
+    if (!table || !table->programs || !table->maps) {
         result = EBPF_INVALID_ARGUMENT;
         goto Done;
     }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -373,7 +373,8 @@ ebpf_program_load_providers(_Inout_ ebpf_program_t* program)
     }
 
     general_helper_program_data = (ebpf_program_data_t*)program->general_helper_provider_data->data;
-    if (general_helper_program_data->program_type_specific_helper_function_addresses == NULL) {
+    if (!general_helper_program_data ||
+        general_helper_program_data->program_type_specific_helper_function_addresses == NULL) {
         EBPF_LOG_MESSAGE_GUID(
             EBPF_TRACELOG_LEVEL_ERROR,
             EBPF_TRACELOG_KEYWORD_PROGRAM,

--- a/libs/platform/ebpf_crypto_hash.c
+++ b/libs/platform/ebpf_crypto_hash.c
@@ -69,6 +69,7 @@ ebpf_cryptographic_hash_append(
     _Inout_ ebpf_cryptographic_hash_t* hash, _In_reads_bytes_(length) const uint8_t* buffer, size_t length)
 {
     NTSTATUS nt_status;
+
     nt_status = BCryptHashData(hash->hash_handle, (uint8_t*)buffer, (unsigned long)length, 0);
     if (!NT_SUCCESS(nt_status)) {
         return EBPF_INVALID_ARGUMENT;

--- a/libs/platform/ebpf_crypto_hash.c
+++ b/libs/platform/ebpf_crypto_hash.c
@@ -68,8 +68,11 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_cryptographic_hash_append(
     _Inout_ ebpf_cryptographic_hash_t* hash, _In_reads_bytes_(length) const uint8_t* buffer, size_t length)
 {
-    NTSTATUS nt_status;
+    if (buffer == NULL) {
+        return EBPF_INVALID_ARGUMENT;
+    }
 
+    NTSTATUS nt_status;
     nt_status = BCryptHashData(hash->hash_handle, (uint8_t*)buffer, (unsigned long)length, 0);
     if (!NT_SUCCESS(nt_status)) {
         return EBPF_INVALID_ARGUMENT;

--- a/libs/platform/ebpf_crypto_hash.c
+++ b/libs/platform/ebpf_crypto_hash.c
@@ -68,10 +68,6 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_cryptographic_hash_append(
     _Inout_ ebpf_cryptographic_hash_t* hash, _In_reads_bytes_(length) const uint8_t* buffer, size_t length)
 {
-    if (buffer == NULL) {
-        return EBPF_INVALID_ARGUMENT;
-    }
-
     NTSTATUS nt_status;
     nt_status = BCryptHashData(hash->hash_handle, (uint8_t*)buffer, (unsigned long)length, 0);
     if (!NT_SUCCESS(nt_status)) {

--- a/libs/platform/user/nmr_impl.cpp
+++ b/libs/platform/user/nmr_impl.cpp
@@ -157,9 +157,11 @@ _nmr::client_attach_provider(
 std::optional<_nmr::pending_action_t>
 _nmr::bind(_Inout_ client_registration& client, _Inout_ provider_registration& provider)
 {
+    PNPIID client_pnpi = client.characteristics.ClientRegistrationInstance.NpiId;
+    PNPIID provider_pnpi = provider.characteristics.ProviderRegistrationInstance.NpiId;
+
     // Match on NPI ID.
-    if (*client.characteristics.ClientRegistrationInstance.NpiId !=
-        *provider.characteristics.ProviderRegistrationInstance.NpiId) {
+    if (!client_pnpi || !provider_pnpi || *client_pnpi != *provider_pnpi) {
         return std::nullopt;
     }
 


### PR DESCRIPTION
## Description
This PR addresses 3 crashes when fault injection is enabled in nmr apis.

Please see the details of call stack in #2101 

## Testing

_Do any existing tests cover this change? Yes
 Are new tests needed?_ No

## Documentation

_Is there any documentation impact for this change?_ No
