### PR TITLE
Prefer HKCU over HKLM for ebpf store

### DIFF
--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -18,11 +18,11 @@ _open_ebpf_store_key(_Out_ ebpf_registry_key_t* store_key)
     // Open root registry path.
     *store_key = nullptr;
 
-    // First try to open the HKLM registry key.
-    uint32_t result = open_registry_key(root_registry_key_local_machine, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
+    // First try to open the HKCU registry key.
+    uint32_t result = open_registry_key(root_registry_key_current_user, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
     if (result != ERROR_SUCCESS) {
-        // Failed to open ebpf store path in HKLM. Fall back to HKCU.
-        result = open_registry_key(root_registry_key_current_user, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
+        // Failed to open ebpf store path in HKCU. Fall back to HKLM.
+        result = open_registry_key(root_registry_key_local_machine, EBPF_STORE_REGISTRY_PATH, KEY_READ, store_key);
     }
 
     return result;


### PR DESCRIPTION
Fixes #2381
Fixes #2360

## Description

If netebpfext is running, it populates HKLM ebpf store. ebpfapi has logic to prefer HKLM over KHCU, if HKLM is present. This causes the build to fail as the HKLM store will not contain data related to sample_ext.

Fix is to prefer HKCU over KHLM.

Note: This issue should be completely fixed once #2339 is fixed.

## Testing

CICD

## Documentation

NA
