### PR TITLE
Fix use after free in native code.

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -246,7 +246,7 @@ Done:
     EBPF_RETURN_RESULT(result);
 }
 
-_Requires_exclusive_lock_held_(module->lock) void ebpf_native_acquire_reference_under_lock(
+_Requires_exclusive_lock_held_(module->lock) static void _ebpf_native_acquire_reference_under_lock(
     _Inout_ ebpf_native_module_t* module)
 {
     ebpf_assert(module->base.marker == _ebpf_native_marker);
@@ -264,7 +264,7 @@ ebpf_native_acquire_reference(_Inout_ ebpf_native_module_t* module)
     ebpf_lock_state_t state = 0;
 
     state = ebpf_lock_lock(&module->lock);
-    ebpf_native_acquire_reference_under_lock(module);
+    _ebpf_native_acquire_reference_under_lock(module);
     ebpf_lock_unlock(&module->lock, state);
 }
 
@@ -1372,7 +1372,7 @@ ebpf_native_load_programs(
 
     // Take a reference on the native module before releasing the lock.
     // This will ensure the driver cannot unload while we are processing this request.
-    ebpf_native_acquire_reference_under_lock(module);
+    _ebpf_native_acquire_reference_under_lock(module);
     module_referenced = true;
 
     ebpf_lock_unlock(&module->lock, module_state);


### PR DESCRIPTION
Fixes #2326

## Description

Fixes use after free in ebpf native module. When all program references have been removed, native module queues a workitem to unload the driver. It is possible that the driver is unloading at the same time. This can cause a race where one thread decrements the ref count to 1, then proceeds to queue a workitem, but second thread makes the ref count 0 at the same time which frees the native module memory.

Fix is to hold the module lock until the workitem is queued to ensure ref count does not go down to 0.

## Testing

existing CICD and new stress tests

## Documentation

NA
