### PR TITLE
propertly initialize pe_section_name_counter

### DIFF
--- a/tools/bpf2c/bpf_code_generator.h
+++ b/tools/bpf2c/bpf_code_generator.h
@@ -397,7 +397,7 @@ class bpf_code_generator
     bool
     is_section_valid(const ELFIO::section* section);
 
-    int pe_section_name_counter;
+    int pe_section_name_counter{};
     std::map<unsafe_string, section_t> sections;
     section_t* current_section;
     ELFIO::elfio reader;


### PR DESCRIPTION
properly initialize the pe_section_name_counter

bpf2c crashes in set_pe_section_name during call to strncpy_s when provided invalid prefix_length as count due to integer underflow. the root cause is pe_section_name_counter is not appropriately initialized to 0
