### PR TITLE
Fix ringbuffer test.

### DIFF
--- a/tests/libs/common/common_tests.cpp
+++ b/tests/libs/common/common_tests.cpp
@@ -195,7 +195,7 @@ ring_buffer_api_test_helper(
     }
 
     // Wait for event handler getting notifications for all RING_BUFFER_TEST_EVENT_COUNT events.
-    REQUIRE(ring_buffer_event_callback.wait_for(1s) == std::future_status::ready);
+    bool notifications_received = (ring_buffer_event_callback.wait_for(1s) == std::future_status::ready);
 
     // Mark the event context as canceled, such that the event callback stops processing events.
     context->canceled = true;
@@ -205,4 +205,6 @@ ring_buffer_api_test_helper(
 
     // Unsubscribe.
     raw_context->unsubscribe();
+
+    REQUIRE(notifications_received);
 }


### PR DESCRIPTION
## Description

The ring buffer test helper function `ring_buffer_api_test_helper` subscribes for ring buffer notification. It uses catch `REQUIRE` macro to ensure wait for all notifications is satisifed. In fault injection tests, this wait may not be satisfied and `REQUIRE` throws an exception causing the test smart pointer object to be destroyed without unsubscribing from ring_buffer which causes the following leak:

```
 "Leak of 56 bytes at 2186619192864." [Type: std::basic_string<char,std::char_traits<char>,std::allocator<char> >]
 : "    ebpf_allocate + 190 (D:\a\ebpf-for-windows\ebpf-for-windows\libs\platform\user\ebpf_platform_user.cpp:398)." [Type: std::basic_string<char,std::char_traits<char>,std::allocator<char> >]
: "    initialize_async_ioctl_operation + 56 (D:\a\ebpf-for-windows\ebpf-for-windows\libs\api_common\device_helper.cpp:171)." [Type: std::basic_string<char,std::char_traits<char>,std::allocator<char> >]
 : "    ebpf_ring_buffer_map_subscribe 

```
The fix is to always unsubscribe even if the notifications do not get fired on time.

Fixes #2251.

## Testing

CI.

## Documentation

N/A.
