### PR TITLE
Capture crash dumps during build phase and upload them

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -73,6 +73,15 @@ jobs:
       with:
         submodules: 'recursive'
 
+    - name: Configure Windows Error Reporting to make a local copy of any crashes that occur.
+      id: configure_windows_error_reporting
+      if: steps.skip_check.outputs.should_skip != 'true'
+      run: |
+        mkdir c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -ErrorAction SilentlyContinue
+        New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpType" -Value 2 -PropertyType DWord -ErrorAction SilentlyContinue
+        New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "c:\dumps\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}" -PropertyType ExpandString -ErrorAction SilentlyContinue
+
     - name: Initialize CodeQL
       if: inputs.build_codeql == true && steps.skip_check.outputs.should_skip != 'true'
       uses: github/codeql-action/init@7df0ce34898d659f95c0c4a09eaa8d4e32ee64db
@@ -225,6 +234,24 @@ jobs:
       with:
         name: ebpf-for-windows - NuGet Redist package (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/eBPF-for-Windows-Redist.*.nupkg
+
+    - name: Check for crash dumps
+      # Check for crash dumps even if the workflow failed.
+      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true')
+      uses: andstor/file-existence-action@20b4d2e596410855db8f9ca21e96fbe18e12930b
+      id: check_dumps
+      with:
+        files: c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/*.dmp
+
+    - name: Upload any crash dumps
+      # Upload crash dumps even if the workflow failed.
+      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_dumps.outputs.files_exists == 'true')
+      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
+      id: upload_crash_dumps
+      with:
+        name: Crash-Dumps-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
+        path: c:/dumps/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        retention-days: 5
 
     - name: Perform CodeQL Analysis
       if: inputs.build_codeql == true && steps.skip_check.outputs.should_skip != 'true'


### PR DESCRIPTION
## Description

Crashes occurring during the bpf2c run need to be investigated and fixed. Currently there is no way to determine what failed.

## Testing

CI/CD

## Documentation

No.
