### PR TITLE
Wait for preemptible work items to complete in UM mock.

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1260,7 +1260,14 @@ _ebpf_native_clean_up_handle_cleanup_context(_Inout_ ebpf_native_handle_cleanup_
         ebpf_free(cleanup_context->handle_information->map_handles);
         ebpf_free(cleanup_context->handle_information->program_handles);
     }
-    ebpf_free_preemptible_work_item(cleanup_context->handle_cleanup_work_item);
+
+    if (cleanup_context->handle_cleanup_work_item != NULL) {
+        // ebpf_free_preemptible_work_item() will free the handle_information.
+        ebpf_free_preemptible_work_item(cleanup_context->handle_cleanup_work_item);
+
+    } else {
+        ebpf_free(cleanup_context->handle_information);
+    }
 }
 
 static ebpf_result_t

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -1408,9 +1408,3 @@ Done:
     ebpf_free(unicode_string);
     return retval;
 }
-
-void
-ebpf_platform_wait_for_preemptible_work_items()
-{
-    ExWaitForRundownProtectionRelease(&_ebpf_platform_preemptible_work_items_rundown);
-}

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -325,7 +325,6 @@ ebpf_platform_initiate()
         auto fault_injection_stack_depth =
             _get_environment_variable_as_size_t(EBPF_FAULT_INJECTION_SIMULATION_ENVIRONMENT_VARIABLE_NAME);
         auto leak_detector = _get_environment_variable_as_bool(EBPF_MEMORY_LEAK_DETECTION_ENVIRONMENT_VARIABLE_NAME);
-        leak_detector = true;
         if (fault_injection_stack_depth || leak_detector) {
             _ebpf_symbol_decoder_initialize();
         }

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -963,7 +963,8 @@ ebpf_allocate_preemptible_work_item(
 
     *work_item = (ebpf_preemptible_work_item_t*)ebpf_allocate(sizeof(ebpf_preemptible_work_item_t));
     if (*work_item == nullptr) {
-        return EBPF_NO_MEMORY;
+        result = EBPF_NO_MEMORY;
+        goto Done;
     }
 
     // It is required to use the InitializeThreadpoolEnvironment function to
@@ -978,6 +979,7 @@ ebpf_allocate_preemptible_work_item(
 
 Done:
     if (result != EBPF_SUCCESS) {
+        ExReleaseRundownProtection(&_ebpf_platform_preemptible_work_items_rundown);
         ebpf_free(*work_item);
         *work_item = nullptr;
     }

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -51,6 +51,9 @@ static GUID _ebpf_native_provider_id = {/* 5e24d2f5-f799-42c3-a945-87feefd930a7 
                                         0x42c3,
                                         {0xa9, 0x45, 0x87, 0xfe, 0xef, 0xd9, 0x30, 0xa7}};
 
+void
+ebpf_platform_wait_for_preemptible_work_items();
+
 typedef struct _service_context
 {
     std::wstring name;
@@ -679,6 +682,9 @@ _test_helper_end_to_end::~_test_helper_end_to_end()
         _duplicate_handles.rundown();
     } catch (Catch::TestFailureException&) {
     }
+
+    // Simulate IO_WORKITEM behavior by waiting for all work items to complete.
+    ebpf_platform_wait_for_preemptible_work_items();
 
     // Verify that all maps were successfully removed.
     uint32_t id;

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -680,42 +680,42 @@ _test_helper_end_to_end::~_test_helper_end_to_end()
 
         // Run down duplicate handles, if any.
         _duplicate_handles.rundown();
+
+        // Detach all the native module clients.
+        _unload_all_native_modules();
+
+        // Simulate IO_WORKITEM behavior by waiting for all preemptible work items to complete.
+        ebpf_platform_wait_for_preemptible_work_items();
+
+        // Verify that all maps were successfully removed.
+        uint32_t id;
+        if (!ebpf_fuzzing_enabled) {
+            REQUIRE(bpf_map_get_next_id(0, &id) < 0);
+            REQUIRE(errno == ENOENT);
+        }
+
+        clear_program_info_cache();
+        if (api_initialized) {
+            ebpf_api_terminate();
+        }
+        if (ec_initialized) {
+            ebpf_core_terminate();
+        }
+
+        device_io_control_handler = nullptr;
+        cancel_io_ex_handler = nullptr;
+        create_file_handler = nullptr;
+        close_handle_handler = nullptr;
+        duplicate_handle_handler = nullptr;
+
+        _expect_native_module_load_failures = false;
+
+        // Change back to original value.
+        _ebpf_platform_is_preemptible = true;
+
+        set_verification_in_progress(false);
     } catch (Catch::TestFailureException&) {
     }
-
-    // Detach all the native module clients.
-    _unload_all_native_modules();
-
-    // Simulate IO_WORKITEM behavior by waiting for all preemptible work items to complete.
-    ebpf_platform_wait_for_preemptible_work_items();
-
-    // Verify that all maps were successfully removed.
-    uint32_t id;
-    if (!ebpf_fuzzing_enabled) {
-        REQUIRE(bpf_map_get_next_id(0, &id) < 0);
-        REQUIRE(errno == ENOENT);
-    }
-
-    clear_program_info_cache();
-    if (api_initialized) {
-        ebpf_api_terminate();
-    }
-    if (ec_initialized) {
-        ebpf_core_terminate();
-    }
-
-    device_io_control_handler = nullptr;
-    cancel_io_ex_handler = nullptr;
-    create_file_handler = nullptr;
-    close_handle_handler = nullptr;
-    duplicate_handle_handler = nullptr;
-
-    _expect_native_module_load_failures = false;
-
-    // Change back to original value.
-    _ebpf_platform_is_preemptible = true;
-
-    set_verification_in_progress(false);
 }
 
 _test_helper_libbpf::_test_helper_libbpf()

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -683,6 +683,9 @@ _test_helper_end_to_end::~_test_helper_end_to_end()
     } catch (Catch::TestFailureException&) {
     }
 
+    // Detach all the native module clients.
+    _unload_all_native_modules();
+
     // Simulate IO_WORKITEM behavior by waiting for all work items to complete.
     ebpf_platform_wait_for_preemptible_work_items();
 
@@ -692,9 +695,6 @@ _test_helper_end_to_end::~_test_helper_end_to_end()
         REQUIRE(bpf_map_get_next_id(0, &id) < 0);
         REQUIRE(errno == ENOENT);
     }
-
-    // Detach all the native module clients.
-    _unload_all_native_modules();
 
     clear_program_info_cache();
     if (api_initialized) {

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -51,9 +51,6 @@ static GUID _ebpf_native_provider_id = {/* 5e24d2f5-f799-42c3-a945-87feefd930a7 
                                         0x42c3,
                                         {0xa9, 0x45, 0x87, 0xfe, 0xef, 0xd9, 0x30, 0xa7}};
 
-void
-ebpf_platform_wait_for_preemptible_work_items();
-
 typedef struct _service_context
 {
     std::wstring name;
@@ -683,16 +680,6 @@ _test_helper_end_to_end::~_test_helper_end_to_end()
 
         // Detach all the native module clients.
         _unload_all_native_modules();
-
-        // Simulate IO_WORKITEM behavior by waiting for all preemptible work items to complete.
-        ebpf_platform_wait_for_preemptible_work_items();
-
-        // Verify that all maps were successfully removed.
-        uint32_t id;
-        if (!ebpf_fuzzing_enabled) {
-            REQUIRE(bpf_map_get_next_id(0, &id) < 0);
-            REQUIRE(errno == ENOENT);
-        }
 
         clear_program_info_cache();
         if (api_initialized) {

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -686,7 +686,7 @@ _test_helper_end_to_end::~_test_helper_end_to_end()
     // Detach all the native module clients.
     _unload_all_native_modules();
 
-    // Simulate IO_WORKITEM behavior by waiting for all work items to complete.
+    // Simulate IO_WORKITEM behavior by waiting for all preemptible work items to complete.
     ebpf_platform_wait_for_preemptible_work_items();
 
     // Verify that all maps were successfully removed.


### PR DESCRIPTION
Fixes #2411
Fixes #2413 

## Description

This PR fixes random test failures which are caused due to timing issue. In kernel, IO_WORKITEMS guarantee that the driver will not be unloaded until all the queued work items are completed. In the user mode mock though, there is no such guarantee currently. This causes the memory leak and other checks to be executed _before_ all the queued work items have completed.

This PR adds a wait where the `test_helper` dtor waits for all preemptible work items to complete before performing various checks.

## Testing

Existing CI/CD

## Documentation

NA
