### PR TITLE
Deregister for helper function change when deleting native module

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -209,6 +209,7 @@ _ebpf_program_program_info_provider_changed(
         if (return_value != EBPF_SUCCESS) {
             EBPF_LOG_MESSAGE(
                 EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_PROGRAM, "Failed to update helpers for program");
+            ebpf_lock_unlock(&program->lock, state);
             goto Exit;
         }
 

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -351,7 +351,7 @@ extern "C"
         _In_ ebpf_program_test_run_complete_callback_t callback);
 
     typedef ebpf_result_t (*ebpf_helper_function_addresses_changed_callback_t)(
-        _Inout_ ebpf_program_t* program, _In_opt_ void* context);
+        size_t address_count, _In_reads_opt_(address_count) uintptr_t* addresses, _In_opt_ void* context);
 
     /**
      * @brief Register to be notified when the helper function addresses change.
@@ -365,7 +365,7 @@ extern "C"
     _Must_inspect_result_ ebpf_result_t
     ebpf_program_register_for_helper_changes(
         _Inout_ ebpf_program_t* program,
-        _In_ ebpf_helper_function_addresses_changed_callback_t callback,
+        _In_opt_ ebpf_helper_function_addresses_changed_callback_t callback,
         _In_opt_ void* context);
 
     /**


### PR DESCRIPTION
Resolves: #2316

## Description

The native module code registers for address change notification with the program object, but fails to unregister when unloading. This results in a notification for address change accessing freed memory.

## Testing

CI/CD + kernel stress.

## Documentation

No.
