### PR TITLE
Initialize new_link fd to ebpf_fd_invalid

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1040,6 +1040,7 @@ _link_ebpf_program(
         EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
     }
     new_link->handle = ebpf_handle_invalid;
+    new_link->fd = ebpf_fd_invalid;
 
     try {
         size_t buffer_size = offsetof(ebpf_operation_link_program_request_t, data) + attach_parameter_size;


### PR DESCRIPTION
Resolves: #2278 

## Description

The function _link_ebpf_program calls ebpf_link_close on failure, which attempts to close the fd associated with the link object. If the function fails before allocating an fd, it will attempt to close fd 0.

## Testing

CI/CD + new km stress test.

## Documentation

No.
