### PR TITLE
Add Fault Injection in Kernel OS APIs in kernel_um.cpp

### DIFF
--- a/libs/platform/user/kernel_um.cpp
+++ b/libs/platform/user/kernel_um.cpp
@@ -610,11 +610,12 @@ SeAccessCheckFromState(
     _Out_ PACCESS_MASK GrantedAccess,
     _Out_ NTSTATUS* AccessStatus)
 {
+    if (Privileges != NULL) {
+        *Privileges = NULL;
+    }
+    *GrantedAccess = DesiredAccess;
+
     if (ebpf_fault_injection_inject_fault()) {
-        if (Privileges != NULL) {
-            *Privileges = NULL;
-        }
-        *GrantedAccess = DesiredAccess;
         *AccessStatus = STATUS_ACCESS_DENIED;
         return false;
     }
@@ -626,10 +627,6 @@ SeAccessCheckFromState(
     UNREFERENCED_PARAMETER(GenericMapping);
     UNREFERENCED_PARAMETER(AccessMode);
 
-    if (Privileges != NULL) {
-        *Privileges = NULL;
-    }
-    *GrantedAccess = DesiredAccess;
     *AccessStatus = STATUS_SUCCESS;
 
     return true;

--- a/libs/platform/user/kernel_um.cpp
+++ b/libs/platform/user/kernel_um.cpp
@@ -558,7 +558,7 @@ NTSTATUS
 RtlAddAccessAllowedAce(_Inout_ PACL Acl, _In_ unsigned long AceRevision, _In_ ACCESS_MASK AccessMask, _In_ PSID Sid)
 {
     if (ebpf_fault_injection_inject_fault()) {
-        return STATUS_BUFFER_TOO_SMALL;
+        return STATUS_INSUFFICIENT_RESOURCES;
     }
 
     UNREFERENCED_PARAMETER(Acl);

--- a/libs/platform/user/kernel_um.cpp
+++ b/libs/platform/user/kernel_um.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
+#include "ebpf_fault_injection.h"
 #include "ebpf_platform.h"
 #include "kernel_um.h"
 
@@ -187,8 +188,8 @@ typedef unsigned long PFN_NUMBER;
 
 #define PAGE_ALIGN(Va) ((void*)((ULONG_PTR)(Va) & ~(PAGE_SIZE - 1)))
 #define BYTE_OFFSET(Va) ((unsigned long)((LONG_PTR)(Va) & (PAGE_SIZE - 1)))
-#define ADDRESS_AND_SIZE_TO_SPAN_PAGES(Va, size)                                                        \
-    (((((size)-1) >> PAGE_SHIFT) +                                                                      \
+#define ADDRESS_AND_SIZE_TO_SPAN_PAGES(Va, size)                                                                \
+    (((((size)-1) >> PAGE_SHIFT) +                                                                              \
       (((((unsigned long)(size - 1) & (PAGE_SIZE - 1)) + (PtrToUlong(Va) & (PAGE_SIZE - 1)))) >> PAGE_SHIFT)) + \
      1L)
 
@@ -373,6 +374,7 @@ IoAllocateMdl(
     _In_ BOOLEAN charge_quota,
     _Inout_opt_ IRP* irp)
 {
+    // Skip Fault Injection as it is already added in ebpf_allocate.
     PMDL mdl;
 
     UNREFERENCED_PARAMETER(secondary_buffer);
@@ -405,6 +407,7 @@ io_work_item_wrapper(_Inout_ PTP_CALLBACK_INSTANCE instance, _Inout_opt_ void* c
 PIO_WORKITEM
 IoAllocateWorkItem(_In_ DEVICE_OBJECT* device_object)
 {
+    // Skip Fault Injection as it is already added in ebpf_allocate.
     auto work_item = reinterpret_cast<IO_WORKITEM*>(ebpf_allocate(sizeof(IO_WORKITEM)));
     if (!work_item) {
         return nullptr;
@@ -464,6 +467,7 @@ KeInitializeSpinLock(_Out_ PKSPIN_LOCK spin_lock)
 _Requires_lock_not_held_(*spin_lock) _Acquires_lock_(*spin_lock) _IRQL_requires_max_(DISPATCH_LEVEL) KIRQL
     KeAcquireSpinLockRaiseToDpc(_Inout_ PKSPIN_LOCK spin_lock)
 {
+    // Skip Fault Injection.
     auto lock = reinterpret_cast<SRWLOCK*>(spin_lock);
     AcquireSRWLockExclusive(lock);
     return 0;
@@ -489,6 +493,10 @@ MmGetSystemAddressForMdlSafe(
     _In_ unsigned long page_priority // MM_PAGE_PRIORITY logically OR'd with MdlMapping*
 )
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return nullptr;
+    }
+
     UNREFERENCED_PARAMETER(page_priority);
     return ((void*)((PUCHAR)(mdl)->start_va + (mdl)->byte_offset));
 }
@@ -499,6 +507,10 @@ RtlULongAdd(
     _In_ unsigned long addend,
     _Out_ _Deref_out_range_(==, augend + addend) unsigned long* result)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_INTEGER_OVERFLOW;
+    }
+
     *result = augend + addend;
     return STATUS_SUCCESS;
 }
@@ -518,6 +530,10 @@ IoGetFileObjectGenericMapping() { return &_mapping; }
 NTSTATUS
 RtlCreateAcl(_Out_ PACL Acl, unsigned long AclLength, unsigned long AclRevision)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
     UNREFERENCED_PARAMETER(Acl);
     UNREFERENCED_PARAMETER(AclRevision);
 
@@ -547,6 +563,10 @@ RtlLengthSid(_In_ PSID Sid)
 NTSTATUS
 RtlAddAccessAllowedAce(_Inout_ PACL Acl, _In_ unsigned long AceRevision, _In_ ACCESS_MASK AccessMask, _In_ PSID Sid)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_BUFFER_TOO_SMALL;
+    }
+
     UNREFERENCED_PARAMETER(Acl);
     UNREFERENCED_PARAMETER(AceRevision);
     UNREFERENCED_PARAMETER(AccessMask);
@@ -563,6 +583,10 @@ RtlSetDaclSecurityDescriptor(
     _In_opt_ PACL Dacl,
     _In_ BOOLEAN DaclDefaulted)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
     UNREFERENCED_PARAMETER(SecurityDescriptor);
     UNREFERENCED_PARAMETER(DaclPresent);
     UNREFERENCED_PARAMETER(Dacl);
@@ -575,6 +599,10 @@ NTSTATUS
 NTAPI
 RtlCreateSecurityDescriptor(_Out_ PSECURITY_DESCRIPTOR SecurityDescriptor, _In_ unsigned long Revision)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
     UNREFERENCED_PARAMETER(Revision);
     memset(SecurityDescriptor, 0, sizeof(SECURITY_DESCRIPTOR));
 
@@ -594,6 +622,15 @@ SeAccessCheckFromState(
     _Out_ PACCESS_MASK GrantedAccess,
     _Out_ NTSTATUS* AccessStatus)
 {
+    if (ebpf_fault_injection_inject_fault()) {
+        if (Privileges != NULL) {
+            *Privileges = NULL;
+        }
+        *GrantedAccess = DesiredAccess;
+        *AccessStatus = STATUS_ACCESS_DENIED;
+        return false;
+    }
+
     UNREFERENCED_PARAMETER(SecurityDescriptor);
     UNREFERENCED_PARAMETER(PrimaryTokenInformation);
     UNREFERENCED_PARAMETER(ClientTokenInformation);

--- a/libs/platform/user/kernel_um.cpp
+++ b/libs/platform/user/kernel_um.cpp
@@ -577,10 +577,7 @@ RtlSetDaclSecurityDescriptor(
     _In_opt_ PACL Dacl,
     _In_ BOOLEAN DaclDefaulted)
 {
-    if (ebpf_fault_injection_inject_fault()) {
-        return STATUS_INVALID_PARAMETER;
-    }
-
+    // Skip Fault Injection.
     UNREFERENCED_PARAMETER(SecurityDescriptor);
     UNREFERENCED_PARAMETER(DaclPresent);
     UNREFERENCED_PARAMETER(Dacl);
@@ -593,10 +590,7 @@ NTSTATUS
 NTAPI
 RtlCreateSecurityDescriptor(_Out_ PSECURITY_DESCRIPTOR SecurityDescriptor, _In_ unsigned long Revision)
 {
-    if (ebpf_fault_injection_inject_fault()) {
-        return STATUS_INVALID_PARAMETER;
-    }
-
+    // Skip Fault Injection.
     UNREFERENCED_PARAMETER(Revision);
     memset(SecurityDescriptor, 0, sizeof(SECURITY_DESCRIPTOR));
 

--- a/libs/platform/user/kernel_um.cpp
+++ b/libs/platform/user/kernel_um.cpp
@@ -507,10 +507,7 @@ RtlULongAdd(
     _In_ unsigned long addend,
     _Out_ _Deref_out_range_(==, augend + addend) unsigned long* result)
 {
-    if (ebpf_fault_injection_inject_fault()) {
-        return STATUS_INTEGER_OVERFLOW;
-    }
-
+    // Skip Fault Injection.
     *result = augend + addend;
     return STATUS_SUCCESS;
 }
@@ -530,10 +527,7 @@ IoGetFileObjectGenericMapping() { return &_mapping; }
 NTSTATUS
 RtlCreateAcl(_Out_ PACL Acl, unsigned long AclLength, unsigned long AclRevision)
 {
-    if (ebpf_fault_injection_inject_fault()) {
-        return STATUS_INVALID_PARAMETER;
-    }
-
+    // Skip Fault Injection.
     UNREFERENCED_PARAMETER(Acl);
     UNREFERENCED_PARAMETER(AclRevision);
 

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -295,7 +295,7 @@ static int32_t
 _ebpf_sock_addr_is_current_admin(_In_ const bpf_sock_addr_t* ctx)
 {
     NTSTATUS status;
-    BOOLEAN access_allowed;
+    BOOLEAN access_allowed = FALSE;
     net_ebpf_sock_addr_t* sock_addr_ctx = NULL;
     int32_t is_admin = 0;
 
@@ -303,8 +303,11 @@ _ebpf_sock_addr_is_current_admin(_In_ const bpf_sock_addr_t* ctx)
     status = _perform_access_check(
         _net_ebpf_ext_security_descriptor_admin, sock_addr_ctx->access_information, &access_allowed);
 
-    // Check the status and access_allowed to determine if the admin access is allowed.
-    if ((status == STATUS_SUCCESS) && access_allowed) {
+    if (!NT_SUCCESS(status)) {
+        return is_admin;
+    }
+
+    if (access_allowed) {
         is_admin = 1;
     }
 

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -614,7 +614,11 @@ _net_ebpf_sock_addr_create_security_descriptor()
     dacl = (ACL*)ExAllocatePoolUninitialized(NonPagedPoolNx, acl_length, NET_EBPF_EXTENSION_POOL_TAG);
     NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, dacl, "dacl", status);
 
-    RtlCreateAcl(dacl, acl_length, ACL_REVISION);
+    status = RtlCreateAcl(dacl, acl_length, ACL_REVISION);
+    if (!NT_SUCCESS(status)) {
+        NET_EBPF_EXT_LOG_NTSTATUS_API_FAILURE(NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR, "RtlCreateAcl", status);
+        goto Exit;
+    }
 
     status = RtlAddAccessAllowedAce(dacl, ACL_REVISION, access_mask, SeExports->SeAliasAdminsSid);
     if (!NT_SUCCESS(status)) {

--- a/netebpfext/user/fwp_um.cpp
+++ b/netebpfext/user/fwp_um.cpp
@@ -874,13 +874,16 @@ _IRQL_requires_min_(PASSIVE_LEVEL) _IRQL_requires_max_(DISPATCH_LEVEL) FWPS_CONN
     FwpsQueryConnectionRedirectState0(
         _In_ HANDLE redirectRecords, _In_ HANDLE redirectHandle, _Outptr_opt_result_maybenull_ void** redirectContext)
 {
-    // Skip fault injection as the return is FWPS_CONNECTION_NOT_REDIRECTED.
-    UNREFERENCED_PARAMETER(redirectRecords);
-    UNREFERENCED_PARAMETER(redirectHandle);
-
     if (redirectContext) {
         *redirectContext = NULL;
     }
+
+    if (ebpf_fault_injection_inject_fault()) {
+        return FWPS_CONNECTION_REDIRECTED_BY_SELF;
+    }
+
+    UNREFERENCED_PARAMETER(redirectRecords);
+    UNREFERENCED_PARAMETER(redirectHandle);
 
     return FWPS_CONNECTION_NOT_REDIRECTED;
 }


### PR DESCRIPTION
## Description

Added Fault Injection to the list of Kernel OS APIs listed.

1. Skip: IoAllocateMdl
2. Skip: IoAllocateWorkItem
3. Added: MmGetMdlByteCount
4. Skip: ExAcquireRundownProtection
5. Skip: ExAcquireSpinLockExclusiveEx
6. Skip: ExAcquireSpinLockSharedEx
7. Skip: QueryInterruptTimeEx
8. Skip: RtlCreateAcl
9. Skip: RtlLengthSid
10. Added: RtlAddAccessAllowedAce
11. Skip: RtlSetDaclSecurityDescriptor
12. Skip: RtlCreateSecurityDescriptor
13. Added: SeAccessCheckFromState
14. Skip: KeGetCurrentIrql
15. Skip: PsGetCurrentProcessId
16. Skip: PsGetCurrentThreadId

## Testing

_Do any existing tests cover this change? Yes.
Coverage of the above APIs is already in test cases with _netebpf_ext_helper user.
```
_netebpf_ext_helper
  | -- net_ebpf_ext_register_providers
       | -- net_ebpf_ext_sock_addr_register_providers()
```
Are new tests needed? Yes (#2445)

## Documentation

_Is there any documentation impact for this change? No
