### PR TITLE
Allow various structs to be const

### DIFF
--- a/include/ebpf_program_attach_type_guids.h
+++ b/include/ebpf_program_attach_type_guids.h
@@ -87,6 +87,11 @@ extern "C"
 
     __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_UNSPECIFIED = {0};
 
+#define EBPF_PROGRAM_TYPE_XDP_GUID                                                     \
+    {                                                                                  \
+        0xf1832a85, 0x85d5, 0x45b0, { 0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0 } \
+    }
+
     /** @brief Program type for handling incoming packets as early as possible.
      *
      * eBPF program prototype: \ref xdp_hook_t
@@ -95,8 +100,12 @@ extern "C"
      *
      * Helpers available: see bpf_helpers.h
      */
-    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_XDP = {
-        0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_XDP = EBPF_PROGRAM_TYPE_XDP_GUID;
+
+#define EBPF_PROGRAM_TYPE_BIND_GUID                                                    \
+    {                                                                                  \
+        0x608c517c, 0x6c52, 0x4a26, { 0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf } \
+    }
 
     /** @brief Program type for handling socket bind() requests.
      *
@@ -106,8 +115,12 @@ extern "C"
      *
      * Helpers available: see bpf_helpers.h
      */
-    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_BIND = {
-        0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
+    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_BIND = EBPF_PROGRAM_TYPE_BIND_GUID;
+
+#define EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID                                        \
+    {                                                                                  \
+        0x92ec8e39, 0xaeec, 0x11ec, { 0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee } \
+    }
 
     /** @brief Program type for handling various socket operations such as connect(), accept() etc.
      *
@@ -119,23 +132,31 @@ extern "C"
      *  \ref EBPF_ATTACH_TYPE_CGROUP_INET4_RECV_ACCEPT
      *  \ref EBPF_ATTACH_TYPE_CGROUP_INET6_RECV_ACCEPT
      */
-    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR = {
-        0x92ec8e39, 0xaeec, 0x11ec, {0x9a, 0x30, 0x18, 0x60, 0x24, 0x89, 0xbe, 0xee}};
+    __declspec(selectany)
+        ebpf_program_type_t EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID;
+
+#define EBPF_PROGRAM_TYPE_SOCK_OPS_GUID                                                \
+    {                                                                                  \
+        0x43fb224d, 0x68f8, 0x46d6, { 0xaa, 0x3f, 0xc8, 0x56, 0x51, 0x8c, 0xbb, 0x32 } \
+    }
 
     /** @brief Program type for handling socket event notifications.
      *
      * Attach type(s): \ref EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS
      */
-    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_SOCK_OPS = {
-        0x43fb224d, 0x68f8, 0x46d6, {0xaa, 0x3f, 0xc8, 0x56, 0x51, 0x8c, 0xbb, 0x32}};
+    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_SOCK_OPS = EBPF_PROGRAM_TYPE_SOCK_OPS_GUID;
+
+#define EBPF_PROGRAM_TYPE_SAMPLE_GUID                                                  \
+    {                                                                                  \
+        0xf788ef4a, 0x207d, 0x4dc3, { 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c } \
+    }
 
     /** @brief Program type for handling calls from the eBPF sample extension. Used for
      * testing.
      *
      * Attach type(s): \ref EBPF_ATTACH_TYPE_SAMPLE
      */
-    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_SAMPLE = {
-        0xf788ef4a, 0x207d, 0x4dc3, {0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c}};
+    __declspec(selectany) ebpf_program_type_t EBPF_PROGRAM_TYPE_SAMPLE = EBPF_PROGRAM_TYPE_SAMPLE_GUID;
 
 #ifdef __cplusplus
 }

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -14,7 +14,7 @@
 typedef struct _ebpf_program_type_descriptor
 {
     const char* name;
-    ebpf_context_descriptor_t* context_descriptor;
+    const ebpf_context_descriptor_t* context_descriptor;
     GUID program_type;
     uint32_t bpf_prog_type;
     char is_privileged;
@@ -32,9 +32,9 @@ typedef struct _ebpf_program_info
 {
     ebpf_program_type_descriptor_t program_type_descriptor;
     uint32_t count_of_program_type_specific_helpers;
-    ebpf_helper_function_prototype_t* program_type_specific_helper_prototype;
+    const ebpf_helper_function_prototype_t* program_type_specific_helper_prototype;
     uint32_t count_of_global_helpers;
-    ebpf_helper_function_prototype_t* global_helper_prototype;
+    const ebpf_helper_function_prototype_t* global_helper_prototype;
 } ebpf_program_info_t;
 
 typedef struct _ebpf_helper_function_addresses
@@ -59,11 +59,11 @@ typedef void (*ebpf_program_context_destroy_t)(
 
 typedef struct _ebpf_program_data
 {
-    ebpf_program_info_t* program_info; ///< Pointer to program information.
-    ebpf_helper_function_addresses_t*
+    const ebpf_program_info_t* program_info; ///< Pointer to program information.
+    const ebpf_helper_function_addresses_t*
         program_type_specific_helper_function_addresses; ///< Pointer to program type specific helper function
                                                          ///< addresses.
-    ebpf_helper_function_addresses_t*
+    const ebpf_helper_function_addresses_t*
         global_helper_function_addresses;           ///< Pointer to global helper function addresses being overriden.
     ebpf_program_context_create_t context_create;   ///< Pointer to context create function.
     ebpf_program_context_destroy_t context_destroy; ///< Pointer to context destroy function.
@@ -73,8 +73,8 @@ typedef struct _ebpf_program_data
 typedef struct _ebpf_program_section_info
 {
     const wchar_t* section_name;
-    GUID* program_type;
-    GUID* attach_type;
+    const GUID* program_type;
+    const GUID* attach_type;
     uint32_t bpf_program_type;
     uint32_t bpf_attach_type;
 } ebpf_program_section_info_t;

--- a/include/ebpf_store_helper.h
+++ b/include/ebpf_store_helper.h
@@ -91,7 +91,7 @@ Exit:
  */
 static __return_type
 _ebpf_store_update_section_information(
-    _In_reads_(section_info_count) ebpf_program_section_info_t* section_info, uint32_t section_info_count)
+    _In_reads_(section_info_count) const ebpf_program_section_info_t* section_info, uint32_t section_info_count)
 {
     __return_type status = _SUCCESS;
     ebpf_registry_key_t provider_key = NULL;
@@ -182,7 +182,7 @@ Exit:
  */
 static __return_type
 _ebpf_store_update_program_information(
-    _In_reads_(program_info_count) ebpf_program_info_t* program_info, uint32_t program_info_count)
+    _In_reads_(program_info_count) const ebpf_program_info_t* program_info, uint32_t program_info_count)
 {
     __return_type status = _SUCCESS;
     ebpf_registry_key_t provider_key = NULL;

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -230,13 +230,13 @@ _load_program_data_information(
                 goto Exit;
             }
 
-            program_information->program_type_specific_helper_prototype =
-                (ebpf_helper_function_prototype_t*)ebpf_allocate(
-                    helper_count * sizeof(ebpf_helper_function_prototype_t));
-            if (program_information->program_type_specific_helper_prototype == nullptr) {
+            ebpf_helper_function_prototype_t* helper_prototype = (ebpf_helper_function_prototype_t*)ebpf_allocate(
+                helper_count * sizeof(ebpf_helper_function_prototype_t));
+            if (helper_prototype == nullptr) {
                 result = EBPF_NO_MEMORY;
                 goto Exit;
             }
+            program_information->program_type_specific_helper_prototype = helper_prototype;
 
             // Add space for null terminator.
             max_helper_name_size += 1;
@@ -257,8 +257,7 @@ _load_program_data_information(
                     goto Exit;
                 }
 
-                result = _load_helper_prototype(
-                    helper_key, helper_name, &program_information->program_type_specific_helper_prototype[index]);
+                result = _load_helper_prototype(helper_key, helper_name, &helper_prototype[index]);
                 if (result != EBPF_SUCCESS) {
                     goto Exit;
                 }

--- a/libs/api_common/windows_helpers.cpp
+++ b/libs/api_common/windows_helpers.cpp
@@ -13,7 +13,7 @@
 #include <stdexcept>
 #include <vector>
 
-static ebpf_helper_function_prototype_t*
+static const ebpf_helper_function_prototype_t*
 _get_helper_function_prototype(const ebpf_program_info_t* info, unsigned int n)
 {
     for (uint32_t i = 0; i < info->count_of_program_type_specific_helpers; i++) {
@@ -49,7 +49,7 @@ get_helper_prototype_windows(int32_t n)
 
     verifier_prototype.context_descriptor = info->program_type_descriptor.context_descriptor;
 
-    ebpf_helper_function_prototype_t* raw_prototype = _get_helper_function_prototype(info, n);
+    const ebpf_helper_function_prototype_t* raw_prototype = _get_helper_function_prototype(info, n);
     if (raw_prototype == nullptr) {
         throw std::runtime_error(std::string("helper prototype not found: ") + std::to_string(n));
     }

--- a/libs/api_common/windows_platform_common.cpp
+++ b/libs/api_common/windows_platform_common.cpp
@@ -522,7 +522,7 @@ _update_global_helpers_for_program_information(
                 new_helpers + global_helper_count,
                 program_info->program_type_specific_helper_prototype,
                 (program_info->count_of_program_type_specific_helpers * sizeof(ebpf_helper_function_prototype_t)));
-            ebpf_free(program_info->program_type_specific_helper_prototype);
+            ebpf_free((void*)program_info->program_type_specific_helper_prototype);
         }
 
         program_info->program_type_specific_helper_prototype = new_helpers;

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -138,8 +138,8 @@ _ebpf_program_program_info_provider_changed(
         // Attach
         program->info_extension_provider_data = provider_data;
 
-        ebpf_helper_function_addresses_t* helper_function_addresses = NULL;
-        ebpf_helper_function_addresses_t* global_helper_function_addresses = NULL;
+        const ebpf_helper_function_addresses_t* helper_function_addresses = NULL;
+        const ebpf_helper_function_addresses_t* global_helper_function_addresses = NULL;
 
         ebpf_program_data_t* program_data = (ebpf_program_data_t*)provider_data->data;
         if (program_data == NULL) {
@@ -760,8 +760,8 @@ _ebpf_program_update_jit_helpers(_Inout_ ebpf_program_t* program, _Inout_ void* 
     ebpf_result_t return_value;
     UNREFERENCED_PARAMETER(context);
     ebpf_program_data_t* program_data = NULL;
-    ebpf_helper_function_addresses_t* helper_function_addresses = NULL;
-    ebpf_helper_function_addresses_t* global_helper_function_addresses = NULL;
+    const ebpf_helper_function_addresses_t* helper_function_addresses = NULL;
+    const ebpf_helper_function_addresses_t* global_helper_function_addresses = NULL;
 
     size_t total_helper_count = 0;
     ebpf_helper_function_addresses_t* total_helper_function_addresses = NULL;
@@ -783,8 +783,8 @@ _ebpf_program_update_jit_helpers(_Inout_ ebpf_program_t* program, _Inout_ void* 
     global_helper_function_addresses = program_data->global_helper_function_addresses;
 
     if (helper_function_addresses != NULL || global_helper_function_addresses != NULL) {
-        ebpf_program_info_t* program_info = program_data->program_info;
-        ebpf_helper_function_prototype_t* helper_prototypes = NULL;
+        const ebpf_program_info_t* program_info = program_data->program_info;
+        const ebpf_helper_function_prototype_t* helper_prototypes = NULL;
         ebpf_assert(program_info != NULL);
         _Analysis_assume_(program_info != NULL);
         if ((helper_function_addresses != NULL && program_info->count_of_program_type_specific_helpers !=
@@ -1362,17 +1362,17 @@ ebpf_program_get_program_info(_In_ const ebpf_program_t* program, _Outptr_ ebpf_
     if (total_count_of_helpers > 0) {
         // Allocate buffer and make a shallow copy of the combined global and program-type specific helper function
         // prototypes.
-        local_program_info->program_type_specific_helper_prototype =
-            (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(
-                total_count_of_helpers * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_PROGRAM);
-        if (local_program_info->program_type_specific_helper_prototype == NULL) {
+        ebpf_helper_function_prototype_t* helper_prototype = (ebpf_helper_function_prototype_t*)ebpf_allocate_with_tag(
+            total_count_of_helpers * sizeof(ebpf_helper_function_prototype_t), EBPF_POOL_TAG_PROGRAM);
+        if (helper_prototype == NULL) {
             result = EBPF_NO_MEMORY;
             goto Exit;
         }
+        local_program_info->program_type_specific_helper_prototype = helper_prototype;
 
         for (uint32_t index = 0; index < program_data->program_info->count_of_program_type_specific_helpers; index++) {
             __analysis_assume(helper_index < total_count_of_helpers);
-            local_program_info->program_type_specific_helper_prototype[helper_index++] =
+            helper_prototype[helper_index++] =
                 program_data->program_info->program_type_specific_helper_prototype[index];
         }
 
@@ -1380,7 +1380,7 @@ ebpf_program_get_program_info(_In_ const ebpf_program_t* program, _Outptr_ ebpf_
              index < general_helper_program_data->program_info->count_of_program_type_specific_helpers;
              index++) {
             __analysis_assume(helper_index < total_count_of_helpers);
-            local_program_info->program_type_specific_helper_prototype[helper_index++] =
+            helper_prototype[helper_index++] =
                 general_helper_program_data->program_info->program_type_specific_helper_prototype[index];
         }
     }
@@ -1404,8 +1404,8 @@ void
 ebpf_program_free_program_info(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info)
 {
     if (program_info != NULL) {
-        ebpf_free(program_info->program_type_specific_helper_prototype);
-        ebpf_free(program_info->global_helper_prototype);
+        ebpf_free((void*)program_info->program_type_specific_helper_prototype);
+        ebpf_free((void*)program_info->global_helper_prototype);
         ebpf_free(program_info);
     }
 }

--- a/libs/platform/ebpf_serialize.c
+++ b/libs/platform/ebpf_serialize.c
@@ -254,26 +254,26 @@ ebpf_program_info_free(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info
 {
     EBPF_LOG_ENTRY();
     if (program_info != NULL) {
-        ebpf_free(program_info->program_type_descriptor.context_descriptor);
+        ebpf_free((void*)program_info->program_type_descriptor.context_descriptor);
         ebpf_free((void*)program_info->program_type_descriptor.name);
         if (program_info->program_type_specific_helper_prototype != NULL) {
             for (uint32_t i = 0; i < program_info->count_of_program_type_specific_helpers; i++) {
-                ebpf_helper_function_prototype_t* helper_prototype =
+                const ebpf_helper_function_prototype_t* helper_prototype =
                     &program_info->program_type_specific_helper_prototype[i];
-                ebpf_free((void*)helper_prototype->name);
-                helper_prototype->name = NULL;
+                void* name = (void*)helper_prototype->name;
+                ebpf_free(name);
             }
         }
         if (program_info->global_helper_prototype != NULL) {
             for (uint32_t i = 0; i < program_info->count_of_global_helpers; i++) {
-                ebpf_helper_function_prototype_t* helper_prototype = &program_info->global_helper_prototype[i];
-                ebpf_free((void*)helper_prototype->name);
-                helper_prototype->name = NULL;
+                const ebpf_helper_function_prototype_t* helper_prototype = &program_info->global_helper_prototype[i];
+                void* name = (void*)helper_prototype->name;
+                ebpf_free(name);
             }
         }
 
-        ebpf_free(program_info->program_type_specific_helper_prototype);
-        ebpf_free(program_info->global_helper_prototype);
+        ebpf_free((void*)program_info->program_type_specific_helper_prototype);
+        ebpf_free((void*)program_info->global_helper_prototype);
         ebpf_free(program_info);
     }
     EBPF_RETURN_VOID();
@@ -291,7 +291,7 @@ ebpf_serialize_program_info(
     ebpf_result_t result = EBPF_SUCCESS;
     uint8_t* current = NULL;
     const ebpf_program_type_descriptor_t* program_type_descriptor;
-    ebpf_helper_function_prototype_t* helper_prototype_array;
+    const ebpf_helper_function_prototype_t* helper_prototype_array;
     uint32_t helper_prototype_index;
     size_t serialized_program_type_descriptor_length;
     size_t program_type_descriptor_name_length;
@@ -376,7 +376,7 @@ ebpf_serialize_program_info(
 
         for (helper_prototype_index = 0; helper_prototype_index < program_info->count_of_program_type_specific_helpers;
              helper_prototype_index++) {
-            ebpf_helper_function_prototype_t* helper_prototype = &helper_prototype_array[helper_prototype_index];
+            const ebpf_helper_function_prototype_t* helper_prototype = &helper_prototype_array[helper_prototype_index];
 
             result = ebpf_safe_size_t_add(
                 serialized_helper_prototype_array_length,
@@ -447,7 +447,7 @@ ebpf_serialize_program_info(
 
         for (helper_prototype_index = 0; helper_prototype_index < program_info->count_of_program_type_specific_helpers;
              helper_prototype_index++) {
-            ebpf_helper_function_prototype_t* helper_prototype = &helper_prototype_array[helper_prototype_index];
+            const ebpf_helper_function_prototype_t* helper_prototype = &helper_prototype_array[helper_prototype_index];
             size_t helper_function_name_length =
                 strnlen_s(helper_prototype->name, EBPF_MAX_HELPER_FUNCTION_NAME_LENGTH);
             ebpf_serialized_helper_function_prototype_t* serialized_helper_prototype =

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -797,8 +797,10 @@ TEST_CASE("serialize_program_info_test", "[platform]")
         out_program_info->count_of_program_type_specific_helpers);
     REQUIRE(out_program_info->program_type_specific_helper_prototype != nullptr);
     for (uint32_t i = 0; i < in_program_info.count_of_program_type_specific_helpers; i++) {
-        ebpf_helper_function_prototype_t* in_prototype = &in_program_info.program_type_specific_helper_prototype[i];
-        ebpf_helper_function_prototype_t* out_prototype = &out_program_info->program_type_specific_helper_prototype[i];
+        const ebpf_helper_function_prototype_t* in_prototype =
+            &in_program_info.program_type_specific_helper_prototype[i];
+        const ebpf_helper_function_prototype_t* out_prototype =
+            &out_program_info->program_type_specific_helper_prototype[i];
         REQUIRE(in_prototype->helper_id == out_prototype->helper_id);
         REQUIRE(in_prototype->return_type == out_prototype->return_type);
         for (int j = 0; j < _countof(in_prototype->arguments); j++) {

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -163,8 +163,7 @@ _net_ebpf_bind_update_store_entries()
         return status;
     }
 
-    // Program information
-    _ebpf_bind_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_BIND;
+    // Update program information.
     status = _ebpf_store_update_program_information(&_ebpf_bind_program_info, 1);
 
     return status;
@@ -187,7 +186,6 @@ net_ebpf_ext_bind_register_providers()
 
     NET_EBPF_EXT_LOG_ENTRY();
 
-    _ebpf_bind_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_BIND;
     // Set the program type as the provider module id.
     _ebpf_bind_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_BIND;
     status = net_ebpf_extension_program_info_provider_register(

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -9,46 +9,46 @@
 #define XDP_EXT_HELPER_FUNCTION_START EBPF_MAX_GENERAL_HELPER_FUNCTION
 
 // XDP helper function prototype descriptors.
-static ebpf_helper_function_prototype_t _xdp_ebpf_extension_helper_function_prototype[] = {
+static const ebpf_helper_function_prototype_t _xdp_ebpf_extension_helper_function_prototype[] = {
     {XDP_EXT_HELPER_FUNCTION_START + 1,
      "bpf_xdp_adjust_head",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_ANYTHING}}};
 
 // XDP program information.
-static ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {
     sizeof(xdp_md_t),
     EBPF_OFFSET_OF(xdp_md_t, data),
     EBPF_OFFSET_OF(xdp_md_t, data_end),
     EBPF_OFFSET_OF(xdp_md_t, data_meta)};
 
-static ebpf_program_info_t _ebpf_xdp_program_info = {
-    {"xdp", &_ebpf_xdp_context_descriptor, {0}, BPF_PROG_TYPE_XDP},
+static const ebpf_program_info_t _ebpf_xdp_program_info = {
+    {"xdp", &_ebpf_xdp_context_descriptor, EBPF_PROGRAM_TYPE_XDP_GUID, BPF_PROG_TYPE_XDP},
     EBPF_COUNT_OF(_xdp_ebpf_extension_helper_function_prototype),
     _xdp_ebpf_extension_helper_function_prototype};
 
-static ebpf_program_section_info_t _ebpf_xdp_section_info[] = {
+static const ebpf_program_section_info_t _ebpf_xdp_section_info[] = {
     {(const wchar_t*)L"xdp", &EBPF_PROGRAM_TYPE_XDP, &EBPF_ATTACH_TYPE_XDP, BPF_PROG_TYPE_XDP, BPF_XDP}};
 
 // Bind program information.
-static ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_bind_context_descriptor = {
     sizeof(bind_md_t), EBPF_OFFSET_OF(bind_md_t, app_id_start), EBPF_OFFSET_OF(bind_md_t, app_id_end), -1};
 
-static ebpf_program_info_t _ebpf_bind_program_info = {
-    {"bind", &_ebpf_bind_context_descriptor, {0}, BPF_PROG_TYPE_BIND}, 0, NULL};
+static const ebpf_program_info_t _ebpf_bind_program_info = {
+    {"bind", &_ebpf_bind_context_descriptor, EBPF_PROGRAM_TYPE_BIND_GUID, BPF_PROG_TYPE_BIND}, 0, NULL};
 
-static ebpf_program_section_info_t _ebpf_bind_section_info[] = {
+static const ebpf_program_section_info_t _ebpf_bind_section_info[] = {
     {L"bind", &EBPF_PROGRAM_TYPE_BIND, &EBPF_ATTACH_TYPE_BIND, BPF_PROG_TYPE_BIND, BPF_ATTACH_TYPE_BIND}};
 
 // CGROUP_SOCK_ADDR extension specific helper function prototypes.
-static ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_function_prototype[] = {
+static const ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_function_prototype[] = {
     {BPF_FUNC_sock_addr_get_current_pid_tgid,
      "bpf_sock_addr_get_current_pid_tgid",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}}};
 
 // CGROUP_SOCK_ADDR global helper function prototypes.
-static ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_function_prototype[] = {
+static const ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_function_prototype[] = {
     {BPF_FUNC_get_current_logon_id,
      "bpf_get_current_logon_id",
      EBPF_RETURN_TYPE_INTEGER,
@@ -56,21 +56,24 @@ static ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_function_p
     {BPF_FUNC_is_current_admin, "bpf_is_current_admin", EBPF_RETURN_TYPE_INTEGER, {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}}};
 
 // CGROUP_SOCK_ADDR program information.
-static ebpf_context_descriptor_t _ebpf_sock_addr_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_sock_addr_context_descriptor = {
     sizeof(bpf_sock_addr_t),
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
     -1, // Offset into ctx struct for pointer to metadata, or -1 if none.
 };
 
-static ebpf_program_info_t _ebpf_sock_addr_program_info = {
-    {"sock_addr", &_ebpf_sock_addr_context_descriptor, {0}, BPF_PROG_TYPE_CGROUP_SOCK_ADDR},
+static const ebpf_program_info_t _ebpf_sock_addr_program_info = {
+    {"sock_addr",
+     &_ebpf_sock_addr_context_descriptor,
+     EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR_GUID,
+     BPF_PROG_TYPE_CGROUP_SOCK_ADDR},
     EBPF_COUNT_OF(_sock_addr_ebpf_extension_helper_function_prototype),
     _sock_addr_ebpf_extension_helper_function_prototype,
     EBPF_COUNT_OF(_ebpf_sock_addr_global_helper_function_prototype),
     _ebpf_sock_addr_global_helper_function_prototype};
 
-static ebpf_program_section_info_t _ebpf_sock_addr_section_info[] = {
+static const ebpf_program_section_info_t _ebpf_sock_addr_section_info[] = {
     {L"cgroup/connect4",
      &EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR,
      &EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT,
@@ -93,17 +96,17 @@ static ebpf_program_section_info_t _ebpf_sock_addr_section_info[] = {
      BPF_CGROUP_INET6_RECV_ACCEPT}};
 
 // SOCK_OPS program information.
-static ebpf_context_descriptor_t _ebpf_sock_ops_context_descriptor = {
+static const ebpf_context_descriptor_t _ebpf_sock_ops_context_descriptor = {
     sizeof(bpf_sock_ops_t),
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
     -1, // Offset into ctx struct for pointer to data, or -1 if none.
     -1, // Offset into ctx struct for pointer to metadata, or -1 if none.
 };
 
-static ebpf_program_info_t _ebpf_sock_ops_program_info = {
-    {"sockops", &_ebpf_sock_ops_context_descriptor, {0}, BPF_PROG_TYPE_SOCK_OPS}, 0, NULL};
+static const ebpf_program_info_t _ebpf_sock_ops_program_info = {
+    {"sockops", &_ebpf_sock_ops_context_descriptor, EBPF_PROGRAM_TYPE_SOCK_OPS_GUID, BPF_PROG_TYPE_SOCK_OPS}, 0, NULL};
 
-static ebpf_program_section_info_t _ebpf_sock_ops_section_info[] = {
+static const ebpf_program_section_info_t _ebpf_sock_ops_section_info[] = {
     {L"sockops",
      &EBPF_PROGRAM_TYPE_SOCK_OPS,
      &EBPF_ATTACH_TYPE_CGROUP_SOCK_OPS,

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -418,7 +418,6 @@ _net_ebpf_sock_addr_update_store_entries()
     }
 
     // Update program information.
-    _ebpf_sock_addr_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR;
     status = _ebpf_store_update_program_information(&_ebpf_sock_addr_program_info, 1);
 
     NET_EBPF_EXT_RETURN_NTSTATUS(status);
@@ -740,7 +739,6 @@ net_ebpf_ext_sock_addr_register_providers()
     const net_ebpf_extension_program_info_provider_parameters_t program_info_provider_parameters = {
         &_ebpf_sock_addr_program_info_provider_moduleid, &_ebpf_sock_addr_program_info_provider_data};
 
-    _ebpf_sock_addr_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR;
     // Set the program type as the provider module id.
     _ebpf_sock_addr_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR;
     status = net_ebpf_extension_program_info_provider_register(

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -265,7 +265,6 @@ _net_ebpf_sock_ops_update_store_entries()
     }
 
     // Update program information.
-    _ebpf_sock_ops_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_SOCK_OPS;
     status = _ebpf_store_update_program_information(&_ebpf_sock_ops_program_info, 1);
 
     return status;
@@ -288,7 +287,6 @@ net_ebpf_ext_sock_ops_register_providers()
 
     NET_EBPF_EXT_LOG_ENTRY();
 
-    _ebpf_sock_ops_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_SOCK_OPS;
     // Set the program type as the provider module id.
     _ebpf_sock_ops_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_SOCK_OPS;
     status = net_ebpf_extension_program_info_provider_register(

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -236,7 +236,6 @@ _net_ebpf_xdp_update_store_entries()
     }
 
     // Update program information.
-    _ebpf_xdp_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_XDP;
     status = _ebpf_store_update_program_information(&_ebpf_xdp_program_info, 1);
 
     return status;
@@ -259,7 +258,6 @@ net_ebpf_ext_xdp_register_providers()
 
     NET_EBPF_EXT_LOG_ENTRY();
 
-    _ebpf_xdp_program_info.program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_XDP;
     // Set the program type as the provider module id.
     _ebpf_xdp_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_XDP;
     status = net_ebpf_extension_program_info_provider_register(

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -539,12 +539,11 @@ typedef class _program_info_provider
             throw std::invalid_argument("Unsupported program type");
         }
         ebpf_program_data_t* program_data = (ebpf_program_data_t*)provider_data->data;
-        program_data->program_info->program_type_descriptor.program_type = program_type;
 
         if (ebpf_provider_load(
                 &provider,
                 &ebpf_program_information_extension_interface_id,
-                &program_type,
+                &program_data->program_info->program_type_descriptor.program_type,
                 nullptr,
                 provider_data,
                 nullptr,

--- a/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
@@ -297,7 +297,8 @@ fuzz_program(
         // No such helper id.
         return;
     }
-    ebpf_helper_function_prototype_t* prototype = &program_info->program_type_specific_helper_prototype[helper_index];
+    const ebpf_helper_function_prototype_t* prototype =
+        &program_info->program_type_specific_helper_prototype[helper_index];
 
     // Get the helper function pointer.
     ebpf_helper_id_t helper_function_id = (ebpf_helper_id_t)prototype->helper_id;

--- a/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/netebpfext_fuzzer/libfuzz_harness.cpp
@@ -20,7 +20,7 @@ typedef struct
 typedef struct _test_client_context
 {
     netebpfext_helper_base_client_context_t base;
-    ebpf_context_descriptor_t* ctx_descriptor;
+    const ebpf_context_descriptor_t* ctx_descriptor;
     netebpfext_fuzzer_metadata_t metadata;
 } test_client_context_t;
 

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -21,9 +21,6 @@
 
 #define SAMPLE_PID_TGID_VALUE 9999
 
-// f788ef4a-207d-4dc3-85cf-0f2ea107213c
-DEFINE_GUID(EBPF_PROGRAM_TYPE_SAMPLE, 0xf788ef4a, 0x207d, 0x4dc3, 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c);
-
 // Sample Extension helper function addresses table.
 static uint64_t
 _sample_get_pid_tgid();
@@ -40,12 +37,12 @@ static const void* _sample_ebpf_extension_helpers[] = {
     (void*)&_sample_ebpf_extension_find,
     (void*)&_sample_ebpf_extension_replace};
 
-static ebpf_helper_function_addresses_t _sample_ebpf_extension_helper_function_address_table = {
+static const ebpf_helper_function_addresses_t _sample_ebpf_extension_helper_function_address_table = {
     EBPF_COUNT_OF(_sample_ebpf_extension_helpers), (uint64_t*)_sample_ebpf_extension_helpers};
 
 static const void* _sample_global_helpers[] = {(void*)&_sample_get_pid_tgid};
 
-static ebpf_helper_function_addresses_t _sample_global_helper_function_address_table = {
+static const ebpf_helper_function_addresses_t _sample_global_helper_function_address_table = {
     EBPF_COUNT_OF(_sample_global_helpers), (uint64_t*)_sample_global_helpers};
 
 static ebpf_program_data_t _sample_ebpf_extension_program_data = {
@@ -53,7 +50,7 @@ static ebpf_program_data_t _sample_ebpf_extension_program_data = {
     &_sample_ebpf_extension_helper_function_address_table,
     &_sample_global_helper_function_address_table};
 
-static ebpf_extension_data_t _sample_ebpf_extension_program_info_provider_data = {
+static const ebpf_extension_data_t _sample_ebpf_extension_program_info_provider_data = {
     SAMPLE_EBPF_EXTENSION_NPI_PROVIDER_VERSION,
     sizeof(_sample_ebpf_extension_program_data),
     &_sample_ebpf_extension_program_data};
@@ -140,9 +137,6 @@ static sample_ebpf_extension_program_info_provider_t _sample_ebpf_extension_prog
 //
 // Hook Provider.
 //
-
-// f788ef4b-207d-4dc3-85cf-0f2ea107213c
-DEFINE_GUID(EBPF_ATTACH_TYPE_SAMPLE, 0xf788ef4b, 0x207d, 0x4dc3, 0x85, 0xcf, 0x0f, 0x2e, 0xa1, 0x07, 0x21, 0x3c);
 
 NPI_MODULEID DECLSPEC_SELECTANY _sample_ebpf_extension_hook_provider_moduleid = {sizeof(NPI_MODULEID), MIT_GUID, {0}};
 
@@ -339,7 +333,6 @@ _sample_ebpf_extension_update_store_entries()
     extension_data = (ebpf_extension_data_t*)_sample_ebpf_extension_program_info_provider_characteristics
                          .ProviderRegistrationInstance.NpiSpecificCharacteristics;
     program_data = (ebpf_program_data_t*)extension_data->data;
-    program_data->program_info->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_SAMPLE;
 
     status = _ebpf_store_update_program_information(program_data->program_info, 1);
 
@@ -363,7 +356,6 @@ sample_ebpf_extension_program_info_provider_register()
     extension_data = (ebpf_extension_data_t*)_sample_ebpf_extension_program_info_provider_characteristics
                          .ProviderRegistrationInstance.NpiSpecificCharacteristics;
     program_data = (ebpf_program_data_t*)extension_data->data;
-    program_data->program_info->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_SAMPLE;
     _sample_ebpf_extension_program_info_provider_moduleid.Guid = EBPF_PROGRAM_TYPE_SAMPLE;
 
     local_provider_context = &_sample_ebpf_extension_program_info_provider_context;

--- a/tests/sample/ext/inc/sample_ext_program_info.h
+++ b/tests/sample/ext/inc/sample_ext_program_info.h
@@ -8,19 +8,20 @@
  */
 
 #include "ebpf_platform.h"
+#include "ebpf_program_attach_type_guids.h" // TODO(issue #2305): remove this include.
 #include "ebpf_structs.h"
 #include "sample_ext_helpers.h"
 
 #define SAMPLE_EXT_HELPER_FUNCTION_START EBPF_MAX_GENERAL_HELPER_FUNCTION
 
-static ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {
+static const ebpf_context_descriptor_t _sample_ebpf_context_descriptor = {
     sizeof(sample_program_context_t),
     EBPF_OFFSET_OF(sample_program_context_t, data_start),
     EBPF_OFFSET_OF(sample_program_context_t, data_end),
     -1};
 
 // Sample Extension Helper function prototype descriptors.
-static ebpf_helper_function_prototype_t _sample_ebpf_extension_helper_function_prototype[] = {
+static const ebpf_helper_function_prototype_t _sample_ebpf_extension_helper_function_prototype[] = {
     {SAMPLE_EXT_HELPER_FUNCTION_START + 1,
      "sample_ebpf_extension_helper_function1",
      EBPF_RETURN_TYPE_INTEGER,
@@ -42,11 +43,11 @@ static ebpf_helper_function_prototype_t _sample_ebpf_extension_helper_function_p
       EBPF_ARGUMENT_TYPE_CONST_SIZE}}};
 
 // Global helper function prototype descriptors.
-static ebpf_helper_function_prototype_t _sample_ebpf_extension_global_helper_function_prototype[] = {
+static const ebpf_helper_function_prototype_t _sample_ebpf_extension_global_helper_function_prototype[] = {
     {BPF_FUNC_get_current_pid_tgid, "bpf_get_current_pid_tgid", EBPF_RETURN_TYPE_INTEGER, {0}}};
 
-static ebpf_program_info_t _sample_ebpf_extension_program_info = {
-    {"sample", &_sample_ebpf_context_descriptor, {0}, BPF_PROG_TYPE_SAMPLE},
+static const ebpf_program_info_t _sample_ebpf_extension_program_info = {
+    {"sample", &_sample_ebpf_context_descriptor, EBPF_PROGRAM_TYPE_SAMPLE_GUID, BPF_PROG_TYPE_SAMPLE},
     EBPF_COUNT_OF(_sample_ebpf_extension_helper_function_prototype),
     _sample_ebpf_extension_helper_function_prototype,
     EBPF_COUNT_OF(_sample_ebpf_extension_global_helper_function_prototype),

--- a/tools/export_program_info/export_program_info.cpp
+++ b/tools/export_program_info/export_program_info.cpp
@@ -22,11 +22,11 @@ extern ebpf_registry_key_t ebpf_root_registry_key;
 
 typedef struct _ebpf_program_section_info_with_count
 {
-    _Field_size_(section_info_count) ebpf_program_section_info_t* section_info;
+    _Field_size_(section_info_count) const ebpf_program_section_info_t* section_info;
     size_t section_info_count;
 } ebpf_program_section_info_with_count_t;
 
-static ebpf_program_info_t* program_information_array[] = {
+static const ebpf_program_info_t* program_information_array[] = {
     &_ebpf_bind_program_info,
     &_ebpf_sock_addr_program_info,
     &_ebpf_sock_ops_program_info,
@@ -50,25 +50,6 @@ export_all_program_information()
     uint32_t status = ERROR_SUCCESS;
     size_t array_size = _countof(program_information_array);
     for (uint32_t i = 0; i < array_size; i++) {
-        auto program_type = program_information_array[i];
-        switch (program_type->program_type_descriptor.bpf_prog_type) {
-        case BPF_PROG_TYPE_BIND:
-            program_type->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_BIND;
-            break;
-        case BPF_PROG_TYPE_XDP:
-            program_type->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_XDP;
-            break;
-        case BPF_PROG_TYPE_CGROUP_SOCK_ADDR:
-            program_type->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR;
-            break;
-        case BPF_PROG_TYPE_SOCK_OPS:
-            program_type->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_SOCK_OPS;
-            break;
-        case BPF_PROG_TYPE_SAMPLE:
-            program_type->program_type_descriptor.program_type = EBPF_PROGRAM_TYPE_SAMPLE;
-            break;
-        };
-
         status = _ebpf_store_update_program_information(program_information_array[i], 1);
         if (status != ERROR_SUCCESS) {
             break;


### PR DESCRIPTION
## Description

Allow various structs to be const so that an extension writer doesn't get build warnings or errors when trying to register a const struct.

Fixes #2145

## Testing

No impact.  Existing CI/CD.

## Documentation

No impact.