### PR TITLE
Add fault injection in ndis_um.cpp

### DIFF
--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -870,7 +870,7 @@ _ebpf_xdp_context_delete(
     net_ebpf_xdp_md_t* xdp_context = (net_ebpf_xdp_md_t*)context;
 
     // Copy the packet data to the output buffer.
-    if (data_out != NULL && data_size_out != NULL) {
+    if (data_out != NULL && data_size_out != NULL && xdp_context->base.data != NULL) {
         size_t data_size = *data_size_out;
         size_t xdp_data_size = (char*)(xdp_context->base.data_end) - (char*)(xdp_context->base.data);
         if (data_size > xdp_data_size) {

--- a/netebpfext/user/ndis_um.cpp
+++ b/netebpfext/user/ndis_um.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include "ebpf_fault_injection.h"
 #include "netebpfext_platform.h"
 
 typedef struct _NDIS_GENERIC_OBJECT
@@ -18,6 +19,10 @@ typedef struct _NDIS_BUFFER_LIST_POOL
 PNDIS_GENERIC_OBJECT
 NdisAllocateGenericObject(_In_opt_ DRIVER_OBJECT* driver_object, _In_ unsigned long tag, _In_ uint16_t size)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return nullptr;
+    }
+
     PNDIS_GENERIC_OBJECT object = reinterpret_cast<NDIS_GENERIC_OBJECT*>(malloc(sizeof(NDIS_GENERIC_OBJECT) + size));
     if (object) {
         object->driver_object = driver_object;
@@ -30,6 +35,10 @@ NdisAllocateGenericObject(_In_opt_ DRIVER_OBJECT* driver_object, _In_ unsigned l
 NDIS_HANDLE
 NdisAllocateNetBufferListPool(_In_opt_ NDIS_HANDLE ndis_handle, _In_ NET_BUFFER_LIST_POOL_PARAMETERS const* parameters)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return nullptr;
+    }
+
     NDIS_BUFFER_LIST_POOL* pool = reinterpret_cast<NDIS_BUFFER_LIST_POOL*>(malloc(sizeof(NDIS_BUFFER_LIST_POOL)));
     if (pool) {
         pool->ndis_handle = ndis_handle;
@@ -47,6 +56,10 @@ NdisFreeNetBufferListPool(_In_ __drv_freesMem(mem) NDIS_HANDLE pool_handle)
 PNET_BUFFER_LIST
 NdisAllocateNetBufferList(_In_ NDIS_HANDLE nbl_pool_handle, _In_ USHORT context_size, _In_ USHORT context_backfill)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return nullptr;
+    }
+
     UNREFERENCED_PARAMETER(nbl_pool_handle);
     UNREFERENCED_PARAMETER(context_size);
     UNREFERENCED_PARAMETER(context_backfill);
@@ -66,6 +79,10 @@ NdisAllocateCloneNetBufferList(
     _In_ NDIS_HANDLE net_buffer_pool_handle,
     ULONG allocate_clone_flags)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return nullptr;
+    }
+
     UNREFERENCED_PARAMETER(allocate_clone_flags);
     NET_BUFFER_LIST* nbl = NdisAllocateNetBufferList(net_buffer_list_pool_handle, 0, 0);
     if (!nbl) {
@@ -97,6 +114,10 @@ NdisFreeGenericObject(_In_ PNDIS_GENERIC_OBJECT ndis_object)
 _Must_inspect_result_ __drv_allocatesMem(mem) NET_BUFFER* NdisAllocateNetBuffer(
     _In_ NDIS_HANDLE pool_handle, _In_opt_ MDL* mdl_chain, _In_ unsigned long data_offset, _In_ SIZE_T data_length)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return nullptr;
+    }
+
     UNREFERENCED_PARAMETER(pool_handle);
     UNREFERENCED_PARAMETER(data_offset);
     NET_BUFFER* nb = reinterpret_cast<NET_BUFFER*>(malloc(sizeof(*nb) + data_length));
@@ -121,6 +142,10 @@ NdisGetDataBuffer(
     _In_ unsigned long align_multiple,
     _In_ unsigned long align_offset)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return nullptr;
+    }
+
     UNREFERENCED_PARAMETER(net_buffer);
     UNREFERENCED_PARAMETER(storage);
     UNREFERENCED_PARAMETER(align_multiple);


### PR DESCRIPTION
## Description

1. Added fault injection condition in ndis OS API functions in ndis_um.cpp file.
2. Fixed a crash in _ebpf_xdp_context_delete() in net_ebpf_ext_xdp.c, which was triggered by xdp_context test case. Call stack details in #2101 

## Testing

_Do any existing tests cover this change? Yes 
Are new tests needed? No

## Documentation

_Is there any documentation impact for this change? No
