### PR TITLE
Add Fault Injection in WFP OS APIs

### DIFF
--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -349,8 +349,12 @@ void
 net_ebpf_extension_delete_wfp_filters(uint32_t filter_count, _Frees_ptr_ _In_count_(filter_count) uint64_t* filter_ids)
 {
     NET_EBPF_EXT_LOG_ENTRY();
+    NTSTATUS status;
     for (uint32_t index = 0; index < filter_count; index++) {
-        FwpmFilterDeleteById(_fwp_engine_handle, filter_ids[index]);
+        status = FwpmFilterDeleteById(_fwp_engine_handle, filter_ids[index]);
+        if (!NT_SUCCESS(status)) {
+            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmFilterDeleteById", status);
+        }
     }
     ExFreePool(filter_ids);
     NET_EBPF_EXT_LOG_EXIT();
@@ -444,7 +448,11 @@ Exit:
             ExFreePool(local_filter_ids);
         }
         if (is_in_transaction) {
-            FwpmTransactionAbort(_fwp_engine_handle);
+            status = FwpmTransactionAbort(_fwp_engine_handle);
+            if (!NT_SUCCESS(status)) {
+                NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
+                    NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmTransactionAbort", status);
+            }
         }
     }
 
@@ -654,11 +662,14 @@ Exit:
 
     if (!NT_SUCCESS(status)) {
         if (is_in_transaction) {
-            status = FwpmTransactionAbort(_fwp_engine_handle);
-            if (!NT_SUCCESS(status)) {
-                NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
-                    NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmTransactionAbort", status);
+            NTSTATUS ret = FwpmTransactionAbort(_fwp_engine_handle);
+            if (!NT_SUCCESS(ret)) {
+                NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmTransactionAbort", ret);
             }
+        }
+
+        if (is_engined_opened) {
+            net_ebpf_extension_uninitialize_wfp_components();
         }
     }
 
@@ -669,16 +680,32 @@ void
 net_ebpf_extension_uninitialize_wfp_components(void)
 {
     size_t index;
+    NTSTATUS status;
+
     if (_fwp_engine_handle != NULL) {
-        FwpmEngineClose(_fwp_engine_handle);
+        status = FwpmEngineClose(_fwp_engine_handle);
+        if (!NT_SUCCESS(status)) {
+            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpmEngineClose", status);
+        }
         _fwp_engine_handle = NULL;
 
         for (index = 0; index < EBPF_COUNT_OF(_net_ebpf_ext_wfp_callout_states); index++) {
-            FwpsCalloutUnregisterById(_net_ebpf_ext_wfp_callout_states[index].assigned_callout_id);
+            status = FwpsCalloutUnregisterById(_net_ebpf_ext_wfp_callout_states[index].assigned_callout_id);
+            if (!NT_SUCCESS(status)) {
+                NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
+                    NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpsCalloutUnregisterById", status);
+            }
         }
     }
 
-    FwpsInjectionHandleDestroy(_net_ebpf_ext_l2_injection_handle);
+    // FwpsInjectionHandleCreate can fail. So, check for NULL.
+    if (_net_ebpf_ext_l2_injection_handle != NULL) {
+        status = FwpsInjectionHandleDestroy(_net_ebpf_ext_l2_injection_handle);
+        if (!NT_SUCCESS(status)) {
+            NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(
+                NET_EBPF_EXT_TRACELOG_KEYWORD_ERROR, "FwpsInjectionHandleDestroy", status);
+        }
+    }
 }
 
 NTSTATUS

--- a/netebpfext/net_ebpf_ext.c
+++ b/netebpfext/net_ebpf_ext.c
@@ -592,7 +592,7 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
 
     UNREFERENCED_PARAMETER(device_object);
 
-    BOOLEAN is_engined_opened = FALSE;
+    BOOLEAN is_engine_opened = FALSE;
     BOOLEAN is_in_transaction = FALSE;
 
     FWPM_SESSION session = {0};
@@ -610,7 +610,7 @@ net_ebpf_extension_initialize_wfp_components(_Inout_ void* device_object)
 
     status = FwpmEngineOpen(NULL, RPC_C_AUTHN_WINNT, NULL, &session, &_fwp_engine_handle);
     NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS("FwpmEngineOpen", status);
-    is_engined_opened = TRUE;
+    is_engine_opened = TRUE;
 
     status = FwpmTransactionBegin(_fwp_engine_handle, 0);
     NET_EBPF_EXT_BAIL_ON_API_FAILURE_STATUS("FwpmTransactionBegin", status);
@@ -668,7 +668,7 @@ Exit:
             }
         }
 
-        if (is_engined_opened) {
+        if (is_engine_opened) {
             net_ebpf_extension_uninitialize_wfp_components();
         }
     }

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -488,10 +488,6 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmTransactionCommit0(_In_ _Release
 
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmTransactionAbort0(_In_ _Releases_lock_(_Curr_) HANDLE engine_handle)
 {
-    if (ebpf_fault_injection_inject_fault()) {
-        return STATUS_NO_MEMORY;
-    }
-
     UNREFERENCED_PARAMETER(engine_handle);
     return STATUS_SUCCESS;
 }

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -432,6 +432,10 @@ static std::unique_ptr<fwp_injection_handle> _injection_handle;
 
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmFilterDeleteById0(_In_ HANDLE engine_handle, _In_ uint64_t id)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
     auto& engine = *reinterpret_cast<_fwp_engine*>(engine_handle);
 
     if (engine.remove_fwpm_filter(id)) {
@@ -444,6 +448,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmFilterDeleteById0(_In_ HANDLE en
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
     FwpmTransactionBegin0(_In_ _Acquires_lock_(_Curr_) HANDLE engine_handle, _In_ uint32_t flags)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     UNREFERENCED_PARAMETER(engine_handle);
     UNREFERENCED_PARAMETER(flags);
     return STATUS_SUCCESS;
@@ -455,6 +463,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmFilterAdd0(
     _In_opt_ PSECURITY_DESCRIPTOR sd,
     _Out_opt_ uint64_t* id)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     UNREFERENCED_PARAMETER(sd);
 
     auto& engine = *reinterpret_cast<_fwp_engine*>(engine_handle);
@@ -476,6 +488,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmTransactionCommit0(_In_ _Release
 
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmTransactionAbort0(_In_ _Releases_lock_(_Curr_) HANDLE engine_handle)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     UNREFERENCED_PARAMETER(engine_handle);
     return STATUS_SUCCESS;
 }
@@ -483,6 +499,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmTransactionAbort0(_In_ _Releases
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
     FwpsCalloutRegister3(_Inout_ void* device_object, _In_ const FWPS_CALLOUT3* callout, _Out_opt_ uint32_t* callout_id)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     UNREFERENCED_PARAMETER(device_object);
 
     auto& engine = *_fwp_engine::get()->get();
@@ -502,6 +522,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmCalloutAdd0(
     _In_opt_ PSECURITY_DESCRIPTOR sd,
     _Out_opt_ uint32_t* id)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     auto& engine = *reinterpret_cast<_fwp_engine*>(engine_handle);
 
     auto id_returned = engine.add_fwpm_callout(callout);
@@ -515,6 +539,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmCalloutAdd0(
 
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpsCalloutUnregisterById0(_In_ const uint32_t callout_id)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     auto& engine = *_fwp_engine::get()->get();
 
     if (engine.remove_fwps_callout(callout_id)) {
@@ -531,6 +559,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmEngineOpen0(
     _In_opt_ const FWPM_SESSION0* session,
     _Out_ HANDLE* engine_handle)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     UNREFERENCED_PARAMETER(server_name);
     UNREFERENCED_PARAMETER(authn_service);
     UNREFERENCED_PARAMETER(auth_identity);
@@ -543,6 +575,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmEngineOpen0(
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
     FwpmProviderAdd0(_In_ HANDLE engine_handle, _In_ const FWPM_PROVIDER0* provider, _In_opt_ PSECURITY_DESCRIPTOR sd)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     auto& engine = *reinterpret_cast<_fwp_engine*>(engine_handle);
 
     engine.add_fwpm_provider(provider);
@@ -554,6 +590,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
     FwpmSubLayerAdd0(_In_ HANDLE engine_handle, _In_ const FWPM_SUBLAYER0* sub_layer, _In_opt_ PSECURITY_DESCRIPTOR sd)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     UNREFERENCED_PARAMETER(sd);
     auto& engine = *reinterpret_cast<_fwp_engine*>(engine_handle);
 
@@ -564,6 +604,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS
 
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmEngineClose0(_Inout_ HANDLE engine_handle)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     if (engine_handle != _fwp_engine::get()->get()) {
         return STATUS_INVALID_PARAMETER;
     } else {
@@ -574,6 +618,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpmEngineClose0(_Inout_ HANDLE engi
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpsInjectionHandleCreate0(
     _In_opt_ ADDRESS_FAMILY address_family, _In_ uint32_t flags, _Out_ HANDLE* injection_handle)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     _injection_handle = std::make_unique<_fwp_injection_handle>(address_family, flags);
     *injection_handle = _injection_handle.get();
 
@@ -582,6 +630,10 @@ _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpsInjectionHandleCreate0(
 
 _IRQL_requires_max_(PASSIVE_LEVEL) NTSTATUS FwpsInjectionHandleDestroy0(_In_ HANDLE injection_handle)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_NO_MEMORY;
+    }
+
     if (injection_handle != _injection_handle.get()) {
         return STATUS_INVALID_PARAMETER;
     } else {


### PR DESCRIPTION
## Description

- Added fault injection condition in the following WFP OS APIs:

1. FwpmFilterDeleteById0
2. FwpmTransactionBegin0
3. FwpmFilterAdd0
4. FwpmTransactionAbort0
5. FwpsCalloutRegister3
6. FwpmCalloutAdd0
7. FwpsCalloutUnregisterById0
8. FwpmEngineOpen0
9. FwpmProviderAdd0
10. FwpmSubLayerAdd0
11. FwpmEngineClose0
12. FwpsInjectionHandleCreate0
13. FwpsInjectionHandleDestroy0

-  In net_ebpf_extension_initialize_wfp_components(), added a call to close the session and to unregister the callouts for the failure paths.

- Fixed an issue in net_ebpf_extension_initialize_wfp_components(), where the failure status was overwritten with FwpmTransactionAbort() return value and returned as success to the caller. This led the code flow to continue with the assumption that the initialization of wfp components (ie, registering callouts and adding callouts) was successful... This caused assert failure during NmrClientAttachProvider flow.

Exit:
   if (!NT_SUCCESS(status)) {  <<< original failed status
        if (is_in_transaction) {
            status = FwpmTransactionAbort(_fwp_engine_handle);   <<<< 
       ...
   }
   NET_EBPF_EXT_RETURN_NTSTATUS(status);   <<<<< 

- Added traces for some failures.

Note: This is an incremental commit. There are 11 more WFP APIs pending in fwp_um.cpp. Please see #2101 for details.

## Testing

_Do any existing tests cover this change? Yes
Are new tests needed? No

Existing test cases with fault injection call stack of 4:
unit_tests.exe: PASSED
netebpfext_unit.exe: PASSED

## Documentation

_Is there any documentation impact for this change? No
