### PR TITLE
Get Build-x64-FuzzerDebug build output even on failure

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -191,13 +191,13 @@ jobs:
         tar -xf ..\..\x64-${{ matrix.configurations }}-cilium-xdp.zip
 
     - name: Zip Build Output
-      if: steps.skip_check.outputs.should_skip != 'true'
+      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true')
       working-directory: ${{github.workspace}}
       run: |
         Compress-Archive -Path ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -DestinationPath .\build-${{ matrix.configurations }}.zip
 
     - name: Upload Build Output
-      if: steps.skip_check.outputs.should_skip != 'true'
+      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true')
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
         name: ${{inputs.build_artifact}}-${{matrix.configurations}}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -191,13 +191,13 @@ jobs:
         tar -xf ..\..\x64-${{ matrix.configurations }}-cilium-xdp.zip
 
     - name: Zip Build Output
-      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true')
+      if: always() && (steps.skip_check.outputs.should_skip != 'true')
       working-directory: ${{github.workspace}}
       run: |
         Compress-Archive -Path ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -DestinationPath .\build-${{ matrix.configurations }}.zip
 
     - name: Upload Build Output
-      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true')
+      if: always() && (steps.skip_check.outputs.should_skip != 'true')
       uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce
       with:
         name: ${{inputs.build_artifact}}-${{matrix.configurations}}


### PR DESCRIPTION
## Description
To enforce Build-x64-FuzzerDebug upload when a crashdump is encountered for fuzzer build failure.

[Note: Still the RCA for FuzzerDebug build failure is not known. So, this PR can help with symbols, when the problem is hit]

## Testing

_Do any existing tests cover this change? Are new tests needed? No

## Documentation

_Is there any documentation impact for this change? No
