### PR TITLE
Fix ebpf_program_batch_end_invoke_function_t definition and clean up NPI

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -252,15 +252,15 @@ There is only one function in the client dispatch table, which is of the followi
 
 ```
 /**
- *  @brief This is the only function in the eBPF Hook NPI client dispatch table.
+ *  @brief This is the only mandatory function in the eBPF Hook NPI client dispatch table.
  */
-typedef ebpf_result_t (*ebpf_invoke_program_function_t)(
+typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
     _In_ const void* client_binding_context, _In_ const void* context, _Out_ uint32_t* result);
 
 ```
 The function pointer can be obtained from the client dispatch table as follows:
 ```
-invoke_program = (ebpf_invoke_program_function_t)client_dispatch_table->function[0];
+invoke_program = (ebpf_program_invoke_function_t)client_dispatch_table->function[0];
 ```
 When an extension invokes this function pointer, then the call flows through the eBPF Execution Context and eventually
 invokes the eBPF program.  When invoking an eBPF program, the extension must supply the client binding context it

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -248,19 +248,30 @@ the provider must free the per-client context passed in via `ProviderBindingCont
 
 ### 2.5 Invoking an eBPF program from Hook NPI Provider
 To invoke an eBPF program, the extension uses the dispatch table supplied by the Hook NPI client during attaching.
-There is only one function in the client dispatch table, which is of the following type:
+The dispatch table is of the following type:
 
+```C
+typedef struct _ebpf_link_dispatch_table
+{
+    uint16_t version; ///< Version of the dispatch table.
+    uint16_t count;   ///< Number of entries in the dispatch table.
+    ebpf_program_invoke_function_t ebpf_program_invoke_function;
+    ebpf_program_batch_begin_invoke_function_t ebpf_program_batch_begin_invoke_function;
+    ebpf_program_batch_invoke_function_t ebpf_program_batch_invoke_function;
+    ebpf_program_batch_end_invoke_function_t ebpf_program_batch_end_invoke_function;
+} ebpf_link_dispatch_table_t;
 ```
-/**
- *  @brief This is the only mandatory function in the eBPF Hook NPI client dispatch table.
- */
+
+The first function pointer in the dispatch table is defined as:
+
+```C
 typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
     _In_ const void* client_binding_context, _In_ const void* context, _Out_ uint32_t* result);
+```
 
-```
 The function pointer can be obtained from the client dispatch table as follows:
-```
-invoke_program = (ebpf_program_invoke_function_t)client_dispatch_table->function[0];
+```C
+invoke_program = ((ebpf_link_dispatch_table_t*)client_dispatch_table)->ebpf_program_invoke_function;
 ```
 When an extension invokes this function pointer, then the call flows through the eBPF Execution Context and eventually
 invokes the eBPF program.  When invoking an eBPF program, the extension must supply the client binding context it

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -6,6 +6,15 @@
 #include "ebpf_structs.h"
 #include "ebpf_windows.h"
 
+typedef ebpf_result_t (*_ebpf_extension_dispatch_function)();
+
+typedef struct _ebpf_extension_dispatch_table
+{
+    uint16_t version; ///< Version of the dispatch table.
+    uint16_t count;   ///< Number of entries in the dispatch table.
+    _Field_size_(count) _ebpf_extension_dispatch_function function[1];
+} ebpf_extension_dispatch_table_t;
+
 typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
     _In_ const void* extension_client_binding_context, _Inout_ void* program_context, _Out_ uint32_t* result);
 
@@ -18,16 +27,18 @@ typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
     _Out_ uint32_t* result,
     _In_ const void* state);
 
-typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(_In_ const void* extension_client_binding_context);
+typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(
+    _In_ const void* extension_client_binding_context, _Inout_ void* state);
 
-typedef ebpf_result_t (*_ebpf_extension_dispatch_function)();
-
-typedef struct _ebpf_extension_dispatch_table
+typedef struct _ebpf_extension_program_dispatch_table
 {
     uint16_t version; ///< Version of the dispatch table.
     uint16_t count;   ///< Number of entries in the dispatch table.
-    _Field_size_(count) _ebpf_extension_dispatch_function function[1];
-} ebpf_extension_dispatch_table_t;
+    ebpf_program_invoke_function_t ebpf_program_invoke_function;
+    ebpf_program_batch_begin_invoke_function_t ebpf_program_batch_begin_invoke_function;
+    ebpf_program_batch_invoke_function_t ebpf_program_batch_invoke_function;
+    ebpf_program_batch_end_invoke_function_t ebpf_program_batch_end_invoke_function;
+} ebpf_extension_program_dispatch_table_t;
 
 typedef struct _ebpf_extension_data
 {

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -30,7 +30,7 @@ typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
 typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(
     _In_ const void* extension_client_binding_context, _Inout_ void* state);
 
-typedef struct _ebpf_extension_program_dispatch_table
+typedef struct _ebpf_link_dispatch_table
 {
     uint16_t version; ///< Version of the dispatch table.
     uint16_t count;   ///< Number of entries in the dispatch table.
@@ -38,7 +38,7 @@ typedef struct _ebpf_extension_program_dispatch_table
     ebpf_program_batch_begin_invoke_function_t ebpf_program_batch_begin_invoke_function;
     ebpf_program_batch_invoke_function_t ebpf_program_batch_invoke_function;
     ebpf_program_batch_end_invoke_function_t ebpf_program_batch_end_invoke_function;
-} ebpf_extension_program_dispatch_table_t;
+} ebpf_link_dispatch_table_t;
 
 typedef struct _ebpf_extension_data
 {

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -65,13 +65,7 @@ typedef enum _ebpf_link_dispatch_table_version
     EBPF_LINK_DISPATCH_TABLE_VERSION = EBPF_LINK_DISPATCH_TABLE_VERSION_1, ///< Current version of the dispatch table.
 } ebpf_link_dispatch_table_version_t;
 
-const typedef struct _ebpf_link_dispatch_table
-{
-    ebpf_extension_dispatch_table_t;
-    _ebpf_extension_dispatch_function new_functions[];
-} ebpf_link_dispatch_table_t;
-
-static ebpf_link_dispatch_table_t _ebpf_link_dispatch_table = {
+static const ebpf_extension_program_dispatch_table_t _ebpf_link_dispatch_table = {
     EBPF_LINK_DISPATCH_TABLE_VERSION,
     4, // Count of functions. This should be updated when new functions are added.
     _ebpf_link_instance_invoke,
@@ -80,8 +74,10 @@ static ebpf_link_dispatch_table_t _ebpf_link_dispatch_table = {
     _ebpf_link_instance_invoke_batch_end,
 };
 
-// Assert that new_functions is aligned with ebpf_extension_dispatch_table_t->function.
-C_ASSERT(sizeof(ebpf_extension_dispatch_table_t) == EBPF_OFFSET_OF(ebpf_link_dispatch_table_t, new_functions));
+// Assert that the invoke function is aligned with ebpf_extension_dispatch_table_t->function.
+C_ASSERT(
+    EBPF_OFFSET_OF(ebpf_extension_dispatch_table_t, function) ==
+    EBPF_OFFSET_OF(ebpf_extension_program_dispatch_table_t, ebpf_program_invoke_function));
 
 static void
 _ebpf_link_free(_Frees_ptr_ ebpf_core_object_t* object)

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -65,7 +65,7 @@ typedef enum _ebpf_link_dispatch_table_version
     EBPF_LINK_DISPATCH_TABLE_VERSION = EBPF_LINK_DISPATCH_TABLE_VERSION_1, ///< Current version of the dispatch table.
 } ebpf_link_dispatch_table_version_t;
 
-static const ebpf_extension_program_dispatch_table_t _ebpf_link_dispatch_table = {
+static const ebpf_link_dispatch_table_t _ebpf_link_dispatch_table = {
     EBPF_LINK_DISPATCH_TABLE_VERSION,
     4, // Count of functions. This should be updated when new functions are added.
     _ebpf_link_instance_invoke,
@@ -77,7 +77,7 @@ static const ebpf_extension_program_dispatch_table_t _ebpf_link_dispatch_table =
 // Assert that the invoke function is aligned with ebpf_extension_dispatch_table_t->function.
 C_ASSERT(
     EBPF_OFFSET_OF(ebpf_extension_dispatch_table_t, function) ==
-    EBPF_OFFSET_OF(ebpf_extension_program_dispatch_table_t, ebpf_program_invoke_function));
+    EBPF_OFFSET_OF(ebpf_link_dispatch_table_t, ebpf_program_invoke_function));
 
 static void
 _ebpf_link_free(_Frees_ptr_ ebpf_core_object_t* object)

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -319,7 +319,7 @@ _net_ebpf_extension_hook_provider_attach_client(
     NTSTATUS status = STATUS_SUCCESS;
     net_ebpf_extension_hook_provider_t* local_provider_context = (net_ebpf_extension_hook_provider_t*)provider_context;
     net_ebpf_extension_hook_client_t* hook_client = NULL;
-    ebpf_extension_program_dispatch_table_t* client_dispatch_table;
+    ebpf_link_dispatch_table_t* client_dispatch_table;
     ebpf_result_t result = EBPF_SUCCESS;
 
     NET_EBPF_EXT_LOG_ENTRY();
@@ -345,7 +345,7 @@ _net_ebpf_extension_hook_provider_attach_client(
     hook_client->client_module_id = client_registration_instance->ModuleId->Guid;
     hook_client->client_binding_context = client_binding_context;
     hook_client->client_data = (const ebpf_extension_data_t*)client_registration_instance->NpiSpecificCharacteristics;
-    client_dispatch_table = (ebpf_extension_program_dispatch_table_t*)client_dispatch;
+    client_dispatch_table = (ebpf_link_dispatch_table_t*)client_dispatch;
     if (client_dispatch_table == NULL) {
         status = STATUS_INVALID_PARAMETER;
         goto Exit;

--- a/netebpfext/net_ebpf_ext_hook_provider.h
+++ b/netebpfext/net_ebpf_ext_hook_provider.h
@@ -150,7 +150,7 @@ net_ebpf_extension_hook_provider_register(
  */
 _Must_inspect_result_ ebpf_result_t
 net_ebpf_extension_hook_invoke_program(
-    _In_ const net_ebpf_extension_hook_client_t* client, _In_ const void* context, _Out_ uint32_t* result);
+    _In_ const net_ebpf_extension_hook_client_t* client, _Inout_ void* context, _Out_ uint32_t* result);
 
 /**
  * @brief Return client attached to the hook NPI provider.

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -388,7 +388,7 @@ _sample_ebpf_extension_hook_provider_attach_client(
     sample_ebpf_extension_hook_provider_t* local_provider_context =
         (sample_ebpf_extension_hook_provider_t*)provider_context;
     sample_ebpf_extension_hook_client_t* hook_client = NULL;
-    ebpf_extension_program_dispatch_table_t* client_dispatch_table;
+    ebpf_link_dispatch_table_t* client_dispatch_table;
 
     if ((provider_binding_context == NULL) || (provider_dispatch == NULL) || (local_provider_context == NULL)) {
         status = STATUS_INVALID_PARAMETER;
@@ -415,7 +415,7 @@ _sample_ebpf_extension_hook_provider_attach_client(
     hook_client->client_module_id = client_registration_instance->ModuleId->Guid;
     hook_client->client_binding_context = client_binding_context;
     hook_client->client_data = client_registration_instance->NpiSpecificCharacteristics;
-    client_dispatch_table = (ebpf_extension_program_dispatch_table_t*)client_dispatch;
+    client_dispatch_table = (ebpf_link_dispatch_table_t*)client_dispatch;
     if (client_dispatch_table == NULL) {
         status = STATUS_INVALID_PARAMETER;
         goto Exit;

--- a/tests/sample/ext/drv/sample_ext.c
+++ b/tests/sample/ext/drv/sample_ext.c
@@ -205,12 +205,6 @@ const NPI_PROVIDER_CHARACTERISTICS _sample_ebpf_extension_hook_provider_characte
      &_sample_ebpf_extension_hook_provider_data},
 };
 
-/**
- *  @brief This is the only function in the eBPF hook NPI client dispatch table.
- */
-typedef ebpf_result_t (*ebpf_invoke_program_function_t)(
-    _In_ const void* client_binding_context, _In_ const void* context, _Out_ uint32_t* result);
-
 typedef struct _sample_ebpf_extension_hook_provider sample_ebpf_extension_hook_provider_t;
 /**
  *  @brief This is the per client binding context for the eBPF Hook
@@ -222,7 +216,7 @@ typedef struct _sample_ebpf_extension_hook_client
     GUID client_module_id;
     const void* client_binding_context;
     const ebpf_extension_data_t* client_data;
-    ebpf_invoke_program_function_t invoke_program;
+    ebpf_program_invoke_function_t invoke_program;
 } sample_ebpf_extension_hook_client_t;
 
 /**
@@ -394,7 +388,7 @@ _sample_ebpf_extension_hook_provider_attach_client(
     sample_ebpf_extension_hook_provider_t* local_provider_context =
         (sample_ebpf_extension_hook_provider_t*)provider_context;
     sample_ebpf_extension_hook_client_t* hook_client = NULL;
-    ebpf_extension_dispatch_table_t* client_dispatch_table;
+    ebpf_extension_program_dispatch_table_t* client_dispatch_table;
 
     if ((provider_binding_context == NULL) || (provider_dispatch == NULL) || (local_provider_context == NULL)) {
         status = STATUS_INVALID_PARAMETER;
@@ -421,12 +415,12 @@ _sample_ebpf_extension_hook_provider_attach_client(
     hook_client->client_module_id = client_registration_instance->ModuleId->Guid;
     hook_client->client_binding_context = client_binding_context;
     hook_client->client_data = client_registration_instance->NpiSpecificCharacteristics;
-    client_dispatch_table = (ebpf_extension_dispatch_table_t*)client_dispatch;
+    client_dispatch_table = (ebpf_extension_program_dispatch_table_t*)client_dispatch;
     if (client_dispatch_table == NULL) {
         status = STATUS_INVALID_PARAMETER;
         goto Exit;
     }
-    hook_client->invoke_program = (ebpf_invoke_program_function_t)client_dispatch_table->function[0];
+    hook_client->invoke_program = client_dispatch_table->ebpf_program_invoke_function;
 
     local_provider_context->attached_client = hook_client;
 
@@ -510,7 +504,7 @@ Exit:
 }
 
 _Must_inspect_result_ ebpf_result_t
-sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* context, _Out_ uint32_t* result)
+sample_ebpf_extension_invoke_program(_Inout_ sample_program_context_t* context, _Out_ uint32_t* result)
 {
     ebpf_result_t return_value = EBPF_SUCCESS;
 
@@ -522,7 +516,7 @@ sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* contex
         return_value = EBPF_FAILED;
         goto Exit;
     }
-    ebpf_invoke_program_function_t invoke_program = hook_client->invoke_program;
+    ebpf_program_invoke_function_t invoke_program = hook_client->invoke_program;
     const void* client_binding_context = hook_client->client_binding_context;
 
     // Run the eBPF program using cached copies of invoke_program and client_binding_context.
@@ -554,7 +548,7 @@ sample_ebpf_extension_profile_program(
         return_value = EBPF_FAILED;
         goto Exit;
     }
-    ebpf_invoke_program_function_t invoke_program = hook_client->invoke_program;
+    ebpf_program_invoke_function_t invoke_program = hook_client->invoke_program;
     const void* client_binding_context = hook_client->client_binding_context;
 
     program_context.uint32_data = KeGetCurrentProcessorNumber();

--- a/tests/sample/ext/drv/sample_ext.h
+++ b/tests/sample/ext/drv/sample_ext.h
@@ -54,7 +54,7 @@ sample_ebpf_extension_hook_provider_unregister();
  * @retval EBPF_OPERATION_NOT_SUPPORTED Operation not supported.
  */
 _Must_inspect_result_ ebpf_result_t
-sample_ebpf_extension_invoke_program(_In_ const sample_program_context_t* context, _Out_ uint32_t* result);
+sample_ebpf_extension_invoke_program(_Inout_ sample_program_context_t* context, _Out_ uint32_t* result);
 
 /**
  * @brief Invoke eBPF program attached to a hook provider instance and measure the execution time.


### PR DESCRIPTION
## Description

The `_ebpf_link_instance_invoke_batch_end` definition in the eBPF implementation diverged from the `ebpf_program_batch_end_invoke_function_t` definition in the extension header: a `state` parameter was added to the implementation, but not the header.

- Update the header to match the implementation.
- To let the compiler catch this error, both in the eBPF project and in extension projects, explicitly define the dispatch table used to invoke programs.
- Remove redundant (and erroneous) definitions throughout the eBPF test and sample codebase.

Resolves #2310 

## Testing

Builds locally. CI/CD should cover the rest.
Note: the batch begin/invoke/end routines do not appear to be tested via NPI dispatch tables in the eBPF project.

## Documentation

Documentation updated.
