### PR TITLE
Kill test process if it takes more than 5 minutes to execute

### DIFF
--- a/scripts/Test-FaultInjection.ps1
+++ b/scripts/Test-FaultInjection.ps1
@@ -22,6 +22,16 @@ Set-Content -Path ($TestProgram + ".fault.log") ""
 
 $iteration = 0
 
+$timer = New-Object System.Timers.Timer
+# Set timer for 5 minutes
+$timer.Interval = 300000
+
+# When the watchdog timer fires, kill the test binary.
+Register-ObjectEvent -InputObject $timer -EventName Elapsed -Action {
+    Write-Error "Test binary exceede time"
+    Get-Process -Name $TestProgram | Stop-Process -Force -ErrorAction SilentlyContinue
+}
+
 # Rerun failing tests until they pass
 while ($true) {
     $previous_passed_tests = $passed_tests
@@ -45,8 +55,14 @@ while ($true) {
     write-host "Running iteration #" $iteration
     $remaining_tests | ForEach-Object { write-host "Running: $_" }
 
+    # Start the watchdog timer
+    $timer.Start()
+
     # Run the test binary with any remaining tests.
     & $TestProgram "-d yes" "--verbosity=quiet" "-f remaining_tests.txt"
+
+    # Stop the watchdog timer
+    $timer.Stop()
 
     if ($LASTEXITCODE -eq 0) {
         write-host "All tests passed"

--- a/scripts/Test-FaultInjection.ps1
+++ b/scripts/Test-FaultInjection.ps1
@@ -28,7 +28,7 @@ $timer.Interval = 300000
 
 # When the watchdog timer fires, kill the test binary.
 Register-ObjectEvent -InputObject $timer -EventName Elapsed -Action {
-    Write-Error "Test binary exceede time"
+    Write-Error "Test binary exceeded time"
     Get-Process -Name $TestProgram | Stop-Process -Force -ErrorAction SilentlyContinue
 }
 


### PR DESCRIPTION
## Description

During fault injection, set a watchdog timer in PS to kill the process if it takes more than 5 minutes to execute.

## Testing

CI/CD

## Documentation

No.
