### PR TITLE
ebpf_platform_user.cpp: Add Fault injection condition in _initialize_thread_pool for OS API

### DIFF
--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -71,7 +71,6 @@ _initialize_thread_pool()
     // Initializes a callback environment for the thread pool.
     // A TP_CALLBACK_ENVIRON structure that defines the callback environment.
     // Using this function, it allocates space for this structure and initializes it.
-    // The caller must call DestroyThreadpoolEnvironment to free the memory.
     InitializeThreadpoolEnvironment(&_callback_environment);
 
     _pool = CreateThreadpool(nullptr);
@@ -366,9 +365,6 @@ ebpf_platform_terminate()
 
     _clean_up_thread_pool();
     _ebpf_emulated_dpcs.resize(0);
-    // Call TpDestroyCallbackEnviron to destroy the callback environment.
-    DestroyThreadpoolEnvironment(&_callback_environment);
-
     if (_ebpf_leak_detector_ptr) {
         _ebpf_leak_detector_ptr->dump_leaks();
         _ebpf_leak_detector_ptr.reset();

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -68,9 +68,7 @@ _initialize_thread_pool()
     bool cleanup_group_created = false;
     bool return_value;
 
-    // Initializes a callback environment for the thread pool.
-    // A TP_CALLBACK_ENVIRON structure that defines the callback environment.
-    // Using this function, it allocates space for this structure and initializes it.
+    // Initializes the callback environment for the thread pool.
     InitializeThreadpoolEnvironment(&_callback_environment);
 
     _pool = CreateThreadpool(nullptr);
@@ -116,8 +114,10 @@ _clean_up_thread_pool()
         return;
     }
 
-    CloseThreadpoolCleanupGroupMembers(_cleanup_group, false, nullptr);
-    CloseThreadpoolCleanupGroup(_cleanup_group);
+    if (_cleanup_group) {
+        CloseThreadpoolCleanupGroupMembers(_cleanup_group, false, nullptr);
+        CloseThreadpoolCleanupGroup(_cleanup_group);
+    }
     CloseThreadpool(_pool);
 }
 

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -366,13 +366,13 @@ ebpf_platform_terminate()
 
     _clean_up_thread_pool();
     _ebpf_emulated_dpcs.resize(0);
+    // Call TpDestroyCallbackEnviron to destroy the callback environment.
+    DestroyThreadpoolEnvironment(&_callback_environment);
+
     if (_ebpf_leak_detector_ptr) {
         _ebpf_leak_detector_ptr->dump_leaks();
         _ebpf_leak_detector_ptr.reset();
     }
-
-    // Call TpDestroyCallbackEnviron to destroy the callback environment.
-    DestroyThreadpoolEnvironment(&_callback_environment);
 }
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -43,7 +43,7 @@ ebpf_leak_detector_ptr _ebpf_leak_detector_ptr;
 #define EBPF_MEMORY_LEAK_DETECTION_ENVIRONMENT_VARIABLE_NAME "EBPF_MEMORY_LEAK_DETECTION"
 
 // Thread pool related globals.
-static TP_CALLBACK_ENVIRON _callback_environment;
+static TP_CALLBACK_ENVIRON _callback_environment{};
 static PTP_POOL _pool = nullptr;
 static PTP_CLEANUP_GROUP _cleanup_group = nullptr;
 
@@ -57,19 +57,17 @@ static std::vector<uint32_t> _ebpf_platform_group_to_index_map;
 static ebpf_result_t
 _initialize_thread_pool()
 {
-    memset(&_callback_environment, 0, sizeof(_callback_environment));
-
-    // CreateThreadpoolCleanupGroup can return nullptr.
-    if (ebpf_fault_injection_is_enabled() && ebpf_fault_injection_inject_fault()) {
-        return EBPF_NO_MEMORY;
-    }
-
     ebpf_result_t result = EBPF_SUCCESS;
     bool cleanup_group_created = false;
     bool return_value;
 
     // Initialize a callback environment for the thread pool.
     InitializeThreadpoolEnvironment(&_callback_environment);
+
+    // CreateThreadpoolCleanupGroup can return nullptr.
+    if (ebpf_fault_injection_is_enabled() && ebpf_fault_injection_inject_fault()) {
+        return EBPF_NO_MEMORY;
+    }
 
     _pool = CreateThreadpool(nullptr);
     if (_pool == nullptr) {
@@ -98,6 +96,7 @@ Exit:
     if (result != EBPF_SUCCESS) {
         if (cleanup_group_created) {
             CloseThreadpoolCleanupGroup(_cleanup_group);
+            _cleanup_group = nullptr;
         }
         if (_pool) {
             CloseThreadpool(_pool);
@@ -115,9 +114,12 @@ _clean_up_thread_pool()
     }
 
     if (_cleanup_group) {
+        CloseThreadpoolCleanupGroupMembers(_cleanup_group, false, nullptr);
         CloseThreadpoolCleanupGroup(_cleanup_group);
+        _cleanup_group = nullptr;
     }
     CloseThreadpool(_pool);
+    _pool = nullptr;
 }
 
 class _ebpf_emulated_dpc;
@@ -945,6 +947,8 @@ ebpf_allocate_preemptible_work_item(
         return EBPF_NO_MEMORY;
     }
 
+    // It is required to use the InitializeThreadpoolEnvironment function to
+    // initialize the _callback_environment structure before calling CreateThreadpoolWork.
     (*work_item)->work = CreateThreadpoolWork(_ebpf_preemptible_routine, *work_item, &_callback_environment);
     if ((*work_item)->work == nullptr) {
         result = win32_error_code_to_ebpf_result(GetLastError());

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -68,7 +68,7 @@ _initialize_thread_pool()
     bool cleanup_group_created = false;
     bool return_value;
 
-    // Initializes the callback environment for the thread pool.
+    // Initialize a callback environment for the thread pool.
     InitializeThreadpoolEnvironment(&_callback_environment);
 
     _pool = CreateThreadpool(nullptr);
@@ -115,7 +115,6 @@ _clean_up_thread_pool()
     }
 
     if (_cleanup_group) {
-        CloseThreadpoolCleanupGroupMembers(_cleanup_group, TRUE, nullptr);
         CloseThreadpoolCleanupGroup(_cleanup_group);
     }
     CloseThreadpool(_pool);

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -115,7 +115,7 @@ _clean_up_thread_pool()
     }
 
     if (_cleanup_group) {
-        CloseThreadpoolCleanupGroupMembers(_cleanup_group, false, nullptr);
+        CloseThreadpoolCleanupGroupMembers(_cleanup_group, TRUE, nullptr);
         CloseThreadpoolCleanupGroup(_cleanup_group);
     }
     CloseThreadpool(_pool);

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -65,7 +65,7 @@ _initialize_thread_pool()
     InitializeThreadpoolEnvironment(&_callback_environment);
 
     // CreateThreadpoolCleanupGroup can return nullptr.
-    if (ebpf_fault_injection_is_enabled() && ebpf_fault_injection_inject_fault()) {
+    if (ebpf_fault_injection_inject_fault()) {
         return EBPF_NO_MEMORY;
     }
 
@@ -96,7 +96,6 @@ Exit:
     if (result != EBPF_SUCCESS) {
         if (cleanup_group_created) {
             CloseThreadpoolCleanupGroup(_cleanup_group);
-            _cleanup_group = nullptr;
         }
         if (_pool) {
             CloseThreadpool(_pool);


### PR DESCRIPTION
## Description
Add fault injection condition in  _initialize_thread_pool() for ebpf_platform_initiate() in ebpf_platform_user.cpp

1. Added fault injection in _initialize_thread_pool().

2. Without initialization ( InitializeThreadpoolEnvironment()), CreateThreadpoolWork OS API and other thread apis give access violation. See both the call stacks below. Hence the fault injection is called after the static callback_environment initialization is done.
```
(8cd0.13564): Access violation - code c0000005 (first chance)
First chance exceptions are reported before any exception handling.
This exception may be expected and handled.
ntdll!InsertTailList+0x4 [inlined in ntdll!TppCleanupGroupMemberInitialize+0x182]:
00007ff9`d6d22e86 483901          cmp     qword ptr [rcx],rax ds:feeefeee`feeefeee=????????????????
0:000> k
 # Child-SP          RetAddr               Call Site
00 (Inline Function) --------`--------     ntdll!InsertTailList+0x4 [onecore\internal\minwin\priv_sdk\inc\ntrtl_x.h @ 975] 
01 000000da`e9cfd200 00007ff9`d6d22c95     ntdll!TppCleanupGroupMemberInitialize+0x182 [minkernel\threadpool\ntdll\cgrpmem.c @ 219] 
02 000000da`e9cfd280 00007ff9`d6d50a75     ntdll!TppWorkInitialize+0x21 [minkernel\threadpool\ntdll\work.c @ 225] 
03 000000da`e9cfd2d0 00007ff9`d4738e29     ntdll!TpAllocWork+0xd5 [minkernel\threadpool\ntdll\work.c @ 341] 
04 000000da`e9cfd340 00007ff7`7904d49f     KERNELBASE!CreateThreadpoolWork+0x19 [minkernel\threadpool\kernel32\threadpool.c @ 149] 
05 000000da`e9cfd370 00007ff7`79014851     unit_tests!ebpf_allocate_preemptible_work_item+0x5f [C:\ebpf\ebpf-for-windows\libs\platform\user\ebpf_platform_user.cpp @ 945] 
06 000000da`e9cfd3b0 00007ff7`78ff1f7c     unit_tests!ebpf_native_load+0x1b1 [C:\ebpf\ebpf-for-windows\libs\execution_context\ebpf_native.c @ 1179] 
07 000000da`e9cfd7d0 00007ff7`78ff7c3f     unit_tests!_ebpf_core_protocol_load_native_module+0x1ac [C:\ebpf\ebpf-for-windows\libs\execution_context\ebpf_core.c @ 610] 
08 000000da`e9cfd970 00007ff7`78e7b285     unit_tests!ebpf_core_invoke_protocol_handler+0x2af [C:\ebpf\ebpf-for-windows\libs\execution_context\ebpf_core.c @ 2430] 
...
10 000000da`e9cfde50 00007ff7`78dfe17d     unit_tests!test_ioctl_load_native_module+0x167 [C:\ebpf\ebpf-for-windows\tests\libs\util\ioctl_helper.cpp @ 48] 

--
(1110.41c): Access violation - code c0000005 (first/second chance not available)
For analysis of this file, run !analyze -v
*** WARNING: Unable to verify checksum for unit_tests.exe
ntdll!TpReleaseCleanupGroupMembers+0x6d:
00007ffa`4a166d4d 488b00          mov     rax,qword ptr [rax] ds:abababab`abababab=????????????????
0:000> k
 # Child-SP          RetAddr               Call Site
00 000000fc`e42fdfb0 00007ff7`7e405dd4     ntdll!TpReleaseCleanupGroupMembers+0x6d [minkernel\threadpool\ntdll\cgrp.c @ 320] 
01 000000fc`e42fe020 00007ff7`7e409304     unit_tests+0x2f5dd4
```

## Testing

_Do any existing tests cover this change? Yes
Are new tests needed? No

Existing test cases:
unit_tests.exe : PASSED
netebpf_ext_unit.exe: PASSED


## Documentation

_Is there any documentation impact for this change? No
