### PR TITLE
Remove premature assert

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -322,10 +322,6 @@ ebpf_link_detach_program(_Inout_ ebpf_link_t* link)
         ebpf_assert(program != NULL);
     }
 
-    if (link->state == EBPF_LINK_STATE_INITIAL || link->state == EBPF_LINK_STATE_DETACHED) {
-        ebpf_assert(link->program == NULL);
-    }
-
     ebpf_lock_unlock(&link->attach_lock, state);
 
     if (!link_is_detaching) {


### PR DESCRIPTION
## Description

This PR fixes a kernel mode `assert`.

The root cause here is that the `assert` itself as it is checking for the link state prematurely. Specifically:

Assuming two threads were racing to detach a program and end up invoking `ebpf_link_detach_program`, only one would acquire `link->lock` causing the other to block.  (At this instant, the detach operation needs the link state to be either 'Attached' (provider loaded) or 'Attaching' (waiting for the provider to load). Any other state causes the ebpf_link_detach_program call to exit.)

The running thread then sets the link state to 'Detaching', sets some local variables and releases the lock prior to
calling `ebpf_program_unload` to detach from the provider.  This results in the invocation of the `_ebpf_link_extension_changed_callback` callback which changes the link state to 'Detached'.

The blocked thread now resumes running and does not enter the 'Attached' or 'Attaching' `if` clause (link state is now 'Detached') and enters the 'Initial' or 'Detached' `if` clause.

Unfortunately, we only clear the `link->program` to null at the end of the `ebpf_link_detach_program` call, which is quite a ways
_after_ this `assert` which is consequently triggered.

In and of itself, this `assert` check was meant to be 'paranoia' check to ensure that the link object was properly cleaned up, but 
the premature nature of the check becomes apparent only in multi-threaded scenarios.  In single threaded scenarios, the first
thread completes the `ebpf_link_detach_program` call, thus also setting `link->program` to null before the next thread calls
into this function.  Therefore, moving this assert lower down 'as-is' does not really buy us anything, so this PR removes it.

Note that so far, this issue has been repro'd only a machine with a high CPU core count (20) and is not seen on more main stream machines (4 - 10 cores).  It _may_ repro with longer runtimes (30 minutes or more), but this needs to be verified.



## Testing

Ensure that the following test completes successfully:
`.\ebpf_stress_tests_km -tt=32 -td=10 jit_load_attach_detach_unload_random_v4_test`


## Documentation

No documentation changes required.

Fixes: #2433 