### PR TITLE
Update scorecard workflow to latest

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -27,6 +27,7 @@ jobs:
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
+      id-token: write
       actions: read
       contents: read
 
@@ -50,7 +51,7 @@ jobs:
 
       - name: "Run analysis"
         if: github.ref_name == 'main'
-        uses: ossf/scorecard-action@b614d455ee90608b5e36e3299cd50d457eb37d5f # Don't update this until they fix PR support
+        uses: ossf/scorecard-action@e38b1902ae4f44df626f11ba0734b14fb91f8f86 # v2.1.2
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Description

Note that we tried this before in PR #1161 and had to revert it in PR #1174 but the issue it was blocked on seems to be fixed and this should fix the various scorecard failures we are now seeing.

MsQuic which originally did the same as we did already snapped to latest as can be seen at
https://github.com/microsoft/msquic/blob/main/.github/workflows/scorecards-analysis.yml and its scorecard runs are passing.

## Testing

Match msquic config which is passing.
Similarly, l3afd was hitting the same scorecard failures we are, and https://github.com/l3af-project/l3afd/pull/230 makes this same fix and scorecards pass with it.

## Documentation

No impact.
