### PR TITLE
Add kernel tests for native_only build.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,7 +51,7 @@ jobs:
       configurations: '["Debug", "FuzzerDebug", "Release"]'
 
   # Perform the native-only build.
-  regular_native-only:
+  regular_native_only:
     # Always run this job.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
     uses: ./.github/workflows/reusable-build.yml
@@ -147,6 +147,25 @@ jobs:
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       name: driver
       build_artifact: Build-x64
+      environment: ebpf_cicd_tests
+      # driver test copies dumps to testlog folder.
+      gather_dumps: false
+      # driver tests manually gather code coverage
+      code_coverage: false
+
+  # Run the native-only driver tests on self-hosted runners.
+  driver_native_only:
+    # Always run this job.
+    # Only run this on repos that have self-host runners.
+    needs: regular_native_only
+    if: github.repository == 'microsoft/ebpf-for-windows'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      pre_test: .\setup_ebpf_cicd_tests.ps1
+      test_command: .\execute_ebpf_cicd_tests.ps1
+      post_test: .\cleanup_ebpf_cicd_tests.ps1
+      name: driver
+      build_artifact: Build-x64-native-only
       environment: ebpf_cicd_tests
       # driver test copies dumps to testlog folder.
       gather_dumps: false

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,7 +51,7 @@ jobs:
       configurations: '["Debug", "FuzzerDebug", "Release"]'
 
   # Perform the native-only build.
-  regular_native_only:
+  regular_native-only:
     # Always run this job.
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
     uses: ./.github/workflows/reusable-build.yml
@@ -157,7 +157,7 @@ jobs:
   driver_native_only:
     # Always run this job.
     # Only run this on repos that have self-host runners.
-    needs: regular_native_only
+    needs: regular_native-only
     if: github.repository == 'microsoft/ebpf-for-windows'
     uses: ./.github/workflows/reusable-test.yml
     with:

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -253,7 +253,7 @@ function Invoke-XDPTest1
     Write-Log "Running XDP Test1 ..."
 
     # Load reflect_packet without specifying interface on VM1.
-    $ProgId = Add-eBPFProgramOnVM -VM $VM1 -Program "reflect_packet.o" -LogFileName $LogFileName
+    $ProgId = Add-eBPFProgramOnVM -VM $VM1 -Program "reflect_packet.sys" -LogFileName $LogFileName
 
     # Run XDP reflect test from VM2 targeting both interfaces of VM1.
     Invoke-XDPTestOnVM $VM2 "xdp_reflect_test" $VM1Interface1V4Address $VM1Interface1V6Address $LogFileName
@@ -280,7 +280,7 @@ function Invoke-XDPTest2
     Write-Log "Running XDP Test2 ..."
 
     # Load reflect_packet on interface1 on VM1.
-    $ProgId = Add-eBPFProgramOnVM -VM $VM1 -Program "reflect_packet.o" -Interface $VM1Interface1Alias -LogFileName $LogFileName
+    $ProgId = Add-eBPFProgramOnVM -VM $VM1 -Program "reflect_packet.sys" -Interface $VM1Interface1Alias -LogFileName $LogFileName
 
     # Attach the program on interface2 on VM1.
     Set-eBPFProgramOnVM -VM $VM1 -ProgId $ProgId -Interface $VM1Interface2Alias -LogFileName $LogFileName
@@ -310,10 +310,10 @@ function Invoke-XDPTest3
     Write-Log "Running XDP Test3 ..."
 
     # Load reflect_packet on interface1 of VM1.
-    $ProgId1 = Add-eBPFProgramOnVM -VM $VM1 -Program "reflect_packet.o" -Interface $VM1Interface1Alias -LogFileName $LogFileName
+    $ProgId1 = Add-eBPFProgramOnVM -VM $VM1 -Program "reflect_packet.sys" -Interface $VM1Interface1Alias -LogFileName $LogFileName
 
     # Load encap_reflact_packet on interface2 on VM1.
-    $ProgId2 = Add-eBPFProgramOnVM -VM $VM1 -Program "encap_reflect_packet.o" -Interface $VM1Interface2Alias -LogFileName $LogFileName
+    $ProgId2 = Add-eBPFProgramOnVM -VM $VM1 -Program "encap_reflect_packet.sys" -Interface $VM1Interface2Alias -LogFileName $LogFileName
 
     # Run XDP reflect test from VM2 targeting first interface of VM1.
     Invoke-XDPTestOnVM $VM2 "xdp_reflect_test" $VM1Interface1V4Address $VM1Interface1V6Address $LogFileName
@@ -339,10 +339,10 @@ function Invoke-XDPTest4
     Write-Log "Running XDP Test4 ..."
 
     # Load encap_reflect_packet on VM1.
-    $ProgId1 = Add-eBPFProgramOnVM -VM $VM1 -Program "encap_reflect_packet.o" -LogFileName $LogFileName
+    $ProgId1 = Add-eBPFProgramOnVM -VM $VM1 -Program "encap_reflect_packet.sys" -LogFileName $LogFileName
 
     # Load decap_permit_packet on VM2.
-    $ProgId2 = Add-eBPFProgramOnVM -VM $VM2 -Program "decap_permit_packet.o" -LogFileName $LogFileName
+    $ProgId2 = Add-eBPFProgramOnVM -VM $VM2 -Program "decap_permit_packet.sys" -LogFileName $LogFileName
 
     # Run XDP reflect test from VM2 targeting first interface of VM1.
     Invoke-XDPTestOnVM $VM2 "xdp_reflect_test" $VM1Interface1V4Address $VM1Interface1V6Address $LogFileName

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -285,6 +285,17 @@ TEST_CASE("pinned_map_enum", "[pinned_map_enum]") { ebpf_test_pinned_map_enum();
 #define INTERPRET_LOAD_RESULT 0
 #endif
 
+static int32_t
+_get_expected_jit_result(int32_t expected_result)
+{
+#if defined(CONFIG_BPF_JIT_DISABLED)
+    UNREFERENCED_PARAMETER(expected_result);
+    return -EOTHER;
+#else
+    return expected_result;
+#endif
+}
+
 // Load droppacket (JIT) without providing expected program type.
 DECLARE_LOAD_TEST_CASE("droppacket.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_JIT, JIT_LOAD_RESULT);
 
@@ -295,7 +306,7 @@ DECLARE_LOAD_TEST_CASE("droppacket.sys", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NA
 DECLARE_DUPLICATE_LOAD_TEST_CASE("droppacket.sys", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_NATIVE, 2, 0);
 
 // Load droppacket (ANY) without providing expected program type.
-DECLARE_LOAD_TEST_CASE("droppacket.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, 0);
+DECLARE_LOAD_TEST_CASE("droppacket.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, JIT_LOAD_RESULT);
 
 // Load droppacket (INTERPRET) without providing expected program type.
 DECLARE_LOAD_TEST_CASE("droppacket.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
@@ -313,17 +324,18 @@ DECLARE_LOAD_TEST_CASE("bindmonitor.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_INT
 DECLARE_LOAD_TEST_CASE("bindmonitor.o", BPF_PROG_TYPE_BIND, EBPF_EXECUTION_JIT, JIT_LOAD_RESULT);
 
 // Try to load bindmonitor with providing wrong program type.
-DECLARE_LOAD_TEST_CASE("bindmonitor.o", BPF_PROG_TYPE_XDP, EBPF_EXECUTION_ANY, -EACCES);
+DECLARE_LOAD_TEST_CASE("bindmonitor.o", BPF_PROG_TYPE_XDP, EBPF_EXECUTION_ANY, _get_expected_jit_result(-EACCES));
 
 // Try to load an unsafe program.
-DECLARE_LOAD_TEST_CASE("droppacket_unsafe.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, -EACCES);
+DECLARE_LOAD_TEST_CASE(
+    "droppacket_unsafe.o", BPF_PROG_TYPE_UNSPEC, EBPF_EXECUTION_ANY, _get_expected_jit_result(-EACCES));
 
 // Try to load multiple programs of different program types
 TEST_CASE("test_ebpf_multiple_programs_load_jit")
 {
     struct _ebpf_program_load_test_parameters test_parameters[] = {
         {"droppacket.o", BPF_PROG_TYPE_XDP}, {"bindmonitor.o", BPF_PROG_TYPE_BIND}};
-    _test_multiple_programs_load(_countof(test_parameters), test_parameters, EBPF_EXECUTION_JIT, 0);
+    _test_multiple_programs_load(_countof(test_parameters), test_parameters, EBPF_EXECUTION_JIT, JIT_LOAD_RESULT);
 }
 
 TEST_CASE("test_ebpf_multiple_programs_load_interpret")
@@ -334,16 +346,30 @@ TEST_CASE("test_ebpf_multiple_programs_load_interpret")
         _countof(test_parameters), test_parameters, EBPF_EXECUTION_INTERPRET, INTERPRET_LOAD_RESULT);
 }
 
-TEST_CASE("test_ebpf_program_next_previous", "[test_ebpf_program_next_previous]")
+#if !defined(CONFIG_BPF_JIT_DISABLED)
+TEST_CASE("test_ebpf_program_next_previous_jit", "[test_ebpf_program_next_previous]")
 {
     _test_program_next_previous("droppacket.o", DROP_PACKET_PROGRAM_COUNT);
     _test_program_next_previous("bindmonitor.o", BIND_MONITOR_PROGRAM_COUNT);
 }
 
-TEST_CASE("test_ebpf_map_next_previous", "[test_ebpf_map_next_previous]")
+TEST_CASE("test_ebpf_map_next_previous_jit", "[test_ebpf_map_next_previous]")
 {
     _test_map_next_previous("droppacket.o", DROP_PACKET_MAP_COUNT);
     _test_map_next_previous("bindmonitor.o", BIND_MONITOR_MAP_COUNT);
+}
+#endif
+
+TEST_CASE("test_ebpf_program_next_previous_native", "[test_ebpf_program_next_previous]")
+{
+    _test_program_next_previous("droppacket.sys", DROP_PACKET_PROGRAM_COUNT);
+    _test_program_next_previous("bindmonitor.sys", BIND_MONITOR_PROGRAM_COUNT);
+}
+
+TEST_CASE("test_ebpf_map_next_previous_native", "[test_ebpf_map_next_previous]")
+{
+    _test_map_next_previous("droppacket.sys", DROP_PACKET_MAP_COUNT);
+    _test_map_next_previous("bindmonitor.sys", BIND_MONITOR_MAP_COUNT);
 }
 
 void
@@ -497,13 +523,14 @@ _test_nested_maps(bpf_map_type type)
 TEST_CASE("array_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_ARRAY_OF_MAPS); }
 TEST_CASE("hash_map_of_maps", "[map_in_map]") { _test_nested_maps(BPF_MAP_TYPE_HASH_OF_MAPS); }
 
-TEST_CASE("tailcall_load_test", "[tailcall_load_test]")
+void
+tailcall_load_test(_In_z_ const char* file_name)
 {
     int result;
     struct bpf_object* object = nullptr;
     fd_t program_fd;
 
-    result = _program_load_helper("tail_call_multiple.o", BPF_PROG_TYPE_XDP, EBPF_EXECUTION_ANY, &object, &program_fd);
+    result = _program_load_helper(file_name, BPF_PROG_TYPE_XDP, EBPF_EXECUTION_ANY, &object, &program_fd);
     REQUIRE(result == 0);
 
     REQUIRE(program_fd > 0);
@@ -538,6 +565,12 @@ TEST_CASE("tailcall_load_test", "[tailcall_load_test]")
 
     bpf_object__close(object);
 }
+
+#if !defined(CONFIG_BPF_JIT_DISABLED)
+TEST_CASE("tailcall_load_test_jit", "[tailcall_load_test]") { tailcall_load_test("tail_call_multiple.o"); }
+#endif
+
+TEST_CASE("tailcall_load_test_native", "[tailcall_load_test]") { tailcall_load_test("tail_call_multiple.sys"); }
 
 int
 perform_bind(_Out_ SOCKET* socket, uint16_t port_number)
@@ -800,7 +833,9 @@ bpf_user_helpers_test(ebpf_execution_type_t execution_type)
     LsaFreeReturnBuffer(data);
 }
 
+#if !defined(CONFIG_BPF_JIT_DISABLED)
 TEST_CASE("bpf_user_helpers_test_jit", "[api_test]") { bpf_user_helpers_test(EBPF_EXECUTION_JIT); }
+#endif
 TEST_CASE("bpf_user_helpers_test_native", "[api_test]") { bpf_user_helpers_test(EBPF_EXECUTION_NATIVE); }
 
 // This test tests resource reclamation and clean-up after a premature/abnormal user mode application exit.

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -10,6 +10,7 @@
 #include "common_tests.h"
 #include "ebpf_structs.h"
 #include "misc_helper.h"
+#include "native_helper.hpp"
 #include "program_helper.h"
 #include "service_helper.h"
 #include "socket_helper.h"
@@ -362,14 +363,20 @@ TEST_CASE("test_ebpf_map_next_previous_jit", "[test_ebpf_map_next_previous]")
 
 TEST_CASE("test_ebpf_program_next_previous_native", "[test_ebpf_program_next_previous]")
 {
-    _test_program_next_previous("droppacket.sys", DROP_PACKET_PROGRAM_COUNT);
-    _test_program_next_previous("bindmonitor.sys", BIND_MONITOR_PROGRAM_COUNT);
+    native_module_helper_t droppacket_helper("droppacket", EBPF_EXECUTION_NATIVE);
+    _test_program_next_previous(droppacket_helper.get_file_name().c_str(), DROP_PACKET_PROGRAM_COUNT);
+
+    native_module_helper_t bindmonitor_helper("bindmonitor", EBPF_EXECUTION_NATIVE);
+    _test_program_next_previous(bindmonitor_helper.get_file_name().c_str(), BIND_MONITOR_PROGRAM_COUNT);
 }
 
 TEST_CASE("test_ebpf_map_next_previous_native", "[test_ebpf_map_next_previous]")
 {
-    _test_map_next_previous("droppacket.sys", DROP_PACKET_MAP_COUNT);
-    _test_map_next_previous("bindmonitor.sys", BIND_MONITOR_MAP_COUNT);
+    native_module_helper_t droppacket_helper("droppacket", EBPF_EXECUTION_NATIVE);
+    _test_map_next_previous(droppacket_helper.get_file_name().c_str(), DROP_PACKET_MAP_COUNT);
+
+    native_module_helper_t bindmonitor_helper("bindmonitor", EBPF_EXECUTION_NATIVE);
+    _test_map_next_previous(bindmonitor_helper.get_file_name().c_str(), BIND_MONITOR_MAP_COUNT);
 }
 
 void
@@ -808,9 +815,9 @@ bpf_user_helpers_test(ebpf_execution_type_t execution_type)
     struct bpf_object* object = nullptr;
     uint64_t process_thread_id = get_current_pid_tgid();
     hook_helper_t hook(EBPF_ATTACH_TYPE_BIND);
-    const char* file_name = (execution_type == EBPF_EXECUTION_NATIVE) ? "bindmonitor.sys" : "bindmonitor.o";
+    native_module_helper_t module_helper("bindmonitor", execution_type);
     program_load_attach_helper_t _helper(
-        file_name, BPF_PROG_TYPE_BIND, "BindMonitor", execution_type, nullptr, 0, hook);
+        module_helper.get_file_name().c_str(), BPF_PROG_TYPE_BIND, "BindMonitor", execution_type, nullptr, 0, hook);
     object = _helper.get_object();
 
     perform_socket_bind(0, true);

--- a/tests/bpftool_tests/bpftool_tests.cpp
+++ b/tests/bpftool_tests/bpftool_tests.cpp
@@ -6,6 +6,7 @@
 #include "capture_helper.hpp"
 #include "catch_wrapper.hpp"
 #include "ebpf_api.h"
+#include "native_helper.hpp"
 
 #include <cstdarg>
 #include <filesystem>
@@ -68,7 +69,7 @@ TEST_CASE("prog help", "[prog][help]")
     REQUIRE(result == 0);
 }
 
-TEST_CASE("prog load map_in_map.o", "[prog][load]")
+TEST_CASE("prog load map_in_map", "[prog][load]")
 {
     int result;
     std::string output;
@@ -77,7 +78,10 @@ TEST_CASE("prog load map_in_map.o", "[prog][load]")
     REQUIRE(output == "");
     REQUIRE(result == 0);
 
-    output = run_command("bpftool --legacy prog load map_in_map.o map_in_map", &result);
+    char command[80];
+    sprintf_s(
+        command, sizeof(command), "bpftool --legacy prog load map_in_map%s map_in_map", EBPF_PROGRAM_FILE_EXTENSION);
+    output = run_command(command, &result);
     REQUIRE(output == "");
     REQUIRE(result == 0);
 
@@ -121,8 +125,11 @@ TEST_CASE("prog attach by interface alias", "[prog][load]")
 {
     int result;
     std::string output;
+    char command[80];
+    sprintf_s(
+        command, sizeof(command), "bpftool --legacy prog load droppacket%s droppacket", EBPF_PROGRAM_FILE_EXTENSION);
 
-    output = run_command("bpftool --legacy prog load droppacket.o droppacket", &result);
+    output = run_command(command, &result);
     REQUIRE(output == "");
     REQUIRE(result == 0);
 
@@ -204,8 +211,11 @@ TEST_CASE("prog prog run", "[prog][load]")
 {
     int result;
     std::string output;
+    char command[80];
+    sprintf_s(
+        command, sizeof(command), "bpftool --legacy prog load droppacket%s droppacket", EBPF_PROGRAM_FILE_EXTENSION);
 
-    output = run_command("bpftool --legacy prog load droppacket.o droppacket", &result);
+    output = run_command(command, &result);
     REQUIRE(output == "");
     REQUIRE(result == 0);
 

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -16,6 +16,7 @@
 #include "ebpf_nethooks.h"
 #include "ebpf_structs.h"
 #include "misc_helper.h"
+#include "native_helper.hpp"
 #include "socket_helper.h"
 #include "socket_tests_common.h"
 #include "watchdog.h"
@@ -24,6 +25,12 @@
 #include <ntsecapi.h>
 
 CATCH_REGISTER_LISTENER(_watchdog)
+
+// #if defined(CONFIG_BPF_JIT_DISABLED)
+// #define CGROUP_SOCK_ADDR_FILE "cgroup_sock_addr2.sys"
+// #else
+// #define CGROUP_SOCK_ADDR_FILE "cgroup_sock_addr2.o"
+// #endif
 
 static std::string _family;
 static std::string _protocol;
@@ -285,7 +292,9 @@ static void
 _load_and_attach_ebpf_programs(_Outptr_ struct bpf_object** return_object)
 {
     int result;
-    struct bpf_object* object = bpf_object__open("cgroup_sock_addr2.o");
+    native_module_helper_t helper("cgroup_sock_addr2");
+
+    struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     REQUIRE(object != nullptr);
 
     REQUIRE(bpf_object__load(object) == 0);

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -290,7 +290,6 @@ _load_and_attach_ebpf_programs(_Outptr_ struct bpf_object** return_object)
 
     struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
     REQUIRE(object != nullptr);
-
     REQUIRE(bpf_object__load(object) == 0);
 
     if (_globals.attach_v4_program) {

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -26,12 +26,6 @@
 
 CATCH_REGISTER_LISTENER(_watchdog)
 
-// #if defined(CONFIG_BPF_JIT_DISABLED)
-// #define CGROUP_SOCK_ADDR_FILE "cgroup_sock_addr2.sys"
-// #else
-// #define CGROUP_SOCK_ADDR_FILE "cgroup_sock_addr2.o"
-// #endif
-
 static std::string _family;
 static std::string _protocol;
 static std::string _vip_v4;

--- a/tests/libs/util/CMakeLists.txt
+++ b/tests/libs/util/CMakeLists.txt
@@ -10,6 +10,9 @@ add_library("test_util" STATIC
   ioctl_helper.h
   ioctl_helper.cpp
 
+  native_helper.hpp
+  native_helper.cpp
+
   netsh_helper.cpp
 
   program_helper.h

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -7,73 +7,11 @@
 
 #include <rpc.h>
 
-static std::string
-_guid_to_string(_In_ const GUID* guid)
-{
-    char guid_string[37] = {0};
-    sprintf_s(
-        guid_string,
-        sizeof(guid_string) / sizeof(guid_string[0]),
-        "%08x-%04x-%04x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-        guid->Data1,
-        guid->Data2,
-        guid->Data3,
-        guid->Data4[0],
-        guid->Data4[1],
-        guid->Data4[2],
-        guid->Data4[3],
-        guid->Data4[4],
-        guid->Data4[5],
-        guid->Data4[6],
-        guid->Data4[7]);
-
-    return std::string(guid_string);
-}
-
-#pragma warning(push)
-#pragma warning(disable : 6101) // Returning uninitialized memory '*unicode_string'
-_Success_(return == 0) int32_t string_to_wide_string(_In_z_ const char* input, _Outptr_ wchar_t** output)
-{
-    wchar_t* unicode_string = NULL;
-    int32_t result;
-    int32_t size;
-
-    // Compute the size needed to hold the unicode string.
-    size = MultiByteToWideChar(CP_UTF8, 0, input, (int32_t)strlen(input), NULL, 0);
-
-    if (size <= 0) {
-        result = GetLastError();
-        goto Done;
-    }
-
-    size++;
-
-    unicode_string = (wchar_t*)malloc(size * sizeof(wchar_t));
-    if (unicode_string == NULL) {
-        result = ERROR_NOT_ENOUGH_MEMORY;
-        goto Done;
-    }
-
-    size = MultiByteToWideChar(CP_UTF8, 0, input, (int32_t)strlen(input), unicode_string, size);
-    if (size == 0) {
-        result = ERROR_INVALID_DATA;
-        goto Done;
-    }
-
-    *output = unicode_string;
-    unicode_string = nullptr;
-    result = ERROR_SUCCESS;
-
-Done:
-    free(unicode_string);
-    return result;
-}
-#pragma warning(pop)
-
 void
 _native_module_helper::initialize(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type)
 {
     GUID random_guid;
+    char* guid_string = nullptr;
 #if defined(CONFIG_BPF_JIT_DISABLED)
     ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_NATIVE;
 #else
@@ -90,9 +28,11 @@ _native_module_helper::initialize(_In_z_ const char* file_name_prefix, ebpf_exec
 
         // Generate a random GUID to append to the file name.
         REQUIRE(UuidCreate(&random_guid) == RPC_S_OK);
-        auto guid_string = _guid_to_string(&random_guid);
 
-        _file_name = file_name_prefix_string + guid_string + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
+        REQUIRE(UuidToStringA(&random_guid, (RPC_CSTR*)&guid_string) == RPC_S_OK);
+
+        _file_name =
+            file_name_prefix_string + std::string(guid_string) + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
         REQUIRE(CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == TRUE);
     } else {
         _file_name = std::string(file_name_prefix) + std::string(EBPF_PROGRAM_FILE_EXTENSION_JIT);

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -41,8 +41,6 @@ _Success_(return == 0) int32_t string_to_wide_string(_In_z_ const char* input, _
     int32_t result;
     int32_t size;
 
-    // *output = nullptr;
-
     // Compute the size needed to hold the unicode string.
     size = MultiByteToWideChar(CP_UTF8, 0, input, (int32_t)strlen(input), NULL, 0);
 
@@ -79,48 +77,27 @@ void
 _native_module_helper::initialize(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type)
 {
     GUID random_guid;
-    // printf("ANUSA: C2 called, execution type = %d\n", execution_type);
 #if defined(CONFIG_BPF_JIT_DISABLED)
     ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_NATIVE;
-    printf("reached 1, file_name_prefix = %s\n", file_name_prefix);
 #else
     ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_ANY;
-    printf("reached 2\n");
 #endif
 
     if (execution_type == ebpf_execution_type_t::EBPF_EXECUTION_ANY) {
         execution_type = system_default;
-        printf("reached 3\n");
     }
     if (execution_type == ebpf_execution_type_t::EBPF_EXECUTION_NATIVE) {
-        printf("reached 4\n");
         _delete_file_on_destruction = true;
-        int32_t random_number;
         std::string file_name_prefix_string(file_name_prefix);
-
         std::string original_file_name = file_name_prefix_string + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
-
-        // printf("====> ANUSA: original_file_name: %s\n", original_file_name.c_str());
-
-        // Generate a random number to append to the file name.
-        random_number = _random_generator.get_random_number();
 
         // Generate a random GUID to append to the file name.
         REQUIRE(UuidCreate(&random_guid) == RPC_S_OK);
         auto guid_string = guid_to_string(&random_guid);
 
-        // printf("====> ANUSA: guid_string: %s\n", guid_string.c_str());
-
-        // std::string random_string = std::to_string(random_number);
         _file_name = file_name_prefix_string + guid_string + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
-
-        printf("====> ANUSA: _file_name: %s\n", _file_name.c_str());
-
         REQUIRE(CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == TRUE);
-
-        // printf("====> ANUSA: _file_name2: %s\n", _file_name.c_str());
     } else {
-        printf("reached 5\n");
         _file_name = std::string(file_name_prefix) + std::string(EBPF_PROGRAM_FILE_EXTENSION_JIT);
     }
 }

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -2,34 +2,96 @@
 // SPDX-License-Identifier: MIT
 
 #include "catch_wrapper.hpp"
+#include "ebpf_execution_type.h"
 #include "native_helper.hpp"
 
-_native_module_helper::_native_module_helper(_In_z_ const char* file_name_prefix)
+#define EBPF_PROGRAM_FILE_EXTENSION_JIT ".o"
+#define EBPF_PROGRAM_FILE_EXTENSION_NATIVE ".sys"
+
+int32_t
+string_to_wide_string(_In_z_ const char* input, _Outptr_ wchar_t** output)
 {
+    wchar_t* unicode_string = NULL;
+    int32_t result;
+    int32_t size;
+
+    // Compute the size needed to hold the unicode string.
+    size = MultiByteToWideChar(CP_UTF8, 0, input, (int32_t)strlen(input), NULL, 0);
+
+    if (size <= 0) {
+        result = GetLastError();
+        goto Done;
+    }
+
+    size++;
+
+    unicode_string = (wchar_t*)malloc(size * sizeof(wchar_t));
+    if (unicode_string == NULL) {
+        result = ERROR_NOT_ENOUGH_MEMORY;
+        goto Done;
+    }
+
+    size = MultiByteToWideChar(CP_UTF8, 0, input, (int32_t)strlen(input), unicode_string, size);
+    if (size == 0) {
+        result = ERROR_INVALID_DATA;
+        goto Done;
+    }
+
+    *output = unicode_string;
+    unicode_string = NULL;
+    result = ERROR_SUCCESS;
+
+Done:
+    free(unicode_string);
+    return result;
+}
+
+void
+_native_module_helper::initialize(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type)
+{
+    // printf("ANUSA: C2 called, execution type = %d\n", execution_type);
 #if defined(CONFIG_BPF_JIT_DISABLED)
-    int32_t random_number;
-    std::string file_name_prefix_string(file_name_prefix);
-
-    std::string original_file_name = file_name_prefix_string + std::string(EBPF_PROGRAM_FILE_EXTENSION);
-
-    // Generate a random number to append to the file name.
-    random_number = _random_generator.get_random_number();
-
-    std::string random_string = std::to_string(random_number);
-    _file_name = file_name_prefix_string + random_string + std::string(EBPF_PROGRAM_FILE_EXTENSION);
-
-    REQUIRE(CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == TRUE);
+    ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_NATIVE;
+    printf("reached 1, file_name_prefix = %s\n", file_name_prefix);
 #else
-    _file_name = std::string(file_name_prefix) + std::string(EBPF_PROGRAM_FILE_EXTENSION);
+    ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_ANY;
+    printf("reached 2\n");
 #endif
+
+    if (execution_type == ebpf_execution_type_t::EBPF_EXECUTION_ANY) {
+        execution_type = system_default;
+        printf("reached 3\n");
+    }
+    if (execution_type == ebpf_execution_type_t::EBPF_EXECUTION_NATIVE) {
+        printf("reached 4\n");
+        _delete_file_on_destruction = true;
+        int32_t random_number;
+        std::string file_name_prefix_string(file_name_prefix);
+
+        std::string original_file_name = file_name_prefix_string + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
+
+        // printf("====> ANUSA: original_file_name: %s\n", original_file_name.c_str());
+
+        // Generate a random number to append to the file name.
+        random_number = _random_generator.get_random_number();
+
+        std::string random_string = std::to_string(random_number);
+        _file_name = file_name_prefix_string + random_string + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
+
+        // printf("====> ANUSA: _file_name: %s\n", _file_name.c_str());
+
+        REQUIRE(CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == TRUE);
+
+        // printf("====> ANUSA: _file_name2: %s\n", _file_name.c_str());
+    } else {
+        printf("reached 5\n");
+        _file_name = std::string(file_name_prefix) + std::string(EBPF_PROGRAM_FILE_EXTENSION_JIT);
+    }
 }
 
 _native_module_helper::~_native_module_helper()
 {
-#if defined(CONFIG_BPF_JIT_DISABLED)
-    DeleteFileA(_file_name.c_str());
-
-    // Sleep for 2 seconds.
-    // Sleep(2000);
-#endif
+    if (_delete_file_on_destruction) {
+        DeleteFileA(_file_name.c_str());
+    }
 }

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -1,0 +1,35 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "catch_wrapper.hpp"
+#include "native_helper.hpp"
+
+_native_module_helper::_native_module_helper(_In_z_ const char* file_name_prefix)
+{
+#if defined(CONFIG_BPF_JIT_DISABLED)
+    int32_t random_number;
+    std::string file_name_prefix_string(file_name_prefix);
+
+    std::string original_file_name = file_name_prefix_string + std::string(EBPF_PROGRAM_FILE_EXTENSION);
+
+    // Generate a random number to append to the file name.
+    random_number = _random_generator.get_random_number();
+
+    std::string random_string = std::to_string(random_number);
+    _file_name = file_name_prefix_string + random_string + std::string(EBPF_PROGRAM_FILE_EXTENSION);
+
+    REQUIRE(CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == TRUE);
+#else
+    _file_name = std::string(file_name_prefix) + std::string(EBPF_PROGRAM_FILE_EXTENSION);
+#endif
+}
+
+_native_module_helper::~_native_module_helper()
+{
+#if defined(CONFIG_BPF_JIT_DISABLED)
+    DeleteFileA(_file_name.c_str());
+
+    // Sleep for 2 seconds.
+    // Sleep(2000);
+#endif
+}

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -7,11 +7,8 @@
 
 #include <rpc.h>
 
-#define EBPF_PROGRAM_FILE_EXTENSION_JIT ".o"
-#define EBPF_PROGRAM_FILE_EXTENSION_NATIVE ".sys"
-
-std::string
-guid_to_string(_In_ const GUID* guid)
+static std::string
+_guid_to_string(_In_ const GUID* guid)
 {
     char guid_string[37] = {0};
     sprintf_s(
@@ -93,7 +90,7 @@ _native_module_helper::initialize(_In_z_ const char* file_name_prefix, ebpf_exec
 
         // Generate a random GUID to append to the file name.
         REQUIRE(UuidCreate(&random_guid) == RPC_S_OK);
-        auto guid_string = guid_to_string(&random_guid);
+        auto guid_string = _guid_to_string(&random_guid);
 
         _file_name = file_name_prefix_string + guid_string + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
         REQUIRE(CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == TRUE);

--- a/tests/libs/util/native_helper.cpp
+++ b/tests/libs/util/native_helper.cpp
@@ -5,6 +5,8 @@
 #include "ebpf_execution_type.h"
 #include "native_helper.hpp"
 
+#include <rpc.h>
+
 #define EBPF_PROGRAM_FILE_EXTENSION_JIT ".o"
 #define EBPF_PROGRAM_FILE_EXTENSION_NATIVE ".sys"
 
@@ -76,6 +78,7 @@ Done:
 void
 _native_module_helper::initialize(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type)
 {
+    GUID random_guid;
     // printf("ANUSA: C2 called, execution type = %d\n", execution_type);
 #if defined(CONFIG_BPF_JIT_DISABLED)
     ebpf_execution_type_t system_default = ebpf_execution_type_t::EBPF_EXECUTION_NATIVE;
@@ -102,8 +105,14 @@ _native_module_helper::initialize(_In_z_ const char* file_name_prefix, ebpf_exec
         // Generate a random number to append to the file name.
         random_number = _random_generator.get_random_number();
 
-        std::string random_string = std::to_string(random_number);
-        _file_name = file_name_prefix_string + random_string + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
+        // Generate a random GUID to append to the file name.
+        REQUIRE(UuidCreate(&random_guid) == RPC_S_OK);
+        auto guid_string = guid_to_string(&random_guid);
+
+        // printf("====> ANUSA: guid_string: %s\n", guid_string.c_str());
+
+        // std::string random_string = std::to_string(random_number);
+        _file_name = file_name_prefix_string + guid_string + std::string(EBPF_PROGRAM_FILE_EXTENSION_NATIVE);
 
         printf("====> ANUSA: _file_name: %s\n", _file_name.c_str());
 

--- a/tests/libs/util/native_helper.hpp
+++ b/tests/libs/util/native_helper.hpp
@@ -8,6 +8,8 @@
 #include <string>
 #include <time.h>
 
+#pragma comment(lib, "rpcrt4")
+
 #if defined(CONFIG_BPF_JIT_DISABLED)
 #define EBPF_PROGRAM_FILE_EXTENSION ".sys"
 #else

--- a/tests/libs/util/native_helper.hpp
+++ b/tests/libs/util/native_helper.hpp
@@ -18,19 +18,6 @@
 #define EBPF_PROGRAM_FILE_EXTENSION EBPF_PROGRAM_FILE_EXTENSION_JIT
 #endif
 
-typedef class _random_generator
-{
-  public:
-    _random_generator() { srand((uint32_t)time(NULL)); }
-    uint32_t
-    get_random_number()
-    {
-        return rand();
-    }
-} random_generator_t;
-
-static random_generator_t _random_generator;
-
 typedef class _native_module_helper
 {
   public:

--- a/tests/libs/util/native_helper.hpp
+++ b/tests/libs/util/native_helper.hpp
@@ -30,14 +30,30 @@ static random_generator_t _random_generator;
 typedef class _native_module_helper
 {
   public:
-    _native_module_helper(_In_z_ const char* file_name);
+    _native_module_helper(_In_z_ const char* file_name_prefix)
+    {
+        // printf("ANUSA: C1 called\n");
+        initialize(file_name_prefix, ebpf_execution_type_t::EBPF_EXECUTION_ANY);
+        // _native_module_helper(file_name_prefix, ebpf_execution_type_t::EBPF_EXECUTION_ANY);
+    }
+    _native_module_helper(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type)
+    {
+        initialize(file_name_prefix, execution_type);
+    }
     std::string
     get_file_name() const
     {
+        printf("====> ANUSA: get_file_name: %s\n", _file_name.c_str());
         return _file_name;
     }
     ~_native_module_helper();
 
   private:
+    void
+    initialize(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type);
     std::string _file_name;
+    bool _delete_file_on_destruction = false;
 } native_module_helper_t;
+
+int32_t
+string_to_wide_string(_In_z_ const char* input, _Outptr_ wchar_t** output);

--- a/tests/libs/util/native_helper.hpp
+++ b/tests/libs/util/native_helper.hpp
@@ -1,0 +1,43 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include <Windows.h>
+#include <cstdint>
+#include <string>
+#include <time.h>
+
+#if defined(CONFIG_BPF_JIT_DISABLED)
+#define EBPF_PROGRAM_FILE_EXTENSION ".sys"
+#else
+#define EBPF_PROGRAM_FILE_EXTENSION ".o"
+#endif
+
+typedef class _random_generator
+{
+  public:
+    _random_generator() { srand((uint32_t)time(NULL)); }
+    uint32_t
+    get_random_number()
+    {
+        return rand();
+    }
+} random_generator_t;
+
+static random_generator_t _random_generator;
+
+typedef class _native_module_helper
+{
+  public:
+    _native_module_helper(_In_z_ const char* file_name);
+    std::string
+    get_file_name() const
+    {
+        return _file_name;
+    }
+    ~_native_module_helper();
+
+  private:
+    std::string _file_name;
+} native_module_helper_t;

--- a/tests/libs/util/native_helper.hpp
+++ b/tests/libs/util/native_helper.hpp
@@ -43,5 +43,3 @@ typedef class _native_module_helper
     std::string _file_name;
     bool _delete_file_on_destruction = false;
 } native_module_helper_t;
-
-_Success_(return == 0) int32_t string_to_wide_string(_In_z_ const char* input, _Outptr_ wchar_t** output);

--- a/tests/libs/util/native_helper.hpp
+++ b/tests/libs/util/native_helper.hpp
@@ -55,5 +55,4 @@ typedef class _native_module_helper
     bool _delete_file_on_destruction = false;
 } native_module_helper_t;
 
-int32_t
-string_to_wide_string(_In_z_ const char* input, _Outptr_ wchar_t** output);
+_Success_(return == 0) int32_t string_to_wide_string(_In_z_ const char* input, _Outptr_ wchar_t** output);

--- a/tests/libs/util/native_helper.hpp
+++ b/tests/libs/util/native_helper.hpp
@@ -10,10 +10,12 @@
 
 #pragma comment(lib, "rpcrt4")
 
+#define EBPF_PROGRAM_FILE_EXTENSION_JIT ".o"
+#define EBPF_PROGRAM_FILE_EXTENSION_NATIVE ".sys"
 #if defined(CONFIG_BPF_JIT_DISABLED)
-#define EBPF_PROGRAM_FILE_EXTENSION ".sys"
+#define EBPF_PROGRAM_FILE_EXTENSION EBPF_PROGRAM_FILE_EXTENSION_NATIVE
 #else
-#define EBPF_PROGRAM_FILE_EXTENSION ".o"
+#define EBPF_PROGRAM_FILE_EXTENSION EBPF_PROGRAM_FILE_EXTENSION_JIT
 #endif
 
 typedef class _random_generator
@@ -34,9 +36,7 @@ typedef class _native_module_helper
   public:
     _native_module_helper(_In_z_ const char* file_name_prefix)
     {
-        // printf("ANUSA: C1 called\n");
         initialize(file_name_prefix, ebpf_execution_type_t::EBPF_EXECUTION_ANY);
-        // _native_module_helper(file_name_prefix, ebpf_execution_type_t::EBPF_EXECUTION_ANY);
     }
     _native_module_helper(_In_z_ const char* file_name_prefix, ebpf_execution_type_t execution_type)
     {
@@ -45,7 +45,7 @@ typedef class _native_module_helper
     std::string
     get_file_name() const
     {
-        printf("====> ANUSA: get_file_name: %s\n", _file_name.c_str());
+        printf("_native_module_helper::get_file_name: %s\n", _file_name.c_str());
         return _file_name;
     }
     ~_native_module_helper();

--- a/tests/libs/util/test_util.vcxproj
+++ b/tests/libs/util/test_util.vcxproj
@@ -22,6 +22,7 @@
     <ClCompile Include="capture_helper.cpp" />
     <ClCompile Include="hash.cpp" />
     <ClCompile Include="ioctl_helper.cpp" />
+    <ClCompile Include="native_helper.cpp" />
     <ClCompile Include="netsh_helper.cpp" />
     <ClCompile Include="service_helper.cpp" />
     <ClCompile Include="socket_helper.cpp" />
@@ -31,6 +32,7 @@
     <ClInclude Include="hash.h" />
     <ClInclude Include="header.h" />
     <ClInclude Include="ioctl_helper.h" />
+    <ClInclude Include="native_helper.hpp" />
     <ClInclude Include="service_helper.h" />
     <ClInclude Include="socket_helper.h" />
     <ClInclude Include="program_helper.h" />

--- a/tests/libs/util/test_util.vcxproj.filters
+++ b/tests/libs/util/test_util.vcxproj.filters
@@ -1,4 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (c) Microsoft Corporation
+  SPDX-License-Identifier: MIT
+-->
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <ClCompile Include="capture_helper.cpp" />
@@ -8,6 +12,7 @@
     <ClCompile Include="socket_helper.cpp" />
     <ClCompile Include="program_helper.cpp" />
     <ClCompile Include="hash.cpp" />
+    <ClCompile Include="native_helper.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ioctl_helper.h" />
@@ -17,5 +22,6 @@
     <ClInclude Include="wer_report.hpp" />
     <ClInclude Include="hash.h" />
     <ClInclude Include="header.h" />
+    <ClInclude Include="native_helper.hpp" />
   </ItemGroup>
 </Project>

--- a/tests/sample/ext/app/sample_ext_app.cpp
+++ b/tests/sample/ext/app/sample_ext_app.cpp
@@ -169,8 +169,12 @@ TEST_CASE("utility_helpers_test_native", "[sample_ext_test]") { utility_helpers_
 TEST_CASE("netsh_add_program_test_sample_ebpf", "[sample_ext_test]")
 {
     int result;
-    std::string output =
-        _run_netsh_command(handle_ebpf_add_program, L"test_sample_ebpf.o", L"pinned=none", nullptr, &result);
+#if defined(CONFIG_BPF_JIT_DISABLED)
+    const wchar_t* file_name = L"test_sample_ebpf.sys";
+#else
+    const wchar_t* file_name = L"test_sample_ebpf.o";
+#endif
+    std::string output = _run_netsh_command(handle_ebpf_add_program, file_name, L"pinned=none", nullptr, &result);
     REQUIRE(result == NO_ERROR);
     REQUIRE(output.starts_with("Loaded with"));
 }

--- a/tests/sample/ext/app/sample_ext_app.cpp
+++ b/tests/sample/ext/app/sample_ext_app.cpp
@@ -174,21 +174,13 @@ TEST_CASE("utility_helpers_test_jit", "[sample_ext_test]") { utility_helpers_tes
 #endif
 TEST_CASE("utility_helpers_test_native", "[sample_ext_test]") { utility_helpers_test(EBPF_EXECUTION_NATIVE); }
 
-// TEST_CASE("netsh_add_program_test_sample_ebpf", "[sample_ext_test]")
-// {
-//     int result;
-//     native_module_helper_t helper("test_sample_ebpf");
-//     std::string file_name_string  = std::string(helper.get_file_name().c_str());
-//     // ebpf_utf8_string_t utf_string = {0};
-//     wchar_t* file_name = nullptr;
-//     // utf_string.length = (uint16_t)file_name_string.length();
-//     // utf_string.value = (uint8_t*)file_name_string.c_str();
-//     // printf("ANUSA: ANUSA: file_name_string: %s\n", file_name_string.c_str());
-//     REQUIRE(string_to_wide_string(file_name_string.c_str(), &file_name) == ERROR_SUCCESS);
-
-//     std::string output = _run_netsh_command(handle_ebpf_add_program, file_name, L"pinned=none", nullptr, &result);
-//     REQUIRE(result == NO_ERROR);
-//     REQUIRE(output.starts_with("Loaded with"));
-
-//     free(file_name);
-// }
+#if !defined(CONFIG_BPF_JIT_DISABLED)
+TEST_CASE("netsh_add_program_test_sample_ebpf", "[sample_ext_test]")
+{
+    int result;
+    std::string output =
+        _run_netsh_command(handle_ebpf_add_program, L"test_sample_ebpf.o", L"pinned=none", nullptr, &result);
+    REQUIRE(result == NO_ERROR);
+    REQUIRE(output.starts_with("Loaded with"));
+}
+#endif

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -29,74 +29,7 @@ using namespace std::chrono_literals;
 
 CATCH_REGISTER_LISTENER(_watchdog)
 
-// #if defined(CONFIG_BPF_JIT_DISABLED)
-// #define EBPF_PROGRAM_FILE_EXTENSION ".sys"
-// #else
-// #define EBPF_PROGRAM_FILE_EXTENSION ".o"
-// #endif
-
-// typedef class _random_generator
-// {
-//   public:
-//     _random_generator() { srand((uint32_t)time(NULL)); }
-//     uint32_t
-//     get_random_number()
-//     {
-//         return rand();
-//     }
-// } random_generator_t;
-
-// random_generator_t random_generator;
-
-// typedef class _native_module_helper
-// {
-// public:
-//     _native_module_helper(_In_z_ const char* file_name);
-//     std::string get_file_name() const { return _file_name; }
-//     ~_native_module_helper();
-
-// private:
-//     std::string _file_name;
-// } native_module_helper_t;
-
-// _native_module_helper::_native_module_helper(_In_z_ const char* file_name_prefix)
-// {
-// #if defined(CONFIG_BPF_JIT_DISABLED)
-//     int32_t random_number;
-//     std::string file_name_prefix_string(file_name_prefix);
-
-//     std::string original_file_name = file_name_prefix_string + std::string(EBPF_PROGRAM_FILE_EXTENSION);
-
-//     // Generate a random number to append to the file name.
-//     // srand((uint32_t)time(NULL));
-//     // random_number = rand();
-//     random_number = random_generator.get_random_number();
-
-//     std::string random_string = std::to_string(random_number);
-//     _file_name = file_name_prefix_string + random_string + std::string(EBPF_PROGRAM_FILE_EXTENSION);
-
-//     // printf("original_file_name = %s\n", original_file_name.c_str());
-//     // printf("copy_file_name = %s\n", _file_name.c_str());
-
-//     // REQUIRE(CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == TRUE);
-//     if (CopyFileA(original_file_name.c_str(), _file_name.c_str(), TRUE) == FALSE) {
-//         int error = GetLastError();
-//         // printf("CopyFileA failed with error %d\n", error);
-//     }
-// #else
-//     _file_name = std::string(file_name_prefix) + std::string(EBPF_PROGRAM_FILE_EXTENSION);
-// #endif
-// }
-
-// _native_module_helper::~_native_module_helper()
-// {
-// #if defined(CONFIG_BPF_JIT_DISABLED)
-//     DeleteFileA(_file_name.c_str());
-
-//     // Sleep for 2 seconds.
-//     // Sleep(2000);
-// #endif
-// }
+typedef std::unique_ptr<bpf_object, close_bpf_object_t> bpf_object_ptr;
 
 void
 connection_test(

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -29,8 +29,6 @@ using namespace std::chrono_literals;
 
 CATCH_REGISTER_LISTENER(_watchdog)
 
-typedef std::unique_ptr<bpf_object, close_bpf_object_t> bpf_object_ptr;
-
 void
 connection_test(
     ADDRESS_FAMILY address_family,


### PR DESCRIPTION
## Description

This PR has the following changes:

1. Add new `driver_native_only` test which runs driver tests on `native_only` artifacts.
2. Update the driver test cases:
	1. If a test already contains both JIT and NATIV variants, disable the JIT test for `native_only` run.
	2. If the test only uses `.o` file, update the test to use `.o` file for regular test, and `.sys` file for `native_only` test.
3. Since quick unloading and reloading of native driver can fail, add `native_module_helper` class which creates a unique copy of the native driver, so that the programs can be immediately reloaded instead add a wait / delay.
4. Reverts the recent regression in connect_redirect tests.

## Testing

This PR adds new tests.

## Documentation

NA
