### PR TITLE
Add a WFP provider object.

### DIFF
--- a/netebpfext/net_ebpf_ext.h
+++ b/netebpfext/net_ebpf_ext.h
@@ -198,6 +198,10 @@ net_ebpf_extension_add_wfp_filters(
 void
 net_ebpf_extension_delete_wfp_filters(uint32_t filter_count, _Frees_ptr_ _In_count_(filter_count) uint64_t* filter_ids);
 
+// eBPF WFP Provider GUID.
+// ddb851f5-841a-4b77-8a46-bb7063e9f162
+DEFINE_GUID(EBPF_WFP_PROVIDER, 0xddb851f5, 0x841a, 0x4b77, 0x8a, 0x46, 0xbb, 0x70, 0x63, 0xe9, 0xf1, 0x62);
+
 // Default eBPF WFP Sublayer GUID.
 // 7c7b3fb9-3331-436a-98e1-b901df457fff
 DEFINE_GUID(EBPF_DEFAULT_SUBLAYER, 0x7c7b3fb9, 0x3331, 0x436a, 0x98, 0xe1, 0xb9, 0x01, 0xdf, 0x45, 0x7f, 0xff);

--- a/netebpfext/net_ebpf_ext_tracelog.h
+++ b/netebpfext/net_ebpf_ext_tracelog.h
@@ -262,3 +262,12 @@ net_ebpf_ext_trace_terminate();
             goto Exit;                                                   \
         }                                                                \
     } while (false);
+
+#define NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(api, status)                                             \
+    do {                                                                                                 \
+        NTSTATUS local_status = (status);                                                                \
+        if (!NT_SUCCESS(local_status)) {                                                                 \
+            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, (api), (status)); \
+            goto Exit;                                                                                   \
+        }                                                                                                \
+    } while (false);

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -538,6 +538,17 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmEngineOpen0(
 }
 
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
+    FwpmProviderAdd0(_In_ HANDLE engine_handle, _In_ const FWPM_PROVIDER0* provider, _In_opt_ PSECURITY_DESCRIPTOR sd)
+{
+    auto& engine = *reinterpret_cast<_fwp_engine*>(engine_handle);
+
+    engine.add_fwpm_provider(provider);
+
+    UNREFERENCED_PARAMETER(sd);
+    return STATUS_SUCCESS;
+}
+
+_IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
     FwpmSubLayerAdd0(_In_ HANDLE engine_handle, _In_ const FWPM_SUBLAYER0* sub_layer, _In_opt_ PSECURITY_DESCRIPTOR sd)
 {
     UNREFERENCED_PARAMETER(sd);

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -171,6 +171,12 @@ typedef class _fwp_engine
         return return_value;
     }
 
+    _Requires_lock_not_held_(this->lock) void add_fwpm_provider(_In_ const FWPM_PROVIDER* sub_layer)
+    {
+        UNREFERENCED_PARAMETER(sub_layer);
+        return;
+    }
+
     _Requires_lock_not_held_(this->lock) uint32_t add_fwpm_sub_layer(_In_ const FWPM_SUBLAYER0* sub_layer)
     {
         exclusive_lock_t l(lock);

--- a/netebpfext/user/fwp_um.h
+++ b/netebpfext/user/fwp_um.h
@@ -171,9 +171,9 @@ typedef class _fwp_engine
         return return_value;
     }
 
-    _Requires_lock_not_held_(this->lock) void add_fwpm_provider(_In_ const FWPM_PROVIDER* sub_layer)
+    _Requires_lock_not_held_(this->lock) void add_fwpm_provider(_In_ const FWPM_PROVIDER* provider)
     {
-        UNREFERENCED_PARAMETER(sub_layer);
+        UNREFERENCED_PARAMETER(provider);
         return;
     }
 


### PR DESCRIPTION
## Description

Windows HLK tests for WFP requires drivers to add a provider object to identify the vendor. The changes were to add the provider to pass the HLK tests.

## Testing

CI.

## Documentation

Not required.
