### PR TITLE
Test Regression: connect redirect kernel tests failing 

### DIFF
--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -66,17 +66,6 @@ CATCH_REGISTER_LISTENER(_watchdog)
 
 extern thread_local bool ebpf_non_preemptible;
 
-typedef struct _close_bpf_object
-{
-    void
-    operator()(_In_opt_ _Post_invalid_ bpf_object* object)
-    {
-        if (object != nullptr) {
-            bpf_object__close(object);
-        }
-    }
-} close_bpf_object_t;
-
 typedef std::unique_ptr<bpf_object, close_bpf_object_t> bpf_object_ptr;
 
 std::vector<uint8_t>

--- a/tests/libs/common/common_tests.h
+++ b/tests/libs/common/common_tests.h
@@ -37,6 +37,17 @@ typedef struct _ring_buffer_test_event_context
     int test_event_count;
 } ring_buffer_test_event_context_t;
 
+typedef struct _close_bpf_object
+{
+    void
+    operator()(_In_opt_ _Post_invalid_ bpf_object* object)
+    {
+        if (object != nullptr) {
+            bpf_object__close(object);
+        }
+    }
+} close_bpf_object_t;
+
 int
 ring_buffer_test_event_handler(_Inout_ void* ctx, _In_opt_ const void* data, size_t size);
 

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -29,6 +29,8 @@ using namespace std::chrono_literals;
 
 CATCH_REGISTER_LISTENER(_watchdog)
 
+typedef std::unique_ptr<bpf_object, close_bpf_object_t> bpf_object_ptr;
+
 void
 connection_test(
     ADDRESS_FAMILY address_family,
@@ -38,18 +40,23 @@ connection_test(
 {
     native_module_helper_t helper("cgroup_sock_addr");
 
-    struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
-    REQUIRE(object != nullptr);
+    bpf_object_ptr object;
+
+    struct bpf_object* raw_object = bpf_object__open("cgroup_sock_addr.o");
+
+    REQUIRE(raw_object != nullptr);
+    object.reset(raw_object);
+    raw_object = nullptr;
     // Load the programs.
-    REQUIRE(bpf_object__load(object) == 0);
+    REQUIRE(bpf_object__load(object.get()) == 0);
 
     const char* connect_program_name = (address_family == AF_INET) ? "authorize_connect4" : "authorize_connect6";
-    bpf_program* connect_program = bpf_object__find_program_by_name(object, connect_program_name);
+    bpf_program* connect_program = bpf_object__find_program_by_name(object.get(), connect_program_name);
     REQUIRE(connect_program != nullptr);
 
     const char* recv_accept_program_name =
         (address_family == AF_INET) ? "authorize_recv_accept4" : "authorize_recv_accept6";
-    bpf_program* recv_accept_program = bpf_object__find_program_by_name(object, recv_accept_program_name);
+    bpf_program* recv_accept_program = bpf_object__find_program_by_name(object.get(), recv_accept_program_name);
     REQUIRE(recv_accept_program != nullptr);
 
     PSOCKADDR local_address = nullptr;
@@ -67,9 +74,9 @@ connection_test(
     printf("tuple.dst_port = %x\n", tuple.dst_port);
     tuple.protocol = protocol;
 
-    bpf_map* ingress_connection_policy_map = bpf_object__find_map_by_name(object, "ingress_connection_policy_map");
+    bpf_map* ingress_connection_policy_map = bpf_object__find_map_by_name(object.get(), "ingress_connection_policy_map");
     REQUIRE(ingress_connection_policy_map != nullptr);
-    bpf_map* egress_connection_policy_map = bpf_object__find_map_by_name(object, "egress_connection_policy_map");
+    bpf_map* egress_connection_policy_map = bpf_object__find_map_by_name(object.get(), "egress_connection_policy_map");
     REQUIRE(egress_connection_policy_map != nullptr);
 
     // Update ingress and egress policy to block loopback packet on test port.
@@ -128,7 +135,6 @@ connection_test(
     sender_socket.send_message_to_remote_host(message, destination_address, SOCKET_TEST_PORT);
     receiver_socket.complete_async_receive();
 
-    bpf_object__close(object);
 }
 
 TEST_CASE("connection_test_udp_v4", "[sock_addr_tests]")
@@ -163,16 +169,20 @@ TEST_CASE("connection_test_tcp_v6", "[sock_addr_tests]")
 
 TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
 {
+    bpf_object_ptr object;
+
     bpf_prog_info program_info = {};
     uint32_t program_info_size = sizeof(program_info);
     native_module_helper_t helper("cgroup_sock_addr");
 
-    struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
-    REQUIRE(object != nullptr);
+    struct bpf_object* raw_object = bpf_object__open("cgroup_sock_addr.o");
+    REQUIRE(raw_object != nullptr);
+    object.reset(raw_object);
+    raw_object = nullptr;
     // Load the programs.
-    REQUIRE(bpf_object__load(object) == 0);
+    REQUIRE(bpf_object__load(object.get()) == 0);
 
-    bpf_program* connect4_program = bpf_object__find_program_by_name(object, "authorize_connect4");
+    bpf_program* connect4_program = bpf_object__find_program_by_name(object.get(), "authorize_connect4");
     REQUIRE(connect4_program != nullptr);
 
     int result = bpf_prog_attach(
@@ -198,7 +208,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
             bpf_program__fd(const_cast<const bpf_program*>(connect4_program)), &program_info, &program_info_size) == 0);
     REQUIRE(program_info.link_count == 0);
 
-    bpf_program* recv_accept4_program = bpf_object__find_program_by_name(object, "authorize_recv_accept4");
+    bpf_program* recv_accept4_program = bpf_object__find_program_by_name(object.get(), "authorize_recv_accept4");
     REQUIRE(recv_accept4_program != nullptr);
 
     result = bpf_prog_attach(
@@ -227,7 +237,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
         0);
     REQUIRE(program_info.link_count == 0);
 
-    bpf_program* connect6_program = bpf_object__find_program_by_name(object, "authorize_connect6");
+    bpf_program* connect6_program = bpf_object__find_program_by_name(object.get(), "authorize_connect6");
     REQUIRE(connect6_program != nullptr);
 
     result = bpf_prog_attach(
@@ -237,7 +247,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
         0);
     REQUIRE(result == 0);
 
-    bpf_program* recv_accept6_program = bpf_object__find_program_by_name(object, "authorize_recv_accept6");
+    bpf_program* recv_accept6_program = bpf_object__find_program_by_name(object.get(), "authorize_recv_accept6");
     REQUIRE(recv_accept6_program != nullptr);
 
     result = bpf_prog_attach(
@@ -247,7 +257,6 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
         0);
     REQUIRE(result == 0);
 
-    bpf_object__close(object);
 }
 
 void
@@ -259,16 +268,21 @@ connection_monitor_test(
     bool disconnect)
 {
     native_module_helper_t helper("sockops");
-    struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
-    REQUIRE(object != nullptr);
+
+    bpf_object_ptr object;
+
+    struct bpf_object* raw_object = bpf_object__open("sockops.o");
+    REQUIRE(raw_object != nullptr);
+    object.reset(raw_object);
+    raw_object = nullptr;
     // Load the programs.
-    REQUIRE(bpf_object__load(object) == 0);
+    REQUIRE(bpf_object__load(object.get()) == 0);
 
     // Ring buffer event callback context.
     std::unique_ptr<ring_buffer_test_event_context_t> context = std::make_unique<ring_buffer_test_event_context_t>();
     context->test_event_count = disconnect ? 4 : 2;
 
-    bpf_program* _program = bpf_object__find_program_by_name(object, "connection_monitor");
+    bpf_program* _program = bpf_object__find_program_by_name(object.get(), "connection_monitor");
     REQUIRE(_program != nullptr);
 
     PSOCKADDR local_address = nullptr;
@@ -321,13 +335,13 @@ connection_monitor_test(
     auto ring_buffer_event_callback = context->ring_buffer_event_promise.get_future();
 
     // Create a new ring buffer manager and subscribe to ring buffer events.
-    bpf_map* ring_buffer_map = bpf_object__find_map_by_name(object, "audit_map");
+    bpf_map* ring_buffer_map = bpf_object__find_map_by_name(object.get(), "audit_map");
     REQUIRE(ring_buffer_map != nullptr);
     context->ring_buffer = ring_buffer__new(
         bpf_map__fd(ring_buffer_map), (ring_buffer_sample_fn)ring_buffer_test_event_handler, context.get(), nullptr);
     REQUIRE(context->ring_buffer != nullptr);
 
-    bpf_map* connection_map = bpf_object__find_map_by_name(object, "connection_map");
+    bpf_map* connection_map = bpf_object__find_map_by_name(object.get(), "connection_map");
     REQUIRE(connection_map != nullptr);
 
     // Update connection map with loopback packet tuple.
@@ -370,7 +384,6 @@ connection_monitor_test(
     // Unsubscribe.
     raw_context->unsubscribe();
 
-    bpf_object__close(object);
 }
 
 TEST_CASE("connection_monitor_test_udp_v4", "[sock_ops_tests]")
@@ -436,18 +449,22 @@ TEST_CASE("connection_monitor_test_disconnect_tcp_v6", "[sock_ops_tests]")
 TEST_CASE("attach_sockops_programs", "[sock_ops_tests]")
 {
     native_module_helper_t helper("sockops");
-    struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
-    REQUIRE(object != nullptr);
-    // Load the programs.
-    REQUIRE(bpf_object__load(object) == 0);
 
-    bpf_program* _program = bpf_object__find_program_by_name(object, "connection_monitor");
+    bpf_object_ptr object;
+
+    struct bpf_object* raw_object = bpf_object__open("sockops.o");
+    REQUIRE(raw_object != nullptr);
+    object.reset(raw_object);
+    raw_object = nullptr;
+    // Load the programs.
+    REQUIRE(bpf_object__load(object.get()) == 0);
+
+    bpf_program* _program = bpf_object__find_program_by_name(object.get(), "connection_monitor");
     REQUIRE(_program != nullptr);
 
     int result = bpf_prog_attach(bpf_program__fd(const_cast<const bpf_program*>(_program)), 0, BPF_CGROUP_SOCK_OPS, 0);
     REQUIRE(result == 0);
 
-    bpf_object__close(object);
 }
 
 int


### PR DESCRIPTION
Test changes in PR https://github.com/microsoft/ebpf-for-windows/pull/2226 are causing all the connect-redirect kernel tests to fail.
Even though the tests are failing, workflow is being marked as passed, which is misleading. Example: https://github.com/microsoft/ebpf-for-windows/actions/runs/4846382234/jobs/8636023791

Added a unique pointer to save the returned pointer if the test cases fail. 
closes #2415 