### PR TITLE
trace_refactor.

### DIFF
--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -665,10 +665,10 @@ Exit:
 
     if (!NT_SUCCESS(status)) {
         if (is_in_transaction) {
-            status = FwpmTransactionAbort(_fwp_engine_handle);
-            if (!NT_SUCCESS(status)) {
+            NTSTATUS abort_status = FwpmTransactionAbort(_fwp_engine_handle);
+            if (!NT_SUCCESS(abort_status)) {
                 NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmTransactionAbort", status);
+                    NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmTransactionAbort", abort_status);
             }
         }
 

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -353,7 +353,8 @@ net_ebpf_extension_delete_wfp_filters(uint32_t filter_count, _Frees_ptr_ _In_cou
     for (uint32_t index = 0; index < filter_count; index++) {
         status = FwpmFilterDeleteById(_fwp_engine_handle, filter_ids[index]);
         if (!NT_SUCCESS(status)) {
-            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmFilterDeleteById", status);
+            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
+                NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmFilterDeleteById", status);
         }
     }
     ExFreePool(filter_ids);
@@ -392,7 +393,7 @@ net_ebpf_extension_add_wfp_filters(
 
     status = FwpmTransactionBegin(_fwp_engine_handle, 0);
     if (!NT_SUCCESS(status)) {
-        NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmTransactionBegin", status);
+        NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmTransactionBegin", status);
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }
@@ -422,7 +423,7 @@ net_ebpf_extension_add_wfp_filters(
         status = FwpmFilterAdd(_fwp_engine_handle, &filter, NULL, &local_filter_ids[index]);
         if (!NT_SUCCESS(status)) {
             NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(
-                NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR,
+                NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
                 "FwpmFilterAdd",
                 status,
                 "Failed to add filter",
@@ -434,7 +435,7 @@ net_ebpf_extension_add_wfp_filters(
 
     status = FwpmTransactionCommit(_fwp_engine_handle);
     if (!NT_SUCCESS(status)) {
-        NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmTransactionCommit", status);
+        NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmTransactionCommit", status);
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }
@@ -451,7 +452,7 @@ Exit:
             status = FwpmTransactionAbort(_fwp_engine_handle);
             if (!NT_SUCCESS(status)) {
                 NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmTransactionAbort", status);
+                    NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmTransactionAbort", status);
             }
         }
     }
@@ -487,7 +488,7 @@ _net_ebpf_ext_register_wfp_callout(_Inout_ net_ebpf_ext_wfp_callout_state_t* cal
     status = FwpsCalloutRegister(device_object, &callout_register_state, &callout_state->assigned_callout_id);
     if (!NT_SUCCESS(status)) {
         NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(
-            NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
             "FwpsCalloutRegister",
             status,
             "Failed to register callout",
@@ -507,7 +508,7 @@ _net_ebpf_ext_register_wfp_callout(_Inout_ net_ebpf_ext_wfp_callout_state_t* cal
     status = FwpmCalloutAdd(_fwp_engine_handle, &callout_add_state, NULL, NULL);
     if (!NT_SUCCESS(status)) {
         NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(
-            NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
             "FwpmCalloutAdd",
             status,
             "Failed to add callout",
@@ -522,7 +523,7 @@ Exit:
             status = FwpsCalloutUnregisterById(callout_state->assigned_callout_id);
             if (!NT_SUCCESS(status)) {
                 NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpsCalloutUnregisterById", status);
+                    NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpsCalloutUnregisterById", status);
             } else {
                 callout_state->assigned_callout_id = 0;
             }
@@ -544,7 +545,8 @@ net_ebpf_ext_initialize_ndis_handles(_In_ const DRIVER_OBJECT* driver_object)
         NdisAllocateGenericObject((DRIVER_OBJECT*)driver_object, NET_EBPF_EXTENSION_POOL_TAG, 0);
     if (_net_ebpf_ext_ndis_handle == NULL) {
         status = STATUS_INSUFFICIENT_RESOURCES;
-        NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "NdisAllocateGenericObject", status);
+        NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
+            NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "NdisAllocateGenericObject", status);
         goto Exit;
     }
 
@@ -609,11 +611,11 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
     session.flags = FWPM_SESSION_FLAG_DYNAMIC;
 
     status = FwpmEngineOpen(NULL, RPC_C_AUTHN_WINNT, NULL, &session, &_fwp_engine_handle);
-    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS("FwpmEngineOpen", status);
+    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmEngineOpen", status);
     is_engine_opened = TRUE;
 
     status = FwpmTransactionBegin(_fwp_engine_handle, 0);
-    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS("FwpmTransactionBegin", status);
+    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmTransactionBegin", status);
     is_in_transaction = TRUE;
 
     // Create the WFP provider.
@@ -621,7 +623,7 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
     ebpf_wfp_provider.displayData.description = L"Windows Networking eBPF Extension";
     ebpf_wfp_provider.providerKey = EBPF_WFP_PROVIDER;
     status = FwpmProviderAdd(_fwp_engine_handle, &ebpf_wfp_provider, NULL);
-    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS("FwpmProviderAdd", status);
+    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmProviderAdd", status);
 
     // Add all the sub layers.
     for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_sublayers); index++) {
@@ -635,7 +637,7 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
         ebpf_hook_sub_layer.weight = _net_ebpf_ext_sublayers[index].weight;
 
         status = FwpmSubLayerAdd(_fwp_engine_handle, &ebpf_hook_sub_layer, NULL);
-        NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS("FwpmSubLayerAdd", status);
+        NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmSubLayerAdd", status);
     }
 
     for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_wfp_callout_states); index++) {
@@ -643,7 +645,7 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
         if (!NT_SUCCESS(status)) {
             NET_EBPF_EXT_LOG_MESSAGE_STRING(
                 NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
-                NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR,
+                NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION,
                 "_net_ebpf_ext_register_wfp_callout() failed to register callout",
                 (char*)_net_ebpf_ext_wfp_callout_states[index].name);
             goto Exit;
@@ -651,20 +653,22 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
     }
 
     status = FwpmTransactionCommit(_fwp_engine_handle);
-    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS("FwpmTransactionCommit", status);
+    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmTransactionCommit", status);
     is_in_transaction = FALSE;
 
     // Create L2 injection handle.
     status = FwpsInjectionHandleCreate(AF_LINK, FWPS_INJECTION_TYPE_L2, &_net_ebpf_ext_l2_injection_handle);
-    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS("FwpsInjectionHandleCreate", status);
+    NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS(
+        NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpsInjectionHandleCreate", status);
 
 Exit:
 
     if (!NT_SUCCESS(status)) {
         if (is_in_transaction) {
-            NTSTATUS ret = FwpmTransactionAbort(_fwp_engine_handle);
-            if (!NT_SUCCESS(ret)) {
-                NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmTransactionAbort", ret);
+            status = FwpmTransactionAbort(_fwp_engine_handle);
+            if (!NT_SUCCESS(status)) {
+                NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
+                    NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmTransactionAbort", status);
             }
         }
 
@@ -685,7 +689,7 @@ net_ebpf_extension_uninitialize_wfp_components(void)
     if (_fwp_engine_handle != NULL) {
         status = FwpmEngineClose(_fwp_engine_handle);
         if (!NT_SUCCESS(status)) {
-            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmEngineClose", status);
+            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpmEngineClose", status);
         }
         _fwp_engine_handle = NULL;
 
@@ -693,7 +697,7 @@ net_ebpf_extension_uninitialize_wfp_components(void)
             status = FwpsCalloutUnregisterById(_net_ebpf_ext_wfp_callout_states[index].assigned_callout_id);
             if (!NT_SUCCESS(status)) {
                 NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpsCalloutUnregisterById", status);
+                    NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpsCalloutUnregisterById", status);
             }
         }
     }
@@ -703,7 +707,7 @@ net_ebpf_extension_uninitialize_wfp_components(void)
         status = FwpsInjectionHandleDestroy(_net_ebpf_ext_l2_injection_handle);
         if (!NT_SUCCESS(status)) {
             NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
-                NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpsInjectionHandleDestroy", status);
+                NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION, "FwpsInjectionHandleDestroy", status);
         }
     }
 }
@@ -721,8 +725,7 @@ net_ebpf_ext_filter_change_notify(
         DEREFERENCE_FILTER_CONTEXT((filter_context));
     }
 
-    NET_EBPF_EXT_LOG_FUNCTION_SUCCESS();
-    return STATUS_SUCCESS;
+    NET_EBPF_EXT_RETURN_NTSTATUS(STATUS_SUCCESS);
 }
 
 static void

--- a/netebpfext/net_ebpf_ext_bind.c
+++ b/netebpfext/net_ebpf_ext_bind.c
@@ -408,7 +408,7 @@ _ebpf_bind_context_create(
 
     if (context_in == NULL || context_size_in < sizeof(bind_md_t)) {
         NET_EBPF_EXT_LOG_MESSAGE(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "Context is required");
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_BIND, "Context is required");
         result = EBPF_INVALID_ARGUMENT;
         goto Exit;
     }
@@ -477,5 +477,5 @@ _ebpf_bind_context_destroy(
     }
 
     ExFreePool(bind_context);
-    NET_EBPF_EXT_LOG_FUNCTION_SUCCESS();
+    NET_EBPF_EXT_LOG_EXIT();
 }

--- a/netebpfext/net_ebpf_ext_hook_provider.c
+++ b/netebpfext/net_ebpf_ext_hook_provider.c
@@ -218,10 +218,7 @@ net_ebpf_extension_hook_invoke_program(
     const void* client_binding_context = client->client_binding_context;
 
     ebpf_result_t invoke_result = invoke_program(client_binding_context, context, result);
-    if (invoke_result != EBPF_SUCCESS) {
-        NET_EBPF_EXT_LOG_FUNCTION_ERROR(invoke_result);
-    }
-    return invoke_result;
+    NET_EBPF_EXT_RETURN_RESULT(invoke_result);
 }
 
 _Must_inspect_result_ ebpf_result_t

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -14,6 +14,165 @@
 #define EXPIRY_TIME 60000 // 60 seconds in ms.
 #define CONVERT_100NS_UNITS_TO_MS(x) ((x) / 10000)
 
+#define NET_EBPF_EXT_SOCK_ADDR_CLASSIFY_MESSAGE "NetEbpfExtSockAddrClassify"
+
+#define NET_EBPF_EXT_LOG_SOCK_ADDR_CLASSIFY_IPV4(                                                              \
+    trace_level, message, handle, protocol, source_ip, source_port, destination_ip, destination_port, verdict) \
+    TraceLoggingWrite(                                                                                         \
+        net_ebpf_ext_tracelog_provider,                                                                        \
+        NET_EBPF_EXT_SOCK_ADDR_CLASSIFY_MESSAGE,                                                               \
+        TraceLoggingLevel(trace_level),                                                                        \
+        TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR),                                          \
+        TraceLoggingString((message), "message"),                                                              \
+        TraceLoggingUInt64((handle), "transport_endpoint_handle"),                                             \
+        TraceLoggingUInt64((protocol), "protocol"),                                                            \
+        TraceLoggingIPv4Address((source_ip), "source_ip"),                                                     \
+        TraceLoggingUInt16((source_port), "source_port"),                                                      \
+        TraceLoggingIPv4Address((destination_ip), "destination_ip"),                                           \
+        TraceLoggingUInt16((destination_port), "destination_port"),                                            \
+        TraceLoggingUInt32((verdict), "verdict"));
+
+#define NET_EBPF_EXT_LOG_SOCK_ADDR_CLASSIFY_IPV6(                                                              \
+    trace_level, message, handle, protocol, source_ip, source_port, destination_ip, destination_port, verdict) \
+    TraceLoggingWrite(                                                                                         \
+        net_ebpf_ext_tracelog_provider,                                                                        \
+        NET_EBPF_EXT_SOCK_ADDR_CLASSIFY_MESSAGE,                                                               \
+        TraceLoggingLevel(trace_level),                                                                        \
+        TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR),                                          \
+        TraceLoggingString((message), "message"),                                                              \
+        TraceLoggingUInt64((handle), "transport_endpoint_handle"),                                             \
+        TraceLoggingUInt64((protocol), "protocol"),                                                            \
+        TraceLoggingIPv6Address((source_ip), "source_ip"),                                                     \
+        TraceLoggingUInt16((source_port), "source_port"),                                                      \
+        TraceLoggingIPv6Address((destination_ip), "destination_ip"),                                           \
+        TraceLoggingUInt16((destination_port), "destination_port"),                                            \
+        TraceLoggingUInt32((verdict), "verdict"));
+
+#define NET_EBPF_EXT_SOCK_ADDR_REDIRECT_MESSAGE "NetEbpfExtSockAddrRedirect"
+
+#define NET_EBPF_EXT_LOG_SOCK_ADDR_REDIRECT_CLASSIFY_IPV4(            \
+    message,                                                          \
+    handle,                                                           \
+    protocol,                                                         \
+    source_ip,                                                        \
+    source_port,                                                      \
+    destination_ip,                                                   \
+    destination_port,                                                 \
+    redirected_ip,                                                    \
+    redirected_port,                                                  \
+    verdict)                                                          \
+    TraceLoggingWrite(                                                \
+        net_ebpf_ext_tracelog_provider,                               \
+        NET_EBPF_EXT_SOCK_ADDR_REDIRECT_MESSAGE,                      \
+        TraceLoggingLevel(NET_EBPF_EXT_TRACELOG_LEVEL_INFO),          \
+        TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR), \
+        TraceLoggingString((message), "message"),                     \
+        TraceLoggingUInt64((handle), "transport_endpoint_handle"),    \
+        TraceLoggingUInt64((protocol), "protocol"),                   \
+        TraceLoggingIPv4Address((source_ip), "source_ip"),            \
+        TraceLoggingUInt16((source_port), "source_port"),             \
+        TraceLoggingIPv4Address((destination_ip), "destination_ip"),  \
+        TraceLoggingUInt16((destination_port), "destination_port"),   \
+        TraceLoggingIPv4Address((redirected_ip), "redirected_ip"),    \
+        TraceLoggingUInt16((redirected_port), "redirected_port"),     \
+        TraceLoggingUInt64((verdict), "verdict"));
+
+#define NET_EBPF_EXT_LOG_SOCK_ADDR_REDIRECT_CLASSIFY_IPV6(            \
+    message,                                                          \
+    handle,                                                           \
+    protocol,                                                         \
+    source_ip,                                                        \
+    source_port,                                                      \
+    destination_ip,                                                   \
+    destination_port,                                                 \
+    redirected_ip,                                                    \
+    redirected_port,                                                  \
+    verdict)                                                          \
+    TraceLoggingWrite(                                                \
+        net_ebpf_ext_tracelog_provider,                               \
+        NET_EBPF_EXT_SOCK_ADDR_REDIRECT_MESSAGE,                      \
+        TraceLoggingLevel(NET_EBPF_EXT_TRACELOG_LEVEL_INFO),          \
+        TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR), \
+        TraceLoggingString((message), "message"),                     \
+        TraceLoggingUInt64((handle), "transport_endpoint_handle"),    \
+        TraceLoggingUInt64((protocol), "protocol"),                   \
+        TraceLoggingIPv6Address((source_ip), "source_ip"),            \
+        TraceLoggingUInt16((source_port), "source_port"),             \
+        TraceLoggingIPv6Address((destination_ip), "destination_ip"),  \
+        TraceLoggingUInt16((destination_port), "destination_port"),   \
+        TraceLoggingIPv6Address((redirected_ip), "redirected_ip"),    \
+        TraceLoggingUInt16((redirected_port), "redirected_port"),     \
+        TraceLoggingUInt64((verdict), "verdict"));
+
+#define DEFINE_SOCK_ADDR_CLASSIFY_LOG_FUNCTION(family)                  \
+    static void _net_ebpf_ext_log_sock_addr_classify_v##family##(       \
+        _In_z_ const char* message,                                     \
+        uint64_t transport_endpoint_handle,                             \
+        _In_ const bpf_sock_addr_t* original_context,                   \
+        _In_opt_ const bpf_sock_addr_t* redirected_context,             \
+        uint32_t verdict)                                               \
+    {                                                                   \
+        if (redirected_context != NULL) {                               \
+            NET_EBPF_EXT_LOG_SOCK_ADDR_REDIRECT_CLASSIFY_IPV##family##( \
+                message,                                                \
+                transport_endpoint_handle,                              \
+                original_context->protocol,                             \
+                original_context->msg_src_ip##family##,                 \
+                ntohs(original_context->msg_src_port),                  \
+                original_context->user_ip##family##,                    \
+                ntohs(original_context->user_port),                     \
+                redirected_context->user_ip##family##,                  \
+                ntohs(redirected_context->user_port),                   \
+                verdict);                                               \
+        } else {                                                        \
+            if (verdict == BPF_SOCK_ADDR_VERDICT_REJECT) {              \
+                NET_EBPF_EXT_LOG_SOCK_ADDR_CLASSIFY_IPV##family##(      \
+                    NET_EBPF_EXT_TRACELOG_LEVEL_INFO,                   \
+                    message,                                            \
+                    transport_endpoint_handle,                          \
+                    original_context->protocol,                         \
+                    original_context->msg_src_ip##family##,             \
+                    ntohs(original_context->msg_src_port),              \
+                    original_context->user_ip##family##,                \
+                    ntohs(original_context->user_port),                 \
+                    verdict);                                           \
+            } else {                                                    \
+                NET_EBPF_EXT_LOG_SOCK_ADDR_CLASSIFY_IPV##family##(      \
+                    NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,                \
+                    message,                                            \
+                    transport_endpoint_handle,                          \
+                    original_context->protocol,                         \
+                    original_context->msg_src_ip##family##,             \
+                    ntohs(original_context->msg_src_port),              \
+                    original_context->msg_src_ip##family##,             \
+                    ntohs(original_context->user_port),                 \
+                    verdict);                                           \
+            }                                                           \
+        }                                                               \
+    }
+
+DEFINE_SOCK_ADDR_CLASSIFY_LOG_FUNCTION(4)
+DEFINE_SOCK_ADDR_CLASSIFY_LOG_FUNCTION(6)
+
+static void
+_net_ebpf_ext_log_sock_addr_classify(
+    _In_z_ const char* message,
+    uint64_t transport_endpoint_handle,
+    _In_ const bpf_sock_addr_t* original_context,
+    _In_opt_ const bpf_sock_addr_t* redirected_context,
+    uint32_t verdict)
+{
+    if (TraceLoggingProviderEnabled(net_ebpf_ext_tracelog_provider, 0, NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR)) {
+        if (original_context->family == AF_INET) {
+            _net_ebpf_ext_log_sock_addr_classify_v4(
+                message, transport_endpoint_handle, original_context, redirected_context, verdict);
+        } else {
+            _net_ebpf_ext_log_sock_addr_classify_v6(
+                message, transport_endpoint_handle, original_context, redirected_context, verdict);
+        }
+    }
+}
+
 typedef struct _net_ebpf_bpf_sock_addr
 {
     bpf_sock_addr_t base;
@@ -437,7 +596,8 @@ _net_ebpf_sock_addr_create_security_descriptor()
 
     admin_security_descriptor = (SECURITY_DESCRIPTOR*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, sizeof(SECURITY_DESCRIPTOR), NET_EBPF_EXTENSION_POOL_TAG);
-    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(admin_security_descriptor, "admin_sd", status);
+    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(
+        NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, admin_security_descriptor, "admin_sd", status);
 
     status = RtlCreateSecurityDescriptor(admin_security_descriptor, SECURITY_DESCRIPTOR_REVISION);
     if (!NT_SUCCESS(status)) {
@@ -452,7 +612,7 @@ _net_ebpf_sock_addr_create_security_descriptor()
     acl_length += RtlLengthSid(SeExports->SeLocalSystemSid) + FIELD_OFFSET(ACCESS_ALLOWED_ACE, SidStart);
 
     dacl = (ACL*)ExAllocatePoolUninitialized(NonPagedPoolNx, acl_length, NET_EBPF_EXTENSION_POOL_TAG);
-    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(dacl, "dacl", status);
+    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, dacl, "dacl", status);
 
     RtlCreateAcl(dacl, acl_length, ACL_REVISION);
 
@@ -522,7 +682,8 @@ _net_ebpf_ext_sock_addr_update_redirect_handle(uint64_t filter_id, HANDLE redire
     net_ebpf_extension_redirect_handle_entry_t* entry =
         (net_ebpf_extension_redirect_handle_entry_t*)ExAllocatePoolUninitialized(
             NonPagedPoolNx, sizeof(net_ebpf_extension_redirect_handle_entry_t), NET_EBPF_EXTENSION_POOL_TAG);
-    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(entry, "redirect_handle", status);
+    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(
+        NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, entry, "redirect_handle", status);
 
     memset(entry, 0, sizeof(net_ebpf_extension_redirect_handle_entry_t));
     entry->filter_id = filter_id;
@@ -983,71 +1144,6 @@ net_ebpf_ext_connect_redirect_filter_change_notify(
 
 Exit:
     NET_EBPF_EXT_RETURN_NTSTATUS(status);
-}
-
-#define DEFINE_SOCK_ADDR_CLASSIFY_LOG_FUNCTION(family)                  \
-    static void _net_ebpf_ext_log_sock_addr_classify_v##family##(       \
-        _In_z_ const char* message,                                     \
-        uint64_t transport_endpoint_handle,                             \
-        _In_ const bpf_sock_addr_t* original_context,                   \
-        _In_opt_ const bpf_sock_addr_t* redirected_context,             \
-        uint32_t verdict)                                               \
-    {                                                                   \
-        if (verdict == BPF_SOCK_ADDR_VERDICT_REJECT) {                  \
-            NET_EBPF_EXT_LOG_SOCK_ADDR_CLASSIFY_IPV##family##(          \
-                NET_EBPF_EXT_TRACELOG_LEVEL_INFO,                       \
-                message,                                                \
-                transport_endpoint_handle,                              \
-                original_context->protocol,                             \
-                original_context->msg_src_ip##family##,                 \
-                ntohs(original_context->msg_src_port),                  \
-                original_context->user_ip##family##,                    \
-                ntohs(original_context->user_port),                     \
-                verdict);                                               \
-        } else if (redirected_context != NULL) {                        \
-            NET_EBPF_EXT_LOG_SOCK_ADDR_REDIRECT_CLASSIFY_IPV##family##( \
-                message,                                                \
-                transport_endpoint_handle,                              \
-                original_context->protocol,                             \
-                original_context->msg_src_ip##family##,                 \
-                ntohs(original_context->msg_src_port),                  \
-                original_context->user_ip##family##,                    \
-                ntohs(original_context->user_port),                     \
-                redirected_context->user_ip##family##,                  \
-                ntohs(redirected_context->user_port),                   \
-                verdict);                                               \
-        } else {                                                        \
-            NET_EBPF_EXT_LOG_SOCK_ADDR_CLASSIFY_IPV##family##(          \
-                NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,                    \
-                message,                                                \
-                transport_endpoint_handle,                              \
-                original_context->protocol,                             \
-                original_context->msg_src_ip##family##,                 \
-                ntohs(original_context->msg_src_port),                  \
-                original_context->msg_src_ip##family##,                 \
-                ntohs(original_context->user_port),                     \
-                verdict);                                               \
-        }                                                               \
-    }
-
-DEFINE_SOCK_ADDR_CLASSIFY_LOG_FUNCTION(4)
-DEFINE_SOCK_ADDR_CLASSIFY_LOG_FUNCTION(6)
-
-static void
-_net_ebpf_ext_log_sock_addr_classify(
-    _In_z_ const char* message,
-    uint64_t transport_endpoint_handle,
-    _In_ const bpf_sock_addr_t* original_context,
-    _In_opt_ const bpf_sock_addr_t* redirected_context,
-    uint32_t verdict)
-{
-    if (original_context->family == AF_INET) {
-        _net_ebpf_ext_log_sock_addr_classify_v4(
-            message, transport_endpoint_handle, original_context, redirected_context, verdict);
-    } else {
-        _net_ebpf_ext_log_sock_addr_classify_v6(
-            message, transport_endpoint_handle, original_context, redirected_context, verdict);
-    }
 }
 
 //
@@ -1571,7 +1667,8 @@ Exit:
 
         blocked_connection_context = (net_ebpf_extension_connection_context_t*)ExAllocatePoolUninitialized(
             NonPagedPoolNx, sizeof(net_ebpf_extension_connection_context_t), NET_EBPF_EXTENSION_POOL_TAG);
-        NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(blocked_connection_context, "blocked_connection", status);
+        NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(
+            NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, blocked_connection_context, "blocked_connection", status);
         memset(blocked_connection_context, 0, sizeof(net_ebpf_extension_connection_context_t));
 
         _net_ebpf_extension_connection_context_initialize(
@@ -1632,7 +1729,8 @@ _ebpf_sock_addr_context_create(
 
     sock_addr_ctx = (bpf_sock_addr_t*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, sizeof(bpf_sock_addr_t), NET_EBPF_EXTENSION_POOL_TAG);
-    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(sock_addr_ctx, "sock_addr_ctx", result);
+    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
+        NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, sock_addr_ctx, "sock_addr_ctx", result);
 
     memcpy(sock_addr_ctx, context_in, sizeof(bpf_sock_addr_t));
 
@@ -1675,5 +1773,5 @@ _ebpf_sock_addr_context_destroy(
     if (context) {
         ExFreePool(context);
     }
-    NET_EBPF_EXT_LOG_FUNCTION_SUCCESS();
+    NET_EBPF_EXT_LOG_EXIT();
 }

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -439,11 +439,8 @@ net_ebpf_extension_sock_ops_flow_established_classify(
 
     local_flow_context = (net_ebpf_extension_sock_ops_wfp_flow_context_t*)ExAllocatePoolUninitialized(
         NonPagedPoolNx, sizeof(net_ebpf_extension_sock_ops_wfp_flow_context_t), NET_EBPF_EXTENSION_POOL_TAG);
-    if (local_flow_context == NULL) {
-        result = EBPF_NO_MEMORY;
-        NET_EBPF_EXT_LOG_FUNCTION_ERROR(result);
-        goto Exit;
-    }
+    NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_RESULT(
+        NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS, local_flow_context, "flow_context", result);
     memset(local_flow_context, 0, sizeof(net_ebpf_extension_sock_ops_wfp_flow_context_t));
 
     // Associate the filter context with the filter context.
@@ -600,7 +597,7 @@ _ebpf_sock_ops_context_create(
     // This provider doesn't support data.
     if (data_in != NULL || data_size_in != 0) {
         NET_EBPF_EXT_LOG_MESSAGE(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "Data is not supported");
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS, "Data is not supported");
         result = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
@@ -608,7 +605,7 @@ _ebpf_sock_ops_context_create(
     // This provider requires context.
     if (context_in == NULL || context_size_in < sizeof(bpf_sock_ops_t)) {
         NET_EBPF_EXT_LOG_MESSAGE(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "Context is required");
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS, "Context is required");
         result = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
@@ -643,6 +640,7 @@ _ebpf_sock_ops_context_destroy(
     _Out_writes_bytes_to_(*context_size_out, *context_size_out) uint8_t* context_out,
     _Inout_ size_t* context_size_out)
 {
+    NET_EBPF_EXT_LOG_ENTRY();
     UNREFERENCED_PARAMETER(data_out);
     if (context == NULL) {
         return;
@@ -660,5 +658,5 @@ _ebpf_sock_ops_context_destroy(
     }
 
     ExFreePool(context);
-    NET_EBPF_EXT_LOG_FUNCTION_SUCCESS();
+    NET_EBPF_EXT_LOG_EXIT();
 }

--- a/netebpfext/net_ebpf_ext_tracelog.c
+++ b/netebpfext/net_ebpf_ext_tracelog.c
@@ -44,3 +44,501 @@ net_ebpf_ext_trace_terminate()
     }
 }
 #pragma optimize("", on)
+
+#define KEYWORD_BASE NET_EBPF_EXT_TRACELOG_KEYWORD_BASE
+#define KEYWORD_BIND NET_EBPF_EXT_TRACELOG_KEYWORD_BIND
+#define KEYWORD_EXT NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION
+#define KEYWORD_SOCK_ADDR NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR
+#define KEYWORD_SOCK_OPS NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS
+#define KEYWORD_XDP NET_EBPF_EXT_TRACELOG_KEYWORD_XDP
+
+#define CASE_BASE case _NET_EBPF_EXT_TRACELOG_KEYWORD_BASE
+#define CASE_BIND case _NET_EBPF_EXT_TRACELOG_KEYWORD_BIND
+#define CASE_EXT case _NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION
+#define CASE_SOCK_ADDR case _NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR
+#define CASE_SOCK_OPS case _NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_OPS
+#define CASE_XDP case _NET_EBPF_EXT_TRACELOG_KEYWORD_XDP
+
+#define LEVEL_LOG_ALWAYS NET_EBPF_EXT_TRACELOG_LEVEL_LOG_ALWAYS
+#define LEVEL_CRITICAL NET_EBPF_EXT_TRACELOG_LEVEL_CRITICAL
+#define LEVEL_ERROR NET_EBPF_EXT_TRACELOG_LEVEL_ERROR
+#define LEVEL_WARNING NET_EBPF_EXT_TRACELOG_LEVEL_WARNING
+#define LEVEL_INFO NET_EBPF_EXT_TRACELOG_LEVEL_INFO
+#define LEVEL_VERBOSE NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE
+
+#define CASE_LOG_ALWAYS case _NET_EBPF_EXT_TRACELOG_LEVEL_LOG_ALWAYS
+#define CASE_CRITICAL case _NET_EBPF_EXT_TRACELOG_LEVEL_CRITICAL
+#define CASE_LEVEL_ERROR case _NET_EBPF_EXT_TRACELOG_LEVEL_ERROR
+#define CASE_WARNING case _NET_EBPF_EXT_TRACELOG_LEVEL_WARNING
+#define CASE_INFO case _NET_EBPF_EXT_TRACELOG_LEVEL_INFO
+#define CASE_VERBOSE case _NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE
+
+#define NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_KEYWORD_SWITCH(api_name, status)       \
+    switch (keyword) {                                                               \
+    CASE_BASE:                                                                       \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_BASE, api_name, status);      \
+        break;                                                                       \
+    CASE_EXT:                                                                        \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_EXT, api_name, status);       \
+        break;                                                                       \
+    CASE_BIND:                                                                       \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_BIND, api_name, status);      \
+        break;                                                                       \
+    CASE_SOCK_ADDR:                                                                  \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_SOCK_ADDR, api_name, status); \
+        break;                                                                       \
+    CASE_SOCK_OPS:                                                                   \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_SOCK_OPS, api_name, status);  \
+        break;                                                                       \
+    CASE_XDP:                                                                        \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(KEYWORD_XDP, api_name, status);       \
+        break;                                                                       \
+    default:                                                                         \
+        break;                                                                       \
+    }
+
+#pragma warning(push)
+#pragma warning(disable : 6262) // Function uses 'N' bytes of stack.  Consider moving some data to heap.
+
+__declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure(
+    net_ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* api_name, NTSTATUS status)
+{
+    NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_KEYWORD_SWITCH(api_name, status);
+}
+
+#define NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING_KEYWORD_SWITCH(api_name, status, message, string_value)  \
+    switch (keyword) {                                                                                                \
+    CASE_BASE:                                                                                                        \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_BASE, api_name, status, message, string_value); \
+        break;                                                                                                        \
+    CASE_EXT:                                                                                                         \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_EXT, api_name, status, message, string_value);  \
+        break;                                                                                                        \
+    CASE_BIND:                                                                                                        \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_BIND, api_name, status, message, string_value); \
+        break;                                                                                                        \
+    CASE_SOCK_ADDR:                                                                                                   \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(                                                        \
+            KEYWORD_SOCK_ADDR, api_name, status, message, string_value);                                              \
+        break;                                                                                                        \
+    CASE_SOCK_OPS:                                                                                                    \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(                                                        \
+            KEYWORD_SOCK_OPS, api_name, status, message, string_value);                                               \
+        break;                                                                                                        \
+    CASE_XDP:                                                                                                         \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING(KEYWORD_XDP, api_name, status, message, string_value);  \
+        break;                                                                                                        \
+    default:                                                                                                          \
+        break;                                                                                                        \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure_message_string(
+    net_ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* api_name,
+    NTSTATUS status,
+    _In_z_ const char* message,
+    _In_z_ const char* string_value)
+{
+    NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_MESSAGE_STRING_KEYWORD_SWITCH(api_name, status, message, string_value);
+}
+
+#define NET_EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(trace_level, message)       \
+    switch (keyword) {                                                      \
+    CASE_BASE:                                                              \
+        _NET_EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_BASE, message);      \
+        break;                                                              \
+    CASE_BIND:                                                              \
+        _NET_EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_BIND, message);      \
+        break;                                                              \
+    CASE_EXT:                                                               \
+        _NET_EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_EXT, message);       \
+        break;                                                              \
+    CASE_SOCK_ADDR:                                                         \
+        _NET_EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_SOCK_ADDR, message); \
+        break;                                                              \
+    CASE_SOCK_OPS:                                                          \
+        _NET_EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_SOCK_OPS, message);  \
+        break;                                                              \
+    CASE_XDP:                                                               \
+        _NET_EBPF_EXT_LOG_MESSAGE(trace_level, KEYWORD_XDP, message);       \
+        break;                                                              \
+    default:                                                                \
+        break;                                                              \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_message(
+    net_ebpf_ext_tracelog_level_t trace_level, net_ebpf_ext_tracelog_keyword_t keyword, _In_z_ const char* message)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        NET_EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message);
+        break;
+    CASE_CRITICAL:
+        NET_EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_CRITICAL, message);
+        break;
+    CASE_LEVEL_ERROR:
+        NET_EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_ERROR, message);
+        break;
+    CASE_WARNING:
+        NET_EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_WARNING, message);
+        break;
+    CASE_INFO:
+        NET_EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_INFO, message);
+        break;
+    CASE_VERBOSE:
+        NET_EBPF_EXT_LOG_MESSAGE_KEYWORD_SWITCH(LEVEL_VERBOSE, message);
+        break;
+    }
+}
+
+#define NET_EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(trace_level, message, string_value)       \
+    switch (keyword) {                                                                           \
+    CASE_BASE:                                                                                   \
+        _NET_EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_BASE, message, string_value);      \
+        break;                                                                                   \
+    CASE_BIND:                                                                                   \
+        _NET_EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_BIND, message, string_value);      \
+        break;                                                                                   \
+    CASE_EXT:                                                                                    \
+        _NET_EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_EXT, message, string_value);       \
+        break;                                                                                   \
+    CASE_SOCK_ADDR:                                                                              \
+        _NET_EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_SOCK_ADDR, message, string_value); \
+        break;                                                                                   \
+    CASE_SOCK_OPS:                                                                               \
+        _NET_EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_SOCK_OPS, message, string_value);  \
+        break;                                                                                   \
+    CASE_XDP:                                                                                    \
+        _NET_EBPF_EXT_LOG_MESSAGE_STRING(trace_level, KEYWORD_XDP, message, string_value);       \
+        break;                                                                                   \
+    default:                                                                                     \
+        break;                                                                                   \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_message_string(
+    net_ebpf_ext_tracelog_level_t trace_level,
+    net_ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    _In_z_ const char* string_value)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        NET_EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, string_value);
+        break;
+    CASE_CRITICAL:
+        NET_EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_CRITICAL, message, string_value);
+        break;
+    CASE_LEVEL_ERROR:
+        NET_EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_ERROR, message, string_value);
+        break;
+    CASE_WARNING:
+        NET_EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_WARNING, message, string_value);
+        break;
+    CASE_INFO:
+        NET_EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_INFO, message, string_value);
+        break;
+    CASE_VERBOSE:
+        NET_EBPF_EXT_LOG_MESSAGE_STRING_KEYWORD_SWITCH(LEVEL_VERBOSE, message, string_value);
+        break;
+    }
+}
+
+#define NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(trace_level, message, status)       \
+    switch (keyword) {                                                                       \
+    CASE_BASE:                                                                               \
+        _NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_BASE, message, status);      \
+        break;                                                                               \
+    CASE_BIND:                                                                               \
+        _NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_BIND, message, status);      \
+        break;                                                                               \
+    CASE_EXT:                                                                                \
+        _NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_EXT, message, status);       \
+        break;                                                                               \
+    CASE_SOCK_ADDR:                                                                          \
+        _NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_SOCK_ADDR, message, status); \
+        break;                                                                               \
+    CASE_SOCK_OPS:                                                                           \
+        _NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_SOCK_OPS, message, status);  \
+        break;                                                                               \
+    CASE_XDP:                                                                                \
+        _NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS(trace_level, KEYWORD_XDP, message, status);       \
+        break;                                                                               \
+    default:                                                                                 \
+        break;                                                                               \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_message_ntstatus(
+    net_ebpf_ext_tracelog_level_t trace_level,
+    net_ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    NTSTATUS status)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, status);
+        break;
+    CASE_CRITICAL:
+        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_CRITICAL, message, status);
+        break;
+    CASE_LEVEL_ERROR:
+        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_ERROR, message, status);
+        break;
+    CASE_WARNING:
+        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_WARNING, message, status);
+        break;
+    CASE_INFO:
+        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_INFO, message, status);
+        break;
+    CASE_VERBOSE:
+        NET_EBPF_EXT_LOG_MESSAGE_NTSTATUS_KEYWORD_SWITCH(LEVEL_VERBOSE, message, status);
+        break;
+    }
+}
+
+#define NET_EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(trace_level, message, status)       \
+    switch (keyword) {                                                                     \
+    CASE_BASE:                                                                             \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_BASE, message, status);      \
+        break;                                                                             \
+    CASE_BIND:                                                                             \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_BIND, message, status);      \
+        break;                                                                             \
+    CASE_EXT:                                                                              \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_EXT, message, status);       \
+        break;                                                                             \
+    CASE_SOCK_ADDR:                                                                        \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_SOCK_ADDR, message, status); \
+        break;                                                                             \
+    CASE_SOCK_OPS:                                                                         \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_SOCK_OPS, message, status);  \
+        break;                                                                             \
+    CASE_XDP:                                                                              \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT32(trace_level, KEYWORD_XDP, message, status);       \
+        break;                                                                             \
+    default:                                                                               \
+        break;                                                                             \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_message_uint32(
+    net_ebpf_ext_tracelog_level_t trace_level,
+    net_ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    uint32_t value)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value);
+        break;
+    CASE_CRITICAL:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value);
+        break;
+    CASE_LEVEL_ERROR:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_ERROR, message, value);
+        break;
+    CASE_WARNING:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_WARNING, message, value);
+        break;
+    CASE_INFO:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_INFO, message, value);
+        break;
+    CASE_VERBOSE:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT32_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value);
+        break;
+    }
+}
+
+#define NET_EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(trace_level, message, status)       \
+    switch (keyword) {                                                                     \
+    CASE_BASE:                                                                             \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_BASE, message, status);      \
+        break;                                                                             \
+    CASE_BIND:                                                                             \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_BIND, message, status);      \
+        break;                                                                             \
+    CASE_EXT:                                                                              \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_EXT, message, status);       \
+        break;                                                                             \
+    CASE_SOCK_ADDR:                                                                        \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_SOCK_ADDR, message, status); \
+        break;                                                                             \
+    CASE_SOCK_OPS:                                                                         \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_SOCK_OPS, message, status);  \
+        break;                                                                             \
+    CASE_XDP:                                                                              \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64(trace_level, KEYWORD_XDP, message, status);       \
+        break;                                                                             \
+    default:                                                                               \
+        break;                                                                             \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_message_uint64(
+    net_ebpf_ext_tracelog_level_t trace_level,
+    net_ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    uint64_t value)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value);
+        break;
+    CASE_CRITICAL:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value);
+        break;
+    CASE_LEVEL_ERROR:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_ERROR, message, value);
+        break;
+    CASE_WARNING:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_WARNING, message, value);
+        break;
+    CASE_INFO:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_INFO, message, value);
+        break;
+    CASE_VERBOSE:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value);
+        break;
+    }
+}
+
+#define NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64_KEYWORD_SWITCH(api_name, status, value1, value2)       \
+    switch (keyword) {                                                                                             \
+    CASE_BASE:                                                                                                     \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_BASE, api_name, status, value1, value2);      \
+        break;                                                                                                     \
+    CASE_EXT:                                                                                                      \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_EXT, api_name, status, value1, value2);       \
+        break;                                                                                                     \
+    CASE_BIND:                                                                                                     \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_BIND, api_name, status, value1, value2);      \
+        break;                                                                                                     \
+    CASE_SOCK_ADDR:                                                                                                \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_SOCK_ADDR, api_name, status, value1, value2); \
+        break;                                                                                                     \
+    CASE_SOCK_OPS:                                                                                                 \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_SOCK_OPS, api_name, status, value1, value2);  \
+        break;                                                                                                     \
+    CASE_XDP:                                                                                                      \
+        _NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64(KEYWORD_XDP, api_name, status, value1, value2);       \
+        break;                                                                                                     \
+    default:                                                                                                       \
+        break;                                                                                                     \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_ntstatus_api_failure_uint64_uint64(
+    net_ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* api_name,
+    NTSTATUS status,
+    uint64_t value1,
+    uint64_t value2)
+{
+    NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE_UINT64_UINT64_KEYWORD_SWITCH(api_name, status, value1, value2);
+}
+
+#define NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(trace_level, message, value1, value2)       \
+    switch (keyword) {                                                                                    \
+    CASE_BASE:                                                                                            \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_BASE, message, value1, value2);      \
+        break;                                                                                            \
+    CASE_EXT:                                                                                             \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_EXT, message, value1, value2);       \
+        break;                                                                                            \
+    CASE_BIND:                                                                                            \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_BIND, message, value1, value2);      \
+        break;                                                                                            \
+    CASE_SOCK_ADDR:                                                                                       \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_SOCK_ADDR, message, value1, value2); \
+        break;                                                                                            \
+    CASE_SOCK_OPS:                                                                                        \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_SOCK_OPS, message, value1, value2);  \
+        break;                                                                                            \
+    CASE_XDP:                                                                                             \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64(trace_level, KEYWORD_XDP, message, value1, value2);       \
+        break;                                                                                            \
+    default:                                                                                              \
+        break;                                                                                            \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_message_uint64_uint64(
+    net_ebpf_ext_tracelog_level_t trace_level,
+    net_ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    uint64_t value1,
+    uint64_t value2)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value1, value2);
+        break;
+    CASE_CRITICAL:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value1, value2);
+        break;
+    CASE_LEVEL_ERROR:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_ERROR, message, value1, value2);
+        break;
+    CASE_WARNING:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_WARNING, message, value1, value2);
+        break;
+    CASE_INFO:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_INFO, message, value1, value2);
+        break;
+    CASE_VERBOSE:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value1, value2);
+        break;
+    }
+}
+
+#define NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(trace_level, message, value1, value2, value3)  \
+    switch (keyword) {                                                                                              \
+    CASE_BASE:                                                                                                      \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_BASE, message, value1, value2, value3); \
+        break;                                                                                                      \
+    CASE_EXT:                                                                                                       \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_EXT, message, value1, value2, value3);  \
+        break;                                                                                                      \
+    CASE_BIND:                                                                                                      \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_BIND, message, value1, value2, value3); \
+        break;                                                                                                      \
+    CASE_SOCK_ADDR:                                                                                                 \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(                                                             \
+            trace_level, KEYWORD_SOCK_ADDR, message, value1, value2, value3);                                       \
+        break;                                                                                                      \
+    CASE_SOCK_OPS:                                                                                                  \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(                                                             \
+            trace_level, KEYWORD_SOCK_OPS, message, value1, value2, value3);                                        \
+        break;                                                                                                      \
+    CASE_XDP:                                                                                                       \
+        _NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64(trace_level, KEYWORD_XDP, message, value1, value2, value3);  \
+        break;                                                                                                      \
+    default:                                                                                                        \
+        break;                                                                                                      \
+    }
+
+__declspec(noinline) void net_ebpf_ext_log_message_uint64_uint64_uint64(
+    net_ebpf_ext_tracelog_level_t trace_level,
+    net_ebpf_ext_tracelog_keyword_t keyword,
+    _In_z_ const char* message,
+    uint64_t value1,
+    uint64_t value2,
+    uint64_t value3)
+{
+    switch (trace_level) {
+    CASE_LOG_ALWAYS:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_LOG_ALWAYS, message, value1, value2, value3);
+        break;
+    CASE_CRITICAL:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_CRITICAL, message, value1, value2, value3);
+        break;
+    CASE_LEVEL_ERROR:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_ERROR, message, value1, value2, value3);
+        break;
+    CASE_WARNING:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_WARNING, message, value1, value2, value3);
+        break;
+    CASE_INFO:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_INFO, message, value1, value2, value3);
+        break;
+    CASE_VERBOSE:
+        NET_EBPF_EXT_LOG_MESSAGE_UINT64_UINT64_UINT64_KEYWORD_SWITCH(LEVEL_VERBOSE, message, value1, value2, value3);
+        break;
+    }
+}
+#pragma warning(pop)

--- a/netebpfext/net_ebpf_ext_xdp.c
+++ b/netebpfext/net_ebpf_ext_xdp.c
@@ -406,11 +406,7 @@ Exit:
         ExFreePool(packet_buffer);
     }
 
-    if (!NT_SUCCESS(status)) {
-        NET_EBPF_EXT_LOG_FUNCTION_ERROR(status);
-    }
-
-    return status;
+    NET_EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
 static void
@@ -528,11 +524,7 @@ _net_ebpf_ext_receive_inject_cloned_nbl(
     }
 
 Exit:
-    if (!NT_SUCCESS(status)) {
-        NET_EBPF_EXT_LOG_FUNCTION_ERROR(status);
-    }
-
-    return status;
+    NET_EBPF_EXT_RETURN_NTSTATUS(status);
 }
 
 static void
@@ -664,7 +656,7 @@ net_ebpf_ext_layer_2_classify(
     }
 
     if (nbl == NULL) {
-        NET_EBPF_EXT_LOG_MESSAGE(NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "Null NBL");
+        NET_EBPF_EXT_LOG_MESSAGE(NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_XDP, "Null NBL");
         goto Done;
     }
 
@@ -683,7 +675,7 @@ net_ebpf_ext_layer_2_classify(
     net_buffer = NET_BUFFER_LIST_FIRST_NB(nbl);
     if (net_buffer == NULL) {
         NET_EBPF_EXT_LOG_MESSAGE(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "net_buffer not present");
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_XDP, "net_buffer not present");
 
         // nothing to do
         goto Done;
@@ -792,7 +784,7 @@ _ebpf_xdp_context_create(
     // Context is optional.
     if (data_in == NULL || data_size_in == 0) {
         NET_EBPF_EXT_LOG_MESSAGE(
-            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "Data is required");
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_XDP, "Data is required");
         result = EBPF_INVALID_ARGUMENT;
         goto Done;
     }
@@ -906,5 +898,5 @@ _ebpf_xdp_context_delete(
     }
 
     ExFreePool(xdp_context);
-    NET_EBPF_EXT_LOG_FUNCTION_SUCCESS();
+    NET_EBPF_EXT_LOG_EXIT();
 }

--- a/netebpfext/sys/netebpfext.vcxproj
+++ b/netebpfext/sys/netebpfext.vcxproj
@@ -99,8 +99,6 @@
     <ClCompile>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH);$(SolutionDir)include;$(SolutionDir)libs\platform;$(SolutionDir)libs\platform\kernel;$(OutputPath);$(SolutionDir)external\ebpf-verifier\src;$(SolutionDir)include\kernel;$(SolutionDir)netebpfext;$(SolutionDir)netebpfext\sys;$(SolutionDir)resource</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>%(PreprocessorDefinitions);BINARY_COMPATIBLE=0;NT;UNICODE;_UNICODE;NDIS60;POOL_NX_OPTIN_AUTO</PreprocessorDefinitions>
-      <!-- Change stack depth for C6262 from 1024 to 4096 -->
-      <PREfastAdditionalOptions>stacksize4096</PREfastAdditionalOptions>
     </ClCompile>
     <Midl>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories);$(DDK_INC_PATH)</AdditionalIncludeDirectories>


### PR DESCRIPTION
## Description
`TraceLoggingWrite` macro pushes distinct local variables on stack for each trace statement. This causes the stack to bloat. There is a chance of bugcheck due to stack size crossing the limit, since there are some functions with a lot of trace statements. The fix is to wrap the tracelog macros in a function (annotated with `__declspec(noinline)`) and invoke the functions instead of the macros directly. There are several helper macros that in turn the tracelog macros and takes trace level and trace keyword as macro parameters. If we now make the keywords as parameters of the wrapper function, the compiler generates error as the Tracelog macros expect literals.

```
    uint64_t foo = 1;
    TraceLoggingWrite(                                                    
        net_ebpf_ext_tracelog_provider,                                   
        NET_EBPF_EXT_TRACELOG_EVENT_SUCCESS,                              
        TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                        
        TraceLoggingKeyword(foo),          
        TraceLoggingString(__FUNCTION__ " returned success", "Message")); 
```
For example, the above code causes the compiler error `error C2099: initializer is not a constant. `

One alternative is to create separate functions for each keyword/trace_level combination; but that would be untenable.

So instead, enum types for the keyword and levels are created, and the wrapper function takes those enum types as parameters. The wrapper functions have nested switch statements for keyword and trace level values and invoke the Tracelog macros with literals for corresponding keyword and trace level values. Macros are used to avoid the functions becoming too long.

I renamed `NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR` to `NET_EBPF_EXT_TRACELOG_KEYWORD_EXTENSION` as a different keyword for error is not needed. Modules should use their keywords along with `NET_EBPF_EXT_TRACELOG_LEVEL_ERROR` for this.

## Testing

CI + manually inspecting the generated tracelogs.

## Documentation

No impact.
