### PR TITLE
Close native object handles in a work item in case of failure

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2508,8 +2508,8 @@ _Requires_lock_not_held_(_ebpf_state_mutex) static ebpf_result_t
 
     try {
         if (result == EBPF_SUCCESS) {
+            std::unique_lock lock(_ebpf_state_mutex);
             for (auto& map : object->maps) {
-                std::unique_lock lock(_ebpf_state_mutex);
                 _ebpf_maps.insert(std::pair<ebpf_handle_t, ebpf_map_t*>(map->map_handle, map));
             }
         }

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -239,6 +239,8 @@ ebpf_core_terminate()
 
     ebpf_program_terminate();
 
+    ebpf_handle_table_terminate();
+
     ebpf_async_terminate();
 
     ebpf_pinning_table_free(_ebpf_core_map_pinning_table);
@@ -256,8 +258,6 @@ ebpf_core_terminate()
     // to be called after ebpf_epoch_terminate() to ensure all the program epoch
     // cleanup work items have been executed by this time.
     ebpf_native_terminate();
-
-    ebpf_handle_table_terminate();
 
     // Verify that all ebpf_core_object_t objects have been freed.
     ebpf_object_tracking_terminate();

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -239,8 +239,6 @@ ebpf_core_terminate()
 
     ebpf_program_terminate();
 
-    ebpf_handle_table_terminate();
-
     ebpf_async_terminate();
 
     ebpf_pinning_table_free(_ebpf_core_map_pinning_table);
@@ -258,6 +256,8 @@ ebpf_core_terminate()
     // to be called after ebpf_epoch_terminate() to ensure all the program epoch
     // cleanup work items have been executed by this time.
     ebpf_native_terminate();
+
+    ebpf_handle_table_terminate();
 
     // Verify that all ebpf_core_object_t objects have been freed.
     ebpf_object_tracking_terminate();

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1244,13 +1244,13 @@ _ebpf_native_close_handles_workitem(_In_opt_ const void* context)
     ebpf_native_handle_information_t* handle_info = (ebpf_native_handle_information_t*)context;
     for (uint32_t i = 0; i < handle_info->count_of_program_handles; i++) {
         if (handle_info->program_handles[i] != ebpf_handle_invalid) {
-            ebpf_handle_close(handle_info->program_handles[i]);
+            ebpf_assert_success(ebpf_handle_close(handle_info->program_handles[i]));
             handle_info->program_handles[i] = ebpf_handle_invalid;
         }
     }
     for (uint32_t i = 0; i < handle_info->count_of_map_handles; i++) {
         if (handle_info->map_handles[i] != ebpf_handle_invalid) {
-            ebpf_handle_close(handle_info->map_handles[i]);
+            ebpf_assert_success(ebpf_handle_close(handle_info->map_handles[i]));
             handle_info->map_handles[i] = ebpf_handle_invalid;
         }
     }

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -54,6 +54,28 @@ typedef enum _ebpf_native_module_state
     MODULE_STATE_UNLOADING,
 } ebpf_native_module_state_t;
 
+// typedef struct _ebpf_native_handle_information
+// {
+//     size_t count_of_program_handles;
+//     ebpf_handle_t* program_handles;
+//     size_t count_of_map_handles;
+//     ebpf_handle_t* map_handles;
+// } ebpf_native_handle_information_t;
+
+typedef struct _ebpf_native_handle_information
+{
+    size_t count_of_program_handles;
+    ebpf_handle_t* program_handles;
+    size_t count_of_map_handles;
+    ebpf_handle_t* map_handles;
+} ebpf_native_handle_information_t;
+
+typedef struct _ebpf_native_handle_cleanup_context
+{
+    ebpf_native_handle_information_t* handle_information;
+    ebpf_preemptible_work_item_t* handle_cleanup_workitem;
+} ebpf_native_handle_cleanup_context_t;
+
 typedef struct _ebpf_native_module
 {
     ebpf_base_object_t base;
@@ -70,6 +92,9 @@ typedef struct _ebpf_native_module
     HANDLE nmr_binding_handle;
     ebpf_list_entry_t list_entry;
     ebpf_preemptible_work_item_t* cleanup_workitem;
+    // ebpf_native_handle_information_t* handle_cleanup_information;
+    // ebpf_preemptible_work_item_t* handle_cleanup_workitem;
+    ebpf_native_handle_cleanup_context_t handle_cleanup_context;
 } ebpf_native_module_t;
 
 static GUID _ebpf_native_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
@@ -152,7 +177,8 @@ _ebpf_native_is_map_in_map(_In_ const ebpf_native_map_t* map)
 }
 
 static void
-_ebpf_native_clean_up_maps(_In_reads_(map_count) _Frees_ptr_ ebpf_native_map_t* maps, size_t map_count, bool unpin)
+_ebpf_native_clean_up_maps(
+    _In_reads_(map_count) _Frees_ptr_ ebpf_native_map_t* maps, size_t map_count, bool unpin, bool close_handles)
 {
     for (uint32_t count = 0; count < map_count; count++) {
         ebpf_native_map_t* map = &maps[count];
@@ -170,16 +196,18 @@ _ebpf_native_clean_up_maps(_In_reads_(map_count) _Frees_ptr_ ebpf_native_map_t* 
             ebpf_free(map->pin_path.value);
 #pragma warning(pop)
         }
-        if (map->handle != ebpf_handle_invalid) {
+        if (close_handles && map->handle != ebpf_handle_invalid) {
             ebpf_assert_success(ebpf_handle_close(map->handle));
         }
+        map->handle = ebpf_handle_invalid;
     }
 
     ebpf_free(maps);
 }
 
 static void
-_ebpf_native_clean_up_programs(_In_reads_(count_of_programs) ebpf_native_program_t* programs, size_t count_of_programs)
+_ebpf_native_clean_up_programs(
+    _In_reads_(count_of_programs) ebpf_native_program_t* programs, size_t count_of_programs, bool close_handles)
 {
     for (uint32_t i = 0; i < count_of_programs; i++) {
         if (programs[i].handle != ebpf_handle_invalid) {
@@ -188,7 +216,10 @@ _ebpf_native_clean_up_programs(_In_reads_(count_of_programs) ebpf_native_program
                 programs[i].handle, EBPF_OBJECT_PROGRAM, (ebpf_core_object_t**)&program_object));
             ebpf_assert_success(ebpf_program_register_for_helper_changes(program_object, NULL, NULL));
             ebpf_object_release_reference((ebpf_core_object_t*)program_object);
-            ebpf_assert_success(ebpf_handle_close(programs[i].handle));
+            if (close_handles) {
+                ebpf_assert_success(ebpf_handle_close(programs[i].handle));
+            }
+            programs[i].handle = ebpf_handle_invalid;
         }
         ebpf_free(programs[i].addresses_changed_callback_context);
         programs[i].addresses_changed_callback_context = NULL;
@@ -200,8 +231,8 @@ _ebpf_native_clean_up_programs(_In_reads_(count_of_programs) ebpf_native_program
 static void
 _ebpf_native_clean_up_module(_In_ _Post_invalid_ ebpf_native_module_t* module)
 {
-    _ebpf_native_clean_up_maps(module->maps, module->map_count, false);
-    _ebpf_native_clean_up_programs(module->programs, module->program_count);
+    _ebpf_native_clean_up_maps(module->maps, module->map_count, false, true);
+    _ebpf_native_clean_up_programs(module->programs, module->program_count, true);
 
     module->maps = NULL;
     module->map_count = 0;
@@ -848,7 +879,11 @@ _ebpf_native_create_maps(_Inout_ ebpf_native_module_t* module)
 
 Done:
     if (result != EBPF_SUCCESS) {
-        _ebpf_native_clean_up_maps(module->maps, module->map_count, true);
+        // Copy the handles in the cleanup context.
+        for (uint32_t i = 0; i < module->map_count; i++) {
+            module->handle_cleanup_context.handle_information->map_handles[i] = module->maps[i].handle;
+        }
+        _ebpf_native_clean_up_maps(module->maps, module->map_count, true, false);
         module->maps = NULL;
         module->map_count = 0;
     }
@@ -1164,7 +1199,10 @@ _ebpf_native_load_programs(_Inout_ ebpf_native_module_t* module)
     }
 
     if (result != EBPF_SUCCESS) {
-        _ebpf_native_clean_up_programs(module->programs, module->program_count);
+        for (uint32_t i = 0; i < module->program_count; i++) {
+            module->handle_cleanup_context.handle_information->program_handles[i] = module->programs[i].handle;
+        }
+        _ebpf_native_clean_up_programs(module->programs, module->program_count, false);
         module->programs = NULL;
         module->program_count = 0;
     }
@@ -1195,6 +1233,91 @@ _ebpf_native_get_count_of_programs(_In_ const ebpf_native_module_t* module)
     return count_of_programs;
 }
 
+static void
+_ebpf_native_close_handles_workitem(_In_opt_ const void* context)
+{
+
+    if (context == NULL) {
+        return;
+    }
+
+    ebpf_native_handle_information_t* handle_info = (ebpf_native_handle_information_t*)context;
+    for (uint32_t i = 0; i < handle_info->count_of_program_handles; i++) {
+        if (handle_info->program_handles[i] != ebpf_handle_invalid) {
+            ebpf_handle_close(handle_info->program_handles[i]);
+            handle_info->program_handles[i] = ebpf_handle_invalid;
+        }
+    }
+    for (uint32_t i = 0; i < handle_info->count_of_map_handles; i++) {
+        if (handle_info->map_handles[i] != ebpf_handle_invalid) {
+            ebpf_handle_close(handle_info->map_handles[i]);
+            handle_info->map_handles[i] = ebpf_handle_invalid;
+        }
+    }
+
+    ebpf_free(handle_info->program_handles);
+    ebpf_free(handle_info->map_handles);
+}
+
+static void
+_ebpf_native_clean_up_handle_cleanup_context(_Inout_ ebpf_native_handle_cleanup_context_t* cleanup_context)
+{
+    if (cleanup_context == NULL) {
+        return;
+    }
+
+    ebpf_free(cleanup_context->handle_information->map_handles);
+    ebpf_free(cleanup_context->handle_information->program_handles);
+    ebpf_free_preemptible_work_item(cleanup_context->handle_cleanup_workitem);
+}
+
+static ebpf_result_t
+_ebpf_native_initialize_handle_cleanup_context(
+    size_t program_handle_count, size_t map_handle_count, _Inout_ ebpf_native_handle_cleanup_context_t* cleanup_context)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+
+    cleanup_context->handle_information =
+        (ebpf_native_handle_information_t*)ebpf_allocate(sizeof(ebpf_native_handle_information_t));
+    if (cleanup_context->handle_information == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Done;
+    }
+    cleanup_context->handle_information->map_handles =
+        (ebpf_handle_t*)ebpf_allocate(sizeof(ebpf_handle_t) * map_handle_count);
+    if (cleanup_context->handle_information->map_handles == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Done;
+    }
+    cleanup_context->handle_information->count_of_map_handles = map_handle_count;
+
+    cleanup_context->handle_information->program_handles =
+        (ebpf_handle_t*)ebpf_allocate(sizeof(ebpf_handle_t) * program_handle_count);
+    if (cleanup_context->handle_information->program_handles == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Done;
+    }
+    cleanup_context->handle_information->count_of_program_handles = program_handle_count;
+
+    for (size_t i = 0; i < map_handle_count; i++) {
+        cleanup_context->handle_information->map_handles[i] = ebpf_handle_invalid;
+    }
+    for (size_t i = 0; i < program_handle_count; i++) {
+        cleanup_context->handle_information->program_handles[i] = ebpf_handle_invalid;
+    }
+
+    result = ebpf_allocate_preemptible_work_item(
+        &cleanup_context->handle_cleanup_workitem,
+        _ebpf_native_close_handles_workitem,
+        cleanup_context->handle_information);
+
+Done:
+    if (result != EBPF_SUCCESS) {
+        _ebpf_native_clean_up_handle_cleanup_context(cleanup_context);
+    }
+    return result;
+}
+
 _Must_inspect_result_ ebpf_result_t
 ebpf_native_load(
     _In_reads_(service_name_length) const wchar_t* service_name,
@@ -1212,7 +1335,7 @@ ebpf_native_load(
     ebpf_native_module_t* module = NULL;
     ebpf_native_module_t** existing_module = NULL;
     wchar_t* local_service_name = NULL;
-    ebpf_handle_t local_module_hande = ebpf_handle_invalid;
+    ebpf_handle_t local_module_handle = ebpf_handle_invalid;
     ebpf_preemptible_work_item_t* cleanup_workitem = NULL;
 
     local_service_name = ebpf_allocate_with_tag((size_t)service_name_length + 2, EBPF_POOL_TAG_NATIVE);
@@ -1224,7 +1347,6 @@ ebpf_native_load(
 
     result = ebpf_allocate_preemptible_work_item(&cleanup_workitem, _ebpf_native_unload_work_item, local_service_name);
     if (result != EBPF_SUCCESS) {
-        ebpf_free(local_service_name);
         goto Done;
     }
 
@@ -1278,8 +1400,9 @@ ebpf_native_load(
     module->state = MODULE_STATE_INITIALIZING;
     ebpf_lock_unlock(&module->lock, state);
 
-    // Create handle for the native module.
-    result = ebpf_handle_create(&local_module_hande, (ebpf_base_object_t*)module);
+    // Create handle for the native module. This should be the last step in initialization which can fail.
+    // Else, we can have a case where the same thread enters epoch recursively.
+    result = ebpf_handle_create(&local_module_handle, (ebpf_base_object_t*)module);
     if (result != EBPF_SUCCESS) {
         EBPF_LOG_MESSAGE_GUID(
             EBPF_TRACELOG_LEVEL_ERROR,
@@ -1292,6 +1415,7 @@ ebpf_native_load(
     state = ebpf_lock_lock(&module->lock);
     module->state = MODULE_STATE_INITIALIZED;
     module->service_name = local_service_name;
+    local_service_name = NULL;
     module->cleanup_workitem = cleanup_workitem;
 
     cleanup_workitem = NULL;
@@ -1301,8 +1425,8 @@ ebpf_native_load(
     // Get map and program count;
     *count_of_maps = _ebpf_native_get_count_of_maps(module);
     *count_of_programs = _ebpf_native_get_count_of_programs(module);
-    *module_handle = local_module_hande;
-    local_module_hande = ebpf_handle_invalid;
+    *module_handle = local_module_handle;
+    local_module_handle = ebpf_handle_invalid;
 
 Done:
     if (table_lock_acquired) {
@@ -1312,9 +1436,10 @@ Done:
     if (result != EBPF_SUCCESS) {
         ebpf_free_preemptible_work_item(cleanup_workitem);
     }
-    if (local_module_hande != ebpf_handle_invalid) {
-        ebpf_assert_success(ebpf_handle_close(local_module_hande));
+    if (local_module_handle != ebpf_handle_invalid) {
+        ebpf_assert_success(ebpf_handle_close(local_module_handle));
     }
+    ebpf_free(local_service_name);
 
     EBPF_RETURN_RESULT(result);
 }
@@ -1392,6 +1517,18 @@ ebpf_native_load_programs(
     ebpf_lock_unlock(&_ebpf_native_client_table_lock, state);
     lock_acquired = false;
 
+    // Create handle cleanup context and work item. This is used to close the handles in a work item in case of failure.
+    result = _ebpf_native_initialize_handle_cleanup_context(
+        count_of_program_handles, count_of_map_handles, &module->handle_cleanup_context);
+    if (result != EBPF_SUCCESS) {
+        EBPF_LOG_MESSAGE_GUID(
+            EBPF_TRACELOG_LEVEL_VERBOSE,
+            EBPF_TRACELOG_KEYWORD_NATIVE,
+            "ebpf_native_load_programs: _ebpf_native_initialize_handle_cleanup_context failed",
+            *module_id);
+        goto Done;
+    }
+
     // Create maps.
     result = _ebpf_native_create_maps(module);
     if (result != EBPF_SUCCESS) {
@@ -1447,11 +1584,19 @@ Done:
     }
     if (result != EBPF_SUCCESS) {
         if (maps_created) {
-            _ebpf_native_clean_up_maps(module->maps, module->map_count, true);
+            for (uint32_t i = 0; i < module->map_count; i++) {
+                module->handle_cleanup_context.handle_information->map_handles[i] = module->maps[i].handle;
+            }
+            _ebpf_native_clean_up_maps(module->maps, module->map_count, true, false);
             module->maps = NULL;
             module->map_count = 0;
         }
         ebpf_free(local_service_name);
+
+        // Queue work item to close map and program handles.
+        ebpf_queue_preemptible_work_item(module->handle_cleanup_context.handle_cleanup_workitem);
+        module->handle_cleanup_context.handle_cleanup_workitem = NULL;
+        module->handle_cleanup_context.handle_information = NULL;
     }
     if (module_referenced) {
         ebpf_native_release_reference(module);

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1231,7 +1231,7 @@ _ebpf_native_close_handles_workitem(_In_opt_ const void* context)
         return;
     }
 
-    ebpf_native_handle_information_t* handle_info = (ebpf_native_handle_information_t*)context;
+    ebpf_native_handle_cleanup_information_t* handle_info = (ebpf_native_handle_cleanup_information_t*)context;
     for (uint32_t i = 0; i < handle_info->count_of_program_handles; i++) {
         if (handle_info->program_handles[i] != ebpf_handle_invalid) {
             ebpf_assert_success(ebpf_handle_close(handle_info->program_handles[i]));
@@ -1268,7 +1268,7 @@ _ebpf_native_initialize_handle_cleanup_context(
     ebpf_result_t result = EBPF_SUCCESS;
 
     cleanup_context->handle_information =
-        (ebpf_native_handle_information_t*)ebpf_allocate(sizeof(ebpf_native_handle_information_t));
+        (ebpf_native_handle_cleanup_information_t*)ebpf_allocate(sizeof(ebpf_native_handle_cleanup_information_t));
     if (cleanup_context->handle_information == NULL) {
         result = EBPF_NO_MEMORY;
         goto Done;

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1279,11 +1279,11 @@ _ebpf_native_initialize_handle_cleanup_context(
 {
     ebpf_result_t result = EBPF_SUCCESS;
 
-    memset(cleanup_context, 0, sizeof(ebpf_native_handle_cleanup_context_t);
-
     if (!ExAcquireRundownProtection(&_ebpf_native_work_item_rundown_reference)) {
         return EBPF_FAILED;
     }
+
+    memset(cleanup_context, 0, sizeof(ebpf_native_handle_cleanup_context_t));
 
     cleanup_context->handle_information =
         (ebpf_native_handle_cleanup_information_t*)ebpf_allocate(sizeof(ebpf_native_handle_cleanup_information_t));

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -54,7 +54,7 @@ typedef enum _ebpf_native_module_state
     MODULE_STATE_UNLOADING,
 } ebpf_native_module_state_t;
 
-typedef struct _ebpf_native_handle_information
+typedef struct _ebpf_native_handle_cleanup_information
 {
     size_t count_of_program_handles;
     ebpf_handle_t* program_handles;

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1234,13 +1234,17 @@ _ebpf_native_close_handles_workitem(_In_opt_ const void* context)
     ebpf_native_handle_cleanup_information_t* handle_info = (ebpf_native_handle_cleanup_information_t*)context;
     for (uint32_t i = 0; i < handle_info->count_of_program_handles; i++) {
         if (handle_info->program_handles[i] != ebpf_handle_invalid) {
-            ebpf_assert_success(ebpf_handle_close(handle_info->program_handles[i]));
+            // ebpf_assert_success(ebpf_handle_close(handle_info->program_handles[i]));
+            ebpf_result_t result = ebpf_handle_close(handle_info->program_handles[i]);
+            ebpf_assert(result == EBPF_SUCCESS);
             handle_info->program_handles[i] = ebpf_handle_invalid;
         }
     }
     for (uint32_t i = 0; i < handle_info->count_of_map_handles; i++) {
         if (handle_info->map_handles[i] != ebpf_handle_invalid) {
-            ebpf_assert_success(ebpf_handle_close(handle_info->map_handles[i]));
+            // ebpf_assert_success(ebpf_handle_close(handle_info->map_handles[i]));
+            ebpf_result_t result = ebpf_handle_close(handle_info->map_handles[i]);
+            ebpf_assert(result == EBPF_SUCCESS);
             handle_info->map_handles[i] = ebpf_handle_invalid;
         }
     }
@@ -1256,8 +1260,10 @@ _ebpf_native_clean_up_handle_cleanup_context(_Inout_ ebpf_native_handle_cleanup_
         return;
     }
 
-    ebpf_free(cleanup_context->handle_information->map_handles);
-    ebpf_free(cleanup_context->handle_information->program_handles);
+    if (cleanup_context->handle_information != NULL) {
+        ebpf_free(cleanup_context->handle_information->map_handles);
+        ebpf_free(cleanup_context->handle_information->program_handles);
+    }
     ebpf_free_preemptible_work_item(cleanup_context->handle_cleanup_workitem);
 }
 

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -376,7 +376,7 @@ ebpf_native_terminate()
     _ebpf_native_client_table = NULL;
     ebpf_lock_destroy(&_ebpf_native_client_table_lock);
 
-    // Wait for all queued work-items to complete.
+    // Wait for all queued work items to complete.
     ExWaitForRundownProtectionRelease(&_ebpf_native_work_item_rundown_reference);
 
     EBPF_RETURN_VOID();

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1347,6 +1347,7 @@ ebpf_native_load(
 
     result = ebpf_allocate_preemptible_work_item(&cleanup_workitem, _ebpf_native_unload_work_item, local_service_name);
     if (result != EBPF_SUCCESS) {
+        ebpf_free(local_service_name);
         goto Done;
     }
 
@@ -1415,10 +1416,10 @@ ebpf_native_load(
     state = ebpf_lock_lock(&module->lock);
     module->state = MODULE_STATE_INITIALIZED;
     module->service_name = local_service_name;
-    local_service_name = NULL;
     module->cleanup_workitem = cleanup_workitem;
 
     cleanup_workitem = NULL;
+    local_service_name = NULL;
 
     ebpf_lock_unlock(&module->lock, state);
 
@@ -1439,7 +1440,6 @@ Done:
     if (local_module_handle != ebpf_handle_invalid) {
         ebpf_assert_success(ebpf_handle_close(local_module_handle));
     }
-    ebpf_free(local_service_name);
 
     EBPF_RETURN_RESULT(result);
 }


### PR DESCRIPTION
Fixes #2354

## Description

In case of native module load failure, currently handles for all the maps and programs created are closed synchronously. That causes the thread to call `epoch_enter` twice. This can cause a deadlock if multiple threads are doing the same.

This PR changes the logic to allocate a `handle cleanup` workitem and context, and in case of failure, use this workitem and context to close the handles.

## Testing

Existing tests and stress tests.

## Documentation

NA
