### PR TITLE
Simulate OS api failure: ebpf_platform_user.cpp api

### DIFF
--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -551,36 +551,36 @@ TEST_CASE("trampoline_test", "[platform]")
     const void* helper_functions2[] = {(void*)function_pointer2};
     ebpf_helper_function_addresses_t helper_function_addresses2 = {
         EBPF_COUNT_OF(helper_functions1), (uint64_t*)helper_functions2};
-    ebpf_result_t status;
+    ebpf_result_t status = EBPF_SUCCESS;
 
     REQUIRE(ebpf_allocate_trampoline_table(1, &table) == EBPF_SUCCESS);
 
     status = ebpf_update_trampoline_table(
         table, EBPF_COUNT_OF(provider_helper_function_ids), provider_helper_function_ids, &helper_function_addresses1);
     if (status != EBPF_SUCCESS) {
-        ebpf_free_trampoline_table(table);
+        goto Exit;
     }
-    REQUIRE(status == EBPF_SUCCESS);
 
     status = ebpf_get_trampoline_function(
         table, EBPF_MAX_GENERAL_HELPER_FUNCTION + 1, reinterpret_cast<void**>(&test_function));
     if (status != EBPF_SUCCESS) {
-        ebpf_free_trampoline_table(table);
+        goto Exit;
     }
 
-    // Verify that the trampoline function invokes the provider function
+    // Verify that the trampoline function invokes the provider function.
     REQUIRE(test_function() == EBPF_SUCCESS);
 
     status = ebpf_update_trampoline_table(
         table, EBPF_COUNT_OF(provider_helper_function_ids), provider_helper_function_ids, &helper_function_addresses2);
     if (status != EBPF_SUCCESS) {
-        ebpf_free_trampoline_table(table);
+        goto Exit;
     }
-    REQUIRE(status == EBPF_SUCCESS);
 
-    // Verify that the trampoline function now invokes the new provider function
+    // Verify that the trampoline function now invokes the new provider function.
     REQUIRE(test_function() == EBPF_OBJECT_ALREADY_EXISTS);
+Exit:
     ebpf_free_trampoline_table(table);
+    REQUIRE(status == EBPF_SUCCESS);
 }
 
 struct ebpf_security_descriptor_t_free

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -6,7 +6,6 @@
 #include "ebpf_async.h"
 #include "ebpf_bitmap.h"
 #include "ebpf_epoch.h"
-#include "ebpf_fault_injection.h"
 #include "ebpf_nethooks.h"
 #include "ebpf_pinning_table.h"
 #include "ebpf_platform.h"
@@ -486,9 +485,8 @@ TEST_CASE("extension_test", "[platform]")
     ebpf_extension_provider_t* provider_context = nullptr;
     ebpf_extension_client_t* client_context = nullptr;
     void* provider_binding_context = nullptr;
-    bool ebpf_fault_injection_enabled = ebpf_fault_injection_is_enabled();
 
-    ebpf_assert(ebpf_guid_create(&interface_id) == EBPF_SUCCESS || ebpf_fault_injection_enabled);
+    REQUIRE(ebpf_guid_create(&interface_id) == EBPF_SUCCESS);
     int callback_context = 0;
     int client_binding_context = 0;
     GUID client_module_id = {};

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -1081,3 +1081,11 @@ TEST_CASE("interlocked operations", "[platform]")
     REQUIRE(ebpf_interlocked_compare_exchange_pointer(&p, &b, &a) == &a);
     REQUIRE(ebpf_interlocked_compare_exchange_pointer(&p, &b, &a) == &b);
 }
+
+TEST_CASE("get_authentication_id", "[platform]")
+{
+    _test_helper test_helper;
+    uint64_t authentication_id = 0;
+
+    REQUIRE(ebpf_platform_get_authentication_id(&authentication_id) == EBPF_SUCCESS);
+}

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -6,6 +6,7 @@
 #include "ebpf_async.h"
 #include "ebpf_bitmap.h"
 #include "ebpf_epoch.h"
+#include "ebpf_fault_injection.h"
 #include "ebpf_nethooks.h"
 #include "ebpf_pinning_table.h"
 #include "ebpf_platform.h"
@@ -485,8 +486,9 @@ TEST_CASE("extension_test", "[platform]")
     ebpf_extension_provider_t* provider_context = nullptr;
     ebpf_extension_client_t* client_context = nullptr;
     void* provider_binding_context = nullptr;
+    bool ebpf_fault_injection_enabled = ebpf_fault_injection_is_enabled();
 
-    ebpf_assert_success(ebpf_guid_create(&interface_id));
+    ebpf_assert(ebpf_guid_create(&interface_id) == EBPF_SUCCESS || ebpf_fault_injection_enabled);
     int callback_context = 0;
     int client_binding_context = 0;
     GUID client_module_id = {};

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -57,7 +57,7 @@ static std::vector<uint32_t> _ebpf_platform_group_to_index_map;
 static ebpf_result_t
 _initialize_thread_pool()
 {
-    // CreateThreadpoolCleanupGroup can return nullptr
+    // CreateThreadpoolCleanupGroup can return nullptr.
     if (ebpf_fault_injection_is_enabled() && ebpf_fault_injection_inject_fault()) {
         return EBPF_NO_MEMORY;
     }
@@ -503,7 +503,7 @@ typedef struct _ebpf_ring_descriptor ebpf_ring_descriptor_t;
 ebpf_memory_descriptor_t*
 ebpf_map_memory(size_t length)
 {
-    // VirtualAlloc OS api can return NULL
+    // VirtualAlloc OS API can return nullptr.
     if (ebpf_fault_injection_inject_fault()) {
         return nullptr;
     }
@@ -550,10 +550,7 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     void* view1 = nullptr;
     void* view2 = nullptr;
 
-    // VirtualAlloc2 OS api can return NULL
-    if (ebpf_fault_injection_inject_fault()) {
-        return nullptr;
-    }
+    // Skip fault injection for this VirtualAlloc2 OS API, as ebpf_allocate already does that.
 
     GetSystemInfo(&sysInfo);
 
@@ -708,7 +705,7 @@ ebpf_ring_map_readonly_user(_In_ const ebpf_ring_descriptor_t* ring)
 _Must_inspect_result_ ebpf_result_t
 ebpf_protect_memory(_In_ const ebpf_memory_descriptor_t* memory_descriptor, ebpf_page_protection_t protection)
 {
-    // VirtualProtect OS api can return NULL
+    // VirtualProtect OS API can return nullptr.
     if (ebpf_fault_injection_inject_fault()) {
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -57,11 +57,6 @@ static std::vector<uint32_t> _ebpf_platform_group_to_index_map;
 static ebpf_result_t
 _initialize_thread_pool()
 {
-    // CreateThreadpoolCleanupGroup can return nullptr.
-    if (ebpf_fault_injection_is_enabled() && ebpf_fault_injection_inject_fault()) {
-        return EBPF_NO_MEMORY;
-    }
-
     ebpf_result_t result = EBPF_SUCCESS;
     bool cleanup_group_created = false;
     bool return_value;
@@ -504,7 +499,6 @@ ebpf_memory_descriptor_t*
 ebpf_map_memory(size_t length)
 {
     // Skip fault injection for this VirtualAlloc OS API, as ebpf_allocate already does that.
-
     ebpf_memory_descriptor_t* descriptor = (ebpf_memory_descriptor_t*)ebpf_allocate(sizeof(ebpf_memory_descriptor_t));
     if (!descriptor) {
         return nullptr;
@@ -548,7 +542,6 @@ ebpf_allocate_ring_buffer_memory(size_t length)
     void* view2 = nullptr;
 
     // Skip fault injection for this VirtualAlloc2 OS API, as ebpf_allocate already does that.
-
     GetSystemInfo(&sysInfo);
 
     if (length == 0) {

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -503,10 +503,7 @@ typedef struct _ebpf_ring_descriptor ebpf_ring_descriptor_t;
 ebpf_memory_descriptor_t*
 ebpf_map_memory(size_t length)
 {
-    // VirtualAlloc OS API can return nullptr.
-    if (ebpf_fault_injection_inject_fault()) {
-        return nullptr;
-    }
+    // Skip fault injection for this VirtualAlloc OS API, as ebpf_allocate already does that.
 
     ebpf_memory_descriptor_t* descriptor = (ebpf_memory_descriptor_t*)ebpf_allocate(sizeof(ebpf_memory_descriptor_t));
     if (!descriptor) {

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -1215,6 +1215,7 @@ ebpf_platform_thread_id()
 _IRQL_requires_max_(PASSIVE_LEVEL) _Must_inspect_result_ ebpf_result_t
     ebpf_platform_get_authentication_id(_Out_ uint64_t* authentication_id)
 {
+    // GetTokenInformation OS API can fail with return value of zero.
     if (ebpf_fault_injection_inject_fault()) {
         return EBPF_NO_MEMORY;
     }

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2623,8 +2623,6 @@ typedef struct _ebpf_scoped_non_preemptible
 
 TEST_CASE("load_native_program_invalid5-non-preemptible", "[end-to-end]")
 {
-    _test_helper_end_to_end test_helper;
-
     // Setting ebpf_non_preemptible to true will ensure ebpf_native_load queues
     // a workitem and that code path is executed.
     ebpf_scoped_non_preemptible_t non_preemptible;

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -12,7 +12,6 @@
 #include "catch_wrapper.hpp"
 #include "common_tests.h"
 #include "ebpf_core.h"
-#include "ebpf_fault_injection.h"
 #include "helpers.h"
 #include "ioctl_helper.h"
 #include "mock.h"
@@ -2610,12 +2609,8 @@ typedef struct _ebpf_scoped_non_preemptible
 {
     _ebpf_scoped_non_preemptible()
     {
-        bool ebpf_fault_injection_enabled = ebpf_fault_injection_is_enabled();
-
-        ebpf_assert(
-            ebpf_set_current_thread_affinity((uintptr_t)1 << ebpf_get_current_cpu(), &old_thread_affinity) ==
-                EBPF_SUCCESS ||
-            ebpf_fault_injection_enabled);
+        ebpf_assert_success(
+            ebpf_set_current_thread_affinity((uintptr_t)1 << ebpf_get_current_cpu(), &old_thread_affinity));
         ebpf_non_preemptible = true;
     }
     ~_ebpf_scoped_non_preemptible()


### PR DESCRIPTION
## Description

Added fault injection in ebpf_platform_user.cpp OS apis.

## Testing

_Do any existing tests cover this change? Yes
platform_unit_test.cpp:  
  - Test case: trampoline_test
  Coverage for ebpf_protect_memory
- Test case: extension_test 
  Coverage for ebpf_guid_create:
- Test case: access_check
  Coverage for ebpf_validate_security_descriptor
  Coverage for ebpf_access_check
 

Are new tests needed? Yes
In platform_unit_test.cpp:  
 - Added Test case: get_authentication_id

Existing test cases: 
unit_tests.exe : Passed
netebpfext_unit.exe: Passed


## Documentation

_Is there any documentation impact for this change?_ No
