### PR TITLE
Ensure valid shift values for *SH* instructions.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -126,7 +126,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.3/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
       test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64

--- a/tests/bpf2c_tests/expected/bindmonitor_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_dll.c
@@ -158,7 +158,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 52 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
+        // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
 #line 52 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=5 dst=r10 src=r8 offset=-72 imm=0
@@ -179,7 +179,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
 #line 55 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
 #line 55 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r1 src=r6 offset=0 imm=0
@@ -194,7 +194,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[2].tail_call) && (r0 == 0))
 #line 56 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
 #line 56 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r2 src=r10 offset=0 imm=0
@@ -224,7 +224,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 58 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
 #line 58 "sample/bindmonitor.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=22 dst=r2 src=r0 offset=0 imm=-84
@@ -242,7 +242,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 308 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
 #line 308 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=519 imm=0
@@ -250,7 +250,7 @@ BindMonitor(void* context)
     if (r7 == IMMEDIATE(0))
 #line 309 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
 #line 309 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=517 imm=0
@@ -258,7 +258,7 @@ BindMonitor(void* context)
     if (r1 == IMMEDIATE(0))
 #line 309 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 64 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-8 imm=0
@@ -312,7 +312,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 69 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
+        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
 #line 70 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 70 "sample/bindmonitor.c"
@@ -335,12 +335,12 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 319 "sample/bindmonitor.c"
         goto label_7;
-    // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
+        // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
 #line 319 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(2))
 #line 319 "sample/bindmonitor.c"
         goto label_4;
-    // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
 #line 336 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=54 dst=r0 src=r0 offset=473 imm=0
@@ -355,7 +355,7 @@ label_3:
     if (r1 != IMMEDIATE(0))
 #line 74 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=58 dst=r1 src=r0 offset=487 imm=0
@@ -363,7 +363,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 78 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
 #line 78 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=485 imm=0
@@ -371,7 +371,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 78 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=62 dst=r8 src=r0 offset=0 imm=-8
@@ -401,7 +401,7 @@ label_3:
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 82 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=72 dst=r2 src=r8 offset=0 imm=0
@@ -416,12 +416,12 @@ label_3:
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
+        // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
 #line 84 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
 #line 98 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=76 dst=r2 src=r6 offset=8 imm=0
@@ -438,7 +438,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 98 "sample/bindmonitor.c"
         goto label_1;
-    // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
 #line 99 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_STXB pc=81 dst=r0 src=r1 offset=4 imm=0
@@ -461,7 +461,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 101 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
+        // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
 #line 102 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_STXB pc=88 dst=r0 src=r1 offset=5 imm=0
@@ -484,7 +484,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 104 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
+        // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
 #line 105 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
     // EBPF_OP_STXB pc=95 dst=r0 src=r1 offset=6 imm=0
@@ -507,7 +507,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 107 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
+        // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
 #line 108 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_STXB pc=102 dst=r0 src=r1 offset=7 imm=0
@@ -530,7 +530,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 110 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
 #line 111 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_STXB pc=109 dst=r0 src=r1 offset=8 imm=0
@@ -553,7 +553,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 113 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
 #line 114 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_STXB pc=116 dst=r0 src=r1 offset=9 imm=0
@@ -576,7 +576,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 116 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
+        // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
 #line 117 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
     // EBPF_OP_STXB pc=123 dst=r0 src=r1 offset=10 imm=0
@@ -599,7 +599,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 119 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
+        // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
 #line 120 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
     // EBPF_OP_STXB pc=130 dst=r0 src=r1 offset=11 imm=0
@@ -622,7 +622,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 122 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
+        // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
 #line 123 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_STXB pc=137 dst=r0 src=r1 offset=12 imm=0
@@ -645,7 +645,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 125 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
+        // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
 #line 126 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_STXB pc=144 dst=r0 src=r1 offset=13 imm=0
@@ -668,7 +668,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 128 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
+        // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
 #line 129 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
     // EBPF_OP_STXB pc=151 dst=r0 src=r1 offset=14 imm=0
@@ -691,7 +691,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 131 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
+        // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
 #line 132 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
     // EBPF_OP_STXB pc=158 dst=r0 src=r1 offset=15 imm=0
@@ -714,7 +714,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 134 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
 #line 135 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_STXB pc=165 dst=r0 src=r1 offset=16 imm=0
@@ -737,7 +737,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 137 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
+        // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
 #line 138 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
     // EBPF_OP_STXB pc=172 dst=r0 src=r1 offset=17 imm=0
@@ -760,7 +760,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 140 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
 #line 141 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_STXB pc=179 dst=r0 src=r1 offset=18 imm=0
@@ -783,7 +783,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 143 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
+        // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
 #line 144 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
     // EBPF_OP_STXB pc=186 dst=r0 src=r1 offset=19 imm=0
@@ -806,7 +806,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 146 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
+        // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
 #line 147 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
     // EBPF_OP_STXB pc=193 dst=r0 src=r1 offset=20 imm=0
@@ -829,7 +829,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 149 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
+        // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
 #line 150 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
     // EBPF_OP_STXB pc=200 dst=r0 src=r1 offset=21 imm=0
@@ -852,7 +852,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 152 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
+        // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
 #line 153 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
     // EBPF_OP_STXB pc=207 dst=r0 src=r1 offset=22 imm=0
@@ -875,7 +875,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 155 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
+        // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
 #line 156 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
     // EBPF_OP_STXB pc=214 dst=r0 src=r1 offset=23 imm=0
@@ -898,7 +898,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 158 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
 #line 159 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_STXB pc=221 dst=r0 src=r1 offset=24 imm=0
@@ -921,7 +921,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 161 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
+        // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
 #line 162 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
     // EBPF_OP_STXB pc=228 dst=r0 src=r1 offset=25 imm=0
@@ -944,7 +944,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 164 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
+        // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
 #line 165 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
     // EBPF_OP_STXB pc=235 dst=r0 src=r1 offset=26 imm=0
@@ -967,7 +967,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 167 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
 #line 168 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_STXB pc=242 dst=r0 src=r1 offset=27 imm=0
@@ -990,7 +990,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 170 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
+        // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
 #line 171 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_STXB pc=249 dst=r0 src=r1 offset=28 imm=0
@@ -1013,7 +1013,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 173 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
+        // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
 #line 174 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
     // EBPF_OP_STXB pc=256 dst=r0 src=r1 offset=29 imm=0
@@ -1036,7 +1036,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 176 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
+        // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
 #line 177 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
     // EBPF_OP_STXB pc=263 dst=r0 src=r1 offset=30 imm=0
@@ -1059,7 +1059,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 179 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
+        // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
 #line 180 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
     // EBPF_OP_STXB pc=270 dst=r0 src=r1 offset=31 imm=0
@@ -1082,7 +1082,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 182 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
+        // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
 #line 183 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
     // EBPF_OP_STXB pc=277 dst=r0 src=r1 offset=32 imm=0
@@ -1105,7 +1105,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 185 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
+        // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
 #line 186 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
     // EBPF_OP_STXB pc=284 dst=r0 src=r1 offset=33 imm=0
@@ -1128,7 +1128,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 188 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
+        // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
 #line 189 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
     // EBPF_OP_STXB pc=291 dst=r0 src=r1 offset=34 imm=0
@@ -1151,7 +1151,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 191 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
+        // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
 #line 192 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
     // EBPF_OP_STXB pc=298 dst=r0 src=r1 offset=35 imm=0
@@ -1174,7 +1174,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 194 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
+        // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
 #line 195 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
     // EBPF_OP_STXB pc=305 dst=r0 src=r1 offset=36 imm=0
@@ -1197,7 +1197,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 197 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
+        // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
 #line 198 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
     // EBPF_OP_STXB pc=312 dst=r0 src=r1 offset=37 imm=0
@@ -1220,7 +1220,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 200 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
+        // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
 #line 201 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
     // EBPF_OP_STXB pc=319 dst=r0 src=r1 offset=38 imm=0
@@ -1243,7 +1243,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 203 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
+        // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
 #line 204 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
     // EBPF_OP_STXB pc=326 dst=r0 src=r1 offset=39 imm=0
@@ -1266,7 +1266,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 206 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
+        // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
 #line 207 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
     // EBPF_OP_STXB pc=333 dst=r0 src=r1 offset=40 imm=0
@@ -1289,7 +1289,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 209 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
+        // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
 #line 210 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
     // EBPF_OP_STXB pc=340 dst=r0 src=r1 offset=41 imm=0
@@ -1312,7 +1312,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 212 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
+        // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
 #line 213 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
     // EBPF_OP_STXB pc=347 dst=r0 src=r1 offset=42 imm=0
@@ -1335,7 +1335,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 215 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
+        // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
 #line 216 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_STXB pc=354 dst=r0 src=r1 offset=43 imm=0
@@ -1358,7 +1358,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 218 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
+        // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
 #line 219 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_STXB pc=361 dst=r0 src=r1 offset=44 imm=0
@@ -1381,7 +1381,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 221 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
+        // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
 #line 222 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_STXB pc=368 dst=r0 src=r1 offset=45 imm=0
@@ -1404,7 +1404,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 224 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
+        // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
 #line 225 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
     // EBPF_OP_STXB pc=375 dst=r0 src=r1 offset=46 imm=0
@@ -1427,7 +1427,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 227 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
+        // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
 #line 228 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_STXB pc=382 dst=r0 src=r1 offset=47 imm=0
@@ -1450,7 +1450,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 230 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
+        // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
 #line 231 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_STXB pc=389 dst=r0 src=r1 offset=48 imm=0
@@ -1473,7 +1473,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 233 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
+        // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
 #line 234 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_STXB pc=396 dst=r0 src=r1 offset=49 imm=0
@@ -1496,7 +1496,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 236 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
+        // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
 #line 237 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
     // EBPF_OP_STXB pc=403 dst=r0 src=r1 offset=50 imm=0
@@ -1519,7 +1519,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 239 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
+        // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
 #line 240 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_STXB pc=410 dst=r0 src=r1 offset=51 imm=0
@@ -1542,7 +1542,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 242 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
+        // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
 #line 243 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
     // EBPF_OP_STXB pc=417 dst=r0 src=r1 offset=52 imm=0
@@ -1565,7 +1565,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 245 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
+        // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
 #line 246 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_STXB pc=424 dst=r0 src=r1 offset=53 imm=0
@@ -1588,7 +1588,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 248 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
+        // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
 #line 249 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
     // EBPF_OP_STXB pc=431 dst=r0 src=r1 offset=54 imm=0
@@ -1611,7 +1611,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 251 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
+        // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
 #line 252 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_STXB pc=438 dst=r0 src=r1 offset=55 imm=0
@@ -1634,7 +1634,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 254 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
+        // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
 #line 255 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
     // EBPF_OP_STXB pc=445 dst=r0 src=r1 offset=56 imm=0
@@ -1657,7 +1657,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 257 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
+        // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
 #line 258 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_STXB pc=452 dst=r0 src=r1 offset=57 imm=0
@@ -1680,7 +1680,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 260 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
+        // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
 #line 261 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
     // EBPF_OP_STXB pc=459 dst=r0 src=r1 offset=58 imm=0
@@ -1703,7 +1703,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 263 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
+        // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
 #line 264 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
     // EBPF_OP_STXB pc=466 dst=r0 src=r1 offset=59 imm=0
@@ -1726,7 +1726,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 266 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
 #line 267 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_STXB pc=473 dst=r0 src=r1 offset=60 imm=0
@@ -1749,7 +1749,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 269 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
+        // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
 #line 270 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
     // EBPF_OP_STXB pc=480 dst=r0 src=r1 offset=61 imm=0
@@ -1772,7 +1772,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 272 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
+        // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
 #line 273 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
     // EBPF_OP_STXB pc=487 dst=r0 src=r1 offset=62 imm=0
@@ -1795,7 +1795,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 275 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
+        // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
 #line 276 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
     // EBPF_OP_STXB pc=494 dst=r0 src=r1 offset=63 imm=0
@@ -1818,7 +1818,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 278 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
+        // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
 #line 279 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
     // EBPF_OP_STXB pc=501 dst=r0 src=r1 offset=64 imm=0
@@ -1841,7 +1841,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 281 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
+        // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
 #line 282 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
     // EBPF_OP_STXB pc=508 dst=r0 src=r1 offset=65 imm=0
@@ -1864,7 +1864,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 284 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
+        // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
 #line 285 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
     // EBPF_OP_STXB pc=515 dst=r0 src=r1 offset=66 imm=0
@@ -1887,7 +1887,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 287 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
+        // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
 #line 288 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
     // EBPF_OP_STXB pc=522 dst=r0 src=r1 offset=67 imm=0
@@ -1905,7 +1905,7 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 328 "sample/bindmonitor.c"
         goto label_6;
-    // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
 #line 329 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
@@ -1917,10 +1917,10 @@ label_5:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=529 dst=r1 src=r0 offset=0 imm=32
 #line 336 "sample/bindmonitor.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=530 dst=r1 src=r0 offset=0 imm=32
 #line 336 "sample/bindmonitor.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=531 dst=r1 src=r0 offset=15 imm=0
 #line 336 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
@@ -1951,7 +1951,7 @@ label_6:
     if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
 #line 338 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
+        // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
 #line 338 "sample/bindmonitor.c"
     goto label_8;
 label_7:
@@ -1969,7 +1969,7 @@ label_7:
     if (r1 >= r2)
 #line 321 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
 #line 325 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=545 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_raw.c
@@ -132,7 +132,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 52 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
+        // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
 #line 52 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=5 dst=r10 src=r8 offset=-72 imm=0
@@ -153,7 +153,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
 #line 55 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
 #line 55 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r1 src=r6 offset=0 imm=0
@@ -168,7 +168,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[2].tail_call) && (r0 == 0))
 #line 56 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
 #line 56 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r2 src=r10 offset=0 imm=0
@@ -198,7 +198,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 58 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
 #line 58 "sample/bindmonitor.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=22 dst=r2 src=r0 offset=0 imm=-84
@@ -216,7 +216,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 308 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
 #line 308 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=519 imm=0
@@ -224,7 +224,7 @@ BindMonitor(void* context)
     if (r7 == IMMEDIATE(0))
 #line 309 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
 #line 309 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=517 imm=0
@@ -232,7 +232,7 @@ BindMonitor(void* context)
     if (r1 == IMMEDIATE(0))
 #line 309 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 64 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-8 imm=0
@@ -286,7 +286,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 69 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
+        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
 #line 70 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 70 "sample/bindmonitor.c"
@@ -309,12 +309,12 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 319 "sample/bindmonitor.c"
         goto label_7;
-    // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
+        // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
 #line 319 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(2))
 #line 319 "sample/bindmonitor.c"
         goto label_4;
-    // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
 #line 336 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=54 dst=r0 src=r0 offset=473 imm=0
@@ -329,7 +329,7 @@ label_3:
     if (r1 != IMMEDIATE(0))
 #line 74 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=58 dst=r1 src=r0 offset=487 imm=0
@@ -337,7 +337,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 78 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
 #line 78 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=485 imm=0
@@ -345,7 +345,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 78 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=62 dst=r8 src=r0 offset=0 imm=-8
@@ -375,7 +375,7 @@ label_3:
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 82 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=72 dst=r2 src=r8 offset=0 imm=0
@@ -390,12 +390,12 @@ label_3:
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
+        // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
 #line 84 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
 #line 98 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=76 dst=r2 src=r6 offset=8 imm=0
@@ -412,7 +412,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 98 "sample/bindmonitor.c"
         goto label_1;
-    // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
 #line 99 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_STXB pc=81 dst=r0 src=r1 offset=4 imm=0
@@ -435,7 +435,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 101 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
+        // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
 #line 102 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_STXB pc=88 dst=r0 src=r1 offset=5 imm=0
@@ -458,7 +458,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 104 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
+        // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
 #line 105 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
     // EBPF_OP_STXB pc=95 dst=r0 src=r1 offset=6 imm=0
@@ -481,7 +481,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 107 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
+        // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
 #line 108 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_STXB pc=102 dst=r0 src=r1 offset=7 imm=0
@@ -504,7 +504,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 110 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
 #line 111 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_STXB pc=109 dst=r0 src=r1 offset=8 imm=0
@@ -527,7 +527,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 113 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
 #line 114 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_STXB pc=116 dst=r0 src=r1 offset=9 imm=0
@@ -550,7 +550,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 116 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
+        // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
 #line 117 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
     // EBPF_OP_STXB pc=123 dst=r0 src=r1 offset=10 imm=0
@@ -573,7 +573,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 119 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
+        // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
 #line 120 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
     // EBPF_OP_STXB pc=130 dst=r0 src=r1 offset=11 imm=0
@@ -596,7 +596,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 122 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
+        // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
 #line 123 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_STXB pc=137 dst=r0 src=r1 offset=12 imm=0
@@ -619,7 +619,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 125 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
+        // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
 #line 126 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_STXB pc=144 dst=r0 src=r1 offset=13 imm=0
@@ -642,7 +642,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 128 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
+        // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
 #line 129 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
     // EBPF_OP_STXB pc=151 dst=r0 src=r1 offset=14 imm=0
@@ -665,7 +665,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 131 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
+        // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
 #line 132 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
     // EBPF_OP_STXB pc=158 dst=r0 src=r1 offset=15 imm=0
@@ -688,7 +688,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 134 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
 #line 135 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_STXB pc=165 dst=r0 src=r1 offset=16 imm=0
@@ -711,7 +711,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 137 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
+        // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
 #line 138 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
     // EBPF_OP_STXB pc=172 dst=r0 src=r1 offset=17 imm=0
@@ -734,7 +734,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 140 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
 #line 141 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_STXB pc=179 dst=r0 src=r1 offset=18 imm=0
@@ -757,7 +757,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 143 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
+        // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
 #line 144 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
     // EBPF_OP_STXB pc=186 dst=r0 src=r1 offset=19 imm=0
@@ -780,7 +780,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 146 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
+        // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
 #line 147 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
     // EBPF_OP_STXB pc=193 dst=r0 src=r1 offset=20 imm=0
@@ -803,7 +803,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 149 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
+        // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
 #line 150 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
     // EBPF_OP_STXB pc=200 dst=r0 src=r1 offset=21 imm=0
@@ -826,7 +826,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 152 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
+        // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
 #line 153 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
     // EBPF_OP_STXB pc=207 dst=r0 src=r1 offset=22 imm=0
@@ -849,7 +849,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 155 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
+        // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
 #line 156 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
     // EBPF_OP_STXB pc=214 dst=r0 src=r1 offset=23 imm=0
@@ -872,7 +872,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 158 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
 #line 159 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_STXB pc=221 dst=r0 src=r1 offset=24 imm=0
@@ -895,7 +895,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 161 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
+        // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
 #line 162 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
     // EBPF_OP_STXB pc=228 dst=r0 src=r1 offset=25 imm=0
@@ -918,7 +918,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 164 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
+        // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
 #line 165 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
     // EBPF_OP_STXB pc=235 dst=r0 src=r1 offset=26 imm=0
@@ -941,7 +941,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 167 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
 #line 168 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_STXB pc=242 dst=r0 src=r1 offset=27 imm=0
@@ -964,7 +964,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 170 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
+        // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
 #line 171 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_STXB pc=249 dst=r0 src=r1 offset=28 imm=0
@@ -987,7 +987,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 173 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
+        // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
 #line 174 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
     // EBPF_OP_STXB pc=256 dst=r0 src=r1 offset=29 imm=0
@@ -1010,7 +1010,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 176 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
+        // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
 #line 177 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
     // EBPF_OP_STXB pc=263 dst=r0 src=r1 offset=30 imm=0
@@ -1033,7 +1033,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 179 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
+        // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
 #line 180 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
     // EBPF_OP_STXB pc=270 dst=r0 src=r1 offset=31 imm=0
@@ -1056,7 +1056,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 182 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
+        // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
 #line 183 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
     // EBPF_OP_STXB pc=277 dst=r0 src=r1 offset=32 imm=0
@@ -1079,7 +1079,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 185 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
+        // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
 #line 186 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
     // EBPF_OP_STXB pc=284 dst=r0 src=r1 offset=33 imm=0
@@ -1102,7 +1102,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 188 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
+        // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
 #line 189 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
     // EBPF_OP_STXB pc=291 dst=r0 src=r1 offset=34 imm=0
@@ -1125,7 +1125,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 191 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
+        // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
 #line 192 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
     // EBPF_OP_STXB pc=298 dst=r0 src=r1 offset=35 imm=0
@@ -1148,7 +1148,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 194 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
+        // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
 #line 195 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
     // EBPF_OP_STXB pc=305 dst=r0 src=r1 offset=36 imm=0
@@ -1171,7 +1171,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 197 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
+        // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
 #line 198 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
     // EBPF_OP_STXB pc=312 dst=r0 src=r1 offset=37 imm=0
@@ -1194,7 +1194,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 200 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
+        // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
 #line 201 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
     // EBPF_OP_STXB pc=319 dst=r0 src=r1 offset=38 imm=0
@@ -1217,7 +1217,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 203 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
+        // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
 #line 204 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
     // EBPF_OP_STXB pc=326 dst=r0 src=r1 offset=39 imm=0
@@ -1240,7 +1240,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 206 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
+        // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
 #line 207 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
     // EBPF_OP_STXB pc=333 dst=r0 src=r1 offset=40 imm=0
@@ -1263,7 +1263,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 209 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
+        // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
 #line 210 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
     // EBPF_OP_STXB pc=340 dst=r0 src=r1 offset=41 imm=0
@@ -1286,7 +1286,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 212 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
+        // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
 #line 213 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
     // EBPF_OP_STXB pc=347 dst=r0 src=r1 offset=42 imm=0
@@ -1309,7 +1309,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 215 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
+        // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
 #line 216 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_STXB pc=354 dst=r0 src=r1 offset=43 imm=0
@@ -1332,7 +1332,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 218 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
+        // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
 #line 219 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_STXB pc=361 dst=r0 src=r1 offset=44 imm=0
@@ -1355,7 +1355,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 221 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
+        // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
 #line 222 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_STXB pc=368 dst=r0 src=r1 offset=45 imm=0
@@ -1378,7 +1378,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 224 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
+        // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
 #line 225 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
     // EBPF_OP_STXB pc=375 dst=r0 src=r1 offset=46 imm=0
@@ -1401,7 +1401,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 227 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
+        // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
 #line 228 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_STXB pc=382 dst=r0 src=r1 offset=47 imm=0
@@ -1424,7 +1424,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 230 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
+        // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
 #line 231 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_STXB pc=389 dst=r0 src=r1 offset=48 imm=0
@@ -1447,7 +1447,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 233 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
+        // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
 #line 234 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_STXB pc=396 dst=r0 src=r1 offset=49 imm=0
@@ -1470,7 +1470,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 236 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
+        // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
 #line 237 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
     // EBPF_OP_STXB pc=403 dst=r0 src=r1 offset=50 imm=0
@@ -1493,7 +1493,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 239 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
+        // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
 #line 240 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_STXB pc=410 dst=r0 src=r1 offset=51 imm=0
@@ -1516,7 +1516,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 242 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
+        // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
 #line 243 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
     // EBPF_OP_STXB pc=417 dst=r0 src=r1 offset=52 imm=0
@@ -1539,7 +1539,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 245 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
+        // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
 #line 246 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_STXB pc=424 dst=r0 src=r1 offset=53 imm=0
@@ -1562,7 +1562,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 248 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
+        // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
 #line 249 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
     // EBPF_OP_STXB pc=431 dst=r0 src=r1 offset=54 imm=0
@@ -1585,7 +1585,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 251 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
+        // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
 #line 252 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_STXB pc=438 dst=r0 src=r1 offset=55 imm=0
@@ -1608,7 +1608,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 254 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
+        // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
 #line 255 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
     // EBPF_OP_STXB pc=445 dst=r0 src=r1 offset=56 imm=0
@@ -1631,7 +1631,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 257 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
+        // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
 #line 258 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_STXB pc=452 dst=r0 src=r1 offset=57 imm=0
@@ -1654,7 +1654,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 260 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
+        // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
 #line 261 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
     // EBPF_OP_STXB pc=459 dst=r0 src=r1 offset=58 imm=0
@@ -1677,7 +1677,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 263 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
+        // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
 #line 264 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
     // EBPF_OP_STXB pc=466 dst=r0 src=r1 offset=59 imm=0
@@ -1700,7 +1700,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 266 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
 #line 267 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_STXB pc=473 dst=r0 src=r1 offset=60 imm=0
@@ -1723,7 +1723,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 269 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
+        // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
 #line 270 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
     // EBPF_OP_STXB pc=480 dst=r0 src=r1 offset=61 imm=0
@@ -1746,7 +1746,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 272 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
+        // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
 #line 273 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
     // EBPF_OP_STXB pc=487 dst=r0 src=r1 offset=62 imm=0
@@ -1769,7 +1769,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 275 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
+        // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
 #line 276 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
     // EBPF_OP_STXB pc=494 dst=r0 src=r1 offset=63 imm=0
@@ -1792,7 +1792,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 278 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
+        // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
 #line 279 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
     // EBPF_OP_STXB pc=501 dst=r0 src=r1 offset=64 imm=0
@@ -1815,7 +1815,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 281 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
+        // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
 #line 282 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
     // EBPF_OP_STXB pc=508 dst=r0 src=r1 offset=65 imm=0
@@ -1838,7 +1838,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 284 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
+        // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
 #line 285 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
     // EBPF_OP_STXB pc=515 dst=r0 src=r1 offset=66 imm=0
@@ -1861,7 +1861,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 287 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
+        // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
 #line 288 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
     // EBPF_OP_STXB pc=522 dst=r0 src=r1 offset=67 imm=0
@@ -1879,7 +1879,7 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 328 "sample/bindmonitor.c"
         goto label_6;
-    // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
 #line 329 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
@@ -1891,10 +1891,10 @@ label_5:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=529 dst=r1 src=r0 offset=0 imm=32
 #line 336 "sample/bindmonitor.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=530 dst=r1 src=r0 offset=0 imm=32
 #line 336 "sample/bindmonitor.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=531 dst=r1 src=r0 offset=15 imm=0
 #line 336 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
@@ -1925,7 +1925,7 @@ label_6:
     if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
 #line 338 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
+        // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
 #line 338 "sample/bindmonitor.c"
     goto label_8;
 label_7:
@@ -1943,7 +1943,7 @@ label_7:
     if (r1 >= r2)
 #line 321 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
 #line 325 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=545 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_sys.c
@@ -293,7 +293,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 52 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
+        // EBPF_OP_STXDW pc=4 dst=r10 src=r0 offset=-8 imm=0
 #line 52 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r0;
     // EBPF_OP_STXDW pc=5 dst=r10 src=r8 offset=-72 imm=0
@@ -314,7 +314,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[1].tail_call) && (r0 == 0))
 #line 55 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXDW pc=9 dst=r10 src=r0 offset=-80 imm=0
 #line 55 "sample/bindmonitor.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=10 dst=r1 src=r6 offset=0 imm=0
@@ -329,7 +329,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[2].tail_call) && (r0 == 0))
 #line 56 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXW pc=12 dst=r10 src=r0 offset=-72 imm=0
 #line 56 "sample/bindmonitor.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint32_t)r0;
     // EBPF_OP_MOV64_REG pc=13 dst=r2 src=r10 offset=0 imm=0
@@ -359,7 +359,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 58 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r2 src=r10 offset=0 imm=0
 #line 58 "sample/bindmonitor.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=22 dst=r2 src=r0 offset=0 imm=-84
@@ -377,7 +377,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 308 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=26 dst=r7 src=r0 offset=0 imm=0
 #line 308 "sample/bindmonitor.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=27 dst=r7 src=r0 offset=519 imm=0
@@ -385,7 +385,7 @@ BindMonitor(void* context)
     if (r7 == IMMEDIATE(0))
 #line 309 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=28 dst=r1 src=r7 offset=0 imm=0
 #line 309 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=29 dst=r1 src=r0 offset=517 imm=0
@@ -393,7 +393,7 @@ BindMonitor(void* context)
     if (r1 == IMMEDIATE(0))
 #line 309 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=30 dst=r1 src=r6 offset=16 imm=0
 #line 64 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-8 imm=0
@@ -447,7 +447,7 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 69 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
+        // EBPF_OP_JEQ_IMM pc=47 dst=r0 src=r0 offset=7 imm=0
 #line 70 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 70 "sample/bindmonitor.c"
@@ -470,12 +470,12 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 319 "sample/bindmonitor.c"
         goto label_7;
-    // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
+        // EBPF_OP_JEQ_IMM pc=52 dst=r1 src=r0 offset=471 imm=2
 #line 319 "sample/bindmonitor.c"
     if (r1 == IMMEDIATE(2))
 #line 319 "sample/bindmonitor.c"
         goto label_4;
-    // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=53 dst=r1 src=r0 offset=0 imm=0
 #line 336 "sample/bindmonitor.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=54 dst=r0 src=r0 offset=473 imm=0
@@ -490,7 +490,7 @@ label_3:
     if (r1 != IMMEDIATE(0))
 #line 74 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=58 dst=r1 src=r0 offset=487 imm=0
@@ -498,7 +498,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 78 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=59 dst=r1 src=r6 offset=8 imm=0
 #line 78 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=485 imm=0
@@ -506,7 +506,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 78 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=61 dst=r8 src=r10 offset=0 imm=0
 #line 78 "sample/bindmonitor.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=62 dst=r8 src=r0 offset=0 imm=-8
@@ -536,7 +536,7 @@ label_3:
     if ((BindMonitor_helpers[3].tail_call) && (r0 == 0))
 #line 82 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=70 dst=r1 src=r0 offset=0 imm=0
 #line 83 "sample/bindmonitor.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=72 dst=r2 src=r8 offset=0 imm=0
@@ -551,12 +551,12 @@ label_3:
     if ((BindMonitor_helpers[4].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
+        // EBPF_OP_JEQ_IMM pc=74 dst=r0 src=r0 offset=471 imm=0
 #line 84 "sample/bindmonitor.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=75 dst=r1 src=r6 offset=0 imm=0
 #line 98 "sample/bindmonitor.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=76 dst=r2 src=r6 offset=8 imm=0
@@ -573,7 +573,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 98 "sample/bindmonitor.c"
         goto label_1;
-    // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXB pc=80 dst=r1 src=r1 offset=0 imm=0
 #line 99 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_STXB pc=81 dst=r0 src=r1 offset=4 imm=0
@@ -596,7 +596,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 101 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
+        // EBPF_OP_LDXB pc=87 dst=r1 src=r1 offset=1 imm=0
 #line 102 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_STXB pc=88 dst=r0 src=r1 offset=5 imm=0
@@ -619,7 +619,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 104 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
+        // EBPF_OP_LDXB pc=94 dst=r1 src=r1 offset=2 imm=0
 #line 105 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
     // EBPF_OP_STXB pc=95 dst=r0 src=r1 offset=6 imm=0
@@ -642,7 +642,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 107 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
+        // EBPF_OP_LDXB pc=101 dst=r1 src=r1 offset=3 imm=0
 #line 108 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_STXB pc=102 dst=r0 src=r1 offset=7 imm=0
@@ -665,7 +665,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 110 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXB pc=108 dst=r1 src=r1 offset=4 imm=0
 #line 111 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_STXB pc=109 dst=r0 src=r1 offset=8 imm=0
@@ -688,7 +688,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 113 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=115 dst=r1 src=r1 offset=5 imm=0
 #line 114 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_STXB pc=116 dst=r0 src=r1 offset=9 imm=0
@@ -711,7 +711,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 116 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
+        // EBPF_OP_LDXB pc=122 dst=r1 src=r1 offset=6 imm=0
 #line 117 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
     // EBPF_OP_STXB pc=123 dst=r0 src=r1 offset=10 imm=0
@@ -734,7 +734,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 119 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
+        // EBPF_OP_LDXB pc=129 dst=r1 src=r1 offset=7 imm=0
 #line 120 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
     // EBPF_OP_STXB pc=130 dst=r0 src=r1 offset=11 imm=0
@@ -757,7 +757,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 122 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
+        // EBPF_OP_LDXB pc=136 dst=r1 src=r1 offset=8 imm=0
 #line 123 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_STXB pc=137 dst=r0 src=r1 offset=12 imm=0
@@ -780,7 +780,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 125 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
+        // EBPF_OP_LDXB pc=143 dst=r1 src=r1 offset=9 imm=0
 #line 126 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_STXB pc=144 dst=r0 src=r1 offset=13 imm=0
@@ -803,7 +803,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 128 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
+        // EBPF_OP_LDXB pc=150 dst=r1 src=r1 offset=10 imm=0
 #line 129 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
     // EBPF_OP_STXB pc=151 dst=r0 src=r1 offset=14 imm=0
@@ -826,7 +826,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 131 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
+        // EBPF_OP_LDXB pc=157 dst=r1 src=r1 offset=11 imm=0
 #line 132 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
     // EBPF_OP_STXB pc=158 dst=r0 src=r1 offset=15 imm=0
@@ -849,7 +849,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 134 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXB pc=164 dst=r1 src=r1 offset=12 imm=0
 #line 135 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_STXB pc=165 dst=r0 src=r1 offset=16 imm=0
@@ -872,7 +872,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 137 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
+        // EBPF_OP_LDXB pc=171 dst=r1 src=r1 offset=13 imm=0
 #line 138 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
     // EBPF_OP_STXB pc=172 dst=r0 src=r1 offset=17 imm=0
@@ -895,7 +895,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 140 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=178 dst=r1 src=r1 offset=14 imm=0
 #line 141 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_STXB pc=179 dst=r0 src=r1 offset=18 imm=0
@@ -918,7 +918,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 143 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
+        // EBPF_OP_LDXB pc=185 dst=r1 src=r1 offset=15 imm=0
 #line 144 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
     // EBPF_OP_STXB pc=186 dst=r0 src=r1 offset=19 imm=0
@@ -941,7 +941,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 146 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
+        // EBPF_OP_LDXB pc=192 dst=r1 src=r1 offset=16 imm=0
 #line 147 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
     // EBPF_OP_STXB pc=193 dst=r0 src=r1 offset=20 imm=0
@@ -964,7 +964,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 149 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
+        // EBPF_OP_LDXB pc=199 dst=r1 src=r1 offset=17 imm=0
 #line 150 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
     // EBPF_OP_STXB pc=200 dst=r0 src=r1 offset=21 imm=0
@@ -987,7 +987,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 152 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
+        // EBPF_OP_LDXB pc=206 dst=r1 src=r1 offset=18 imm=0
 #line 153 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
     // EBPF_OP_STXB pc=207 dst=r0 src=r1 offset=22 imm=0
@@ -1010,7 +1010,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 155 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
+        // EBPF_OP_LDXB pc=213 dst=r1 src=r1 offset=19 imm=0
 #line 156 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
     // EBPF_OP_STXB pc=214 dst=r0 src=r1 offset=23 imm=0
@@ -1033,7 +1033,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 158 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=220 dst=r1 src=r1 offset=20 imm=0
 #line 159 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_STXB pc=221 dst=r0 src=r1 offset=24 imm=0
@@ -1056,7 +1056,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 161 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
+        // EBPF_OP_LDXB pc=227 dst=r1 src=r1 offset=21 imm=0
 #line 162 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
     // EBPF_OP_STXB pc=228 dst=r0 src=r1 offset=25 imm=0
@@ -1079,7 +1079,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 164 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
+        // EBPF_OP_LDXB pc=234 dst=r1 src=r1 offset=22 imm=0
 #line 165 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
     // EBPF_OP_STXB pc=235 dst=r0 src=r1 offset=26 imm=0
@@ -1102,7 +1102,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 167 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=241 dst=r1 src=r1 offset=23 imm=0
 #line 168 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_STXB pc=242 dst=r0 src=r1 offset=27 imm=0
@@ -1125,7 +1125,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 170 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
+        // EBPF_OP_LDXB pc=248 dst=r1 src=r1 offset=24 imm=0
 #line 171 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_STXB pc=249 dst=r0 src=r1 offset=28 imm=0
@@ -1148,7 +1148,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 173 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
+        // EBPF_OP_LDXB pc=255 dst=r1 src=r1 offset=25 imm=0
 #line 174 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
     // EBPF_OP_STXB pc=256 dst=r0 src=r1 offset=29 imm=0
@@ -1171,7 +1171,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 176 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
+        // EBPF_OP_LDXB pc=262 dst=r1 src=r1 offset=26 imm=0
 #line 177 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
     // EBPF_OP_STXB pc=263 dst=r0 src=r1 offset=30 imm=0
@@ -1194,7 +1194,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 179 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
+        // EBPF_OP_LDXB pc=269 dst=r1 src=r1 offset=27 imm=0
 #line 180 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
     // EBPF_OP_STXB pc=270 dst=r0 src=r1 offset=31 imm=0
@@ -1217,7 +1217,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 182 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
+        // EBPF_OP_LDXB pc=276 dst=r1 src=r1 offset=28 imm=0
 #line 183 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
     // EBPF_OP_STXB pc=277 dst=r0 src=r1 offset=32 imm=0
@@ -1240,7 +1240,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 185 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
+        // EBPF_OP_LDXB pc=283 dst=r1 src=r1 offset=29 imm=0
 #line 186 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
     // EBPF_OP_STXB pc=284 dst=r0 src=r1 offset=33 imm=0
@@ -1263,7 +1263,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 188 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
+        // EBPF_OP_LDXB pc=290 dst=r1 src=r1 offset=30 imm=0
 #line 189 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
     // EBPF_OP_STXB pc=291 dst=r0 src=r1 offset=34 imm=0
@@ -1286,7 +1286,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 191 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
+        // EBPF_OP_LDXB pc=297 dst=r1 src=r1 offset=31 imm=0
 #line 192 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
     // EBPF_OP_STXB pc=298 dst=r0 src=r1 offset=35 imm=0
@@ -1309,7 +1309,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 194 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
+        // EBPF_OP_LDXB pc=304 dst=r1 src=r1 offset=32 imm=0
 #line 195 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
     // EBPF_OP_STXB pc=305 dst=r0 src=r1 offset=36 imm=0
@@ -1332,7 +1332,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 197 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
+        // EBPF_OP_LDXB pc=311 dst=r1 src=r1 offset=33 imm=0
 #line 198 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
     // EBPF_OP_STXB pc=312 dst=r0 src=r1 offset=37 imm=0
@@ -1355,7 +1355,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 200 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
+        // EBPF_OP_LDXB pc=318 dst=r1 src=r1 offset=34 imm=0
 #line 201 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
     // EBPF_OP_STXB pc=319 dst=r0 src=r1 offset=38 imm=0
@@ -1378,7 +1378,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 203 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
+        // EBPF_OP_LDXB pc=325 dst=r1 src=r1 offset=35 imm=0
 #line 204 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
     // EBPF_OP_STXB pc=326 dst=r0 src=r1 offset=39 imm=0
@@ -1401,7 +1401,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 206 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
+        // EBPF_OP_LDXB pc=332 dst=r1 src=r1 offset=36 imm=0
 #line 207 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
     // EBPF_OP_STXB pc=333 dst=r0 src=r1 offset=40 imm=0
@@ -1424,7 +1424,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 209 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
+        // EBPF_OP_LDXB pc=339 dst=r1 src=r1 offset=37 imm=0
 #line 210 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
     // EBPF_OP_STXB pc=340 dst=r0 src=r1 offset=41 imm=0
@@ -1447,7 +1447,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 212 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
+        // EBPF_OP_LDXB pc=346 dst=r1 src=r1 offset=38 imm=0
 #line 213 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
     // EBPF_OP_STXB pc=347 dst=r0 src=r1 offset=42 imm=0
@@ -1470,7 +1470,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 215 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
+        // EBPF_OP_LDXB pc=353 dst=r1 src=r1 offset=39 imm=0
 #line 216 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_STXB pc=354 dst=r0 src=r1 offset=43 imm=0
@@ -1493,7 +1493,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 218 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
+        // EBPF_OP_LDXB pc=360 dst=r1 src=r1 offset=40 imm=0
 #line 219 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_STXB pc=361 dst=r0 src=r1 offset=44 imm=0
@@ -1516,7 +1516,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 221 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
+        // EBPF_OP_LDXB pc=367 dst=r1 src=r1 offset=41 imm=0
 #line 222 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_STXB pc=368 dst=r0 src=r1 offset=45 imm=0
@@ -1539,7 +1539,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 224 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
+        // EBPF_OP_LDXB pc=374 dst=r1 src=r1 offset=42 imm=0
 #line 225 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
     // EBPF_OP_STXB pc=375 dst=r0 src=r1 offset=46 imm=0
@@ -1562,7 +1562,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 227 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
+        // EBPF_OP_LDXB pc=381 dst=r1 src=r1 offset=43 imm=0
 #line 228 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_STXB pc=382 dst=r0 src=r1 offset=47 imm=0
@@ -1585,7 +1585,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 230 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
+        // EBPF_OP_LDXB pc=388 dst=r1 src=r1 offset=44 imm=0
 #line 231 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_STXB pc=389 dst=r0 src=r1 offset=48 imm=0
@@ -1608,7 +1608,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 233 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
+        // EBPF_OP_LDXB pc=395 dst=r1 src=r1 offset=45 imm=0
 #line 234 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_STXB pc=396 dst=r0 src=r1 offset=49 imm=0
@@ -1631,7 +1631,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 236 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
+        // EBPF_OP_LDXB pc=402 dst=r1 src=r1 offset=46 imm=0
 #line 237 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
     // EBPF_OP_STXB pc=403 dst=r0 src=r1 offset=50 imm=0
@@ -1654,7 +1654,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 239 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
+        // EBPF_OP_LDXB pc=409 dst=r1 src=r1 offset=47 imm=0
 #line 240 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_STXB pc=410 dst=r0 src=r1 offset=51 imm=0
@@ -1677,7 +1677,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 242 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
+        // EBPF_OP_LDXB pc=416 dst=r1 src=r1 offset=48 imm=0
 #line 243 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
     // EBPF_OP_STXB pc=417 dst=r0 src=r1 offset=52 imm=0
@@ -1700,7 +1700,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 245 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
+        // EBPF_OP_LDXB pc=423 dst=r1 src=r1 offset=49 imm=0
 #line 246 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_STXB pc=424 dst=r0 src=r1 offset=53 imm=0
@@ -1723,7 +1723,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 248 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
+        // EBPF_OP_LDXB pc=430 dst=r1 src=r1 offset=50 imm=0
 #line 249 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
     // EBPF_OP_STXB pc=431 dst=r0 src=r1 offset=54 imm=0
@@ -1746,7 +1746,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 251 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
+        // EBPF_OP_LDXB pc=437 dst=r1 src=r1 offset=51 imm=0
 #line 252 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_STXB pc=438 dst=r0 src=r1 offset=55 imm=0
@@ -1769,7 +1769,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 254 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
+        // EBPF_OP_LDXB pc=444 dst=r1 src=r1 offset=52 imm=0
 #line 255 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
     // EBPF_OP_STXB pc=445 dst=r0 src=r1 offset=56 imm=0
@@ -1792,7 +1792,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 257 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
+        // EBPF_OP_LDXB pc=451 dst=r1 src=r1 offset=53 imm=0
 #line 258 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_STXB pc=452 dst=r0 src=r1 offset=57 imm=0
@@ -1815,7 +1815,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 260 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
+        // EBPF_OP_LDXB pc=458 dst=r1 src=r1 offset=54 imm=0
 #line 261 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
     // EBPF_OP_STXB pc=459 dst=r0 src=r1 offset=58 imm=0
@@ -1838,7 +1838,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 263 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
+        // EBPF_OP_LDXB pc=465 dst=r1 src=r1 offset=55 imm=0
 #line 264 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
     // EBPF_OP_STXB pc=466 dst=r0 src=r1 offset=59 imm=0
@@ -1861,7 +1861,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 266 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXB pc=472 dst=r1 src=r1 offset=56 imm=0
 #line 267 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_STXB pc=473 dst=r0 src=r1 offset=60 imm=0
@@ -1884,7 +1884,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 269 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
+        // EBPF_OP_LDXB pc=479 dst=r1 src=r1 offset=57 imm=0
 #line 270 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
     // EBPF_OP_STXB pc=480 dst=r0 src=r1 offset=61 imm=0
@@ -1907,7 +1907,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 272 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
+        // EBPF_OP_LDXB pc=486 dst=r1 src=r1 offset=58 imm=0
 #line 273 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
     // EBPF_OP_STXB pc=487 dst=r0 src=r1 offset=62 imm=0
@@ -1930,7 +1930,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 275 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
+        // EBPF_OP_LDXB pc=493 dst=r1 src=r1 offset=59 imm=0
 #line 276 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
     // EBPF_OP_STXB pc=494 dst=r0 src=r1 offset=63 imm=0
@@ -1953,7 +1953,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 278 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
+        // EBPF_OP_LDXB pc=500 dst=r1 src=r1 offset=60 imm=0
 #line 279 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
     // EBPF_OP_STXB pc=501 dst=r0 src=r1 offset=64 imm=0
@@ -1976,7 +1976,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 281 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
+        // EBPF_OP_LDXB pc=507 dst=r1 src=r1 offset=61 imm=0
 #line 282 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
     // EBPF_OP_STXB pc=508 dst=r0 src=r1 offset=65 imm=0
@@ -1999,7 +1999,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 284 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
+        // EBPF_OP_LDXB pc=514 dst=r1 src=r1 offset=62 imm=0
 #line 285 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
     // EBPF_OP_STXB pc=515 dst=r0 src=r1 offset=66 imm=0
@@ -2022,7 +2022,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 287 "sample/bindmonitor.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
+        // EBPF_OP_LDXB pc=521 dst=r1 src=r1 offset=63 imm=0
 #line 288 "sample/bindmonitor.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
     // EBPF_OP_STXB pc=522 dst=r0 src=r1 offset=67 imm=0
@@ -2040,7 +2040,7 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 328 "sample/bindmonitor.c"
         goto label_6;
-    // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=-1
 #line 329 "sample/bindmonitor.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0
@@ -2052,10 +2052,10 @@ label_5:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=529 dst=r1 src=r0 offset=0 imm=32
 #line 336 "sample/bindmonitor.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=530 dst=r1 src=r0 offset=0 imm=32
 #line 336 "sample/bindmonitor.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=531 dst=r1 src=r0 offset=15 imm=0
 #line 336 "sample/bindmonitor.c"
     if (r1 != IMMEDIATE(0))
@@ -2086,7 +2086,7 @@ label_6:
     if ((BindMonitor_helpers[5].tail_call) && (r0 == 0))
 #line 338 "sample/bindmonitor.c"
         return 0;
-    // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
+        // EBPF_OP_JA pc=539 dst=r0 src=r0 offset=6 imm=0
 #line 338 "sample/bindmonitor.c"
     goto label_8;
 label_7:
@@ -2104,7 +2104,7 @@ label_7:
     if (r1 >= r2)
 #line 321 "sample/bindmonitor.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=544 dst=r1 src=r0 offset=0 imm=1
 #line 325 "sample/bindmonitor.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=545 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_dll.c
@@ -206,12 +206,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 318 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 320 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 320 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 323 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -313,12 +313,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 334 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 336 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 336 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 339 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -425,7 +425,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 351 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 351 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=519 imm=0
@@ -433,7 +433,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 352 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 352 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=517 imm=0
@@ -441,7 +441,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 352 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -495,7 +495,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
@@ -518,12 +518,12 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 362 "sample/bindmonitor_tailcall.c"
         goto label_7;
-    // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
+        // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
 #line 362 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(2))
 #line 362 "sample/bindmonitor_tailcall.c"
         goto label_4;
-    // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 379 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=36 dst=r0 src=r0 offset=473 imm=0
@@ -538,7 +538,7 @@ label_3:
     if (r1 != IMMEDIATE(0))
 #line 88 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=40 dst=r1 src=r0 offset=487 imm=0
@@ -546,7 +546,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=485 imm=0
@@ -554,7 +554,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=44 dst=r8 src=r0 offset=0 imm=-8
@@ -584,7 +584,7 @@ label_3:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 96 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 97 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=54 dst=r2 src=r8 offset=0 imm=0
@@ -599,12 +599,12 @@ label_3:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 97 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
+        // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
 #line 98 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 98 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 112 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=58 dst=r2 src=r6 offset=8 imm=0
@@ -621,7 +621,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 112 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
 #line 113 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_STXB pc=63 dst=r0 src=r1 offset=4 imm=0
@@ -644,7 +644,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 115 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
+        // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
 #line 116 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_STXB pc=70 dst=r0 src=r1 offset=5 imm=0
@@ -667,7 +667,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 118 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
+        // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
 #line 119 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
     // EBPF_OP_STXB pc=77 dst=r0 src=r1 offset=6 imm=0
@@ -690,7 +690,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 121 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
+        // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
 #line 122 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_STXB pc=84 dst=r0 src=r1 offset=7 imm=0
@@ -713,7 +713,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 124 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
 #line 125 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_STXB pc=91 dst=r0 src=r1 offset=8 imm=0
@@ -736,7 +736,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 127 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
 #line 128 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_STXB pc=98 dst=r0 src=r1 offset=9 imm=0
@@ -759,7 +759,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 130 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
+        // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
 #line 131 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
     // EBPF_OP_STXB pc=105 dst=r0 src=r1 offset=10 imm=0
@@ -782,7 +782,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 133 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
+        // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
 #line 134 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
     // EBPF_OP_STXB pc=112 dst=r0 src=r1 offset=11 imm=0
@@ -805,7 +805,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 136 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
+        // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
 #line 137 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_STXB pc=119 dst=r0 src=r1 offset=12 imm=0
@@ -828,7 +828,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 139 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
+        // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
 #line 140 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_STXB pc=126 dst=r0 src=r1 offset=13 imm=0
@@ -851,7 +851,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 142 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
+        // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
 #line 143 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
     // EBPF_OP_STXB pc=133 dst=r0 src=r1 offset=14 imm=0
@@ -874,7 +874,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 145 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
+        // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
 #line 146 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
     // EBPF_OP_STXB pc=140 dst=r0 src=r1 offset=15 imm=0
@@ -897,7 +897,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 148 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
 #line 149 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_STXB pc=147 dst=r0 src=r1 offset=16 imm=0
@@ -920,7 +920,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
+        // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
 #line 152 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
     // EBPF_OP_STXB pc=154 dst=r0 src=r1 offset=17 imm=0
@@ -943,7 +943,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 154 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
 #line 155 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_STXB pc=161 dst=r0 src=r1 offset=18 imm=0
@@ -966,7 +966,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
+        // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
 #line 158 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
     // EBPF_OP_STXB pc=168 dst=r0 src=r1 offset=19 imm=0
@@ -989,7 +989,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
+        // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
 #line 161 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
     // EBPF_OP_STXB pc=175 dst=r0 src=r1 offset=20 imm=0
@@ -1012,7 +1012,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 163 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
+        // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
 #line 164 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
     // EBPF_OP_STXB pc=182 dst=r0 src=r1 offset=21 imm=0
@@ -1035,7 +1035,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 166 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
+        // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
     // EBPF_OP_STXB pc=189 dst=r0 src=r1 offset=22 imm=0
@@ -1058,7 +1058,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
+        // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
 #line 170 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
     // EBPF_OP_STXB pc=196 dst=r0 src=r1 offset=23 imm=0
@@ -1081,7 +1081,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 172 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
 #line 173 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_STXB pc=203 dst=r0 src=r1 offset=24 imm=0
@@ -1104,7 +1104,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 175 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
+        // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
     // EBPF_OP_STXB pc=210 dst=r0 src=r1 offset=25 imm=0
@@ -1127,7 +1127,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 178 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
+        // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
 #line 179 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
     // EBPF_OP_STXB pc=217 dst=r0 src=r1 offset=26 imm=0
@@ -1150,7 +1150,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 181 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
 #line 182 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_STXB pc=224 dst=r0 src=r1 offset=27 imm=0
@@ -1173,7 +1173,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 184 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
+        // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
 #line 185 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_STXB pc=231 dst=r0 src=r1 offset=28 imm=0
@@ -1196,7 +1196,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 187 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
+        // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
 #line 188 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
     // EBPF_OP_STXB pc=238 dst=r0 src=r1 offset=29 imm=0
@@ -1219,7 +1219,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 190 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
+        // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
 #line 191 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
     // EBPF_OP_STXB pc=245 dst=r0 src=r1 offset=30 imm=0
@@ -1242,7 +1242,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 193 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
+        // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
 #line 194 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
     // EBPF_OP_STXB pc=252 dst=r0 src=r1 offset=31 imm=0
@@ -1265,7 +1265,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 196 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
+        // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
 #line 197 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
     // EBPF_OP_STXB pc=259 dst=r0 src=r1 offset=32 imm=0
@@ -1288,7 +1288,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 199 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
+        // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
 #line 200 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
     // EBPF_OP_STXB pc=266 dst=r0 src=r1 offset=33 imm=0
@@ -1311,7 +1311,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 202 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
+        // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
 #line 203 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
     // EBPF_OP_STXB pc=273 dst=r0 src=r1 offset=34 imm=0
@@ -1334,7 +1334,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 205 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
+        // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
 #line 206 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
     // EBPF_OP_STXB pc=280 dst=r0 src=r1 offset=35 imm=0
@@ -1357,7 +1357,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 208 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
+        // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
 #line 209 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
     // EBPF_OP_STXB pc=287 dst=r0 src=r1 offset=36 imm=0
@@ -1380,7 +1380,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 211 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
+        // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
 #line 212 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
     // EBPF_OP_STXB pc=294 dst=r0 src=r1 offset=37 imm=0
@@ -1403,7 +1403,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 214 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
+        // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
 #line 215 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
     // EBPF_OP_STXB pc=301 dst=r0 src=r1 offset=38 imm=0
@@ -1426,7 +1426,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 217 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
+        // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
 #line 218 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
     // EBPF_OP_STXB pc=308 dst=r0 src=r1 offset=39 imm=0
@@ -1449,7 +1449,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 220 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
+        // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
 #line 221 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
     // EBPF_OP_STXB pc=315 dst=r0 src=r1 offset=40 imm=0
@@ -1472,7 +1472,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 223 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
+        // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
 #line 224 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
     // EBPF_OP_STXB pc=322 dst=r0 src=r1 offset=41 imm=0
@@ -1495,7 +1495,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 226 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
+        // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
 #line 227 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
     // EBPF_OP_STXB pc=329 dst=r0 src=r1 offset=42 imm=0
@@ -1518,7 +1518,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 229 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
+        // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
 #line 230 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_STXB pc=336 dst=r0 src=r1 offset=43 imm=0
@@ -1541,7 +1541,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 232 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
+        // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
 #line 233 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_STXB pc=343 dst=r0 src=r1 offset=44 imm=0
@@ -1564,7 +1564,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 235 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
+        // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
 #line 236 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_STXB pc=350 dst=r0 src=r1 offset=45 imm=0
@@ -1587,7 +1587,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 238 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
+        // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
 #line 239 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
     // EBPF_OP_STXB pc=357 dst=r0 src=r1 offset=46 imm=0
@@ -1610,7 +1610,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 241 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
+        // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
 #line 242 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_STXB pc=364 dst=r0 src=r1 offset=47 imm=0
@@ -1633,7 +1633,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 244 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
+        // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
 #line 245 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_STXB pc=371 dst=r0 src=r1 offset=48 imm=0
@@ -1656,7 +1656,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 247 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
+        // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
 #line 248 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_STXB pc=378 dst=r0 src=r1 offset=49 imm=0
@@ -1679,7 +1679,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 250 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
+        // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
 #line 251 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
     // EBPF_OP_STXB pc=385 dst=r0 src=r1 offset=50 imm=0
@@ -1702,7 +1702,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 253 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
+        // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
 #line 254 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_STXB pc=392 dst=r0 src=r1 offset=51 imm=0
@@ -1725,7 +1725,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 256 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
+        // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
 #line 257 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
     // EBPF_OP_STXB pc=399 dst=r0 src=r1 offset=52 imm=0
@@ -1748,7 +1748,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 259 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
+        // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
 #line 260 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_STXB pc=406 dst=r0 src=r1 offset=53 imm=0
@@ -1771,7 +1771,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 262 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
+        // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
 #line 263 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
     // EBPF_OP_STXB pc=413 dst=r0 src=r1 offset=54 imm=0
@@ -1794,7 +1794,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 265 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
+        // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
 #line 266 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_STXB pc=420 dst=r0 src=r1 offset=55 imm=0
@@ -1817,7 +1817,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 268 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
+        // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
 #line 269 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
     // EBPF_OP_STXB pc=427 dst=r0 src=r1 offset=56 imm=0
@@ -1840,7 +1840,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 271 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
+        // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
 #line 272 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_STXB pc=434 dst=r0 src=r1 offset=57 imm=0
@@ -1863,7 +1863,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 274 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
+        // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
 #line 275 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
     // EBPF_OP_STXB pc=441 dst=r0 src=r1 offset=58 imm=0
@@ -1886,7 +1886,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 277 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
+        // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
 #line 278 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
     // EBPF_OP_STXB pc=448 dst=r0 src=r1 offset=59 imm=0
@@ -1909,7 +1909,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 280 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
 #line 281 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_STXB pc=455 dst=r0 src=r1 offset=60 imm=0
@@ -1932,7 +1932,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 283 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
+        // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
 #line 284 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
     // EBPF_OP_STXB pc=462 dst=r0 src=r1 offset=61 imm=0
@@ -1955,7 +1955,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 286 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
+        // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
 #line 287 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
     // EBPF_OP_STXB pc=469 dst=r0 src=r1 offset=62 imm=0
@@ -1978,7 +1978,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 289 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
+        // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
 #line 290 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
     // EBPF_OP_STXB pc=476 dst=r0 src=r1 offset=63 imm=0
@@ -2001,7 +2001,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 292 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
+        // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
 #line 293 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
     // EBPF_OP_STXB pc=483 dst=r0 src=r1 offset=64 imm=0
@@ -2024,7 +2024,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 295 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
+        // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
 #line 296 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
     // EBPF_OP_STXB pc=490 dst=r0 src=r1 offset=65 imm=0
@@ -2047,7 +2047,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 298 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
+        // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
 #line 299 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
     // EBPF_OP_STXB pc=497 dst=r0 src=r1 offset=66 imm=0
@@ -2070,7 +2070,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 301 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
+        // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
 #line 302 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
     // EBPF_OP_STXB pc=504 dst=r0 src=r1 offset=67 imm=0
@@ -2088,7 +2088,7 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 371 "sample/bindmonitor_tailcall.c"
         goto label_6;
-    // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
 #line 372 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=509 dst=r0 src=r1 offset=0 imm=0
@@ -2100,10 +2100,10 @@ label_5:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
 #line 379 "sample/bindmonitor_tailcall.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=512 dst=r1 src=r0 offset=0 imm=32
 #line 379 "sample/bindmonitor_tailcall.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=513 dst=r1 src=r0 offset=15 imm=0
 #line 379 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
@@ -2134,7 +2134,7 @@ label_6:
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
 #line 381 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
+        // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
 #line 381 "sample/bindmonitor_tailcall.c"
     goto label_8;
 label_7:
@@ -2152,7 +2152,7 @@ label_7:
     if (r1 >= r2)
 #line 364 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
 #line 368 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_raw.c
@@ -180,12 +180,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 318 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 320 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 320 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 323 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -287,12 +287,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 334 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 336 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 336 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 339 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -399,7 +399,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 351 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 351 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=519 imm=0
@@ -407,7 +407,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 352 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 352 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=517 imm=0
@@ -415,7 +415,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 352 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -469,7 +469,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
@@ -492,12 +492,12 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 362 "sample/bindmonitor_tailcall.c"
         goto label_7;
-    // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
+        // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
 #line 362 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(2))
 #line 362 "sample/bindmonitor_tailcall.c"
         goto label_4;
-    // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 379 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=36 dst=r0 src=r0 offset=473 imm=0
@@ -512,7 +512,7 @@ label_3:
     if (r1 != IMMEDIATE(0))
 #line 88 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=40 dst=r1 src=r0 offset=487 imm=0
@@ -520,7 +520,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=485 imm=0
@@ -528,7 +528,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=44 dst=r8 src=r0 offset=0 imm=-8
@@ -558,7 +558,7 @@ label_3:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 96 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 97 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=54 dst=r2 src=r8 offset=0 imm=0
@@ -573,12 +573,12 @@ label_3:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 97 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
+        // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
 #line 98 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 98 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 112 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=58 dst=r2 src=r6 offset=8 imm=0
@@ -595,7 +595,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 112 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
 #line 113 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_STXB pc=63 dst=r0 src=r1 offset=4 imm=0
@@ -618,7 +618,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 115 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
+        // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
 #line 116 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_STXB pc=70 dst=r0 src=r1 offset=5 imm=0
@@ -641,7 +641,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 118 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
+        // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
 #line 119 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
     // EBPF_OP_STXB pc=77 dst=r0 src=r1 offset=6 imm=0
@@ -664,7 +664,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 121 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
+        // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
 #line 122 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_STXB pc=84 dst=r0 src=r1 offset=7 imm=0
@@ -687,7 +687,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 124 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
 #line 125 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_STXB pc=91 dst=r0 src=r1 offset=8 imm=0
@@ -710,7 +710,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 127 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
 #line 128 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_STXB pc=98 dst=r0 src=r1 offset=9 imm=0
@@ -733,7 +733,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 130 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
+        // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
 #line 131 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
     // EBPF_OP_STXB pc=105 dst=r0 src=r1 offset=10 imm=0
@@ -756,7 +756,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 133 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
+        // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
 #line 134 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
     // EBPF_OP_STXB pc=112 dst=r0 src=r1 offset=11 imm=0
@@ -779,7 +779,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 136 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
+        // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
 #line 137 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_STXB pc=119 dst=r0 src=r1 offset=12 imm=0
@@ -802,7 +802,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 139 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
+        // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
 #line 140 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_STXB pc=126 dst=r0 src=r1 offset=13 imm=0
@@ -825,7 +825,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 142 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
+        // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
 #line 143 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
     // EBPF_OP_STXB pc=133 dst=r0 src=r1 offset=14 imm=0
@@ -848,7 +848,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 145 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
+        // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
 #line 146 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
     // EBPF_OP_STXB pc=140 dst=r0 src=r1 offset=15 imm=0
@@ -871,7 +871,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 148 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
 #line 149 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_STXB pc=147 dst=r0 src=r1 offset=16 imm=0
@@ -894,7 +894,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
+        // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
 #line 152 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
     // EBPF_OP_STXB pc=154 dst=r0 src=r1 offset=17 imm=0
@@ -917,7 +917,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 154 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
 #line 155 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_STXB pc=161 dst=r0 src=r1 offset=18 imm=0
@@ -940,7 +940,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
+        // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
 #line 158 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
     // EBPF_OP_STXB pc=168 dst=r0 src=r1 offset=19 imm=0
@@ -963,7 +963,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
+        // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
 #line 161 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
     // EBPF_OP_STXB pc=175 dst=r0 src=r1 offset=20 imm=0
@@ -986,7 +986,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 163 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
+        // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
 #line 164 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
     // EBPF_OP_STXB pc=182 dst=r0 src=r1 offset=21 imm=0
@@ -1009,7 +1009,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 166 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
+        // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
     // EBPF_OP_STXB pc=189 dst=r0 src=r1 offset=22 imm=0
@@ -1032,7 +1032,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
+        // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
 #line 170 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
     // EBPF_OP_STXB pc=196 dst=r0 src=r1 offset=23 imm=0
@@ -1055,7 +1055,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 172 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
 #line 173 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_STXB pc=203 dst=r0 src=r1 offset=24 imm=0
@@ -1078,7 +1078,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 175 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
+        // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
     // EBPF_OP_STXB pc=210 dst=r0 src=r1 offset=25 imm=0
@@ -1101,7 +1101,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 178 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
+        // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
 #line 179 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
     // EBPF_OP_STXB pc=217 dst=r0 src=r1 offset=26 imm=0
@@ -1124,7 +1124,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 181 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
 #line 182 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_STXB pc=224 dst=r0 src=r1 offset=27 imm=0
@@ -1147,7 +1147,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 184 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
+        // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
 #line 185 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_STXB pc=231 dst=r0 src=r1 offset=28 imm=0
@@ -1170,7 +1170,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 187 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
+        // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
 #line 188 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
     // EBPF_OP_STXB pc=238 dst=r0 src=r1 offset=29 imm=0
@@ -1193,7 +1193,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 190 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
+        // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
 #line 191 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
     // EBPF_OP_STXB pc=245 dst=r0 src=r1 offset=30 imm=0
@@ -1216,7 +1216,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 193 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
+        // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
 #line 194 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
     // EBPF_OP_STXB pc=252 dst=r0 src=r1 offset=31 imm=0
@@ -1239,7 +1239,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 196 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
+        // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
 #line 197 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
     // EBPF_OP_STXB pc=259 dst=r0 src=r1 offset=32 imm=0
@@ -1262,7 +1262,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 199 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
+        // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
 #line 200 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
     // EBPF_OP_STXB pc=266 dst=r0 src=r1 offset=33 imm=0
@@ -1285,7 +1285,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 202 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
+        // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
 #line 203 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
     // EBPF_OP_STXB pc=273 dst=r0 src=r1 offset=34 imm=0
@@ -1308,7 +1308,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 205 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
+        // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
 #line 206 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
     // EBPF_OP_STXB pc=280 dst=r0 src=r1 offset=35 imm=0
@@ -1331,7 +1331,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 208 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
+        // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
 #line 209 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
     // EBPF_OP_STXB pc=287 dst=r0 src=r1 offset=36 imm=0
@@ -1354,7 +1354,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 211 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
+        // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
 #line 212 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
     // EBPF_OP_STXB pc=294 dst=r0 src=r1 offset=37 imm=0
@@ -1377,7 +1377,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 214 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
+        // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
 #line 215 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
     // EBPF_OP_STXB pc=301 dst=r0 src=r1 offset=38 imm=0
@@ -1400,7 +1400,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 217 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
+        // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
 #line 218 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
     // EBPF_OP_STXB pc=308 dst=r0 src=r1 offset=39 imm=0
@@ -1423,7 +1423,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 220 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
+        // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
 #line 221 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
     // EBPF_OP_STXB pc=315 dst=r0 src=r1 offset=40 imm=0
@@ -1446,7 +1446,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 223 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
+        // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
 #line 224 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
     // EBPF_OP_STXB pc=322 dst=r0 src=r1 offset=41 imm=0
@@ -1469,7 +1469,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 226 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
+        // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
 #line 227 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
     // EBPF_OP_STXB pc=329 dst=r0 src=r1 offset=42 imm=0
@@ -1492,7 +1492,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 229 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
+        // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
 #line 230 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_STXB pc=336 dst=r0 src=r1 offset=43 imm=0
@@ -1515,7 +1515,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 232 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
+        // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
 #line 233 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_STXB pc=343 dst=r0 src=r1 offset=44 imm=0
@@ -1538,7 +1538,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 235 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
+        // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
 #line 236 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_STXB pc=350 dst=r0 src=r1 offset=45 imm=0
@@ -1561,7 +1561,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 238 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
+        // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
 #line 239 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
     // EBPF_OP_STXB pc=357 dst=r0 src=r1 offset=46 imm=0
@@ -1584,7 +1584,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 241 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
+        // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
 #line 242 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_STXB pc=364 dst=r0 src=r1 offset=47 imm=0
@@ -1607,7 +1607,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 244 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
+        // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
 #line 245 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_STXB pc=371 dst=r0 src=r1 offset=48 imm=0
@@ -1630,7 +1630,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 247 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
+        // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
 #line 248 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_STXB pc=378 dst=r0 src=r1 offset=49 imm=0
@@ -1653,7 +1653,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 250 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
+        // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
 #line 251 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
     // EBPF_OP_STXB pc=385 dst=r0 src=r1 offset=50 imm=0
@@ -1676,7 +1676,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 253 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
+        // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
 #line 254 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_STXB pc=392 dst=r0 src=r1 offset=51 imm=0
@@ -1699,7 +1699,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 256 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
+        // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
 #line 257 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
     // EBPF_OP_STXB pc=399 dst=r0 src=r1 offset=52 imm=0
@@ -1722,7 +1722,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 259 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
+        // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
 #line 260 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_STXB pc=406 dst=r0 src=r1 offset=53 imm=0
@@ -1745,7 +1745,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 262 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
+        // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
 #line 263 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
     // EBPF_OP_STXB pc=413 dst=r0 src=r1 offset=54 imm=0
@@ -1768,7 +1768,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 265 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
+        // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
 #line 266 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_STXB pc=420 dst=r0 src=r1 offset=55 imm=0
@@ -1791,7 +1791,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 268 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
+        // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
 #line 269 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
     // EBPF_OP_STXB pc=427 dst=r0 src=r1 offset=56 imm=0
@@ -1814,7 +1814,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 271 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
+        // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
 #line 272 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_STXB pc=434 dst=r0 src=r1 offset=57 imm=0
@@ -1837,7 +1837,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 274 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
+        // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
 #line 275 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
     // EBPF_OP_STXB pc=441 dst=r0 src=r1 offset=58 imm=0
@@ -1860,7 +1860,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 277 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
+        // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
 #line 278 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
     // EBPF_OP_STXB pc=448 dst=r0 src=r1 offset=59 imm=0
@@ -1883,7 +1883,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 280 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
 #line 281 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_STXB pc=455 dst=r0 src=r1 offset=60 imm=0
@@ -1906,7 +1906,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 283 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
+        // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
 #line 284 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
     // EBPF_OP_STXB pc=462 dst=r0 src=r1 offset=61 imm=0
@@ -1929,7 +1929,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 286 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
+        // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
 #line 287 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
     // EBPF_OP_STXB pc=469 dst=r0 src=r1 offset=62 imm=0
@@ -1952,7 +1952,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 289 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
+        // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
 #line 290 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
     // EBPF_OP_STXB pc=476 dst=r0 src=r1 offset=63 imm=0
@@ -1975,7 +1975,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 292 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
+        // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
 #line 293 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
     // EBPF_OP_STXB pc=483 dst=r0 src=r1 offset=64 imm=0
@@ -1998,7 +1998,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 295 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
+        // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
 #line 296 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
     // EBPF_OP_STXB pc=490 dst=r0 src=r1 offset=65 imm=0
@@ -2021,7 +2021,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 298 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
+        // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
 #line 299 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
     // EBPF_OP_STXB pc=497 dst=r0 src=r1 offset=66 imm=0
@@ -2044,7 +2044,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 301 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
+        // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
 #line 302 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
     // EBPF_OP_STXB pc=504 dst=r0 src=r1 offset=67 imm=0
@@ -2062,7 +2062,7 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 371 "sample/bindmonitor_tailcall.c"
         goto label_6;
-    // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
 #line 372 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=509 dst=r0 src=r1 offset=0 imm=0
@@ -2074,10 +2074,10 @@ label_5:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
 #line 379 "sample/bindmonitor_tailcall.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=512 dst=r1 src=r0 offset=0 imm=32
 #line 379 "sample/bindmonitor_tailcall.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=513 dst=r1 src=r0 offset=15 imm=0
 #line 379 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
@@ -2108,7 +2108,7 @@ label_6:
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
 #line 381 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
+        // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
 #line 381 "sample/bindmonitor_tailcall.c"
     goto label_8;
 label_7:
@@ -2126,7 +2126,7 @@ label_7:
     if (r1 >= r2)
 #line 364 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
 #line 368 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_tailcall_sys.c
@@ -341,12 +341,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 318 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 320 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 320 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 323 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -448,12 +448,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 334 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 336 "sample/bindmonitor_tailcall.c"
     if (r0 != IMMEDIATE(0))
 #line 336 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 339 "sample/bindmonitor_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -560,7 +560,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 351 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 351 "sample/bindmonitor_tailcall.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=519 imm=0
@@ -568,7 +568,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 352 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 352 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=517 imm=0
@@ -576,7 +576,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 352 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 78 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -630,7 +630,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 83 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=7 imm=0
 #line 84 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 84 "sample/bindmonitor_tailcall.c"
@@ -653,12 +653,12 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 362 "sample/bindmonitor_tailcall.c"
         goto label_7;
-    // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
+        // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=471 imm=2
 #line 362 "sample/bindmonitor_tailcall.c"
     if (r1 == IMMEDIATE(2))
 #line 362 "sample/bindmonitor_tailcall.c"
         goto label_4;
-    // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=35 dst=r1 src=r0 offset=0 imm=0
 #line 379 "sample/bindmonitor_tailcall.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=36 dst=r0 src=r0 offset=473 imm=0
@@ -673,7 +673,7 @@ label_3:
     if (r1 != IMMEDIATE(0))
 #line 88 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=39 dst=r1 src=r6 offset=0 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=40 dst=r1 src=r0 offset=487 imm=0
@@ -681,7 +681,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=41 dst=r1 src=r6 offset=8 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=42 dst=r1 src=r0 offset=485 imm=0
@@ -689,7 +689,7 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 92 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=43 dst=r8 src=r10 offset=0 imm=0
 #line 92 "sample/bindmonitor_tailcall.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=44 dst=r8 src=r0 offset=0 imm=-8
@@ -719,7 +719,7 @@ label_3:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 96 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 97 "sample/bindmonitor_tailcall.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=54 dst=r2 src=r8 offset=0 imm=0
@@ -734,12 +734,12 @@ label_3:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 97 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
+        // EBPF_OP_JEQ_IMM pc=56 dst=r0 src=r0 offset=471 imm=0
 #line 98 "sample/bindmonitor_tailcall.c"
     if (r0 == IMMEDIATE(0))
 #line 98 "sample/bindmonitor_tailcall.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=57 dst=r1 src=r6 offset=0 imm=0
 #line 112 "sample/bindmonitor_tailcall.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_LDXDW pc=58 dst=r2 src=r6 offset=8 imm=0
@@ -756,7 +756,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 112 "sample/bindmonitor_tailcall.c"
         goto label_1;
-    // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXB pc=62 dst=r1 src=r1 offset=0 imm=0
 #line 113 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_STXB pc=63 dst=r0 src=r1 offset=4 imm=0
@@ -779,7 +779,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 115 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
+        // EBPF_OP_LDXB pc=69 dst=r1 src=r1 offset=1 imm=0
 #line 116 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_STXB pc=70 dst=r0 src=r1 offset=5 imm=0
@@ -802,7 +802,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 118 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
+        // EBPF_OP_LDXB pc=76 dst=r1 src=r1 offset=2 imm=0
 #line 119 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
     // EBPF_OP_STXB pc=77 dst=r0 src=r1 offset=6 imm=0
@@ -825,7 +825,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 121 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
+        // EBPF_OP_LDXB pc=83 dst=r1 src=r1 offset=3 imm=0
 #line 122 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_STXB pc=84 dst=r0 src=r1 offset=7 imm=0
@@ -848,7 +848,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 124 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXB pc=90 dst=r1 src=r1 offset=4 imm=0
 #line 125 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_STXB pc=91 dst=r0 src=r1 offset=8 imm=0
@@ -871,7 +871,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 127 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=97 dst=r1 src=r1 offset=5 imm=0
 #line 128 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_STXB pc=98 dst=r0 src=r1 offset=9 imm=0
@@ -894,7 +894,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 130 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
+        // EBPF_OP_LDXB pc=104 dst=r1 src=r1 offset=6 imm=0
 #line 131 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(6));
     // EBPF_OP_STXB pc=105 dst=r0 src=r1 offset=10 imm=0
@@ -917,7 +917,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 133 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
+        // EBPF_OP_LDXB pc=111 dst=r1 src=r1 offset=7 imm=0
 #line 134 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(7));
     // EBPF_OP_STXB pc=112 dst=r0 src=r1 offset=11 imm=0
@@ -940,7 +940,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 136 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
+        // EBPF_OP_LDXB pc=118 dst=r1 src=r1 offset=8 imm=0
 #line 137 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
     // EBPF_OP_STXB pc=119 dst=r0 src=r1 offset=12 imm=0
@@ -963,7 +963,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 139 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
+        // EBPF_OP_LDXB pc=125 dst=r1 src=r1 offset=9 imm=0
 #line 140 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
     // EBPF_OP_STXB pc=126 dst=r0 src=r1 offset=13 imm=0
@@ -986,7 +986,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 142 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
+        // EBPF_OP_LDXB pc=132 dst=r1 src=r1 offset=10 imm=0
 #line 143 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
     // EBPF_OP_STXB pc=133 dst=r0 src=r1 offset=14 imm=0
@@ -1009,7 +1009,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 145 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
+        // EBPF_OP_LDXB pc=139 dst=r1 src=r1 offset=11 imm=0
 #line 146 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
     // EBPF_OP_STXB pc=140 dst=r0 src=r1 offset=15 imm=0
@@ -1032,7 +1032,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 148 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXB pc=146 dst=r1 src=r1 offset=12 imm=0
 #line 149 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_STXB pc=147 dst=r0 src=r1 offset=16 imm=0
@@ -1055,7 +1055,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 151 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
+        // EBPF_OP_LDXB pc=153 dst=r1 src=r1 offset=13 imm=0
 #line 152 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
     // EBPF_OP_STXB pc=154 dst=r0 src=r1 offset=17 imm=0
@@ -1078,7 +1078,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 154 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=160 dst=r1 src=r1 offset=14 imm=0
 #line 155 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_STXB pc=161 dst=r0 src=r1 offset=18 imm=0
@@ -1101,7 +1101,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 157 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
+        // EBPF_OP_LDXB pc=167 dst=r1 src=r1 offset=15 imm=0
 #line 158 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
     // EBPF_OP_STXB pc=168 dst=r0 src=r1 offset=19 imm=0
@@ -1124,7 +1124,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 160 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
+        // EBPF_OP_LDXB pc=174 dst=r1 src=r1 offset=16 imm=0
 #line 161 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
     // EBPF_OP_STXB pc=175 dst=r0 src=r1 offset=20 imm=0
@@ -1147,7 +1147,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 163 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
+        // EBPF_OP_LDXB pc=181 dst=r1 src=r1 offset=17 imm=0
 #line 164 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
     // EBPF_OP_STXB pc=182 dst=r0 src=r1 offset=21 imm=0
@@ -1170,7 +1170,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 166 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
+        // EBPF_OP_LDXB pc=188 dst=r1 src=r1 offset=18 imm=0
 #line 167 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
     // EBPF_OP_STXB pc=189 dst=r0 src=r1 offset=22 imm=0
@@ -1193,7 +1193,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 169 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
+        // EBPF_OP_LDXB pc=195 dst=r1 src=r1 offset=19 imm=0
 #line 170 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
     // EBPF_OP_STXB pc=196 dst=r0 src=r1 offset=23 imm=0
@@ -1216,7 +1216,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 172 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=202 dst=r1 src=r1 offset=20 imm=0
 #line 173 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_STXB pc=203 dst=r0 src=r1 offset=24 imm=0
@@ -1239,7 +1239,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 175 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
+        // EBPF_OP_LDXB pc=209 dst=r1 src=r1 offset=21 imm=0
 #line 176 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
     // EBPF_OP_STXB pc=210 dst=r0 src=r1 offset=25 imm=0
@@ -1262,7 +1262,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 178 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
+        // EBPF_OP_LDXB pc=216 dst=r1 src=r1 offset=22 imm=0
 #line 179 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
     // EBPF_OP_STXB pc=217 dst=r0 src=r1 offset=26 imm=0
@@ -1285,7 +1285,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 181 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=223 dst=r1 src=r1 offset=23 imm=0
 #line 182 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_STXB pc=224 dst=r0 src=r1 offset=27 imm=0
@@ -1308,7 +1308,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 184 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
+        // EBPF_OP_LDXB pc=230 dst=r1 src=r1 offset=24 imm=0
 #line 185 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(24));
     // EBPF_OP_STXB pc=231 dst=r0 src=r1 offset=28 imm=0
@@ -1331,7 +1331,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 187 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
+        // EBPF_OP_LDXB pc=237 dst=r1 src=r1 offset=25 imm=0
 #line 188 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(25));
     // EBPF_OP_STXB pc=238 dst=r0 src=r1 offset=29 imm=0
@@ -1354,7 +1354,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 190 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
+        // EBPF_OP_LDXB pc=244 dst=r1 src=r1 offset=26 imm=0
 #line 191 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(26));
     // EBPF_OP_STXB pc=245 dst=r0 src=r1 offset=30 imm=0
@@ -1377,7 +1377,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 193 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
+        // EBPF_OP_LDXB pc=251 dst=r1 src=r1 offset=27 imm=0
 #line 194 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(27));
     // EBPF_OP_STXB pc=252 dst=r0 src=r1 offset=31 imm=0
@@ -1400,7 +1400,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 196 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
+        // EBPF_OP_LDXB pc=258 dst=r1 src=r1 offset=28 imm=0
 #line 197 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
     // EBPF_OP_STXB pc=259 dst=r0 src=r1 offset=32 imm=0
@@ -1423,7 +1423,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 199 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
+        // EBPF_OP_LDXB pc=265 dst=r1 src=r1 offset=29 imm=0
 #line 200 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
     // EBPF_OP_STXB pc=266 dst=r0 src=r1 offset=33 imm=0
@@ -1446,7 +1446,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 202 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
+        // EBPF_OP_LDXB pc=272 dst=r1 src=r1 offset=30 imm=0
 #line 203 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
     // EBPF_OP_STXB pc=273 dst=r0 src=r1 offset=34 imm=0
@@ -1469,7 +1469,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 205 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
+        // EBPF_OP_LDXB pc=279 dst=r1 src=r1 offset=31 imm=0
 #line 206 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
     // EBPF_OP_STXB pc=280 dst=r0 src=r1 offset=35 imm=0
@@ -1492,7 +1492,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 208 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
+        // EBPF_OP_LDXB pc=286 dst=r1 src=r1 offset=32 imm=0
 #line 209 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
     // EBPF_OP_STXB pc=287 dst=r0 src=r1 offset=36 imm=0
@@ -1515,7 +1515,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 211 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
+        // EBPF_OP_LDXB pc=293 dst=r1 src=r1 offset=33 imm=0
 #line 212 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
     // EBPF_OP_STXB pc=294 dst=r0 src=r1 offset=37 imm=0
@@ -1538,7 +1538,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 214 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
+        // EBPF_OP_LDXB pc=300 dst=r1 src=r1 offset=34 imm=0
 #line 215 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
     // EBPF_OP_STXB pc=301 dst=r0 src=r1 offset=38 imm=0
@@ -1561,7 +1561,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 217 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
+        // EBPF_OP_LDXB pc=307 dst=r1 src=r1 offset=35 imm=0
 #line 218 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
     // EBPF_OP_STXB pc=308 dst=r0 src=r1 offset=39 imm=0
@@ -1584,7 +1584,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 220 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
+        // EBPF_OP_LDXB pc=314 dst=r1 src=r1 offset=36 imm=0
 #line 221 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
     // EBPF_OP_STXB pc=315 dst=r0 src=r1 offset=40 imm=0
@@ -1607,7 +1607,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 223 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
+        // EBPF_OP_LDXB pc=321 dst=r1 src=r1 offset=37 imm=0
 #line 224 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
     // EBPF_OP_STXB pc=322 dst=r0 src=r1 offset=41 imm=0
@@ -1630,7 +1630,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 226 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
+        // EBPF_OP_LDXB pc=328 dst=r1 src=r1 offset=38 imm=0
 #line 227 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
     // EBPF_OP_STXB pc=329 dst=r0 src=r1 offset=42 imm=0
@@ -1653,7 +1653,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 229 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
+        // EBPF_OP_LDXB pc=335 dst=r1 src=r1 offset=39 imm=0
 #line 230 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_STXB pc=336 dst=r0 src=r1 offset=43 imm=0
@@ -1676,7 +1676,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 232 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
+        // EBPF_OP_LDXB pc=342 dst=r1 src=r1 offset=40 imm=0
 #line 233 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
     // EBPF_OP_STXB pc=343 dst=r0 src=r1 offset=44 imm=0
@@ -1699,7 +1699,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 235 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
+        // EBPF_OP_LDXB pc=349 dst=r1 src=r1 offset=41 imm=0
 #line 236 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_STXB pc=350 dst=r0 src=r1 offset=45 imm=0
@@ -1722,7 +1722,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 238 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
+        // EBPF_OP_LDXB pc=356 dst=r1 src=r1 offset=42 imm=0
 #line 239 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
     // EBPF_OP_STXB pc=357 dst=r0 src=r1 offset=46 imm=0
@@ -1745,7 +1745,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 241 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
+        // EBPF_OP_LDXB pc=363 dst=r1 src=r1 offset=43 imm=0
 #line 242 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_STXB pc=364 dst=r0 src=r1 offset=47 imm=0
@@ -1768,7 +1768,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 244 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
+        // EBPF_OP_LDXB pc=370 dst=r1 src=r1 offset=44 imm=0
 #line 245 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
     // EBPF_OP_STXB pc=371 dst=r0 src=r1 offset=48 imm=0
@@ -1791,7 +1791,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 247 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
+        // EBPF_OP_LDXB pc=377 dst=r1 src=r1 offset=45 imm=0
 #line 248 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_STXB pc=378 dst=r0 src=r1 offset=49 imm=0
@@ -1814,7 +1814,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 250 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
+        // EBPF_OP_LDXB pc=384 dst=r1 src=r1 offset=46 imm=0
 #line 251 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
     // EBPF_OP_STXB pc=385 dst=r0 src=r1 offset=50 imm=0
@@ -1837,7 +1837,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 253 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
+        // EBPF_OP_LDXB pc=391 dst=r1 src=r1 offset=47 imm=0
 #line 254 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_STXB pc=392 dst=r0 src=r1 offset=51 imm=0
@@ -1860,7 +1860,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 256 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
+        // EBPF_OP_LDXB pc=398 dst=r1 src=r1 offset=48 imm=0
 #line 257 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
     // EBPF_OP_STXB pc=399 dst=r0 src=r1 offset=52 imm=0
@@ -1883,7 +1883,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 259 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
+        // EBPF_OP_LDXB pc=405 dst=r1 src=r1 offset=49 imm=0
 #line 260 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_STXB pc=406 dst=r0 src=r1 offset=53 imm=0
@@ -1906,7 +1906,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 262 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
+        // EBPF_OP_LDXB pc=412 dst=r1 src=r1 offset=50 imm=0
 #line 263 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
     // EBPF_OP_STXB pc=413 dst=r0 src=r1 offset=54 imm=0
@@ -1929,7 +1929,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 265 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
+        // EBPF_OP_LDXB pc=419 dst=r1 src=r1 offset=51 imm=0
 #line 266 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_STXB pc=420 dst=r0 src=r1 offset=55 imm=0
@@ -1952,7 +1952,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 268 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
+        // EBPF_OP_LDXB pc=426 dst=r1 src=r1 offset=52 imm=0
 #line 269 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
     // EBPF_OP_STXB pc=427 dst=r0 src=r1 offset=56 imm=0
@@ -1975,7 +1975,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 271 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
+        // EBPF_OP_LDXB pc=433 dst=r1 src=r1 offset=53 imm=0
 #line 272 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_STXB pc=434 dst=r0 src=r1 offset=57 imm=0
@@ -1998,7 +1998,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 274 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
+        // EBPF_OP_LDXB pc=440 dst=r1 src=r1 offset=54 imm=0
 #line 275 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(54));
     // EBPF_OP_STXB pc=441 dst=r0 src=r1 offset=58 imm=0
@@ -2021,7 +2021,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 277 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
+        // EBPF_OP_LDXB pc=447 dst=r1 src=r1 offset=55 imm=0
 #line 278 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(55));
     // EBPF_OP_STXB pc=448 dst=r0 src=r1 offset=59 imm=0
@@ -2044,7 +2044,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 280 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXB pc=454 dst=r1 src=r1 offset=56 imm=0
 #line 281 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_STXB pc=455 dst=r0 src=r1 offset=60 imm=0
@@ -2067,7 +2067,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 283 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
+        // EBPF_OP_LDXB pc=461 dst=r1 src=r1 offset=57 imm=0
 #line 284 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(57));
     // EBPF_OP_STXB pc=462 dst=r0 src=r1 offset=61 imm=0
@@ -2090,7 +2090,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 286 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
+        // EBPF_OP_LDXB pc=468 dst=r1 src=r1 offset=58 imm=0
 #line 287 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(58));
     // EBPF_OP_STXB pc=469 dst=r0 src=r1 offset=62 imm=0
@@ -2113,7 +2113,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 289 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
+        // EBPF_OP_LDXB pc=475 dst=r1 src=r1 offset=59 imm=0
 #line 290 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(59));
     // EBPF_OP_STXB pc=476 dst=r0 src=r1 offset=63 imm=0
@@ -2136,7 +2136,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 292 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
+        // EBPF_OP_LDXB pc=482 dst=r1 src=r1 offset=60 imm=0
 #line 293 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(60));
     // EBPF_OP_STXB pc=483 dst=r0 src=r1 offset=64 imm=0
@@ -2159,7 +2159,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 295 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
+        // EBPF_OP_LDXB pc=489 dst=r1 src=r1 offset=61 imm=0
 #line 296 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(61));
     // EBPF_OP_STXB pc=490 dst=r0 src=r1 offset=65 imm=0
@@ -2182,7 +2182,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 298 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
+        // EBPF_OP_LDXB pc=496 dst=r1 src=r1 offset=62 imm=0
 #line 299 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(62));
     // EBPF_OP_STXB pc=497 dst=r0 src=r1 offset=66 imm=0
@@ -2205,7 +2205,7 @@ label_3:
     if ((int64_t)r3 > (int64_t)r2)
 #line 301 "sample/bindmonitor_tailcall.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
+        // EBPF_OP_LDXB pc=503 dst=r1 src=r1 offset=63 imm=0
 #line 302 "sample/bindmonitor_tailcall.c"
     r1 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(63));
     // EBPF_OP_STXB pc=504 dst=r0 src=r1 offset=67 imm=0
@@ -2223,7 +2223,7 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 371 "sample/bindmonitor_tailcall.c"
         goto label_6;
-    // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=508 dst=r1 src=r0 offset=0 imm=-1
 #line 372 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=509 dst=r0 src=r1 offset=0 imm=0
@@ -2235,10 +2235,10 @@ label_5:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=511 dst=r1 src=r0 offset=0 imm=32
 #line 379 "sample/bindmonitor_tailcall.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=512 dst=r1 src=r0 offset=0 imm=32
 #line 379 "sample/bindmonitor_tailcall.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=513 dst=r1 src=r0 offset=15 imm=0
 #line 379 "sample/bindmonitor_tailcall.c"
     if (r1 != IMMEDIATE(0))
@@ -2269,7 +2269,7 @@ label_6:
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
 #line 381 "sample/bindmonitor_tailcall.c"
         return 0;
-    // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
+        // EBPF_OP_JA pc=521 dst=r0 src=r0 offset=6 imm=0
 #line 381 "sample/bindmonitor_tailcall.c"
     goto label_8;
 label_7:
@@ -2287,7 +2287,7 @@ label_7:
     if (r1 >= r2)
 #line 364 "sample/bindmonitor_tailcall.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=526 dst=r1 src=r0 offset=0 imm=1
 #line 368 "sample/bindmonitor_tailcall.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=527 dst=r0 src=r1 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -170,7 +170,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 60 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
+        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
 #line 60 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 60 "sample/cgroup_sock_addr2.c"
@@ -184,7 +184,7 @@ label_1:
     if (r1 != IMMEDIATE(2))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
 #line 64 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=17 dst=r2 src=r0 offset=0 imm=-32
@@ -202,7 +202,7 @@ label_1:
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
 #line 69 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
 #line 69 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=22 dst=r9 src=r0 offset=0 imm=0
@@ -216,7 +216,7 @@ label_1:
     if (r8 == IMMEDIATE(0))
 #line 70 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=26 dst=r10 src=r1 offset=-38 imm=0
@@ -276,7 +276,7 @@ label_1:
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
 #line 71 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
+        // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=48 dst=r6 src=r1 offset=24 imm=0
@@ -313,7 +313,7 @@ label_2:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
@@ -331,7 +331,7 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
@@ -346,7 +346,7 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
+        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=65 dst=r1 src=r6 offset=20 imm=0
@@ -475,7 +475,7 @@ connect_redirect6(void* context)
     if (r1 == IMMEDIATE(17))
 #line 89 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
+        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
 #line 89 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 89 "sample/cgroup_sock_addr2.c"
@@ -489,12 +489,12 @@ label_1:
     if (r2 != IMMEDIATE(23))
 #line 93 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=11 dst=r2 src=r0 offset=0 imm=32
 #line 100 "sample/cgroup_sock_addr2.c"
-    r2 <<= IMMEDIATE(32);
+    r2 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=12 dst=r3 src=r6 offset=32 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
@@ -509,7 +509,7 @@ label_1:
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=32
 #line 100 "sample/cgroup_sock_addr2.c"
-    r2 <<= IMMEDIATE(32);
+    r2 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=17 dst=r3 src=r6 offset=24 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
@@ -546,7 +546,7 @@ label_1:
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
 #line 105 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
 #line 105 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r9 src=r0 offset=0 imm=0
@@ -560,7 +560,7 @@ label_1:
     if (r8 == IMMEDIATE(0))
 #line 106 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=33 dst=r7 src=r0 offset=0 imm=24
@@ -614,7 +614,7 @@ label_1:
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
 #line 107 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
+        // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
 #line 108 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=52 dst=r7 src=r1 offset=12 imm=0
@@ -669,7 +669,7 @@ label_2:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
@@ -687,7 +687,7 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
+        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
@@ -702,7 +702,7 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
+        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=75 dst=r1 src=r6 offset=20 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -144,7 +144,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 60 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
+        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
 #line 60 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 60 "sample/cgroup_sock_addr2.c"
@@ -158,7 +158,7 @@ label_1:
     if (r1 != IMMEDIATE(2))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
 #line 64 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=17 dst=r2 src=r0 offset=0 imm=-32
@@ -176,7 +176,7 @@ label_1:
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
 #line 69 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
 #line 69 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=22 dst=r9 src=r0 offset=0 imm=0
@@ -190,7 +190,7 @@ label_1:
     if (r8 == IMMEDIATE(0))
 #line 70 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=26 dst=r10 src=r1 offset=-38 imm=0
@@ -250,7 +250,7 @@ label_1:
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
 #line 71 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
+        // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=48 dst=r6 src=r1 offset=24 imm=0
@@ -287,7 +287,7 @@ label_2:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
@@ -305,7 +305,7 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
@@ -320,7 +320,7 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
+        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=65 dst=r1 src=r6 offset=20 imm=0
@@ -449,7 +449,7 @@ connect_redirect6(void* context)
     if (r1 == IMMEDIATE(17))
 #line 89 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
+        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
 #line 89 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 89 "sample/cgroup_sock_addr2.c"
@@ -463,12 +463,12 @@ label_1:
     if (r2 != IMMEDIATE(23))
 #line 93 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=11 dst=r2 src=r0 offset=0 imm=32
 #line 100 "sample/cgroup_sock_addr2.c"
-    r2 <<= IMMEDIATE(32);
+    r2 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=12 dst=r3 src=r6 offset=32 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
@@ -483,7 +483,7 @@ label_1:
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=32
 #line 100 "sample/cgroup_sock_addr2.c"
-    r2 <<= IMMEDIATE(32);
+    r2 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=17 dst=r3 src=r6 offset=24 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
@@ -520,7 +520,7 @@ label_1:
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
 #line 105 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
 #line 105 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r9 src=r0 offset=0 imm=0
@@ -534,7 +534,7 @@ label_1:
     if (r8 == IMMEDIATE(0))
 #line 106 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=33 dst=r7 src=r0 offset=0 imm=24
@@ -588,7 +588,7 @@ label_1:
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
 #line 107 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
+        // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
 #line 108 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=52 dst=r7 src=r1 offset=12 imm=0
@@ -643,7 +643,7 @@ label_2:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
@@ -661,7 +661,7 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
+        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
@@ -676,7 +676,7 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
+        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=75 dst=r1 src=r6 offset=20 imm=0

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -305,7 +305,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 60 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
+        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
 #line 60 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 60 "sample/cgroup_sock_addr2.c"
@@ -319,7 +319,7 @@ label_1:
     if (r1 != IMMEDIATE(2))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
 #line 64 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=17 dst=r2 src=r0 offset=0 imm=-32
@@ -337,7 +337,7 @@ label_1:
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
 #line 69 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
 #line 69 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=22 dst=r9 src=r0 offset=0 imm=0
@@ -351,7 +351,7 @@ label_1:
     if (r8 == IMMEDIATE(0))
 #line 70 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=26 dst=r10 src=r1 offset=-38 imm=0
@@ -411,7 +411,7 @@ label_1:
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
 #line 71 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
+        // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=48 dst=r6 src=r1 offset=24 imm=0
@@ -448,7 +448,7 @@ label_2:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
@@ -466,7 +466,7 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
+        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
@@ -481,7 +481,7 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
+        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=65 dst=r1 src=r6 offset=20 imm=0
@@ -610,7 +610,7 @@ connect_redirect6(void* context)
     if (r1 == IMMEDIATE(17))
 #line 89 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
+        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
 #line 89 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 89 "sample/cgroup_sock_addr2.c"
@@ -624,12 +624,12 @@ label_1:
     if (r2 != IMMEDIATE(23))
 #line 93 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=11 dst=r2 src=r0 offset=0 imm=32
 #line 100 "sample/cgroup_sock_addr2.c"
-    r2 <<= IMMEDIATE(32);
+    r2 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=12 dst=r3 src=r6 offset=32 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
@@ -644,7 +644,7 @@ label_1:
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=32
 #line 100 "sample/cgroup_sock_addr2.c"
-    r2 <<= IMMEDIATE(32);
+    r2 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=17 dst=r3 src=r6 offset=24 imm=0
 #line 100 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
@@ -681,7 +681,7 @@ label_1:
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
 #line 105 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
 #line 105 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r9 src=r0 offset=0 imm=0
@@ -695,7 +695,7 @@ label_1:
     if (r8 == IMMEDIATE(0))
 #line 106 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=33 dst=r7 src=r0 offset=0 imm=24
@@ -749,7 +749,7 @@ label_1:
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
 #line 107 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
+        // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
 #line 108 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=52 dst=r7 src=r1 offset=12 imm=0
@@ -804,7 +804,7 @@ label_2:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 42 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
 #line 42 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
@@ -822,7 +822,7 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 43 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
+        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
@@ -837,7 +837,7 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
+        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=75 dst=r1 src=r6 offset=20 imm=0

--- a/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_dll.c
@@ -102,7 +102,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
@@ -110,12 +110,12 @@ decapsulate_permit_packet(void* context)
     if (r5 == IMMEDIATE(56710))
 #line 99 "sample/decap_permit_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 99 "sample/decap_permit_packet.c"
     if (r5 != IMMEDIATE(8))
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -126,7 +126,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
@@ -134,12 +134,12 @@ decapsulate_permit_packet(void* context)
     if (r5 != IMMEDIATE(4))
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 105 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
 #line 105 "sample/decap_permit_packet.c"
-    r5 <<= IMMEDIATE(2);
+    r5 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
 #line 105 "sample/decap_permit_packet.c"
     r5 &= IMMEDIATE(60);
@@ -154,7 +154,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 107 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -168,7 +168,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -179,7 +179,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 38 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -275,15 +275,15 @@ decapsulate_permit_packet(void* context)
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 41 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
 #line 41 "sample/decap_permit_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
 #line 41 "sample/decap_permit_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
 #line 41 "sample/decap_permit_packet.c"
     r0 = IMMEDIATE(2);
@@ -295,7 +295,7 @@ decapsulate_permit_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 41 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 41 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -310,7 +310,7 @@ label_1:
     if (r4 > r3)
 #line 114 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 114 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -321,7 +321,7 @@ label_1:
     if (r4 > r3)
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 120 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
@@ -329,7 +329,7 @@ label_1:
     if (r3 != IMMEDIATE(41))
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 67 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -425,15 +425,15 @@ label_1:
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 70 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
 #line 70 "sample/decap_permit_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
 #line 70 "sample/decap_permit_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
 #line 70 "sample/decap_permit_packet.c"
     r0 = IMMEDIATE(2);

--- a/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_raw.c
@@ -76,7 +76,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
@@ -84,12 +84,12 @@ decapsulate_permit_packet(void* context)
     if (r5 == IMMEDIATE(56710))
 #line 99 "sample/decap_permit_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 99 "sample/decap_permit_packet.c"
     if (r5 != IMMEDIATE(8))
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -100,7 +100,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
@@ -108,12 +108,12 @@ decapsulate_permit_packet(void* context)
     if (r5 != IMMEDIATE(4))
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 105 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
 #line 105 "sample/decap_permit_packet.c"
-    r5 <<= IMMEDIATE(2);
+    r5 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
 #line 105 "sample/decap_permit_packet.c"
     r5 &= IMMEDIATE(60);
@@ -128,7 +128,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 107 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -142,7 +142,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -153,7 +153,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 38 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -249,15 +249,15 @@ decapsulate_permit_packet(void* context)
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 41 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
 #line 41 "sample/decap_permit_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
 #line 41 "sample/decap_permit_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
 #line 41 "sample/decap_permit_packet.c"
     r0 = IMMEDIATE(2);
@@ -269,7 +269,7 @@ decapsulate_permit_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 41 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 41 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -284,7 +284,7 @@ label_1:
     if (r4 > r3)
 #line 114 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 114 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -295,7 +295,7 @@ label_1:
     if (r4 > r3)
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 120 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
@@ -303,7 +303,7 @@ label_1:
     if (r3 != IMMEDIATE(41))
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 67 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -399,15 +399,15 @@ label_1:
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 70 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
 #line 70 "sample/decap_permit_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
 #line 70 "sample/decap_permit_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
 #line 70 "sample/decap_permit_packet.c"
     r0 = IMMEDIATE(2);

--- a/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
+++ b/tests/bpf2c_tests/expected/decap_permit_packet_sys.c
@@ -237,7 +237,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 94 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r5 src=r2 offset=12 imm=0
 #line 99 "sample/decap_permit_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r5 src=r0 offset=56 imm=56710
@@ -245,12 +245,12 @@ decapsulate_permit_packet(void* context)
     if (r5 == IMMEDIATE(56710))
 #line 99 "sample/decap_permit_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r5 src=r0 offset=100 imm=8
 #line 99 "sample/decap_permit_packet.c"
     if (r5 != IMMEDIATE(8))
 #line 99 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r5 src=r2 offset=0 imm=0
 #line 100 "sample/decap_permit_packet.c"
     r5 = r2;
     // EBPF_OP_ADD64_IMM pc=10 dst=r5 src=r0 offset=0 imm=34
@@ -261,7 +261,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 100 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r5 src=r2 offset=23 imm=0
 #line 106 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r5 src=r0 offset=95 imm=4
@@ -269,12 +269,12 @@ decapsulate_permit_packet(void* context)
     if (r5 != IMMEDIATE(4))
 #line 106 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r5 src=r4 offset=0 imm=0
 #line 105 "sample/decap_permit_packet.c"
     r5 = *(uint8_t*)(uintptr_t)(r4 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=15 dst=r5 src=r0 offset=0 imm=2
 #line 105 "sample/decap_permit_packet.c"
-    r5 <<= IMMEDIATE(2);
+    r5 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=16 dst=r5 src=r0 offset=0 imm=60
 #line 105 "sample/decap_permit_packet.c"
     r5 &= IMMEDIATE(60);
@@ -289,7 +289,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 107 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=20 dst=r4 src=r2 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_REG pc=21 dst=r4 src=r5 offset=0 imm=0
@@ -303,7 +303,7 @@ decapsulate_permit_packet(void* context)
     if (r4 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r5 src=r4 offset=0 imm=0
 #line 29 "sample/decap_permit_packet.c"
     r5 = r4;
     // EBPF_OP_ADD64_IMM pc=25 dst=r5 src=r0 offset=0 imm=14
@@ -314,7 +314,7 @@ decapsulate_permit_packet(void* context)
     if (r5 > r3)
 #line 29 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=27 dst=r3 src=r2 offset=13 imm=0
 #line 38 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=28 dst=r4 src=r3 offset=13 imm=0
@@ -410,15 +410,15 @@ decapsulate_permit_packet(void* context)
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 41 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=58 dst=r1 src=r0 offset=0 imm=32
 #line 41 "sample/decap_permit_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=59 dst=r1 src=r0 offset=0 imm=32
 #line 41 "sample/decap_permit_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=60 dst=r0 src=r0 offset=0 imm=2
 #line 41 "sample/decap_permit_packet.c"
     r0 = IMMEDIATE(2);
@@ -430,7 +430,7 @@ decapsulate_permit_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 41 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=44 imm=0
 #line 41 "sample/decap_permit_packet.c"
     goto label_2;
 label_1:
@@ -445,7 +445,7 @@ label_1:
     if (r4 > r3)
 #line 114 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r4 src=r2 offset=0 imm=0
 #line 114 "sample/decap_permit_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=68 dst=r4 src=r0 offset=0 imm=94
@@ -456,7 +456,7 @@ label_1:
     if (r4 > r3)
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r3 src=r2 offset=20 imm=0
 #line 120 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r3 src=r0 offset=37 imm=41
@@ -464,7 +464,7 @@ label_1:
     if (r3 != IMMEDIATE(41))
 #line 120 "sample/decap_permit_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
+        // EBPF_OP_LDXB pc=72 dst=r3 src=r2 offset=13 imm=0
 #line 67 "sample/decap_permit_packet.c"
     r3 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(13));
     // EBPF_OP_STXB pc=73 dst=r2 src=r3 offset=53 imm=0
@@ -560,15 +560,15 @@ label_1:
     if ((decapsulate_permit_packet_helpers[0].tail_call) && (r0 == 0))
 #line 70 "sample/decap_permit_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=102 dst=r1 src=r0 offset=0 imm=0
 #line 70 "sample/decap_permit_packet.c"
     r1 = r0;
     // EBPF_OP_LSH64_IMM pc=103 dst=r1 src=r0 offset=0 imm=32
 #line 70 "sample/decap_permit_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=104 dst=r1 src=r0 offset=0 imm=32
 #line 70 "sample/decap_permit_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=105 dst=r0 src=r0 offset=0 imm=2
 #line 70 "sample/decap_permit_packet.c"
     r0 = IMMEDIATE(2);

--- a/tests/bpf2c_tests/expected/droppacket_dll.c
+++ b/tests/bpf2c_tests/expected/droppacket_dll.c
@@ -145,7 +145,7 @@ DropPacket(void* context)
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 48 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
@@ -153,7 +153,7 @@ DropPacket(void* context)
     if (r1 == IMMEDIATE(0))
 #line 49 "sample/droppacket.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 49 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -188,7 +188,7 @@ label_1:
     if (r3 > r2)
 #line 56 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 61 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
@@ -196,7 +196,7 @@ label_1:
     if (r3 != IMMEDIATE(8))
 #line 61 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 64 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
@@ -204,7 +204,7 @@ label_1:
     if (r3 != IMMEDIATE(17))
 #line 64 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 64 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -212,7 +212,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=26 dst=r3 src=r0 offset=0 imm=2
 #line 66 "sample/droppacket.c"
-    r3 <<= IMMEDIATE(2);
+    r3 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=27 dst=r3 src=r0 offset=0 imm=60
 #line 66 "sample/droppacket.c"
     r3 &= IMMEDIATE(60);
@@ -230,7 +230,7 @@ label_1:
     if (r3 > r2)
 #line 67 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 71 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -243,7 +243,7 @@ label_1:
     if (r1 > IMMEDIATE(8))
 #line 71 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 71 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -261,7 +261,7 @@ label_1:
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 72 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 72 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -272,7 +272,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 73 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 74 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_raw.c
+++ b/tests/bpf2c_tests/expected/droppacket_raw.c
@@ -119,7 +119,7 @@ DropPacket(void* context)
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 48 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
@@ -127,7 +127,7 @@ DropPacket(void* context)
     if (r1 == IMMEDIATE(0))
 #line 49 "sample/droppacket.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 49 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -162,7 +162,7 @@ label_1:
     if (r3 > r2)
 #line 56 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 61 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
@@ -170,7 +170,7 @@ label_1:
     if (r3 != IMMEDIATE(8))
 #line 61 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 64 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
@@ -178,7 +178,7 @@ label_1:
     if (r3 != IMMEDIATE(17))
 #line 64 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 64 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -186,7 +186,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=26 dst=r3 src=r0 offset=0 imm=2
 #line 66 "sample/droppacket.c"
-    r3 <<= IMMEDIATE(2);
+    r3 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=27 dst=r3 src=r0 offset=0 imm=60
 #line 66 "sample/droppacket.c"
     r3 &= IMMEDIATE(60);
@@ -204,7 +204,7 @@ label_1:
     if (r3 > r2)
 #line 67 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 71 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -217,7 +217,7 @@ label_1:
     if (r1 > IMMEDIATE(8))
 #line 71 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 71 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -235,7 +235,7 @@ label_1:
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 72 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 72 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -246,7 +246,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 73 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 74 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/droppacket_sys.c
+++ b/tests/bpf2c_tests/expected/droppacket_sys.c
@@ -280,7 +280,7 @@ DropPacket(void* context)
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r1 src=r0 offset=0 imm=0
 #line 48 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r1 src=r0 offset=4 imm=0
@@ -288,7 +288,7 @@ DropPacket(void* context)
     if (r1 == IMMEDIATE(0))
 #line 49 "sample/droppacket.c"
         goto label_1;
-    // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
+        // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=1
 #line 49 "sample/droppacket.c"
     r0 = IMMEDIATE(1);
     // EBPF_OP_LDXW pc=11 dst=r1 src=r1 offset=0 imm=0
@@ -323,7 +323,7 @@ label_1:
     if (r3 > r2)
 #line 56 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=20 dst=r3 src=r1 offset=12 imm=0
 #line 61 "sample/droppacket.c"
     r3 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JNE_IMM pc=21 dst=r3 src=r0 offset=24 imm=8
@@ -331,7 +331,7 @@ label_1:
     if (r3 != IMMEDIATE(8))
 #line 61 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=22 dst=r3 src=r1 offset=23 imm=0
 #line 64 "sample/droppacket.c"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=23 dst=r3 src=r0 offset=22 imm=17
@@ -339,7 +339,7 @@ label_1:
     if (r3 != IMMEDIATE(17))
 #line 64 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
+        // EBPF_OP_ADD64_IMM pc=24 dst=r1 src=r0 offset=0 imm=14
 #line 64 "sample/droppacket.c"
     r1 += IMMEDIATE(14);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=0 imm=0
@@ -347,7 +347,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_LSH64_IMM pc=26 dst=r3 src=r0 offset=0 imm=2
 #line 66 "sample/droppacket.c"
-    r3 <<= IMMEDIATE(2);
+    r3 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=27 dst=r3 src=r0 offset=0 imm=60
 #line 66 "sample/droppacket.c"
     r3 &= IMMEDIATE(60);
@@ -365,7 +365,7 @@ label_1:
     if (r3 > r2)
 #line 67 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
+        // EBPF_OP_LDXH pc=32 dst=r1 src=r1 offset=4 imm=0
 #line 71 "sample/droppacket.c"
     r1 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(4));
     // EBPF_OP_BE pc=33 dst=r1 src=r0 offset=0 imm=16
@@ -378,7 +378,7 @@ label_1:
     if (r1 > IMMEDIATE(8))
 #line 71 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
 #line 71 "sample/droppacket.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-8
@@ -396,7 +396,7 @@ label_1:
     if ((DropPacket_helpers[0].tail_call) && (r0 == 0))
 #line 72 "sample/droppacket.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=40 dst=r1 src=r0 offset=0 imm=0
 #line 72 "sample/droppacket.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=41 dst=r0 src=r0 offset=0 imm=2
@@ -407,7 +407,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 73 "sample/droppacket.c"
         goto label_2;
-    // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=43 dst=r2 src=r1 offset=0 imm=0
 #line 74 "sample/droppacket.c"
     r2 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(0));
     // EBPF_OP_ADD64_IMM pc=44 dst=r2 src=r0 offset=0 imm=1

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_dll.c
@@ -108,7 +108,7 @@ encap_reflect_packet(void* context)
     if (r3 > r1)
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 160 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=105 imm=56710
@@ -116,12 +116,12 @@ encap_reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
+        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
 #line 160 "sample/encap_reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 161 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -132,7 +132,7 @@ encap_reflect_packet(void* context)
     if (r4 > r1)
 #line 161 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 167 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=282 imm=17
@@ -140,12 +140,12 @@ encap_reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 167 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 167 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
 #line 167 "sample/encap_reflect_packet.c"
-    r2 <<= IMMEDIATE(2);
+    r2 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=17 dst=r2 src=r0 offset=0 imm=60
 #line 167 "sample/encap_reflect_packet.c"
     r2 &= IMMEDIATE(60);
@@ -163,7 +163,7 @@ encap_reflect_packet(void* context)
     if (r2 > r1)
 #line 167 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 173 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=273 imm=7459
@@ -171,7 +171,7 @@ encap_reflect_packet(void* context)
     if (r1 != IMMEDIATE(7459))
 #line 173 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -186,7 +186,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -194,10 +194,10 @@ encap_reflect_packet(void* context)
     r0 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=30 dst=r1 src=r0 offset=0 imm=32
 #line 22 "sample/encap_reflect_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=31 dst=r1 src=r0 offset=0 imm=32
 #line 22 "sample/encap_reflect_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=32 dst=r2 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r2 = IMMEDIATE(0);
@@ -206,7 +206,7 @@ encap_reflect_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 22 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 28 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r6 src=r6 offset=0 imm=0
@@ -223,7 +223,7 @@ encap_reflect_packet(void* context)
     if (r3 > r4)
 #line 28 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
 #line 35 "sample/encap_reflect_packet.c"
     r2 = r6;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -234,7 +234,7 @@ encap_reflect_packet(void* context)
     if (r2 > r4)
 #line 35 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -245,7 +245,7 @@ encap_reflect_packet(void* context)
     if (r1 > r4)
 #line 43 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r5 = r6;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -256,7 +256,7 @@ encap_reflect_packet(void* context)
     if (r5 > r4)
 #line 43 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 56 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r6 src=r4 offset=4 imm=0
@@ -431,7 +431,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
 #line 73 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=104 dst=r1 src=r0 offset=0 imm=65535
@@ -439,10 +439,10 @@ encap_reflect_packet(void* context)
     r1 &= IMMEDIATE(65535);
     // EBPF_OP_LSH64_IMM pc=105 dst=r0 src=r0 offset=0 imm=32
 #line 73 "sample/encap_reflect_packet.c"
-    r0 <<= IMMEDIATE(32);
+    r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=106 dst=r0 src=r0 offset=0 imm=48
 #line 41 "sample/./xdp_common.h"
-    r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(48);
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(48) & 63);
     // EBPF_OP_ADD64_REG pc=107 dst=r0 src=r1 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r0 += r1;
@@ -451,7 +451,7 @@ encap_reflect_packet(void* context)
     r1 = r0;
     // EBPF_OP_RSH64_IMM pc=109 dst=r1 src=r0 offset=0 imm=16
 #line 42 "sample/./xdp_common.h"
-    r1 >>= IMMEDIATE(16);
+    r1 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_ADD64_REG pc=110 dst=r1 src=r0 offset=0 imm=0
 #line 42 "sample/./xdp_common.h"
     r1 += r0;
@@ -476,7 +476,7 @@ label_1:
     if (r3 > r1)
 #line 178 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
 #line 178 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
@@ -487,7 +487,7 @@ label_1:
     if (r3 > r1)
 #line 184 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
 #line 184 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
@@ -495,7 +495,7 @@ label_1:
     if (r1 != IMMEDIATE(17))
 #line 184 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
+        // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 190 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=123 dst=r1 src=r0 offset=173 imm=7459
@@ -503,7 +503,7 @@ label_1:
     if (r1 != IMMEDIATE(7459))
 #line 190 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=125 dst=r2 src=r0 offset=0 imm=-40
@@ -518,7 +518,7 @@ label_1:
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 87 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=129 dst=r0 src=r0 offset=0 imm=2
@@ -526,10 +526,10 @@ label_1:
     r0 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=130 dst=r1 src=r0 offset=0 imm=32
 #line 87 "sample/encap_reflect_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=131 dst=r1 src=r0 offset=0 imm=32
 #line 87 "sample/encap_reflect_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=132 dst=r2 src=r0 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r2 = IMMEDIATE(0);
@@ -538,7 +538,7 @@ label_1:
     if ((int64_t)r2 > (int64_t)r1)
 #line 87 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
 #line 93 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=135 dst=r1 src=r6 offset=0 imm=0
@@ -555,7 +555,7 @@ label_1:
     if (r2 > r5)
 #line 93 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=140 dst=r4 src=r0 offset=0 imm=40
@@ -566,7 +566,7 @@ label_1:
     if (r4 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
 #line 108 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=143 dst=r3 src=r0 offset=0 imm=54
@@ -577,7 +577,7 @@ label_1:
     if (r3 > r5)
 #line 108 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
 #line 108 "sample/encap_reflect_packet.c"
     r6 = r1;
     // EBPF_OP_ADD64_IMM pc=146 dst=r6 src=r0 offset=0 imm=94
@@ -588,7 +588,7 @@ label_1:
     if (r6 > r5)
 #line 108 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
+        // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
 #line 121 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=149 dst=r1 src=r5 offset=4 imm=0
@@ -662,7 +662,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(87));
     // EBPF_OP_LSH64_IMM pc=172 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=173 dst=r4 src=r1 offset=86 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(86));
@@ -674,7 +674,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(89));
     // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=177 dst=r0 src=r1 offset=88 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(88));
@@ -683,7 +683,7 @@ label_1:
     r4 |= r0;
     // EBPF_OP_LSH64_IMM pc=179 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=180 dst=r4 src=r5 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r5;
@@ -692,7 +692,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(91));
     // EBPF_OP_LSH64_IMM pc=182 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=183 dst=r5 src=r1 offset=90 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(90));
@@ -704,7 +704,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(93));
     // EBPF_OP_LSH64_IMM pc=186 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=187 dst=r6 src=r1 offset=92 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(92));
@@ -713,13 +713,13 @@ label_1:
     r5 |= r6;
     // EBPF_OP_LSH64_IMM pc=189 dst=r5 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(16);
+    r5 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=190 dst=r5 src=r0 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 |= r0;
     // EBPF_OP_LSH64_IMM pc=191 dst=r5 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=192 dst=r5 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 |= r4;
@@ -728,7 +728,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(79));
     // EBPF_OP_LSH64_IMM pc=194 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=195 dst=r4 src=r1 offset=78 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(78));
@@ -740,7 +740,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(81));
     // EBPF_OP_LSH64_IMM pc=198 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=199 dst=r6 src=r1 offset=80 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(80));
@@ -752,7 +752,7 @@ label_1:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r5;
     // EBPF_OP_LSH64_IMM pc=202 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=203 dst=r4 src=r0 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r0;
@@ -761,7 +761,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(83));
     // EBPF_OP_LSH64_IMM pc=205 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=206 dst=r0 src=r1 offset=82 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(82));
@@ -773,7 +773,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(85));
     // EBPF_OP_LSH64_IMM pc=209 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=210 dst=r6 src=r1 offset=84 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(84));
@@ -782,13 +782,13 @@ label_1:
     r0 |= r6;
     // EBPF_OP_LSH64_IMM pc=212 dst=r0 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(16);
+    r0 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=213 dst=r0 src=r5 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 |= r5;
     // EBPF_OP_LSH64_IMM pc=214 dst=r0 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(32);
+    r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=215 dst=r0 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 |= r4;
@@ -827,7 +827,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=227 dst=r5 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(48);
+    r5 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=228 dst=r1 src=r5 offset=68 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(68)) = (uint8_t)r5;
@@ -836,7 +836,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=230 dst=r5 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(56);
+    r5 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=231 dst=r1 src=r5 offset=69 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(69)) = (uint8_t)r5;
@@ -845,7 +845,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=233 dst=r5 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(32);
+    r5 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=234 dst=r1 src=r5 offset=66 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(66)) = (uint8_t)r5;
@@ -854,7 +854,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=236 dst=r5 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(40);
+    r5 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=237 dst=r1 src=r5 offset=67 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(67)) = (uint8_t)r5;
@@ -863,7 +863,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=239 dst=r5 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(16);
+    r5 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=240 dst=r1 src=r5 offset=64 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(64)) = (uint8_t)r5;
@@ -872,7 +872,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=242 dst=r5 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(24);
+    r5 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=243 dst=r1 src=r5 offset=65 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(65)) = (uint8_t)r5;
@@ -881,7 +881,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(62)) = (uint8_t)r4;
     // EBPF_OP_RSH64_IMM pc=245 dst=r4 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r4 >>= IMMEDIATE(8);
+    r4 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=246 dst=r1 src=r4 offset=63 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(63)) = (uint8_t)r4;
@@ -893,7 +893,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=249 dst=r5 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(48);
+    r5 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=250 dst=r1 src=r5 offset=76 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(76)) = (uint8_t)r5;
@@ -902,7 +902,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=252 dst=r5 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(56);
+    r5 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=253 dst=r1 src=r5 offset=77 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(77)) = (uint8_t)r5;
@@ -911,7 +911,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=255 dst=r5 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(32);
+    r5 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=256 dst=r1 src=r5 offset=74 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(74)) = (uint8_t)r5;
@@ -920,7 +920,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=258 dst=r5 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(40);
+    r5 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=259 dst=r1 src=r5 offset=75 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(75)) = (uint8_t)r5;
@@ -929,7 +929,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=261 dst=r5 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(16);
+    r5 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=262 dst=r1 src=r5 offset=72 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(72)) = (uint8_t)r5;
@@ -938,7 +938,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=264 dst=r5 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(24);
+    r5 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=265 dst=r1 src=r5 offset=73 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(73)) = (uint8_t)r5;
@@ -947,7 +947,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(70)) = (uint8_t)r4;
     // EBPF_OP_RSH64_IMM pc=267 dst=r4 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r4 >>= IMMEDIATE(8);
+    r4 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=268 dst=r1 src=r4 offset=71 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(71)) = (uint8_t)r4;

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_raw.c
@@ -82,7 +82,7 @@ encap_reflect_packet(void* context)
     if (r3 > r1)
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 160 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=105 imm=56710
@@ -90,12 +90,12 @@ encap_reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
+        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
 #line 160 "sample/encap_reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 161 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -106,7 +106,7 @@ encap_reflect_packet(void* context)
     if (r4 > r1)
 #line 161 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 167 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=282 imm=17
@@ -114,12 +114,12 @@ encap_reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 167 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 167 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
 #line 167 "sample/encap_reflect_packet.c"
-    r2 <<= IMMEDIATE(2);
+    r2 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=17 dst=r2 src=r0 offset=0 imm=60
 #line 167 "sample/encap_reflect_packet.c"
     r2 &= IMMEDIATE(60);
@@ -137,7 +137,7 @@ encap_reflect_packet(void* context)
     if (r2 > r1)
 #line 167 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 173 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=273 imm=7459
@@ -145,7 +145,7 @@ encap_reflect_packet(void* context)
     if (r1 != IMMEDIATE(7459))
 #line 173 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -160,7 +160,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -168,10 +168,10 @@ encap_reflect_packet(void* context)
     r0 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=30 dst=r1 src=r0 offset=0 imm=32
 #line 22 "sample/encap_reflect_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=31 dst=r1 src=r0 offset=0 imm=32
 #line 22 "sample/encap_reflect_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=32 dst=r2 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r2 = IMMEDIATE(0);
@@ -180,7 +180,7 @@ encap_reflect_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 22 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 28 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r6 src=r6 offset=0 imm=0
@@ -197,7 +197,7 @@ encap_reflect_packet(void* context)
     if (r3 > r4)
 #line 28 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
 #line 35 "sample/encap_reflect_packet.c"
     r2 = r6;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -208,7 +208,7 @@ encap_reflect_packet(void* context)
     if (r2 > r4)
 #line 35 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -219,7 +219,7 @@ encap_reflect_packet(void* context)
     if (r1 > r4)
 #line 43 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r5 = r6;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -230,7 +230,7 @@ encap_reflect_packet(void* context)
     if (r5 > r4)
 #line 43 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 56 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r6 src=r4 offset=4 imm=0
@@ -405,7 +405,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
 #line 73 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=104 dst=r1 src=r0 offset=0 imm=65535
@@ -413,10 +413,10 @@ encap_reflect_packet(void* context)
     r1 &= IMMEDIATE(65535);
     // EBPF_OP_LSH64_IMM pc=105 dst=r0 src=r0 offset=0 imm=32
 #line 73 "sample/encap_reflect_packet.c"
-    r0 <<= IMMEDIATE(32);
+    r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=106 dst=r0 src=r0 offset=0 imm=48
 #line 41 "sample/./xdp_common.h"
-    r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(48);
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(48) & 63);
     // EBPF_OP_ADD64_REG pc=107 dst=r0 src=r1 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r0 += r1;
@@ -425,7 +425,7 @@ encap_reflect_packet(void* context)
     r1 = r0;
     // EBPF_OP_RSH64_IMM pc=109 dst=r1 src=r0 offset=0 imm=16
 #line 42 "sample/./xdp_common.h"
-    r1 >>= IMMEDIATE(16);
+    r1 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_ADD64_REG pc=110 dst=r1 src=r0 offset=0 imm=0
 #line 42 "sample/./xdp_common.h"
     r1 += r0;
@@ -450,7 +450,7 @@ label_1:
     if (r3 > r1)
 #line 178 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
 #line 178 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
@@ -461,7 +461,7 @@ label_1:
     if (r3 > r1)
 #line 184 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
 #line 184 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
@@ -469,7 +469,7 @@ label_1:
     if (r1 != IMMEDIATE(17))
 #line 184 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
+        // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 190 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=123 dst=r1 src=r0 offset=173 imm=7459
@@ -477,7 +477,7 @@ label_1:
     if (r1 != IMMEDIATE(7459))
 #line 190 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=125 dst=r2 src=r0 offset=0 imm=-40
@@ -492,7 +492,7 @@ label_1:
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 87 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=129 dst=r0 src=r0 offset=0 imm=2
@@ -500,10 +500,10 @@ label_1:
     r0 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=130 dst=r1 src=r0 offset=0 imm=32
 #line 87 "sample/encap_reflect_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=131 dst=r1 src=r0 offset=0 imm=32
 #line 87 "sample/encap_reflect_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=132 dst=r2 src=r0 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r2 = IMMEDIATE(0);
@@ -512,7 +512,7 @@ label_1:
     if ((int64_t)r2 > (int64_t)r1)
 #line 87 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
 #line 93 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=135 dst=r1 src=r6 offset=0 imm=0
@@ -529,7 +529,7 @@ label_1:
     if (r2 > r5)
 #line 93 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=140 dst=r4 src=r0 offset=0 imm=40
@@ -540,7 +540,7 @@ label_1:
     if (r4 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
 #line 108 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=143 dst=r3 src=r0 offset=0 imm=54
@@ -551,7 +551,7 @@ label_1:
     if (r3 > r5)
 #line 108 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
 #line 108 "sample/encap_reflect_packet.c"
     r6 = r1;
     // EBPF_OP_ADD64_IMM pc=146 dst=r6 src=r0 offset=0 imm=94
@@ -562,7 +562,7 @@ label_1:
     if (r6 > r5)
 #line 108 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
+        // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
 #line 121 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=149 dst=r1 src=r5 offset=4 imm=0
@@ -636,7 +636,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(87));
     // EBPF_OP_LSH64_IMM pc=172 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=173 dst=r4 src=r1 offset=86 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(86));
@@ -648,7 +648,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(89));
     // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=177 dst=r0 src=r1 offset=88 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(88));
@@ -657,7 +657,7 @@ label_1:
     r4 |= r0;
     // EBPF_OP_LSH64_IMM pc=179 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=180 dst=r4 src=r5 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r5;
@@ -666,7 +666,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(91));
     // EBPF_OP_LSH64_IMM pc=182 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=183 dst=r5 src=r1 offset=90 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(90));
@@ -678,7 +678,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(93));
     // EBPF_OP_LSH64_IMM pc=186 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=187 dst=r6 src=r1 offset=92 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(92));
@@ -687,13 +687,13 @@ label_1:
     r5 |= r6;
     // EBPF_OP_LSH64_IMM pc=189 dst=r5 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(16);
+    r5 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=190 dst=r5 src=r0 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 |= r0;
     // EBPF_OP_LSH64_IMM pc=191 dst=r5 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=192 dst=r5 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 |= r4;
@@ -702,7 +702,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(79));
     // EBPF_OP_LSH64_IMM pc=194 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=195 dst=r4 src=r1 offset=78 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(78));
@@ -714,7 +714,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(81));
     // EBPF_OP_LSH64_IMM pc=198 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=199 dst=r6 src=r1 offset=80 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(80));
@@ -726,7 +726,7 @@ label_1:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r5;
     // EBPF_OP_LSH64_IMM pc=202 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=203 dst=r4 src=r0 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r0;
@@ -735,7 +735,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(83));
     // EBPF_OP_LSH64_IMM pc=205 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=206 dst=r0 src=r1 offset=82 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(82));
@@ -747,7 +747,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(85));
     // EBPF_OP_LSH64_IMM pc=209 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=210 dst=r6 src=r1 offset=84 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(84));
@@ -756,13 +756,13 @@ label_1:
     r0 |= r6;
     // EBPF_OP_LSH64_IMM pc=212 dst=r0 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(16);
+    r0 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=213 dst=r0 src=r5 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 |= r5;
     // EBPF_OP_LSH64_IMM pc=214 dst=r0 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(32);
+    r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=215 dst=r0 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 |= r4;
@@ -801,7 +801,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=227 dst=r5 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(48);
+    r5 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=228 dst=r1 src=r5 offset=68 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(68)) = (uint8_t)r5;
@@ -810,7 +810,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=230 dst=r5 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(56);
+    r5 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=231 dst=r1 src=r5 offset=69 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(69)) = (uint8_t)r5;
@@ -819,7 +819,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=233 dst=r5 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(32);
+    r5 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=234 dst=r1 src=r5 offset=66 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(66)) = (uint8_t)r5;
@@ -828,7 +828,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=236 dst=r5 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(40);
+    r5 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=237 dst=r1 src=r5 offset=67 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(67)) = (uint8_t)r5;
@@ -837,7 +837,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=239 dst=r5 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(16);
+    r5 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=240 dst=r1 src=r5 offset=64 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(64)) = (uint8_t)r5;
@@ -846,7 +846,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=242 dst=r5 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(24);
+    r5 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=243 dst=r1 src=r5 offset=65 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(65)) = (uint8_t)r5;
@@ -855,7 +855,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(62)) = (uint8_t)r4;
     // EBPF_OP_RSH64_IMM pc=245 dst=r4 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r4 >>= IMMEDIATE(8);
+    r4 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=246 dst=r1 src=r4 offset=63 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(63)) = (uint8_t)r4;
@@ -867,7 +867,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=249 dst=r5 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(48);
+    r5 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=250 dst=r1 src=r5 offset=76 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(76)) = (uint8_t)r5;
@@ -876,7 +876,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=252 dst=r5 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(56);
+    r5 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=253 dst=r1 src=r5 offset=77 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(77)) = (uint8_t)r5;
@@ -885,7 +885,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=255 dst=r5 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(32);
+    r5 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=256 dst=r1 src=r5 offset=74 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(74)) = (uint8_t)r5;
@@ -894,7 +894,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=258 dst=r5 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(40);
+    r5 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=259 dst=r1 src=r5 offset=75 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(75)) = (uint8_t)r5;
@@ -903,7 +903,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=261 dst=r5 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(16);
+    r5 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=262 dst=r1 src=r5 offset=72 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(72)) = (uint8_t)r5;
@@ -912,7 +912,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=264 dst=r5 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(24);
+    r5 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=265 dst=r1 src=r5 offset=73 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(73)) = (uint8_t)r5;
@@ -921,7 +921,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(70)) = (uint8_t)r4;
     // EBPF_OP_RSH64_IMM pc=267 dst=r4 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r4 >>= IMMEDIATE(8);
+    r4 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=268 dst=r1 src=r4 offset=71 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(71)) = (uint8_t)r4;

--- a/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/encap_reflect_packet_sys.c
@@ -243,7 +243,7 @@ encap_reflect_packet(void* context)
     if (r3 > r1)
 #line 155 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
+        // EBPF_OP_LDXH pc=7 dst=r4 src=r2 offset=12 imm=0
 #line 160 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=8 dst=r4 src=r0 offset=105 imm=56710
@@ -251,12 +251,12 @@ encap_reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
+        // EBPF_OP_JNE_IMM pc=9 dst=r4 src=r0 offset=287 imm=8
 #line 160 "sample/encap_reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 160 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=10 dst=r4 src=r2 offset=0 imm=0
 #line 161 "sample/encap_reflect_packet.c"
     r4 = r2;
     // EBPF_OP_ADD64_IMM pc=11 dst=r4 src=r0 offset=0 imm=34
@@ -267,7 +267,7 @@ encap_reflect_packet(void* context)
     if (r4 > r1)
 #line 161 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
+        // EBPF_OP_LDXB pc=13 dst=r4 src=r2 offset=23 imm=0
 #line 167 "sample/encap_reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=14 dst=r4 src=r0 offset=282 imm=17
@@ -275,12 +275,12 @@ encap_reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 167 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
+        // EBPF_OP_LDXB pc=15 dst=r2 src=r2 offset=14 imm=0
 #line 167 "sample/encap_reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=2
 #line 167 "sample/encap_reflect_packet.c"
-    r2 <<= IMMEDIATE(2);
+    r2 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=17 dst=r2 src=r0 offset=0 imm=60
 #line 167 "sample/encap_reflect_packet.c"
     r2 &= IMMEDIATE(60);
@@ -298,7 +298,7 @@ encap_reflect_packet(void* context)
     if (r2 > r1)
 #line 167 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=22 dst=r1 src=r3 offset=2 imm=0
 #line 173 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=23 dst=r1 src=r0 offset=273 imm=7459
@@ -306,7 +306,7 @@ encap_reflect_packet(void* context)
     if (r1 != IMMEDIATE(7459))
 #line 173 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=25 dst=r2 src=r0 offset=0 imm=-20
@@ -321,7 +321,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 22 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r1 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=29 dst=r0 src=r0 offset=0 imm=2
@@ -329,10 +329,10 @@ encap_reflect_packet(void* context)
     r0 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=30 dst=r1 src=r0 offset=0 imm=32
 #line 22 "sample/encap_reflect_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=31 dst=r1 src=r0 offset=0 imm=32
 #line 22 "sample/encap_reflect_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=32 dst=r2 src=r0 offset=0 imm=0
 #line 22 "sample/encap_reflect_packet.c"
     r2 = IMMEDIATE(0);
@@ -341,7 +341,7 @@ encap_reflect_packet(void* context)
     if ((int64_t)r2 > (int64_t)r1)
 #line 22 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=34 dst=r4 src=r6 offset=8 imm=0
 #line 28 "sample/encap_reflect_packet.c"
     r4 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=35 dst=r6 src=r6 offset=0 imm=0
@@ -358,7 +358,7 @@ encap_reflect_packet(void* context)
     if (r3 > r4)
 #line 28 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r6 offset=0 imm=0
 #line 35 "sample/encap_reflect_packet.c"
     r2 = r6;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=20
@@ -369,7 +369,7 @@ encap_reflect_packet(void* context)
     if (r2 > r4)
 #line 35 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r6 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_ADD64_IMM pc=43 dst=r1 src=r0 offset=0 imm=34
@@ -380,7 +380,7 @@ encap_reflect_packet(void* context)
     if (r1 > r4)
 #line 43 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=45 dst=r5 src=r6 offset=0 imm=0
 #line 43 "sample/encap_reflect_packet.c"
     r5 = r6;
     // EBPF_OP_ADD64_IMM pc=46 dst=r5 src=r0 offset=0 imm=54
@@ -391,7 +391,7 @@ encap_reflect_packet(void* context)
     if (r5 > r4)
 #line 43 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
+        // EBPF_OP_LDXH pc=48 dst=r4 src=r2 offset=4 imm=0
 #line 56 "sample/encap_reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(4));
     // EBPF_OP_STXH pc=49 dst=r6 src=r4 offset=4 imm=0
@@ -566,7 +566,7 @@ encap_reflect_packet(void* context)
     if ((encap_reflect_packet_helpers[1].tail_call) && (r0 == 0))
 #line 73 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=103 dst=r1 src=r0 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r1 = r0;
     // EBPF_OP_AND64_IMM pc=104 dst=r1 src=r0 offset=0 imm=65535
@@ -574,10 +574,10 @@ encap_reflect_packet(void* context)
     r1 &= IMMEDIATE(65535);
     // EBPF_OP_LSH64_IMM pc=105 dst=r0 src=r0 offset=0 imm=32
 #line 73 "sample/encap_reflect_packet.c"
-    r0 <<= IMMEDIATE(32);
+    r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=106 dst=r0 src=r0 offset=0 imm=48
 #line 41 "sample/./xdp_common.h"
-    r0 = (int64_t)r0 >> (uint32_t)IMMEDIATE(48);
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(48) & 63);
     // EBPF_OP_ADD64_REG pc=107 dst=r0 src=r1 offset=0 imm=0
 #line 41 "sample/./xdp_common.h"
     r0 += r1;
@@ -586,7 +586,7 @@ encap_reflect_packet(void* context)
     r1 = r0;
     // EBPF_OP_RSH64_IMM pc=109 dst=r1 src=r0 offset=0 imm=16
 #line 42 "sample/./xdp_common.h"
-    r1 >>= IMMEDIATE(16);
+    r1 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_ADD64_REG pc=110 dst=r1 src=r0 offset=0 imm=0
 #line 42 "sample/./xdp_common.h"
     r1 += r0;
@@ -611,7 +611,7 @@ label_1:
     if (r3 > r1)
 #line 178 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=117 dst=r3 src=r2 offset=0 imm=0
 #line 178 "sample/encap_reflect_packet.c"
     r3 = r2;
     // EBPF_OP_ADD64_IMM pc=118 dst=r3 src=r0 offset=0 imm=62
@@ -622,7 +622,7 @@ label_1:
     if (r3 > r1)
 #line 184 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
+        // EBPF_OP_LDXB pc=120 dst=r1 src=r2 offset=20 imm=0
 #line 184 "sample/encap_reflect_packet.c"
     r1 = *(uint8_t*)(uintptr_t)(r2 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=121 dst=r1 src=r0 offset=175 imm=17
@@ -630,7 +630,7 @@ label_1:
     if (r1 != IMMEDIATE(17))
 #line 184 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
+        // EBPF_OP_LDXH pc=122 dst=r1 src=r2 offset=56 imm=0
 #line 190 "sample/encap_reflect_packet.c"
     r1 = *(uint16_t*)(uintptr_t)(r2 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=123 dst=r1 src=r0 offset=173 imm=7459
@@ -638,7 +638,7 @@ label_1:
     if (r1 != IMMEDIATE(7459))
 #line 190 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=124 dst=r1 src=r6 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=125 dst=r2 src=r0 offset=0 imm=-40
@@ -653,7 +653,7 @@ label_1:
     if ((encap_reflect_packet_helpers[0].tail_call) && (r0 == 0))
 #line 87 "sample/encap_reflect_packet.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=128 dst=r1 src=r0 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r1 = r0;
     // EBPF_OP_MOV64_IMM pc=129 dst=r0 src=r0 offset=0 imm=2
@@ -661,10 +661,10 @@ label_1:
     r0 = IMMEDIATE(2);
     // EBPF_OP_LSH64_IMM pc=130 dst=r1 src=r0 offset=0 imm=32
 #line 87 "sample/encap_reflect_packet.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=131 dst=r1 src=r0 offset=0 imm=32
 #line 87 "sample/encap_reflect_packet.c"
-    r1 = (int64_t)r1 >> (uint32_t)IMMEDIATE(32);
+    r1 = (int64_t)r1 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=132 dst=r2 src=r0 offset=0 imm=0
 #line 87 "sample/encap_reflect_packet.c"
     r2 = IMMEDIATE(0);
@@ -673,7 +673,7 @@ label_1:
     if ((int64_t)r2 > (int64_t)r1)
 #line 87 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=134 dst=r5 src=r6 offset=8 imm=0
 #line 93 "sample/encap_reflect_packet.c"
     r5 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_LDXDW pc=135 dst=r1 src=r6 offset=0 imm=0
@@ -690,7 +690,7 @@ label_1:
     if (r2 > r5)
 #line 93 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=139 dst=r4 src=r1 offset=0 imm=0
 #line 100 "sample/encap_reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=140 dst=r4 src=r0 offset=0 imm=40
@@ -701,7 +701,7 @@ label_1:
     if (r4 > r5)
 #line 100 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=142 dst=r3 src=r1 offset=0 imm=0
 #line 108 "sample/encap_reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=143 dst=r3 src=r0 offset=0 imm=54
@@ -712,7 +712,7 @@ label_1:
     if (r3 > r5)
 #line 108 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=145 dst=r6 src=r1 offset=0 imm=0
 #line 108 "sample/encap_reflect_packet.c"
     r6 = r1;
     // EBPF_OP_ADD64_IMM pc=146 dst=r6 src=r0 offset=0 imm=94
@@ -723,7 +723,7 @@ label_1:
     if (r6 > r5)
 #line 108 "sample/encap_reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
+        // EBPF_OP_LDXH pc=148 dst=r5 src=r4 offset=4 imm=0
 #line 121 "sample/encap_reflect_packet.c"
     r5 = *(uint16_t*)(uintptr_t)(r4 + OFFSET(4));
     // EBPF_OP_STXH pc=149 dst=r1 src=r5 offset=4 imm=0
@@ -797,7 +797,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(87));
     // EBPF_OP_LSH64_IMM pc=172 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=173 dst=r4 src=r1 offset=86 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(86));
@@ -809,7 +809,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(89));
     // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=177 dst=r0 src=r1 offset=88 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(88));
@@ -818,7 +818,7 @@ label_1:
     r4 |= r0;
     // EBPF_OP_LSH64_IMM pc=179 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=180 dst=r4 src=r5 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r5;
@@ -827,7 +827,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(91));
     // EBPF_OP_LSH64_IMM pc=182 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=183 dst=r5 src=r1 offset=90 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(90));
@@ -839,7 +839,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(93));
     // EBPF_OP_LSH64_IMM pc=186 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=187 dst=r6 src=r1 offset=92 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(92));
@@ -848,13 +848,13 @@ label_1:
     r5 |= r6;
     // EBPF_OP_LSH64_IMM pc=189 dst=r5 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(16);
+    r5 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=190 dst=r5 src=r0 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 |= r0;
     // EBPF_OP_LSH64_IMM pc=191 dst=r5 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=192 dst=r5 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 |= r4;
@@ -863,7 +863,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(79));
     // EBPF_OP_LSH64_IMM pc=194 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=195 dst=r4 src=r1 offset=78 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(78));
@@ -875,7 +875,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(81));
     // EBPF_OP_LSH64_IMM pc=198 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=199 dst=r6 src=r1 offset=80 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(80));
@@ -887,7 +887,7 @@ label_1:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r5;
     // EBPF_OP_LSH64_IMM pc=202 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=203 dst=r4 src=r0 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r0;
@@ -896,7 +896,7 @@ label_1:
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(83));
     // EBPF_OP_LSH64_IMM pc=205 dst=r5 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=206 dst=r0 src=r1 offset=82 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(82));
@@ -908,7 +908,7 @@ label_1:
     r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(85));
     // EBPF_OP_LSH64_IMM pc=209 dst=r0 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(8);
+    r0 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=210 dst=r6 src=r1 offset=84 imm=0
 #line 32 "sample/./xdp_common.h"
     r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(84));
@@ -917,13 +917,13 @@ label_1:
     r0 |= r6;
     // EBPF_OP_LSH64_IMM pc=212 dst=r0 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(16);
+    r0 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=213 dst=r0 src=r5 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 |= r5;
     // EBPF_OP_LSH64_IMM pc=214 dst=r0 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r0 <<= IMMEDIATE(32);
+    r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=215 dst=r0 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r0 |= r4;
@@ -962,7 +962,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=227 dst=r5 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(48);
+    r5 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=228 dst=r1 src=r5 offset=68 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(68)) = (uint8_t)r5;
@@ -971,7 +971,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=230 dst=r5 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(56);
+    r5 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=231 dst=r1 src=r5 offset=69 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(69)) = (uint8_t)r5;
@@ -980,7 +980,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=233 dst=r5 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(32);
+    r5 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=234 dst=r1 src=r5 offset=66 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(66)) = (uint8_t)r5;
@@ -989,7 +989,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=236 dst=r5 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(40);
+    r5 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=237 dst=r1 src=r5 offset=67 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(67)) = (uint8_t)r5;
@@ -998,7 +998,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=239 dst=r5 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(16);
+    r5 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=240 dst=r1 src=r5 offset=64 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(64)) = (uint8_t)r5;
@@ -1007,7 +1007,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=242 dst=r5 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(24);
+    r5 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=243 dst=r1 src=r5 offset=65 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(65)) = (uint8_t)r5;
@@ -1016,7 +1016,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(62)) = (uint8_t)r4;
     // EBPF_OP_RSH64_IMM pc=245 dst=r4 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r4 >>= IMMEDIATE(8);
+    r4 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=246 dst=r1 src=r4 offset=63 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(63)) = (uint8_t)r4;
@@ -1028,7 +1028,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=249 dst=r5 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(48);
+    r5 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=250 dst=r1 src=r5 offset=76 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(76)) = (uint8_t)r5;
@@ -1037,7 +1037,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=252 dst=r5 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(56);
+    r5 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=253 dst=r1 src=r5 offset=77 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(77)) = (uint8_t)r5;
@@ -1046,7 +1046,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=255 dst=r5 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(32);
+    r5 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=256 dst=r1 src=r5 offset=74 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(74)) = (uint8_t)r5;
@@ -1055,7 +1055,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=258 dst=r5 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(40);
+    r5 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=259 dst=r1 src=r5 offset=75 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(75)) = (uint8_t)r5;
@@ -1064,7 +1064,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=261 dst=r5 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(16);
+    r5 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=262 dst=r1 src=r5 offset=72 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(72)) = (uint8_t)r5;
@@ -1073,7 +1073,7 @@ label_1:
     r5 = r4;
     // EBPF_OP_RSH64_IMM pc=264 dst=r5 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r5 >>= IMMEDIATE(24);
+    r5 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=265 dst=r1 src=r5 offset=73 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(73)) = (uint8_t)r5;
@@ -1082,7 +1082,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(70)) = (uint8_t)r4;
     // EBPF_OP_RSH64_IMM pc=267 dst=r4 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r4 >>= IMMEDIATE(8);
+    r4 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=268 dst=r1 src=r4 offset=71 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(71)) = (uint8_t)r4;

--- a/tests/bpf2c_tests/expected/invalid_helpers_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_dll.c
@@ -206,12 +206,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 131 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 133 "sample/unsafe/invalid_helpers.c"
     if (r0 != IMMEDIATE(0))
 #line 133 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 136 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -313,12 +313,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 147 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 149 "sample/unsafe/invalid_helpers.c"
     if (r0 != IMMEDIATE(0))
 #line 149 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 152 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -428,7 +428,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 164 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/unsafe/invalid_helpers.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=89 imm=0
@@ -436,7 +436,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=87 imm=0
@@ -444,7 +444,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 82 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -498,12 +498,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 87 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 88 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_1:
@@ -525,12 +525,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 92 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 93 "sample/unsafe/invalid_helpers.c"
         goto label_2;
-    // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_2:
@@ -542,7 +542,7 @@ label_2:
     if (r1 != IMMEDIATE(0))
 #line 97 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=41 dst=r1 src=r0 offset=56 imm=0
@@ -550,7 +550,7 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=43 dst=r1 src=r0 offset=54 imm=0
@@ -558,7 +558,7 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r8 src=r0 offset=0 imm=-8
@@ -591,7 +591,7 @@ label_2:
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
 #line 105 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
 #line 106 "sample/unsafe/invalid_helpers.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=56 dst=r2 src=r8 offset=0 imm=0
@@ -606,12 +606,12 @@ label_2:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 106 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 107 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=4
@@ -632,7 +632,7 @@ label_3:
     if (r2 >= r3)
 #line 112 "sample/unsafe/invalid_helpers.c"
         goto label_4;
-    // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
 #line 116 "sample/unsafe/invalid_helpers.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=66 dst=r3 src=r9 offset=0 imm=0
@@ -661,12 +661,12 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_5;
-    // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
 #line 175 "sample/unsafe/invalid_helpers.c"
     if (r1 == IMMEDIATE(2))
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_6;
-    // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=11 imm=0
@@ -687,7 +687,7 @@ label_5:
     if (r1 >= r2)
 #line 177 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=81 dst=r0 src=r1 offset=0 imm=0
@@ -705,7 +705,7 @@ label_6:
     if (r1 == IMMEDIATE(0))
 #line 184 "sample/unsafe/invalid_helpers.c"
         goto label_8;
-    // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
 #line 185 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=86 dst=r0 src=r1 offset=0 imm=0
@@ -717,10 +717,10 @@ label_7:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=88 dst=r1 src=r0 offset=0 imm=32
 #line 192 "sample/unsafe/invalid_helpers.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=89 dst=r1 src=r0 offset=0 imm=32
 #line 192 "sample/unsafe/invalid_helpers.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/invalid_helpers_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_raw.c
@@ -180,12 +180,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 131 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 133 "sample/unsafe/invalid_helpers.c"
     if (r0 != IMMEDIATE(0))
 #line 133 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 136 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -287,12 +287,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 147 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 149 "sample/unsafe/invalid_helpers.c"
     if (r0 != IMMEDIATE(0))
 #line 149 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 152 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -402,7 +402,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 164 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/unsafe/invalid_helpers.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=89 imm=0
@@ -410,7 +410,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=87 imm=0
@@ -418,7 +418,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 82 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -472,12 +472,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 87 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 88 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_1:
@@ -499,12 +499,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 92 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 93 "sample/unsafe/invalid_helpers.c"
         goto label_2;
-    // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_2:
@@ -516,7 +516,7 @@ label_2:
     if (r1 != IMMEDIATE(0))
 #line 97 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=41 dst=r1 src=r0 offset=56 imm=0
@@ -524,7 +524,7 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=43 dst=r1 src=r0 offset=54 imm=0
@@ -532,7 +532,7 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r8 src=r0 offset=0 imm=-8
@@ -565,7 +565,7 @@ label_2:
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
 #line 105 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
 #line 106 "sample/unsafe/invalid_helpers.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=56 dst=r2 src=r8 offset=0 imm=0
@@ -580,12 +580,12 @@ label_2:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 106 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 107 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=4
@@ -606,7 +606,7 @@ label_3:
     if (r2 >= r3)
 #line 112 "sample/unsafe/invalid_helpers.c"
         goto label_4;
-    // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
 #line 116 "sample/unsafe/invalid_helpers.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=66 dst=r3 src=r9 offset=0 imm=0
@@ -635,12 +635,12 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_5;
-    // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
 #line 175 "sample/unsafe/invalid_helpers.c"
     if (r1 == IMMEDIATE(2))
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_6;
-    // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=11 imm=0
@@ -661,7 +661,7 @@ label_5:
     if (r1 >= r2)
 #line 177 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=81 dst=r0 src=r1 offset=0 imm=0
@@ -679,7 +679,7 @@ label_6:
     if (r1 == IMMEDIATE(0))
 #line 184 "sample/unsafe/invalid_helpers.c"
         goto label_8;
-    // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
 #line 185 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=86 dst=r0 src=r1 offset=0 imm=0
@@ -691,10 +691,10 @@ label_7:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=88 dst=r1 src=r0 offset=0 imm=32
 #line 192 "sample/unsafe/invalid_helpers.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=89 dst=r1 src=r0 offset=0 imm=32
 #line 192 "sample/unsafe/invalid_helpers.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/invalid_helpers_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_helpers_sys.c
@@ -341,12 +341,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 131 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 133 "sample/unsafe/invalid_helpers.c"
     if (r0 != IMMEDIATE(0))
 #line 133 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 136 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -448,12 +448,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 147 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 149 "sample/unsafe/invalid_helpers.c"
     if (r0 != IMMEDIATE(0))
 #line 149 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 152 "sample/unsafe/invalid_helpers.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -563,7 +563,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 164 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 164 "sample/unsafe/invalid_helpers.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=89 imm=0
@@ -571,7 +571,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 165 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=87 imm=0
@@ -579,7 +579,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 165 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 82 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -633,12 +633,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 87 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 88 "sample/unsafe/invalid_helpers.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=40 imm=0
 #line 88 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_1:
@@ -660,12 +660,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 92 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=36 dst=r0 src=r0 offset=1 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 93 "sample/unsafe/invalid_helpers.c"
         goto label_2;
-    // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=37 dst=r0 src=r0 offset=33 imm=0
 #line 93 "sample/unsafe/invalid_helpers.c"
     goto label_4;
 label_2:
@@ -677,7 +677,7 @@ label_2:
     if (r1 != IMMEDIATE(0))
 #line 97 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=40 dst=r1 src=r6 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=41 dst=r1 src=r0 offset=56 imm=0
@@ -685,7 +685,7 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=42 dst=r1 src=r6 offset=8 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=43 dst=r1 src=r0 offset=54 imm=0
@@ -693,7 +693,7 @@ label_2:
     if (r1 == IMMEDIATE(0))
 #line 101 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=44 dst=r8 src=r10 offset=0 imm=0
 #line 101 "sample/unsafe/invalid_helpers.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=45 dst=r8 src=r0 offset=0 imm=-8
@@ -726,7 +726,7 @@ label_2:
     if ((BindMonitor_Callee1_helpers[2].tail_call) && (r0 == 0))
 #line 105 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=0
 #line 106 "sample/unsafe/invalid_helpers.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=56 dst=r2 src=r8 offset=0 imm=0
@@ -741,12 +741,12 @@ label_2:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 106 "sample/unsafe/invalid_helpers.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=58 dst=r0 src=r0 offset=39 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     if (r0 == IMMEDIATE(0))
 #line 107 "sample/unsafe/invalid_helpers.c"
         goto label_9;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r0 offset=0 imm=0
 #line 107 "sample/unsafe/invalid_helpers.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=4
@@ -767,7 +767,7 @@ label_3:
     if (r2 >= r3)
 #line 112 "sample/unsafe/invalid_helpers.c"
         goto label_4;
-    // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=65 dst=r3 src=r1 offset=0 imm=0
 #line 116 "sample/unsafe/invalid_helpers.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=66 dst=r3 src=r9 offset=0 imm=0
@@ -796,12 +796,12 @@ label_4:
     if (r1 == IMMEDIATE(0))
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_5;
-    // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=73 dst=r1 src=r0 offset=9 imm=2
 #line 175 "sample/unsafe/invalid_helpers.c"
     if (r1 == IMMEDIATE(2))
 #line 175 "sample/unsafe/invalid_helpers.c"
         goto label_6;
-    // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=74 dst=r1 src=r0 offset=0 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=75 dst=r0 src=r0 offset=11 imm=0
@@ -822,7 +822,7 @@ label_5:
     if (r1 >= r2)
 #line 177 "sample/unsafe/invalid_helpers.c"
         goto label_10;
-    // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=80 dst=r1 src=r0 offset=0 imm=1
 #line 181 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=81 dst=r0 src=r1 offset=0 imm=0
@@ -840,7 +840,7 @@ label_6:
     if (r1 == IMMEDIATE(0))
 #line 184 "sample/unsafe/invalid_helpers.c"
         goto label_8;
-    // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=85 dst=r1 src=r0 offset=0 imm=-1
 #line 185 "sample/unsafe/invalid_helpers.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=86 dst=r0 src=r1 offset=0 imm=0
@@ -852,10 +852,10 @@ label_7:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=88 dst=r1 src=r0 offset=0 imm=32
 #line 192 "sample/unsafe/invalid_helpers.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=89 dst=r1 src=r0 offset=0 imm=32
 #line 192 "sample/unsafe/invalid_helpers.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 192 "sample/unsafe/invalid_helpers.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/invalid_maps1_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_dll.c
@@ -218,12 +218,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 138 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 140 "sample/unsafe/invalid_maps1.c"
     if (r0 != IMMEDIATE(0))
 #line 140 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 143 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -325,12 +325,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 154 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 156 "sample/unsafe/invalid_maps1.c"
     if (r0 != IMMEDIATE(0))
 #line 156 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 159 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -439,7 +439,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 171 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 171 "sample/unsafe/invalid_maps1.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -447,7 +447,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -455,7 +455,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 94 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -509,12 +509,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 99 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     if (r0 == IMMEDIATE(0))
 #line 100 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     goto label_3;
 label_1:
@@ -526,7 +526,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 104 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -534,7 +534,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -542,7 +542,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -575,7 +575,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 112 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 113 "sample/unsafe/invalid_maps1.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -590,12 +590,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 113 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     if (r0 == IMMEDIATE(0))
 #line 114 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -616,7 +616,7 @@ label_2:
     if (r2 >= r3)
 #line 119 "sample/unsafe/invalid_maps1.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 123 "sample/unsafe/invalid_maps1.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -645,12 +645,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 182 "sample/unsafe/invalid_maps1.c"
     if (r1 == IMMEDIATE(2))
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -671,7 +671,7 @@ label_4:
     if (r1 >= r2)
 #line 184 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 188 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -689,7 +689,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 191 "sample/unsafe/invalid_maps1.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 192 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -701,10 +701,10 @@ label_6:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
 #line 199 "sample/unsafe/invalid_maps1.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
 #line 199 "sample/unsafe/invalid_maps1.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/invalid_maps1_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_raw.c
@@ -192,12 +192,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 138 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 140 "sample/unsafe/invalid_maps1.c"
     if (r0 != IMMEDIATE(0))
 #line 140 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 143 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -299,12 +299,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 154 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 156 "sample/unsafe/invalid_maps1.c"
     if (r0 != IMMEDIATE(0))
 #line 156 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 159 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -413,7 +413,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 171 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 171 "sample/unsafe/invalid_maps1.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -421,7 +421,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -429,7 +429,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 94 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -483,12 +483,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 99 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     if (r0 == IMMEDIATE(0))
 #line 100 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     goto label_3;
 label_1:
@@ -500,7 +500,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 104 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -508,7 +508,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -516,7 +516,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -549,7 +549,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 112 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 113 "sample/unsafe/invalid_maps1.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -564,12 +564,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 113 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     if (r0 == IMMEDIATE(0))
 #line 114 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -590,7 +590,7 @@ label_2:
     if (r2 >= r3)
 #line 119 "sample/unsafe/invalid_maps1.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 123 "sample/unsafe/invalid_maps1.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -619,12 +619,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 182 "sample/unsafe/invalid_maps1.c"
     if (r1 == IMMEDIATE(2))
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -645,7 +645,7 @@ label_4:
     if (r1 >= r2)
 #line 184 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 188 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -663,7 +663,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 191 "sample/unsafe/invalid_maps1.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 192 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -675,10 +675,10 @@ label_6:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
 #line 199 "sample/unsafe/invalid_maps1.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
 #line 199 "sample/unsafe/invalid_maps1.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/invalid_maps1_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_maps1_sys.c
@@ -353,12 +353,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 138 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 140 "sample/unsafe/invalid_maps1.c"
     if (r0 != IMMEDIATE(0))
 #line 140 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 143 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -460,12 +460,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 154 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 156 "sample/unsafe/invalid_maps1.c"
     if (r0 != IMMEDIATE(0))
 #line 156 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 159 "sample/unsafe/invalid_maps1.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -574,7 +574,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 171 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 171 "sample/unsafe/invalid_maps1.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -582,7 +582,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 172 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -590,7 +590,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 172 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 94 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -644,12 +644,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 99 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     if (r0 == IMMEDIATE(0))
 #line 100 "sample/unsafe/invalid_maps1.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 100 "sample/unsafe/invalid_maps1.c"
     goto label_3;
 label_1:
@@ -661,7 +661,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 104 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -669,7 +669,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -677,7 +677,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 108 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 108 "sample/unsafe/invalid_maps1.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -710,7 +710,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 112 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 113 "sample/unsafe/invalid_maps1.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -725,12 +725,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 113 "sample/unsafe/invalid_maps1.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     if (r0 == IMMEDIATE(0))
 #line 114 "sample/unsafe/invalid_maps1.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 114 "sample/unsafe/invalid_maps1.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -751,7 +751,7 @@ label_2:
     if (r2 >= r3)
 #line 119 "sample/unsafe/invalid_maps1.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 123 "sample/unsafe/invalid_maps1.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -780,12 +780,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 182 "sample/unsafe/invalid_maps1.c"
     if (r1 == IMMEDIATE(2))
 #line 182 "sample/unsafe/invalid_maps1.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -806,7 +806,7 @@ label_4:
     if (r1 >= r2)
 #line 184 "sample/unsafe/invalid_maps1.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 188 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -824,7 +824,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 191 "sample/unsafe/invalid_maps1.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 192 "sample/unsafe/invalid_maps1.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -836,10 +836,10 @@ label_6:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
 #line 199 "sample/unsafe/invalid_maps1.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
 #line 199 "sample/unsafe/invalid_maps1.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 199 "sample/unsafe/invalid_maps1.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/invalid_maps2_dll.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_dll.c
@@ -230,12 +230,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 149 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 151 "sample/unsafe/invalid_maps2.c"
     if (r0 != IMMEDIATE(0))
 #line 151 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 154 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -337,12 +337,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 165 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 167 "sample/unsafe/invalid_maps2.c"
     if (r0 != IMMEDIATE(0))
 #line 167 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 170 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -451,7 +451,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 182 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 182 "sample/unsafe/invalid_maps2.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -459,7 +459,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -467,7 +467,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 105 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -521,12 +521,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 110 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     if (r0 == IMMEDIATE(0))
 #line 111 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     goto label_3;
 label_1:
@@ -538,7 +538,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 115 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -546,7 +546,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -554,7 +554,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -587,7 +587,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 123 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 124 "sample/unsafe/invalid_maps2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -602,12 +602,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 124 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     if (r0 == IMMEDIATE(0))
 #line 125 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -628,7 +628,7 @@ label_2:
     if (r2 >= r3)
 #line 130 "sample/unsafe/invalid_maps2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 134 "sample/unsafe/invalid_maps2.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -657,12 +657,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 193 "sample/unsafe/invalid_maps2.c"
     if (r1 == IMMEDIATE(2))
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -683,7 +683,7 @@ label_4:
     if (r1 >= r2)
 #line 195 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 199 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -701,7 +701,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 202 "sample/unsafe/invalid_maps2.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 203 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -713,10 +713,10 @@ label_6:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
 #line 210 "sample/unsafe/invalid_maps2.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
 #line 210 "sample/unsafe/invalid_maps2.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/invalid_maps2_raw.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_raw.c
@@ -204,12 +204,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 149 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 151 "sample/unsafe/invalid_maps2.c"
     if (r0 != IMMEDIATE(0))
 #line 151 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 154 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -311,12 +311,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 165 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 167 "sample/unsafe/invalid_maps2.c"
     if (r0 != IMMEDIATE(0))
 #line 167 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 170 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -425,7 +425,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 182 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 182 "sample/unsafe/invalid_maps2.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -433,7 +433,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -441,7 +441,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 105 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -495,12 +495,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 110 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     if (r0 == IMMEDIATE(0))
 #line 111 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     goto label_3;
 label_1:
@@ -512,7 +512,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 115 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -520,7 +520,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -528,7 +528,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -561,7 +561,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 123 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 124 "sample/unsafe/invalid_maps2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -576,12 +576,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 124 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     if (r0 == IMMEDIATE(0))
 #line 125 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -602,7 +602,7 @@ label_2:
     if (r2 >= r3)
 #line 130 "sample/unsafe/invalid_maps2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 134 "sample/unsafe/invalid_maps2.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -631,12 +631,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 193 "sample/unsafe/invalid_maps2.c"
     if (r1 == IMMEDIATE(2))
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -657,7 +657,7 @@ label_4:
     if (r1 >= r2)
 #line 195 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 199 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -675,7 +675,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 202 "sample/unsafe/invalid_maps2.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 203 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -687,10 +687,10 @@ label_6:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
 #line 210 "sample/unsafe/invalid_maps2.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
 #line 210 "sample/unsafe/invalid_maps2.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/invalid_maps2_sys.c
+++ b/tests/bpf2c_tests/expected/invalid_maps2_sys.c
@@ -365,12 +365,12 @@ BindMonitor(void* context)
     if ((BindMonitor_helpers[0].tail_call) && (r0 == 0))
 #line 149 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 151 "sample/unsafe/invalid_maps2.c"
     if (r0 != IMMEDIATE(0))
 #line 151 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 154 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -472,12 +472,12 @@ BindMonitor_Callee0(void* context)
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
 #line 165 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
+        // EBPF_OP_JNE_IMM pc=8 dst=r0 src=r0 offset=5 imm=0
 #line 167 "sample/unsafe/invalid_maps2.c"
     if (r0 != IMMEDIATE(0))
 #line 167 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r6 offset=0 imm=0
 #line 170 "sample/unsafe/invalid_maps2.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=10 dst=r2 src=r0 offset=0 imm=0
@@ -586,7 +586,7 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 182 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=8 dst=r7 src=r0 offset=0 imm=0
 #line 182 "sample/unsafe/invalid_maps2.c"
     r7 = r0;
     // EBPF_OP_JEQ_IMM pc=9 dst=r7 src=r0 offset=82 imm=0
@@ -594,7 +594,7 @@ BindMonitor_Callee1(void* context)
     if (r7 == IMMEDIATE(0))
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
+        // EBPF_OP_LDXW pc=10 dst=r1 src=r7 offset=0 imm=0
 #line 183 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r7 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=11 dst=r1 src=r0 offset=80 imm=0
@@ -602,7 +602,7 @@ BindMonitor_Callee1(void* context)
     if (r1 == IMMEDIATE(0))
 #line 183 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=12 dst=r1 src=r6 offset=16 imm=0
 #line 105 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-8 imm=0
@@ -656,12 +656,12 @@ BindMonitor_Callee1(void* context)
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 110 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
+        // EBPF_OP_JEQ_IMM pc=29 dst=r0 src=r0 offset=1 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     if (r0 == IMMEDIATE(0))
 #line 111 "sample/unsafe/invalid_maps2.c"
         goto label_1;
-    // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
+        // EBPF_OP_JA pc=30 dst=r0 src=r0 offset=33 imm=0
 #line 111 "sample/unsafe/invalid_maps2.c"
     goto label_3;
 label_1:
@@ -673,7 +673,7 @@ label_1:
     if (r1 != IMMEDIATE(0))
 #line 115 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
+        // EBPF_OP_LDXDW pc=33 dst=r1 src=r6 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JEQ_IMM pc=34 dst=r1 src=r0 offset=56 imm=0
@@ -681,7 +681,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
+        // EBPF_OP_LDXDW pc=35 dst=r1 src=r6 offset=8 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(8));
     // EBPF_OP_JEQ_IMM pc=36 dst=r1 src=r0 offset=54 imm=0
@@ -689,7 +689,7 @@ label_1:
     if (r1 == IMMEDIATE(0))
 #line 119 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r8 src=r10 offset=0 imm=0
 #line 119 "sample/unsafe/invalid_maps2.c"
     r8 = r10;
     // EBPF_OP_ADD64_IMM pc=38 dst=r8 src=r0 offset=0 imm=-8
@@ -722,7 +722,7 @@ label_1:
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
 #line 123 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 124 "sample/unsafe/invalid_maps2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_REG pc=49 dst=r2 src=r8 offset=0 imm=0
@@ -737,12 +737,12 @@ label_1:
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
 #line 124 "sample/unsafe/invalid_maps2.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
+        // EBPF_OP_JEQ_IMM pc=51 dst=r0 src=r0 offset=39 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     if (r0 == IMMEDIATE(0))
 #line 125 "sample/unsafe/invalid_maps2.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=52 dst=r1 src=r0 offset=0 imm=0
 #line 125 "sample/unsafe/invalid_maps2.c"
     r1 = r0;
     // EBPF_OP_ADD64_IMM pc=53 dst=r1 src=r0 offset=0 imm=4
@@ -763,7 +763,7 @@ label_2:
     if (r2 >= r3)
 #line 130 "sample/unsafe/invalid_maps2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=58 dst=r3 src=r1 offset=0 imm=0
 #line 134 "sample/unsafe/invalid_maps2.c"
     r3 = r1;
     // EBPF_OP_ADD64_REG pc=59 dst=r3 src=r9 offset=0 imm=0
@@ -792,12 +792,12 @@ label_3:
     if (r1 == IMMEDIATE(0))
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_4;
-    // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
+        // EBPF_OP_JEQ_IMM pc=66 dst=r1 src=r0 offset=9 imm=2
 #line 193 "sample/unsafe/invalid_maps2.c"
     if (r1 == IMMEDIATE(2))
 #line 193 "sample/unsafe/invalid_maps2.c"
         goto label_5;
-    // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_LDXW pc=67 dst=r1 src=r0 offset=0 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     r1 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
     // EBPF_OP_JA pc=68 dst=r0 src=r0 offset=11 imm=0
@@ -818,7 +818,7 @@ label_4:
     if (r1 >= r2)
 #line 195 "sample/unsafe/invalid_maps2.c"
         goto label_9;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
+        // EBPF_OP_ADD64_IMM pc=73 dst=r1 src=r0 offset=0 imm=1
 #line 199 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(1);
     // EBPF_OP_STXW pc=74 dst=r0 src=r1 offset=0 imm=0
@@ -836,7 +836,7 @@ label_5:
     if (r1 == IMMEDIATE(0))
 #line 202 "sample/unsafe/invalid_maps2.c"
         goto label_7;
-    // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
+        // EBPF_OP_ADD64_IMM pc=78 dst=r1 src=r0 offset=0 imm=-1
 #line 203 "sample/unsafe/invalid_maps2.c"
     r1 += IMMEDIATE(-1);
     // EBPF_OP_STXW pc=79 dst=r0 src=r1 offset=0 imm=0
@@ -848,10 +848,10 @@ label_6:
     r8 = IMMEDIATE(0);
     // EBPF_OP_LSH64_IMM pc=81 dst=r1 src=r0 offset=0 imm=32
 #line 210 "sample/unsafe/invalid_maps2.c"
-    r1 <<= IMMEDIATE(32);
+    r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_RSH64_IMM pc=82 dst=r1 src=r0 offset=0 imm=32
 #line 210 "sample/unsafe/invalid_maps2.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JNE_IMM pc=83 dst=r1 src=r0 offset=8 imm=0
 #line 210 "sample/unsafe/invalid_maps2.c"
     if (r1 != IMMEDIATE(0))

--- a/tests/bpf2c_tests/expected/map_dll.c
+++ b/tests/bpf2c_tests/expected/map_dll.c
@@ -256,10 +256,10 @@ test_maps(void* context)
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=14 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=15 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=16 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -390,10 +390,10 @@ label_4:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=60 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=61 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=62 dst=r3 src=r0 offset=41 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -485,10 +485,10 @@ label_7:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=96 dst=r3 src=r0 offset=0 imm=32
 #line 289 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=97 dst=r3 src=r0 offset=0 imm=32
 #line 289 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=98 dst=r1 src=r10 offset=0 imm=0
 #line 289 "sample/map.c"
     r1 = r10;
@@ -551,10 +551,10 @@ label_10:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=114 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=115 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=116 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -689,10 +689,10 @@ label_12:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=161 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=162 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=163 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -823,10 +823,10 @@ label_16:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=207 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=208 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=209 dst=r3 src=r0 offset=42 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -924,10 +924,10 @@ label_19:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=246 dst=r3 src=r0 offset=0 imm=32
 #line 290 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=247 dst=r3 src=r0 offset=0 imm=32
 #line 290 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=248 dst=r1 src=r10 offset=0 imm=0
 #line 290 "sample/map.c"
     r1 = r10;
@@ -976,10 +976,10 @@ label_20:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=262 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=263 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=264 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1114,10 +1114,10 @@ label_22:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=309 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=310 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=311 dst=r3 src=r0 offset=1 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1231,10 +1231,10 @@ label_24:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=347 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=348 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=349 dst=r3 src=r0 offset=9 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1297,10 +1297,10 @@ label_25:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=370 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=371 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=372 dst=r3 src=r0 offset=41 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1398,10 +1398,10 @@ label_28:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=408 dst=r3 src=r0 offset=0 imm=32
 #line 291 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=409 dst=r3 src=r0 offset=0 imm=32
 #line 291 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=410 dst=r1 src=r10 offset=0 imm=0
 #line 291 "sample/map.c"
     r1 = r10;
@@ -1459,10 +1459,10 @@ label_29:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=427 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=428 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=429 dst=r3 src=r0 offset=1 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1576,10 +1576,10 @@ label_31:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=465 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=466 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=467 dst=r3 src=r0 offset=9 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1642,10 +1642,10 @@ label_32:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=488 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=489 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=490 dst=r3 src=r0 offset=42 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1743,10 +1743,10 @@ label_35:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=527 dst=r3 src=r0 offset=0 imm=32
 #line 292 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=528 dst=r3 src=r0 offset=0 imm=32
 #line 292 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=529 dst=r1 src=r10 offset=0 imm=0
 #line 292 "sample/map.c"
     r1 = r10;
@@ -1804,10 +1804,10 @@ label_36:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=546 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=547 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=548 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1938,10 +1938,10 @@ label_40:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=592 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=593 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=594 dst=r3 src=r0 offset=40 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2032,10 +2032,10 @@ label_42:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=629 dst=r3 src=r0 offset=0 imm=32
 #line 293 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=630 dst=r3 src=r0 offset=0 imm=32
 #line 293 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=631 dst=r1 src=r10 offset=0 imm=0
 #line 293 "sample/map.c"
     r1 = r10;
@@ -2084,10 +2084,10 @@ label_43:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=645 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=646 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=647 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2222,10 +2222,10 @@ label_45:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=692 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=693 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=694 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2356,10 +2356,10 @@ label_49:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=738 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=739 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=740 dst=r3 src=r0 offset=43 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2456,10 +2456,10 @@ label_51:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=778 dst=r3 src=r0 offset=0 imm=32
 #line 294 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=779 dst=r3 src=r0 offset=0 imm=32
 #line 294 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=780 dst=r1 src=r10 offset=0 imm=0
 #line 294 "sample/map.c"
     r1 = r10;
@@ -2508,10 +2508,10 @@ label_52:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=794 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=795 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=796 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2646,10 +2646,10 @@ label_54:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=841 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=842 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=843 dst=r3 src=r0 offset=1 imm=-1
 #line 126 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2697,10 +2697,10 @@ label_55:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=856 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=857 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=858 dst=r3 src=r0 offset=1 imm=-1
 #line 132 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2751,10 +2751,10 @@ label_56:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=872 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=873 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=874 dst=r3 src=r0 offset=1 imm=-1
 #line 138 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2805,10 +2805,10 @@ label_57:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=888 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=889 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=890 dst=r3 src=r0 offset=1 imm=-1
 #line 144 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2859,10 +2859,10 @@ label_58:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=904 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=905 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=906 dst=r3 src=r0 offset=1 imm=-1
 #line 150 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2913,10 +2913,10 @@ label_59:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=920 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=921 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=922 dst=r3 src=r0 offset=1 imm=-1
 #line 156 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2967,10 +2967,10 @@ label_60:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=936 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=937 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=938 dst=r3 src=r0 offset=1 imm=-1
 #line 162 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3021,10 +3021,10 @@ label_61:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=952 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=953 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=954 dst=r3 src=r0 offset=1 imm=-1
 #line 168 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3075,10 +3075,10 @@ label_62:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=968 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=969 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=970 dst=r3 src=r0 offset=1 imm=-1
 #line 174 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3129,10 +3129,10 @@ label_63:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=984 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=985 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=986 dst=r3 src=r0 offset=1 imm=-1
 #line 180 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3186,10 +3186,10 @@ label_64:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1001 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1002 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1003 dst=r3 src=r0 offset=32 imm=-1
 #line 186 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3319,10 +3319,10 @@ label_66:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1049 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1050 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1051 dst=r3 src=r0 offset=1 imm=-1
 #line 126 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3370,10 +3370,10 @@ label_67:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1064 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1065 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1066 dst=r3 src=r0 offset=1 imm=-1
 #line 132 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3424,10 +3424,10 @@ label_68:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1080 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1081 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1082 dst=r3 src=r0 offset=1 imm=-1
 #line 138 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3478,10 +3478,10 @@ label_69:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1096 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1097 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1098 dst=r3 src=r0 offset=1 imm=-1
 #line 144 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3532,10 +3532,10 @@ label_70:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1112 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1113 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1114 dst=r3 src=r0 offset=1 imm=-1
 #line 150 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3586,10 +3586,10 @@ label_71:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1128 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1129 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1130 dst=r3 src=r0 offset=1 imm=-1
 #line 156 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3640,10 +3640,10 @@ label_72:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1144 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1145 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1146 dst=r3 src=r0 offset=1 imm=-1
 #line 162 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3694,10 +3694,10 @@ label_73:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1160 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1161 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1162 dst=r3 src=r0 offset=1 imm=-1
 #line 168 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3748,10 +3748,10 @@ label_74:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1176 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1177 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1178 dst=r3 src=r0 offset=1 imm=-1
 #line 174 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3802,10 +3802,10 @@ label_75:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1192 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1193 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1194 dst=r3 src=r0 offset=1 imm=-1
 #line 180 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3859,10 +3859,10 @@ label_76:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1209 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1210 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1211 dst=r3 src=r0 offset=35 imm=-1
 #line 186 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3983,13 +3983,13 @@ label_78:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1255 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1256 dst=r1 src=r4 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1257 dst=r1 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1258 dst=r2 src=r0 offset=0 imm=-7
 #line 236 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4043,7 +4043,7 @@ label_79:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1281 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1282 dst=r1 src=r10 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r10;
@@ -4147,10 +4147,10 @@ label_85:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1315 dst=r3 src=r0 offset=0 imm=32
 #line 299 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1316 dst=r3 src=r0 offset=0 imm=32
 #line 299 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1317 dst=r3 src=r0 offset=1 imm=-1
 #line 299 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -4192,13 +4192,13 @@ label_86:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=1328 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1329 dst=r1 src=r4 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1330 dst=r1 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1331 dst=r2 src=r0 offset=0 imm=-7
 #line 236 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4252,7 +4252,7 @@ label_87:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1354 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1355 dst=r1 src=r10 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r10;
@@ -4354,13 +4354,13 @@ label_90:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1389 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1390 dst=r1 src=r4 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1391 dst=r1 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1392 dst=r2 src=r0 offset=0 imm=-7
 #line 237 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4411,7 +4411,7 @@ label_91:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1414 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1415 dst=r1 src=r10 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r10;
@@ -4512,13 +4512,13 @@ label_94:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1450 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1451 dst=r1 src=r5 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1452 dst=r1 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1453 dst=r1 src=r0 offset=31 imm=0
 #line 245 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4582,7 +4582,7 @@ label_96:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=1478 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1479 dst=r1 src=r10 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r10;
@@ -4647,13 +4647,13 @@ label_98:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1496 dst=r5 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1497 dst=r1 src=r5 offset=0 imm=0
 #line 246 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1498 dst=r1 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1499 dst=r1 src=r0 offset=1 imm=0
 #line 246 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4701,13 +4701,13 @@ label_99:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1512 dst=r5 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1513 dst=r1 src=r5 offset=0 imm=0
 #line 247 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1514 dst=r1 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1515 dst=r1 src=r0 offset=1 imm=0
 #line 247 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4755,13 +4755,13 @@ label_100:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1528 dst=r5 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1529 dst=r1 src=r5 offset=0 imm=0
 #line 248 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1530 dst=r1 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1531 dst=r1 src=r0 offset=1 imm=0
 #line 248 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4809,13 +4809,13 @@ label_101:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1544 dst=r5 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1545 dst=r1 src=r5 offset=0 imm=0
 #line 249 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1546 dst=r1 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1547 dst=r1 src=r0 offset=1 imm=0
 #line 249 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4863,13 +4863,13 @@ label_102:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1560 dst=r5 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1561 dst=r1 src=r5 offset=0 imm=0
 #line 250 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1562 dst=r1 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1563 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4917,13 +4917,13 @@ label_103:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1576 dst=r5 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1577 dst=r1 src=r5 offset=0 imm=0
 #line 251 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1578 dst=r1 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1579 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4971,13 +4971,13 @@ label_104:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1592 dst=r5 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1593 dst=r1 src=r5 offset=0 imm=0
 #line 252 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1594 dst=r1 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1595 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5025,13 +5025,13 @@ label_105:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1608 dst=r5 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1609 dst=r1 src=r5 offset=0 imm=0
 #line 253 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1610 dst=r1 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1611 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5079,13 +5079,13 @@ label_106:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1624 dst=r5 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1625 dst=r1 src=r5 offset=0 imm=0
 #line 254 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1626 dst=r1 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1627 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5133,13 +5133,13 @@ label_107:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1640 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1641 dst=r1 src=r5 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1642 dst=r1 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1643 dst=r2 src=r0 offset=0 imm=-29
 #line 257 "sample/map.c"
     r2 = (uint64_t)4294967267;
@@ -5204,7 +5204,7 @@ label_107:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=1670 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1671 dst=r1 src=r10 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r10;
@@ -5253,13 +5253,13 @@ label_108:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1685 dst=r5 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1686 dst=r1 src=r5 offset=0 imm=0
 #line 258 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1687 dst=r1 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1688 dst=r1 src=r0 offset=25 imm=0
 #line 258 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5355,13 +5355,13 @@ label_109:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1723 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1724 dst=r1 src=r4 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1725 dst=r1 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1726 dst=r1 src=r0 offset=27 imm=0
 #line 260 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5411,7 +5411,7 @@ label_109:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1747 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1748 dst=r1 src=r10 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r10;
@@ -5530,13 +5530,13 @@ label_112:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1787 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1788 dst=r1 src=r4 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1789 dst=r1 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1790 dst=r1 src=r0 offset=24 imm=0
 #line 268 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5584,7 +5584,7 @@ label_113:
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint8_t)r7;
     // EBPF_OP_ARSH64_IMM pc=1810 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1811 dst=r1 src=r10 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r10;
@@ -5684,13 +5684,13 @@ label_115:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1846 dst=r4 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1847 dst=r1 src=r4 offset=0 imm=0
 #line 269 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1848 dst=r1 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1849 dst=r1 src=r0 offset=1 imm=0
 #line 269 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5786,13 +5786,13 @@ label_117:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1882 dst=r4 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1883 dst=r1 src=r4 offset=0 imm=0
 #line 270 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1884 dst=r1 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1885 dst=r1 src=r0 offset=1 imm=0
 #line 270 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5888,13 +5888,13 @@ label_119:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1918 dst=r4 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1919 dst=r1 src=r4 offset=0 imm=0
 #line 271 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1920 dst=r1 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1921 dst=r1 src=r0 offset=1 imm=0
 #line 271 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5990,13 +5990,13 @@ label_121:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1954 dst=r4 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1955 dst=r1 src=r4 offset=0 imm=0
 #line 272 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1956 dst=r1 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1957 dst=r1 src=r0 offset=1 imm=0
 #line 272 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6092,13 +6092,13 @@ label_123:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1990 dst=r4 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1991 dst=r1 src=r4 offset=0 imm=0
 #line 273 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1992 dst=r1 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1993 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6194,13 +6194,13 @@ label_125:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2026 dst=r4 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2027 dst=r1 src=r4 offset=0 imm=0
 #line 274 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2028 dst=r1 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2029 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6296,13 +6296,13 @@ label_127:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2062 dst=r4 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2063 dst=r1 src=r4 offset=0 imm=0
 #line 275 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2064 dst=r1 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2065 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6398,13 +6398,13 @@ label_129:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2099 dst=r1 src=r4 offset=0 imm=0
 #line 276 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2100 dst=r1 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2101 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6500,13 +6500,13 @@ label_131:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2134 dst=r4 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2135 dst=r1 src=r4 offset=0 imm=0
 #line 277 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2136 dst=r1 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2137 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6602,13 +6602,13 @@ label_133:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2170 dst=r4 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2171 dst=r1 src=r4 offset=0 imm=0
 #line 280 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2172 dst=r1 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2173 dst=r2 src=r0 offset=0 imm=-7
 #line 280 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -6665,13 +6665,13 @@ label_135:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2189 dst=r4 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2190 dst=r1 src=r4 offset=0 imm=0
 #line 281 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2191 dst=r1 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2192 dst=r2 src=r0 offset=0 imm=-7
 #line 281 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -6776,10 +6776,10 @@ label_141:
     r3 = r7;
     // EBPF_OP_LSH64_IMM pc=2227 dst=r3 src=r0 offset=0 imm=32
 #line 300 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=2228 dst=r3 src=r0 offset=0 imm=32
 #line 300 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=2229 dst=r3 src=r0 offset=-2128 imm=-1
 #line 300 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -6872,13 +6872,13 @@ label_142:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2260 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2261 dst=r1 src=r4 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2262 dst=r1 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2263 dst=r2 src=r0 offset=0 imm=-7
 #line 237 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -6929,7 +6929,7 @@ label_143:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=2285 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2286 dst=r1 src=r10 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r10;
@@ -7030,13 +7030,13 @@ label_146:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2321 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2322 dst=r1 src=r5 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2323 dst=r1 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2324 dst=r1 src=r0 offset=31 imm=0
 #line 245 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7100,7 +7100,7 @@ label_148:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=2349 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2350 dst=r1 src=r10 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r10;
@@ -7165,13 +7165,13 @@ label_150:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2367 dst=r5 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2368 dst=r1 src=r5 offset=0 imm=0
 #line 246 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2369 dst=r1 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2370 dst=r1 src=r0 offset=1 imm=0
 #line 246 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7219,13 +7219,13 @@ label_151:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2383 dst=r5 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2384 dst=r1 src=r5 offset=0 imm=0
 #line 247 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2385 dst=r1 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2386 dst=r1 src=r0 offset=1 imm=0
 #line 247 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7273,13 +7273,13 @@ label_152:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2399 dst=r5 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2400 dst=r1 src=r5 offset=0 imm=0
 #line 248 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2401 dst=r1 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2402 dst=r1 src=r0 offset=1 imm=0
 #line 248 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7327,13 +7327,13 @@ label_153:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2415 dst=r5 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2416 dst=r1 src=r5 offset=0 imm=0
 #line 249 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2417 dst=r1 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2418 dst=r1 src=r0 offset=1 imm=0
 #line 249 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7381,13 +7381,13 @@ label_154:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2431 dst=r5 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2432 dst=r1 src=r5 offset=0 imm=0
 #line 250 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2433 dst=r1 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2434 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7435,13 +7435,13 @@ label_155:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2447 dst=r5 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2448 dst=r1 src=r5 offset=0 imm=0
 #line 251 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2449 dst=r1 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2450 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7489,13 +7489,13 @@ label_156:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2463 dst=r5 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2464 dst=r1 src=r5 offset=0 imm=0
 #line 252 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2465 dst=r1 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2466 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7543,13 +7543,13 @@ label_157:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2479 dst=r5 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2480 dst=r1 src=r5 offset=0 imm=0
 #line 253 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2481 dst=r1 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2482 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7597,13 +7597,13 @@ label_158:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2495 dst=r5 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2496 dst=r1 src=r5 offset=0 imm=0
 #line 254 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2497 dst=r1 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2498 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7651,13 +7651,13 @@ label_159:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2511 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2512 dst=r1 src=r5 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2513 dst=r1 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2514 dst=r2 src=r0 offset=0 imm=-29
 #line 257 "sample/map.c"
     r2 = (uint64_t)4294967267;
@@ -7722,7 +7722,7 @@ label_159:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=2541 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2542 dst=r1 src=r10 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r10;
@@ -7771,13 +7771,13 @@ label_160:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2556 dst=r5 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2557 dst=r1 src=r5 offset=0 imm=0
 #line 258 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2558 dst=r1 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2559 dst=r1 src=r0 offset=25 imm=0
 #line 258 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7873,13 +7873,13 @@ label_161:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2594 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2595 dst=r1 src=r4 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2596 dst=r1 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2597 dst=r1 src=r0 offset=27 imm=0
 #line 260 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7929,7 +7929,7 @@ label_161:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=2618 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2619 dst=r1 src=r10 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r10;
@@ -8048,13 +8048,13 @@ label_164:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2658 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2659 dst=r1 src=r4 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2660 dst=r1 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2661 dst=r1 src=r0 offset=24 imm=0
 #line 268 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8102,7 +8102,7 @@ label_165:
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint8_t)r6;
     // EBPF_OP_ARSH64_IMM pc=2681 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2682 dst=r1 src=r10 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r10;
@@ -8202,13 +8202,13 @@ label_167:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2717 dst=r4 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2718 dst=r1 src=r4 offset=0 imm=0
 #line 269 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2719 dst=r1 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2720 dst=r1 src=r0 offset=1 imm=0
 #line 269 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8304,13 +8304,13 @@ label_169:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2753 dst=r4 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2754 dst=r1 src=r4 offset=0 imm=0
 #line 270 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2755 dst=r1 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2756 dst=r1 src=r0 offset=1 imm=0
 #line 270 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8406,13 +8406,13 @@ label_171:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2789 dst=r4 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2790 dst=r1 src=r4 offset=0 imm=0
 #line 271 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2791 dst=r1 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2792 dst=r1 src=r0 offset=1 imm=0
 #line 271 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8508,13 +8508,13 @@ label_173:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2825 dst=r4 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2826 dst=r1 src=r4 offset=0 imm=0
 #line 272 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2827 dst=r1 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2828 dst=r1 src=r0 offset=1 imm=0
 #line 272 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8610,13 +8610,13 @@ label_175:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2861 dst=r4 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2862 dst=r1 src=r4 offset=0 imm=0
 #line 273 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2863 dst=r1 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2864 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8712,13 +8712,13 @@ label_177:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2897 dst=r4 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2898 dst=r1 src=r4 offset=0 imm=0
 #line 274 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2899 dst=r1 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2900 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8814,13 +8814,13 @@ label_179:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2933 dst=r4 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2934 dst=r1 src=r4 offset=0 imm=0
 #line 275 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2935 dst=r1 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2936 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8916,13 +8916,13 @@ label_181:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2969 dst=r4 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2970 dst=r1 src=r4 offset=0 imm=0
 #line 276 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2971 dst=r1 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2972 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -9018,13 +9018,13 @@ label_183:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3005 dst=r4 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3006 dst=r1 src=r4 offset=0 imm=0
 #line 277 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3007 dst=r1 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=3008 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -9120,13 +9120,13 @@ label_185:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3041 dst=r4 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3042 dst=r1 src=r4 offset=0 imm=0
 #line 280 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3043 dst=r1 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=3044 dst=r2 src=r0 offset=0 imm=-7
 #line 280 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -9183,13 +9183,13 @@ label_187:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3060 dst=r4 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3061 dst=r1 src=r4 offset=0 imm=0
 #line 281 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3062 dst=r1 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=3063 dst=r2 src=r0 offset=0 imm=-7
 #line 281 "sample/map.c"
     r2 = (uint64_t)4294967289;

--- a/tests/bpf2c_tests/expected/map_raw.c
+++ b/tests/bpf2c_tests/expected/map_raw.c
@@ -230,10 +230,10 @@ test_maps(void* context)
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=14 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=15 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=16 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -364,10 +364,10 @@ label_4:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=60 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=61 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=62 dst=r3 src=r0 offset=41 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -459,10 +459,10 @@ label_7:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=96 dst=r3 src=r0 offset=0 imm=32
 #line 289 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=97 dst=r3 src=r0 offset=0 imm=32
 #line 289 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=98 dst=r1 src=r10 offset=0 imm=0
 #line 289 "sample/map.c"
     r1 = r10;
@@ -525,10 +525,10 @@ label_10:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=114 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=115 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=116 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -663,10 +663,10 @@ label_12:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=161 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=162 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=163 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -797,10 +797,10 @@ label_16:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=207 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=208 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=209 dst=r3 src=r0 offset=42 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -898,10 +898,10 @@ label_19:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=246 dst=r3 src=r0 offset=0 imm=32
 #line 290 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=247 dst=r3 src=r0 offset=0 imm=32
 #line 290 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=248 dst=r1 src=r10 offset=0 imm=0
 #line 290 "sample/map.c"
     r1 = r10;
@@ -950,10 +950,10 @@ label_20:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=262 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=263 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=264 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1088,10 +1088,10 @@ label_22:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=309 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=310 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=311 dst=r3 src=r0 offset=1 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1205,10 +1205,10 @@ label_24:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=347 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=348 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=349 dst=r3 src=r0 offset=9 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1271,10 +1271,10 @@ label_25:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=370 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=371 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=372 dst=r3 src=r0 offset=41 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1372,10 +1372,10 @@ label_28:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=408 dst=r3 src=r0 offset=0 imm=32
 #line 291 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=409 dst=r3 src=r0 offset=0 imm=32
 #line 291 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=410 dst=r1 src=r10 offset=0 imm=0
 #line 291 "sample/map.c"
     r1 = r10;
@@ -1433,10 +1433,10 @@ label_29:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=427 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=428 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=429 dst=r3 src=r0 offset=1 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1550,10 +1550,10 @@ label_31:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=465 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=466 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=467 dst=r3 src=r0 offset=9 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1616,10 +1616,10 @@ label_32:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=488 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=489 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=490 dst=r3 src=r0 offset=42 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1717,10 +1717,10 @@ label_35:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=527 dst=r3 src=r0 offset=0 imm=32
 #line 292 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=528 dst=r3 src=r0 offset=0 imm=32
 #line 292 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=529 dst=r1 src=r10 offset=0 imm=0
 #line 292 "sample/map.c"
     r1 = r10;
@@ -1778,10 +1778,10 @@ label_36:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=546 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=547 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=548 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1912,10 +1912,10 @@ label_40:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=592 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=593 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=594 dst=r3 src=r0 offset=40 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2006,10 +2006,10 @@ label_42:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=629 dst=r3 src=r0 offset=0 imm=32
 #line 293 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=630 dst=r3 src=r0 offset=0 imm=32
 #line 293 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=631 dst=r1 src=r10 offset=0 imm=0
 #line 293 "sample/map.c"
     r1 = r10;
@@ -2058,10 +2058,10 @@ label_43:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=645 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=646 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=647 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2196,10 +2196,10 @@ label_45:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=692 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=693 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=694 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2330,10 +2330,10 @@ label_49:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=738 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=739 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=740 dst=r3 src=r0 offset=43 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2430,10 +2430,10 @@ label_51:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=778 dst=r3 src=r0 offset=0 imm=32
 #line 294 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=779 dst=r3 src=r0 offset=0 imm=32
 #line 294 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=780 dst=r1 src=r10 offset=0 imm=0
 #line 294 "sample/map.c"
     r1 = r10;
@@ -2482,10 +2482,10 @@ label_52:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=794 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=795 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=796 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2620,10 +2620,10 @@ label_54:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=841 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=842 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=843 dst=r3 src=r0 offset=1 imm=-1
 #line 126 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2671,10 +2671,10 @@ label_55:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=856 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=857 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=858 dst=r3 src=r0 offset=1 imm=-1
 #line 132 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2725,10 +2725,10 @@ label_56:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=872 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=873 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=874 dst=r3 src=r0 offset=1 imm=-1
 #line 138 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2779,10 +2779,10 @@ label_57:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=888 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=889 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=890 dst=r3 src=r0 offset=1 imm=-1
 #line 144 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2833,10 +2833,10 @@ label_58:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=904 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=905 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=906 dst=r3 src=r0 offset=1 imm=-1
 #line 150 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2887,10 +2887,10 @@ label_59:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=920 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=921 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=922 dst=r3 src=r0 offset=1 imm=-1
 #line 156 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2941,10 +2941,10 @@ label_60:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=936 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=937 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=938 dst=r3 src=r0 offset=1 imm=-1
 #line 162 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2995,10 +2995,10 @@ label_61:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=952 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=953 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=954 dst=r3 src=r0 offset=1 imm=-1
 #line 168 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3049,10 +3049,10 @@ label_62:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=968 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=969 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=970 dst=r3 src=r0 offset=1 imm=-1
 #line 174 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3103,10 +3103,10 @@ label_63:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=984 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=985 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=986 dst=r3 src=r0 offset=1 imm=-1
 #line 180 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3160,10 +3160,10 @@ label_64:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1001 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1002 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1003 dst=r3 src=r0 offset=32 imm=-1
 #line 186 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3293,10 +3293,10 @@ label_66:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1049 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1050 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1051 dst=r3 src=r0 offset=1 imm=-1
 #line 126 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3344,10 +3344,10 @@ label_67:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1064 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1065 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1066 dst=r3 src=r0 offset=1 imm=-1
 #line 132 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3398,10 +3398,10 @@ label_68:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1080 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1081 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1082 dst=r3 src=r0 offset=1 imm=-1
 #line 138 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3452,10 +3452,10 @@ label_69:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1096 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1097 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1098 dst=r3 src=r0 offset=1 imm=-1
 #line 144 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3506,10 +3506,10 @@ label_70:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1112 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1113 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1114 dst=r3 src=r0 offset=1 imm=-1
 #line 150 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3560,10 +3560,10 @@ label_71:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1128 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1129 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1130 dst=r3 src=r0 offset=1 imm=-1
 #line 156 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3614,10 +3614,10 @@ label_72:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1144 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1145 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1146 dst=r3 src=r0 offset=1 imm=-1
 #line 162 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3668,10 +3668,10 @@ label_73:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1160 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1161 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1162 dst=r3 src=r0 offset=1 imm=-1
 #line 168 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3722,10 +3722,10 @@ label_74:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1176 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1177 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1178 dst=r3 src=r0 offset=1 imm=-1
 #line 174 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3776,10 +3776,10 @@ label_75:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1192 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1193 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1194 dst=r3 src=r0 offset=1 imm=-1
 #line 180 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3833,10 +3833,10 @@ label_76:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1209 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1210 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1211 dst=r3 src=r0 offset=35 imm=-1
 #line 186 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3957,13 +3957,13 @@ label_78:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1255 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1256 dst=r1 src=r4 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1257 dst=r1 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1258 dst=r2 src=r0 offset=0 imm=-7
 #line 236 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4017,7 +4017,7 @@ label_79:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1281 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1282 dst=r1 src=r10 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r10;
@@ -4121,10 +4121,10 @@ label_85:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1315 dst=r3 src=r0 offset=0 imm=32
 #line 299 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1316 dst=r3 src=r0 offset=0 imm=32
 #line 299 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1317 dst=r3 src=r0 offset=1 imm=-1
 #line 299 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -4166,13 +4166,13 @@ label_86:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=1328 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1329 dst=r1 src=r4 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1330 dst=r1 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1331 dst=r2 src=r0 offset=0 imm=-7
 #line 236 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4226,7 +4226,7 @@ label_87:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1354 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1355 dst=r1 src=r10 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r10;
@@ -4328,13 +4328,13 @@ label_90:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1389 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1390 dst=r1 src=r4 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1391 dst=r1 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1392 dst=r2 src=r0 offset=0 imm=-7
 #line 237 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4385,7 +4385,7 @@ label_91:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1414 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1415 dst=r1 src=r10 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r10;
@@ -4486,13 +4486,13 @@ label_94:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1450 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1451 dst=r1 src=r5 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1452 dst=r1 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1453 dst=r1 src=r0 offset=31 imm=0
 #line 245 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4556,7 +4556,7 @@ label_96:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=1478 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1479 dst=r1 src=r10 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r10;
@@ -4621,13 +4621,13 @@ label_98:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1496 dst=r5 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1497 dst=r1 src=r5 offset=0 imm=0
 #line 246 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1498 dst=r1 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1499 dst=r1 src=r0 offset=1 imm=0
 #line 246 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4675,13 +4675,13 @@ label_99:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1512 dst=r5 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1513 dst=r1 src=r5 offset=0 imm=0
 #line 247 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1514 dst=r1 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1515 dst=r1 src=r0 offset=1 imm=0
 #line 247 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4729,13 +4729,13 @@ label_100:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1528 dst=r5 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1529 dst=r1 src=r5 offset=0 imm=0
 #line 248 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1530 dst=r1 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1531 dst=r1 src=r0 offset=1 imm=0
 #line 248 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4783,13 +4783,13 @@ label_101:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1544 dst=r5 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1545 dst=r1 src=r5 offset=0 imm=0
 #line 249 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1546 dst=r1 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1547 dst=r1 src=r0 offset=1 imm=0
 #line 249 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4837,13 +4837,13 @@ label_102:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1560 dst=r5 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1561 dst=r1 src=r5 offset=0 imm=0
 #line 250 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1562 dst=r1 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1563 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4891,13 +4891,13 @@ label_103:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1576 dst=r5 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1577 dst=r1 src=r5 offset=0 imm=0
 #line 251 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1578 dst=r1 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1579 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4945,13 +4945,13 @@ label_104:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1592 dst=r5 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1593 dst=r1 src=r5 offset=0 imm=0
 #line 252 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1594 dst=r1 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1595 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4999,13 +4999,13 @@ label_105:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1608 dst=r5 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1609 dst=r1 src=r5 offset=0 imm=0
 #line 253 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1610 dst=r1 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1611 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5053,13 +5053,13 @@ label_106:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1624 dst=r5 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1625 dst=r1 src=r5 offset=0 imm=0
 #line 254 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1626 dst=r1 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1627 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5107,13 +5107,13 @@ label_107:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1640 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1641 dst=r1 src=r5 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1642 dst=r1 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1643 dst=r2 src=r0 offset=0 imm=-29
 #line 257 "sample/map.c"
     r2 = (uint64_t)4294967267;
@@ -5178,7 +5178,7 @@ label_107:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=1670 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1671 dst=r1 src=r10 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r10;
@@ -5227,13 +5227,13 @@ label_108:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1685 dst=r5 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1686 dst=r1 src=r5 offset=0 imm=0
 #line 258 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1687 dst=r1 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1688 dst=r1 src=r0 offset=25 imm=0
 #line 258 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5329,13 +5329,13 @@ label_109:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1723 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1724 dst=r1 src=r4 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1725 dst=r1 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1726 dst=r1 src=r0 offset=27 imm=0
 #line 260 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5385,7 +5385,7 @@ label_109:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1747 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1748 dst=r1 src=r10 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r10;
@@ -5504,13 +5504,13 @@ label_112:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1787 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1788 dst=r1 src=r4 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1789 dst=r1 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1790 dst=r1 src=r0 offset=24 imm=0
 #line 268 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5558,7 +5558,7 @@ label_113:
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint8_t)r7;
     // EBPF_OP_ARSH64_IMM pc=1810 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1811 dst=r1 src=r10 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r10;
@@ -5658,13 +5658,13 @@ label_115:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1846 dst=r4 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1847 dst=r1 src=r4 offset=0 imm=0
 #line 269 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1848 dst=r1 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1849 dst=r1 src=r0 offset=1 imm=0
 #line 269 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5760,13 +5760,13 @@ label_117:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1882 dst=r4 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1883 dst=r1 src=r4 offset=0 imm=0
 #line 270 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1884 dst=r1 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1885 dst=r1 src=r0 offset=1 imm=0
 #line 270 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5862,13 +5862,13 @@ label_119:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1918 dst=r4 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1919 dst=r1 src=r4 offset=0 imm=0
 #line 271 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1920 dst=r1 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1921 dst=r1 src=r0 offset=1 imm=0
 #line 271 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5964,13 +5964,13 @@ label_121:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1954 dst=r4 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1955 dst=r1 src=r4 offset=0 imm=0
 #line 272 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1956 dst=r1 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1957 dst=r1 src=r0 offset=1 imm=0
 #line 272 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6066,13 +6066,13 @@ label_123:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1990 dst=r4 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1991 dst=r1 src=r4 offset=0 imm=0
 #line 273 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1992 dst=r1 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1993 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6168,13 +6168,13 @@ label_125:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2026 dst=r4 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2027 dst=r1 src=r4 offset=0 imm=0
 #line 274 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2028 dst=r1 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2029 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6270,13 +6270,13 @@ label_127:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2062 dst=r4 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2063 dst=r1 src=r4 offset=0 imm=0
 #line 275 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2064 dst=r1 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2065 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6372,13 +6372,13 @@ label_129:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2099 dst=r1 src=r4 offset=0 imm=0
 #line 276 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2100 dst=r1 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2101 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6474,13 +6474,13 @@ label_131:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2134 dst=r4 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2135 dst=r1 src=r4 offset=0 imm=0
 #line 277 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2136 dst=r1 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2137 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6576,13 +6576,13 @@ label_133:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2170 dst=r4 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2171 dst=r1 src=r4 offset=0 imm=0
 #line 280 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2172 dst=r1 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2173 dst=r2 src=r0 offset=0 imm=-7
 #line 280 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -6639,13 +6639,13 @@ label_135:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2189 dst=r4 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2190 dst=r1 src=r4 offset=0 imm=0
 #line 281 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2191 dst=r1 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2192 dst=r2 src=r0 offset=0 imm=-7
 #line 281 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -6750,10 +6750,10 @@ label_141:
     r3 = r7;
     // EBPF_OP_LSH64_IMM pc=2227 dst=r3 src=r0 offset=0 imm=32
 #line 300 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=2228 dst=r3 src=r0 offset=0 imm=32
 #line 300 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=2229 dst=r3 src=r0 offset=-2128 imm=-1
 #line 300 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -6846,13 +6846,13 @@ label_142:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2260 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2261 dst=r1 src=r4 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2262 dst=r1 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2263 dst=r2 src=r0 offset=0 imm=-7
 #line 237 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -6903,7 +6903,7 @@ label_143:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=2285 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2286 dst=r1 src=r10 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r10;
@@ -7004,13 +7004,13 @@ label_146:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2321 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2322 dst=r1 src=r5 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2323 dst=r1 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2324 dst=r1 src=r0 offset=31 imm=0
 #line 245 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7074,7 +7074,7 @@ label_148:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=2349 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2350 dst=r1 src=r10 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r10;
@@ -7139,13 +7139,13 @@ label_150:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2367 dst=r5 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2368 dst=r1 src=r5 offset=0 imm=0
 #line 246 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2369 dst=r1 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2370 dst=r1 src=r0 offset=1 imm=0
 #line 246 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7193,13 +7193,13 @@ label_151:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2383 dst=r5 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2384 dst=r1 src=r5 offset=0 imm=0
 #line 247 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2385 dst=r1 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2386 dst=r1 src=r0 offset=1 imm=0
 #line 247 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7247,13 +7247,13 @@ label_152:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2399 dst=r5 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2400 dst=r1 src=r5 offset=0 imm=0
 #line 248 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2401 dst=r1 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2402 dst=r1 src=r0 offset=1 imm=0
 #line 248 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7301,13 +7301,13 @@ label_153:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2415 dst=r5 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2416 dst=r1 src=r5 offset=0 imm=0
 #line 249 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2417 dst=r1 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2418 dst=r1 src=r0 offset=1 imm=0
 #line 249 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7355,13 +7355,13 @@ label_154:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2431 dst=r5 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2432 dst=r1 src=r5 offset=0 imm=0
 #line 250 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2433 dst=r1 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2434 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7409,13 +7409,13 @@ label_155:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2447 dst=r5 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2448 dst=r1 src=r5 offset=0 imm=0
 #line 251 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2449 dst=r1 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2450 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7463,13 +7463,13 @@ label_156:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2463 dst=r5 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2464 dst=r1 src=r5 offset=0 imm=0
 #line 252 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2465 dst=r1 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2466 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7517,13 +7517,13 @@ label_157:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2479 dst=r5 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2480 dst=r1 src=r5 offset=0 imm=0
 #line 253 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2481 dst=r1 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2482 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7571,13 +7571,13 @@ label_158:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2495 dst=r5 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2496 dst=r1 src=r5 offset=0 imm=0
 #line 254 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2497 dst=r1 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2498 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7625,13 +7625,13 @@ label_159:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2511 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2512 dst=r1 src=r5 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2513 dst=r1 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2514 dst=r2 src=r0 offset=0 imm=-29
 #line 257 "sample/map.c"
     r2 = (uint64_t)4294967267;
@@ -7696,7 +7696,7 @@ label_159:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=2541 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2542 dst=r1 src=r10 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r10;
@@ -7745,13 +7745,13 @@ label_160:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2556 dst=r5 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2557 dst=r1 src=r5 offset=0 imm=0
 #line 258 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2558 dst=r1 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2559 dst=r1 src=r0 offset=25 imm=0
 #line 258 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7847,13 +7847,13 @@ label_161:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2594 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2595 dst=r1 src=r4 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2596 dst=r1 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2597 dst=r1 src=r0 offset=27 imm=0
 #line 260 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7903,7 +7903,7 @@ label_161:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=2618 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2619 dst=r1 src=r10 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r10;
@@ -8022,13 +8022,13 @@ label_164:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2658 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2659 dst=r1 src=r4 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2660 dst=r1 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2661 dst=r1 src=r0 offset=24 imm=0
 #line 268 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8076,7 +8076,7 @@ label_165:
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint8_t)r6;
     // EBPF_OP_ARSH64_IMM pc=2681 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2682 dst=r1 src=r10 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r10;
@@ -8176,13 +8176,13 @@ label_167:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2717 dst=r4 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2718 dst=r1 src=r4 offset=0 imm=0
 #line 269 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2719 dst=r1 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2720 dst=r1 src=r0 offset=1 imm=0
 #line 269 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8278,13 +8278,13 @@ label_169:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2753 dst=r4 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2754 dst=r1 src=r4 offset=0 imm=0
 #line 270 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2755 dst=r1 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2756 dst=r1 src=r0 offset=1 imm=0
 #line 270 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8380,13 +8380,13 @@ label_171:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2789 dst=r4 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2790 dst=r1 src=r4 offset=0 imm=0
 #line 271 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2791 dst=r1 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2792 dst=r1 src=r0 offset=1 imm=0
 #line 271 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8482,13 +8482,13 @@ label_173:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2825 dst=r4 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2826 dst=r1 src=r4 offset=0 imm=0
 #line 272 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2827 dst=r1 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2828 dst=r1 src=r0 offset=1 imm=0
 #line 272 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8584,13 +8584,13 @@ label_175:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2861 dst=r4 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2862 dst=r1 src=r4 offset=0 imm=0
 #line 273 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2863 dst=r1 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2864 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8686,13 +8686,13 @@ label_177:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2897 dst=r4 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2898 dst=r1 src=r4 offset=0 imm=0
 #line 274 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2899 dst=r1 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2900 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8788,13 +8788,13 @@ label_179:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2933 dst=r4 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2934 dst=r1 src=r4 offset=0 imm=0
 #line 275 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2935 dst=r1 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2936 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8890,13 +8890,13 @@ label_181:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2969 dst=r4 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2970 dst=r1 src=r4 offset=0 imm=0
 #line 276 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2971 dst=r1 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2972 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8992,13 +8992,13 @@ label_183:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3005 dst=r4 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3006 dst=r1 src=r4 offset=0 imm=0
 #line 277 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3007 dst=r1 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=3008 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -9094,13 +9094,13 @@ label_185:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3041 dst=r4 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3042 dst=r1 src=r4 offset=0 imm=0
 #line 280 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3043 dst=r1 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=3044 dst=r2 src=r0 offset=0 imm=-7
 #line 280 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -9157,13 +9157,13 @@ label_187:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3060 dst=r4 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3061 dst=r1 src=r4 offset=0 imm=0
 #line 281 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3062 dst=r1 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=3063 dst=r2 src=r0 offset=0 imm=-7
 #line 281 "sample/map.c"
     r2 = (uint64_t)4294967289;

--- a/tests/bpf2c_tests/expected/map_sys.c
+++ b/tests/bpf2c_tests/expected/map_sys.c
@@ -391,10 +391,10 @@ test_maps(void* context)
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=14 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=15 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=16 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -525,10 +525,10 @@ label_4:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=60 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=61 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=62 dst=r3 src=r0 offset=41 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -620,10 +620,10 @@ label_7:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=96 dst=r3 src=r0 offset=0 imm=32
 #line 289 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=97 dst=r3 src=r0 offset=0 imm=32
 #line 289 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=98 dst=r1 src=r10 offset=0 imm=0
 #line 289 "sample/map.c"
     r1 = r10;
@@ -686,10 +686,10 @@ label_10:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=114 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=115 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=116 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -824,10 +824,10 @@ label_12:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=161 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=162 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=163 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -958,10 +958,10 @@ label_16:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=207 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=208 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=209 dst=r3 src=r0 offset=42 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1059,10 +1059,10 @@ label_19:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=246 dst=r3 src=r0 offset=0 imm=32
 #line 290 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=247 dst=r3 src=r0 offset=0 imm=32
 #line 290 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=248 dst=r1 src=r10 offset=0 imm=0
 #line 290 "sample/map.c"
     r1 = r10;
@@ -1111,10 +1111,10 @@ label_20:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=262 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=263 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=264 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1249,10 +1249,10 @@ label_22:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=309 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=310 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=311 dst=r3 src=r0 offset=1 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1366,10 +1366,10 @@ label_24:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=347 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=348 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=349 dst=r3 src=r0 offset=9 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1432,10 +1432,10 @@ label_25:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=370 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=371 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=372 dst=r3 src=r0 offset=41 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1533,10 +1533,10 @@ label_28:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=408 dst=r3 src=r0 offset=0 imm=32
 #line 291 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=409 dst=r3 src=r0 offset=0 imm=32
 #line 291 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=410 dst=r1 src=r10 offset=0 imm=0
 #line 291 "sample/map.c"
     r1 = r10;
@@ -1594,10 +1594,10 @@ label_29:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=427 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=428 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=429 dst=r3 src=r0 offset=1 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1711,10 +1711,10 @@ label_31:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=465 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=466 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=467 dst=r3 src=r0 offset=9 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1777,10 +1777,10 @@ label_32:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=488 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=489 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=490 dst=r3 src=r0 offset=42 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -1878,10 +1878,10 @@ label_35:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=527 dst=r3 src=r0 offset=0 imm=32
 #line 292 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=528 dst=r3 src=r0 offset=0 imm=32
 #line 292 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=529 dst=r1 src=r10 offset=0 imm=0
 #line 292 "sample/map.c"
     r1 = r10;
@@ -1939,10 +1939,10 @@ label_36:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=546 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=547 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=548 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2073,10 +2073,10 @@ label_40:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=592 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=593 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=594 dst=r3 src=r0 offset=40 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2167,10 +2167,10 @@ label_42:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=629 dst=r3 src=r0 offset=0 imm=32
 #line 293 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=630 dst=r3 src=r0 offset=0 imm=32
 #line 293 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=631 dst=r1 src=r10 offset=0 imm=0
 #line 293 "sample/map.c"
     r1 = r10;
@@ -2219,10 +2219,10 @@ label_43:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=645 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=646 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=647 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2357,10 +2357,10 @@ label_45:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=692 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=693 dst=r3 src=r0 offset=0 imm=32
 #line 70 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=694 dst=r3 src=r0 offset=9 imm=-1
 #line 71 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2491,10 +2491,10 @@ label_49:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=738 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=739 dst=r3 src=r0 offset=0 imm=32
 #line 82 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=740 dst=r3 src=r0 offset=43 imm=-1
 #line 83 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2591,10 +2591,10 @@ label_51:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=778 dst=r3 src=r0 offset=0 imm=32
 #line 294 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=779 dst=r3 src=r0 offset=0 imm=32
 #line 294 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=780 dst=r1 src=r10 offset=0 imm=0
 #line 294 "sample/map.c"
     r1 = r10;
@@ -2643,10 +2643,10 @@ label_52:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=794 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=795 dst=r3 src=r0 offset=0 imm=32
 #line 88 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=796 dst=r3 src=r0 offset=1 imm=-1
 #line 89 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2781,10 +2781,10 @@ label_54:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=841 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=842 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=843 dst=r3 src=r0 offset=1 imm=-1
 #line 126 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2832,10 +2832,10 @@ label_55:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=856 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=857 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=858 dst=r3 src=r0 offset=1 imm=-1
 #line 132 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2886,10 +2886,10 @@ label_56:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=872 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=873 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=874 dst=r3 src=r0 offset=1 imm=-1
 #line 138 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2940,10 +2940,10 @@ label_57:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=888 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=889 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=890 dst=r3 src=r0 offset=1 imm=-1
 #line 144 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -2994,10 +2994,10 @@ label_58:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=904 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=905 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=906 dst=r3 src=r0 offset=1 imm=-1
 #line 150 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3048,10 +3048,10 @@ label_59:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=920 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=921 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=922 dst=r3 src=r0 offset=1 imm=-1
 #line 156 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3102,10 +3102,10 @@ label_60:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=936 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=937 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=938 dst=r3 src=r0 offset=1 imm=-1
 #line 162 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3156,10 +3156,10 @@ label_61:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=952 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=953 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=954 dst=r3 src=r0 offset=1 imm=-1
 #line 168 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3210,10 +3210,10 @@ label_62:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=968 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=969 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=970 dst=r3 src=r0 offset=1 imm=-1
 #line 174 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3264,10 +3264,10 @@ label_63:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=984 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=985 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=986 dst=r3 src=r0 offset=1 imm=-1
 #line 180 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3321,10 +3321,10 @@ label_64:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1001 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1002 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1003 dst=r3 src=r0 offset=32 imm=-1
 #line 186 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3454,10 +3454,10 @@ label_66:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1049 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1050 dst=r3 src=r0 offset=0 imm=32
 #line 125 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1051 dst=r3 src=r0 offset=1 imm=-1
 #line 126 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3505,10 +3505,10 @@ label_67:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1064 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1065 dst=r3 src=r0 offset=0 imm=32
 #line 131 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1066 dst=r3 src=r0 offset=1 imm=-1
 #line 132 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3559,10 +3559,10 @@ label_68:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1080 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1081 dst=r3 src=r0 offset=0 imm=32
 #line 137 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1082 dst=r3 src=r0 offset=1 imm=-1
 #line 138 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3613,10 +3613,10 @@ label_69:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1096 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1097 dst=r3 src=r0 offset=0 imm=32
 #line 143 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1098 dst=r3 src=r0 offset=1 imm=-1
 #line 144 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3667,10 +3667,10 @@ label_70:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1112 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1113 dst=r3 src=r0 offset=0 imm=32
 #line 149 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1114 dst=r3 src=r0 offset=1 imm=-1
 #line 150 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3721,10 +3721,10 @@ label_71:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1128 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1129 dst=r3 src=r0 offset=0 imm=32
 #line 155 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1130 dst=r3 src=r0 offset=1 imm=-1
 #line 156 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3775,10 +3775,10 @@ label_72:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1144 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1145 dst=r3 src=r0 offset=0 imm=32
 #line 161 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1146 dst=r3 src=r0 offset=1 imm=-1
 #line 162 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3829,10 +3829,10 @@ label_73:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1160 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1161 dst=r3 src=r0 offset=0 imm=32
 #line 167 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1162 dst=r3 src=r0 offset=1 imm=-1
 #line 168 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3883,10 +3883,10 @@ label_74:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1176 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1177 dst=r3 src=r0 offset=0 imm=32
 #line 173 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1178 dst=r3 src=r0 offset=1 imm=-1
 #line 174 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3937,10 +3937,10 @@ label_75:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1192 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1193 dst=r3 src=r0 offset=0 imm=32
 #line 179 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1194 dst=r3 src=r0 offset=1 imm=-1
 #line 180 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -3994,10 +3994,10 @@ label_76:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1209 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1210 dst=r3 src=r0 offset=0 imm=32
 #line 185 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1211 dst=r3 src=r0 offset=35 imm=-1
 #line 186 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -4118,13 +4118,13 @@ label_78:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1255 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1256 dst=r1 src=r4 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1257 dst=r1 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1258 dst=r2 src=r0 offset=0 imm=-7
 #line 236 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4178,7 +4178,7 @@ label_79:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1281 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1282 dst=r1 src=r10 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r10;
@@ -4282,10 +4282,10 @@ label_85:
     r3 = r6;
     // EBPF_OP_LSH64_IMM pc=1315 dst=r3 src=r0 offset=0 imm=32
 #line 299 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=1316 dst=r3 src=r0 offset=0 imm=32
 #line 299 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=1317 dst=r3 src=r0 offset=1 imm=-1
 #line 299 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -4327,13 +4327,13 @@ label_86:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=1328 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1329 dst=r1 src=r4 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1330 dst=r1 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1331 dst=r2 src=r0 offset=0 imm=-7
 #line 236 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4387,7 +4387,7 @@ label_87:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1354 dst=r4 src=r0 offset=0 imm=32
 #line 236 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1355 dst=r1 src=r10 offset=0 imm=0
 #line 236 "sample/map.c"
     r1 = r10;
@@ -4489,13 +4489,13 @@ label_90:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1389 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1390 dst=r1 src=r4 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1391 dst=r1 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1392 dst=r2 src=r0 offset=0 imm=-7
 #line 237 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -4546,7 +4546,7 @@ label_91:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1414 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1415 dst=r1 src=r10 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r10;
@@ -4647,13 +4647,13 @@ label_94:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1450 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1451 dst=r1 src=r5 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1452 dst=r1 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1453 dst=r1 src=r0 offset=31 imm=0
 #line 245 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4717,7 +4717,7 @@ label_96:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=1478 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1479 dst=r1 src=r10 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r10;
@@ -4782,13 +4782,13 @@ label_98:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1496 dst=r5 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1497 dst=r1 src=r5 offset=0 imm=0
 #line 246 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1498 dst=r1 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1499 dst=r1 src=r0 offset=1 imm=0
 #line 246 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4836,13 +4836,13 @@ label_99:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1512 dst=r5 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1513 dst=r1 src=r5 offset=0 imm=0
 #line 247 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1514 dst=r1 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1515 dst=r1 src=r0 offset=1 imm=0
 #line 247 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4890,13 +4890,13 @@ label_100:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1528 dst=r5 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1529 dst=r1 src=r5 offset=0 imm=0
 #line 248 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1530 dst=r1 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1531 dst=r1 src=r0 offset=1 imm=0
 #line 248 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4944,13 +4944,13 @@ label_101:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1544 dst=r5 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1545 dst=r1 src=r5 offset=0 imm=0
 #line 249 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1546 dst=r1 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1547 dst=r1 src=r0 offset=1 imm=0
 #line 249 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -4998,13 +4998,13 @@ label_102:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1560 dst=r5 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1561 dst=r1 src=r5 offset=0 imm=0
 #line 250 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1562 dst=r1 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1563 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5052,13 +5052,13 @@ label_103:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1576 dst=r5 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1577 dst=r1 src=r5 offset=0 imm=0
 #line 251 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1578 dst=r1 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1579 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5106,13 +5106,13 @@ label_104:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1592 dst=r5 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1593 dst=r1 src=r5 offset=0 imm=0
 #line 252 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1594 dst=r1 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1595 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5160,13 +5160,13 @@ label_105:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1608 dst=r5 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1609 dst=r1 src=r5 offset=0 imm=0
 #line 253 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1610 dst=r1 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1611 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5214,13 +5214,13 @@ label_106:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1624 dst=r5 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1625 dst=r1 src=r5 offset=0 imm=0
 #line 254 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1626 dst=r1 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1627 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5268,13 +5268,13 @@ label_107:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1640 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1641 dst=r1 src=r5 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1642 dst=r1 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=1643 dst=r2 src=r0 offset=0 imm=-29
 #line 257 "sample/map.c"
     r2 = (uint64_t)4294967267;
@@ -5339,7 +5339,7 @@ label_107:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=1670 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1671 dst=r1 src=r10 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r10;
@@ -5388,13 +5388,13 @@ label_108:
     r5 = r6;
     // EBPF_OP_LSH64_IMM pc=1685 dst=r5 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1686 dst=r1 src=r5 offset=0 imm=0
 #line 258 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=1687 dst=r1 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1688 dst=r1 src=r0 offset=25 imm=0
 #line 258 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5490,13 +5490,13 @@ label_109:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1723 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1724 dst=r1 src=r4 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1725 dst=r1 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1726 dst=r1 src=r0 offset=27 imm=0
 #line 260 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5546,7 +5546,7 @@ label_109:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=1747 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1748 dst=r1 src=r10 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r10;
@@ -5665,13 +5665,13 @@ label_112:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1787 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1788 dst=r1 src=r4 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1789 dst=r1 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1790 dst=r1 src=r0 offset=24 imm=0
 #line 268 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5719,7 +5719,7 @@ label_113:
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint8_t)r7;
     // EBPF_OP_ARSH64_IMM pc=1810 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1811 dst=r1 src=r10 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r10;
@@ -5819,13 +5819,13 @@ label_115:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1846 dst=r4 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1847 dst=r1 src=r4 offset=0 imm=0
 #line 269 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1848 dst=r1 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1849 dst=r1 src=r0 offset=1 imm=0
 #line 269 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -5921,13 +5921,13 @@ label_117:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1882 dst=r4 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1883 dst=r1 src=r4 offset=0 imm=0
 #line 270 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1884 dst=r1 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1885 dst=r1 src=r0 offset=1 imm=0
 #line 270 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6023,13 +6023,13 @@ label_119:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1918 dst=r4 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1919 dst=r1 src=r4 offset=0 imm=0
 #line 271 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1920 dst=r1 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1921 dst=r1 src=r0 offset=1 imm=0
 #line 271 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6125,13 +6125,13 @@ label_121:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1954 dst=r4 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1955 dst=r1 src=r4 offset=0 imm=0
 #line 272 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1956 dst=r1 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1957 dst=r1 src=r0 offset=1 imm=0
 #line 272 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6227,13 +6227,13 @@ label_123:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=1990 dst=r4 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=1991 dst=r1 src=r4 offset=0 imm=0
 #line 273 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=1992 dst=r1 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=1993 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6329,13 +6329,13 @@ label_125:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2026 dst=r4 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2027 dst=r1 src=r4 offset=0 imm=0
 #line 274 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2028 dst=r1 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2029 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6431,13 +6431,13 @@ label_127:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2062 dst=r4 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2063 dst=r1 src=r4 offset=0 imm=0
 #line 275 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2064 dst=r1 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2065 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6533,13 +6533,13 @@ label_129:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2098 dst=r4 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2099 dst=r1 src=r4 offset=0 imm=0
 #line 276 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2100 dst=r1 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2101 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6635,13 +6635,13 @@ label_131:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2134 dst=r4 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2135 dst=r1 src=r4 offset=0 imm=0
 #line 277 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2136 dst=r1 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2137 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -6737,13 +6737,13 @@ label_133:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2170 dst=r4 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2171 dst=r1 src=r4 offset=0 imm=0
 #line 280 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2172 dst=r1 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2173 dst=r2 src=r0 offset=0 imm=-7
 #line 280 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -6800,13 +6800,13 @@ label_135:
     r4 = r6;
     // EBPF_OP_LSH64_IMM pc=2189 dst=r4 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2190 dst=r1 src=r4 offset=0 imm=0
 #line 281 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2191 dst=r1 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2192 dst=r2 src=r0 offset=0 imm=-7
 #line 281 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -6911,10 +6911,10 @@ label_141:
     r3 = r7;
     // EBPF_OP_LSH64_IMM pc=2227 dst=r3 src=r0 offset=0 imm=32
 #line 300 "sample/map.c"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=2228 dst=r3 src=r0 offset=0 imm=32
 #line 300 "sample/map.c"
-    r3 = (int64_t)r3 >> (uint32_t)IMMEDIATE(32);
+    r3 = (int64_t)r3 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_JSGT_IMM pc=2229 dst=r3 src=r0 offset=-2128 imm=-1
 #line 300 "sample/map.c"
     if ((int64_t)r3 > IMMEDIATE(-1))
@@ -7007,13 +7007,13 @@ label_142:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2260 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2261 dst=r1 src=r4 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2262 dst=r1 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2263 dst=r2 src=r0 offset=0 imm=-7
 #line 237 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -7064,7 +7064,7 @@ label_143:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=2285 dst=r4 src=r0 offset=0 imm=32
 #line 237 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2286 dst=r1 src=r10 offset=0 imm=0
 #line 237 "sample/map.c"
     r1 = r10;
@@ -7165,13 +7165,13 @@ label_146:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2321 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2322 dst=r1 src=r5 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2323 dst=r1 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2324 dst=r1 src=r0 offset=31 imm=0
 #line 245 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7235,7 +7235,7 @@ label_148:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=2349 dst=r5 src=r0 offset=0 imm=32
 #line 245 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2350 dst=r1 src=r10 offset=0 imm=0
 #line 245 "sample/map.c"
     r1 = r10;
@@ -7300,13 +7300,13 @@ label_150:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2367 dst=r5 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2368 dst=r1 src=r5 offset=0 imm=0
 #line 246 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2369 dst=r1 src=r0 offset=0 imm=32
 #line 246 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2370 dst=r1 src=r0 offset=1 imm=0
 #line 246 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7354,13 +7354,13 @@ label_151:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2383 dst=r5 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2384 dst=r1 src=r5 offset=0 imm=0
 #line 247 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2385 dst=r1 src=r0 offset=0 imm=32
 #line 247 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2386 dst=r1 src=r0 offset=1 imm=0
 #line 247 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7408,13 +7408,13 @@ label_152:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2399 dst=r5 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2400 dst=r1 src=r5 offset=0 imm=0
 #line 248 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2401 dst=r1 src=r0 offset=0 imm=32
 #line 248 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2402 dst=r1 src=r0 offset=1 imm=0
 #line 248 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7462,13 +7462,13 @@ label_153:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2415 dst=r5 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2416 dst=r1 src=r5 offset=0 imm=0
 #line 249 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2417 dst=r1 src=r0 offset=0 imm=32
 #line 249 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2418 dst=r1 src=r0 offset=1 imm=0
 #line 249 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7516,13 +7516,13 @@ label_154:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2431 dst=r5 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2432 dst=r1 src=r5 offset=0 imm=0
 #line 250 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2433 dst=r1 src=r0 offset=0 imm=32
 #line 250 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2434 dst=r1 src=r0 offset=1 imm=0
 #line 250 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7570,13 +7570,13 @@ label_155:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2447 dst=r5 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2448 dst=r1 src=r5 offset=0 imm=0
 #line 251 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2449 dst=r1 src=r0 offset=0 imm=32
 #line 251 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2450 dst=r1 src=r0 offset=1 imm=0
 #line 251 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7624,13 +7624,13 @@ label_156:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2463 dst=r5 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2464 dst=r1 src=r5 offset=0 imm=0
 #line 252 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2465 dst=r1 src=r0 offset=0 imm=32
 #line 252 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2466 dst=r1 src=r0 offset=1 imm=0
 #line 252 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7678,13 +7678,13 @@ label_157:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2479 dst=r5 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2480 dst=r1 src=r5 offset=0 imm=0
 #line 253 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2481 dst=r1 src=r0 offset=0 imm=32
 #line 253 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2482 dst=r1 src=r0 offset=1 imm=0
 #line 253 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7732,13 +7732,13 @@ label_158:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2495 dst=r5 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2496 dst=r1 src=r5 offset=0 imm=0
 #line 254 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2497 dst=r1 src=r0 offset=0 imm=32
 #line 254 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2498 dst=r1 src=r0 offset=1 imm=0
 #line 254 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -7786,13 +7786,13 @@ label_159:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2511 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2512 dst=r1 src=r5 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2513 dst=r1 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=2514 dst=r2 src=r0 offset=0 imm=-29
 #line 257 "sample/map.c"
     r2 = (uint64_t)4294967267;
@@ -7857,7 +7857,7 @@ label_159:
     r3 = *(uint32_t*)(uintptr_t)(r10 + OFFSET(-4));
     // EBPF_OP_ARSH64_IMM pc=2541 dst=r5 src=r0 offset=0 imm=32
 #line 257 "sample/map.c"
-    r5 = (int64_t)r5 >> (uint32_t)IMMEDIATE(32);
+    r5 = (int64_t)r5 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2542 dst=r1 src=r10 offset=0 imm=0
 #line 257 "sample/map.c"
     r1 = r10;
@@ -7906,13 +7906,13 @@ label_160:
     r5 = r7;
     // EBPF_OP_LSH64_IMM pc=2556 dst=r5 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r5 <<= IMMEDIATE(32);
+    r5 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2557 dst=r1 src=r5 offset=0 imm=0
 #line 258 "sample/map.c"
     r1 = r5;
     // EBPF_OP_RSH64_IMM pc=2558 dst=r1 src=r0 offset=0 imm=32
 #line 258 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2559 dst=r1 src=r0 offset=25 imm=0
 #line 258 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8008,13 +8008,13 @@ label_161:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2594 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2595 dst=r1 src=r4 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2596 dst=r1 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2597 dst=r1 src=r0 offset=27 imm=0
 #line 260 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8064,7 +8064,7 @@ label_161:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_ARSH64_IMM pc=2618 dst=r4 src=r0 offset=0 imm=32
 #line 260 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2619 dst=r1 src=r10 offset=0 imm=0
 #line 260 "sample/map.c"
     r1 = r10;
@@ -8183,13 +8183,13 @@ label_164:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2658 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2659 dst=r1 src=r4 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2660 dst=r1 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2661 dst=r1 src=r0 offset=24 imm=0
 #line 268 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8237,7 +8237,7 @@ label_165:
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint8_t)r6;
     // EBPF_OP_ARSH64_IMM pc=2681 dst=r4 src=r0 offset=0 imm=32
 #line 268 "sample/map.c"
-    r4 = (int64_t)r4 >> (uint32_t)IMMEDIATE(32);
+    r4 = (int64_t)r4 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2682 dst=r1 src=r10 offset=0 imm=0
 #line 268 "sample/map.c"
     r1 = r10;
@@ -8337,13 +8337,13 @@ label_167:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2717 dst=r4 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2718 dst=r1 src=r4 offset=0 imm=0
 #line 269 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2719 dst=r1 src=r0 offset=0 imm=32
 #line 269 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2720 dst=r1 src=r0 offset=1 imm=0
 #line 269 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8439,13 +8439,13 @@ label_169:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2753 dst=r4 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2754 dst=r1 src=r4 offset=0 imm=0
 #line 270 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2755 dst=r1 src=r0 offset=0 imm=32
 #line 270 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2756 dst=r1 src=r0 offset=1 imm=0
 #line 270 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8541,13 +8541,13 @@ label_171:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2789 dst=r4 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2790 dst=r1 src=r4 offset=0 imm=0
 #line 271 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2791 dst=r1 src=r0 offset=0 imm=32
 #line 271 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2792 dst=r1 src=r0 offset=1 imm=0
 #line 271 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8643,13 +8643,13 @@ label_173:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2825 dst=r4 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2826 dst=r1 src=r4 offset=0 imm=0
 #line 272 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2827 dst=r1 src=r0 offset=0 imm=32
 #line 272 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2828 dst=r1 src=r0 offset=1 imm=0
 #line 272 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8745,13 +8745,13 @@ label_175:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2861 dst=r4 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2862 dst=r1 src=r4 offset=0 imm=0
 #line 273 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2863 dst=r1 src=r0 offset=0 imm=32
 #line 273 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2864 dst=r1 src=r0 offset=1 imm=0
 #line 273 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8847,13 +8847,13 @@ label_177:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2897 dst=r4 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2898 dst=r1 src=r4 offset=0 imm=0
 #line 274 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2899 dst=r1 src=r0 offset=0 imm=32
 #line 274 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2900 dst=r1 src=r0 offset=1 imm=0
 #line 274 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -8949,13 +8949,13 @@ label_179:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2933 dst=r4 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2934 dst=r1 src=r4 offset=0 imm=0
 #line 275 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2935 dst=r1 src=r0 offset=0 imm=32
 #line 275 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2936 dst=r1 src=r0 offset=1 imm=0
 #line 275 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -9051,13 +9051,13 @@ label_181:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=2969 dst=r4 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=2970 dst=r1 src=r4 offset=0 imm=0
 #line 276 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=2971 dst=r1 src=r0 offset=0 imm=32
 #line 276 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=2972 dst=r1 src=r0 offset=1 imm=0
 #line 276 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -9153,13 +9153,13 @@ label_183:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3005 dst=r4 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3006 dst=r1 src=r4 offset=0 imm=0
 #line 277 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3007 dst=r1 src=r0 offset=0 imm=32
 #line 277 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_JEQ_IMM pc=3008 dst=r1 src=r0 offset=1 imm=0
 #line 277 "sample/map.c"
     if (r1 == IMMEDIATE(0))
@@ -9255,13 +9255,13 @@ label_185:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3041 dst=r4 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3042 dst=r1 src=r4 offset=0 imm=0
 #line 280 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3043 dst=r1 src=r0 offset=0 imm=32
 #line 280 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=3044 dst=r2 src=r0 offset=0 imm=-7
 #line 280 "sample/map.c"
     r2 = (uint64_t)4294967289;
@@ -9318,13 +9318,13 @@ label_187:
     r4 = r7;
     // EBPF_OP_LSH64_IMM pc=3060 dst=r4 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=3061 dst=r1 src=r4 offset=0 imm=0
 #line 281 "sample/map.c"
     r1 = r4;
     // EBPF_OP_RSH64_IMM pc=3062 dst=r1 src=r0 offset=0 imm=32
 #line 281 "sample/map.c"
-    r1 >>= IMMEDIATE(32);
+    r1 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDDW pc=3063 dst=r2 src=r0 offset=0 imm=-7
 #line 281 "sample/map.c"
     r2 = (uint64_t)4294967289;

--- a/tests/bpf2c_tests/expected/pidtgid_dll.c
+++ b/tests/bpf2c_tests/expected/pidtgid_dll.c
@@ -118,7 +118,7 @@ func(void* context)
     if (r2 > r1)
 #line 42 "sample/pidtgid.c"
         goto label_1;
-    // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
+        // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
 #line 42 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
@@ -126,7 +126,7 @@ func(void* context)
     if (r1 != IMMEDIATE(15295))
 #line 42 "sample/pidtgid.c"
         goto label_1;
-    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
+        // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
 #line 43 "sample/pidtgid.c"
     r0 = func_helpers[0].address
 #line 43 "sample/pidtgid.c"
@@ -135,7 +135,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/pidtgid.c"
         return 0;
-    // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
 #line 45 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
@@ -143,7 +143,7 @@ func(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r0;
     // EBPF_OP_RSH64_IMM pc=9 dst=r0 src=r0 offset=0 imm=32
 #line 45 "sample/pidtgid.c"
-    r0 >>= IMMEDIATE(32);
+    r0 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=10 dst=r10 src=r0 offset=-12 imm=0
 #line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r0;

--- a/tests/bpf2c_tests/expected/pidtgid_raw.c
+++ b/tests/bpf2c_tests/expected/pidtgid_raw.c
@@ -92,7 +92,7 @@ func(void* context)
     if (r2 > r1)
 #line 42 "sample/pidtgid.c"
         goto label_1;
-    // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
+        // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
 #line 42 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
@@ -100,7 +100,7 @@ func(void* context)
     if (r1 != IMMEDIATE(15295))
 #line 42 "sample/pidtgid.c"
         goto label_1;
-    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
+        // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
 #line 43 "sample/pidtgid.c"
     r0 = func_helpers[0].address
 #line 43 "sample/pidtgid.c"
@@ -109,7 +109,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/pidtgid.c"
         return 0;
-    // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
 #line 45 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
@@ -117,7 +117,7 @@ func(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r0;
     // EBPF_OP_RSH64_IMM pc=9 dst=r0 src=r0 offset=0 imm=32
 #line 45 "sample/pidtgid.c"
-    r0 >>= IMMEDIATE(32);
+    r0 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=10 dst=r10 src=r0 offset=-12 imm=0
 #line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r0;

--- a/tests/bpf2c_tests/expected/pidtgid_sys.c
+++ b/tests/bpf2c_tests/expected/pidtgid_sys.c
@@ -253,7 +253,7 @@ func(void* context)
     if (r2 > r1)
 #line 42 "sample/pidtgid.c"
         goto label_1;
-    // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
+        // EBPF_OP_LDXH pc=4 dst=r1 src=r6 offset=26 imm=0
 #line 42 "sample/pidtgid.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(26));
     // EBPF_OP_JNE_IMM pc=5 dst=r1 src=r0 offset=16 imm=15295
@@ -261,7 +261,7 @@ func(void* context)
     if (r1 != IMMEDIATE(15295))
 #line 42 "sample/pidtgid.c"
         goto label_1;
-    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
+        // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=19
 #line 43 "sample/pidtgid.c"
     r0 = func_helpers[0].address
 #line 43 "sample/pidtgid.c"
@@ -270,7 +270,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 43 "sample/pidtgid.c"
         return 0;
-    // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
+        // EBPF_OP_LDXDW pc=7 dst=r1 src=r6 offset=16 imm=0
 #line 45 "sample/pidtgid.c"
     r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(16));
     // EBPF_OP_STXW pc=8 dst=r10 src=r0 offset=-8 imm=0
@@ -278,7 +278,7 @@ func(void* context)
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r0;
     // EBPF_OP_RSH64_IMM pc=9 dst=r0 src=r0 offset=0 imm=32
 #line 45 "sample/pidtgid.c"
-    r0 >>= IMMEDIATE(32);
+    r0 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXW pc=10 dst=r10 src=r0 offset=-12 imm=0
 #line 44 "sample/pidtgid.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r0;

--- a/tests/bpf2c_tests/expected/printk_dll.c
+++ b/tests/bpf2c_tests/expected/printk_dll.c
@@ -131,7 +131,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 23 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r9 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -164,7 +164,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=19
@@ -176,7 +176,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=1852404597
@@ -205,7 +205,7 @@ func(void* context)
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_RSH64_IMM pc=34 dst=r8 src=r0 offset=0 imm=32
 #line 28 "sample/printk.c"
-    r8 >>= IMMEDIATE(32);
+    r8 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r10 offset=0 imm=0
 #line 28 "sample/printk.c"
     r1 = r10;
@@ -227,7 +227,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 28 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
+        // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
 #line 28 "sample/printk.c"
     r1 = IMMEDIATE(7695397);
     // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-16 imm=0
@@ -269,7 +269,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 29 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
+        // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
 #line 29 "sample/printk.c"
     r1 = IMMEDIATE(1819026725);
     // EBPF_OP_STXW pc=55 dst=r10 src=r1 offset=-16 imm=0
@@ -314,7 +314,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
 #line 30 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_STXH pc=70 dst=r10 src=r9 offset=-16 imm=0
@@ -356,7 +356,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 31 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
+        // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(117);
     // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-4 imm=0
@@ -410,7 +410,7 @@ func(void* context)
     if ((func_helpers[4].tail_call) && (r0 == 0))
 #line 33 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-28 imm=0
@@ -449,7 +449,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 37 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
 #line 37 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-32 imm=0
@@ -482,7 +482,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 38 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
 #line 38 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-32 imm=0
@@ -515,7 +515,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 39 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
 #line 39 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=133 dst=r10 src=r1 offset=-32 imm=0
@@ -545,7 +545,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 40 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
 #line 40 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=141 dst=r10 src=r1 offset=-32 imm=0
@@ -578,7 +578,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 44 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
 #line 44 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=151 dst=r10 src=r1 offset=-32 imm=0
@@ -605,7 +605,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 45 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
 #line 48 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=158 dst=r1 src=r0 offset=0 imm=25966
@@ -641,7 +641,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
 #line 48 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=169 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_raw.c
+++ b/tests/bpf2c_tests/expected/printk_raw.c
@@ -105,7 +105,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 23 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r9 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -138,7 +138,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=19
@@ -150,7 +150,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=1852404597
@@ -179,7 +179,7 @@ func(void* context)
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_RSH64_IMM pc=34 dst=r8 src=r0 offset=0 imm=32
 #line 28 "sample/printk.c"
-    r8 >>= IMMEDIATE(32);
+    r8 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r10 offset=0 imm=0
 #line 28 "sample/printk.c"
     r1 = r10;
@@ -201,7 +201,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 28 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
+        // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
 #line 28 "sample/printk.c"
     r1 = IMMEDIATE(7695397);
     // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-16 imm=0
@@ -243,7 +243,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 29 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
+        // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
 #line 29 "sample/printk.c"
     r1 = IMMEDIATE(1819026725);
     // EBPF_OP_STXW pc=55 dst=r10 src=r1 offset=-16 imm=0
@@ -288,7 +288,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
 #line 30 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_STXH pc=70 dst=r10 src=r9 offset=-16 imm=0
@@ -330,7 +330,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 31 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
+        // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(117);
     // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-4 imm=0
@@ -384,7 +384,7 @@ func(void* context)
     if ((func_helpers[4].tail_call) && (r0 == 0))
 #line 33 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-28 imm=0
@@ -423,7 +423,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 37 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
 #line 37 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-32 imm=0
@@ -456,7 +456,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 38 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
 #line 38 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-32 imm=0
@@ -489,7 +489,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 39 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
 #line 39 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=133 dst=r10 src=r1 offset=-32 imm=0
@@ -519,7 +519,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 40 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
 #line 40 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=141 dst=r10 src=r1 offset=-32 imm=0
@@ -552,7 +552,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 44 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
 #line 44 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=151 dst=r10 src=r1 offset=-32 imm=0
@@ -579,7 +579,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 45 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
 #line 48 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=158 dst=r1 src=r0 offset=0 imm=25966
@@ -615,7 +615,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
 #line 48 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=169 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/printk_sys.c
+++ b/tests/bpf2c_tests/expected/printk_sys.c
@@ -266,7 +266,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 23 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=12 dst=r9 src=r0 offset=0 imm=0
 #line 23 "sample/printk.c"
     r9 = r0;
     // EBPF_OP_MOV64_IMM pc=13 dst=r1 src=r0 offset=0 imm=10
@@ -299,7 +299,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 24 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=21 dst=r6 src=r0 offset=0 imm=0
 #line 24 "sample/printk.c"
     r6 = r0;
     // EBPF_OP_CALL pc=22 dst=r0 src=r0 offset=0 imm=19
@@ -311,7 +311,7 @@ func(void* context)
     if ((func_helpers[1].tail_call) && (r0 == 0))
 #line 27 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=23 dst=r8 src=r0 offset=0 imm=0
 #line 27 "sample/printk.c"
     r8 = r0;
     // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=1852404597
@@ -340,7 +340,7 @@ func(void* context)
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_RSH64_IMM pc=34 dst=r8 src=r0 offset=0 imm=32
 #line 28 "sample/printk.c"
-    r8 >>= IMMEDIATE(32);
+    r8 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_REG pc=35 dst=r1 src=r10 offset=0 imm=0
 #line 28 "sample/printk.c"
     r1 = r10;
@@ -362,7 +362,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 28 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
+        // EBPF_OP_MOV64_IMM pc=40 dst=r1 src=r0 offset=0 imm=7695397
 #line 28 "sample/printk.c"
     r1 = IMMEDIATE(7695397);
     // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-16 imm=0
@@ -404,7 +404,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 29 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
+        // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=1819026725
 #line 29 "sample/printk.c"
     r1 = IMMEDIATE(1819026725);
     // EBPF_OP_STXW pc=55 dst=r10 src=r1 offset=-16 imm=0
@@ -449,7 +449,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 30 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=69 dst=r6 src=r0 offset=0 imm=0
 #line 30 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_STXH pc=70 dst=r10 src=r9 offset=-16 imm=0
@@ -491,7 +491,7 @@ func(void* context)
     if ((func_helpers[3].tail_call) && (r0 == 0))
 #line 31 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
+        // EBPF_OP_MOV64_IMM pc=83 dst=r1 src=r0 offset=0 imm=117
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(117);
     // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-4 imm=0
@@ -545,7 +545,7 @@ func(void* context)
     if ((func_helpers[4].tail_call) && (r0 == 0))
 #line 33 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
+        // EBPF_OP_MOV64_IMM pc=100 dst=r1 src=r0 offset=0 imm=9504
 #line 33 "sample/printk.c"
     r1 = IMMEDIATE(9504);
     // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-28 imm=0
@@ -584,7 +584,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 37 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
+        // EBPF_OP_LDDW pc=111 dst=r1 src=r0 offset=0 imm=843333954
 #line 37 "sample/printk.c"
     r1 = (uint64_t)7812660273793483074;
     // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-32 imm=0
@@ -617,7 +617,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 38 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
+        // EBPF_OP_LDDW pc=121 dst=r1 src=r0 offset=0 imm=860111170
 #line 38 "sample/printk.c"
     r1 = (uint64_t)7220718397787750722;
     // EBPF_OP_STXDW pc=123 dst=r10 src=r1 offset=-32 imm=0
@@ -650,7 +650,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 39 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
+        // EBPF_OP_LDDW pc=131 dst=r1 src=r0 offset=0 imm=876888386
 #line 39 "sample/printk.c"
     r1 = (uint64_t)31566017637663042;
     // EBPF_OP_STXDW pc=133 dst=r10 src=r1 offset=-32 imm=0
@@ -680,7 +680,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 40 "sample/printk.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
+        // EBPF_OP_MOV64_IMM pc=140 dst=r1 src=r0 offset=0 imm=893665602
 #line 40 "sample/printk.c"
     r1 = IMMEDIATE(893665602);
     // EBPF_OP_STXW pc=141 dst=r10 src=r1 offset=-32 imm=0
@@ -713,7 +713,7 @@ func(void* context)
     if ((func_helpers[2].tail_call) && (r0 == 0))
 #line 44 "sample/printk.c"
         return 0;
-    // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
+        // EBPF_OP_LDDW pc=149 dst=r1 src=r0 offset=0 imm=910442818
 #line 44 "sample/printk.c"
     r1 = (uint64_t)32973392554770754;
     // EBPF_OP_STXDW pc=151 dst=r10 src=r1 offset=-32 imm=0
@@ -740,7 +740,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 45 "sample/printk.c"
         return 0;
-    // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
+        // EBPF_OP_STXB pc=157 dst=r10 src=r8 offset=-22 imm=0
 #line 48 "sample/printk.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-22)) = (uint8_t)r8;
     // EBPF_OP_MOV64_IMM pc=158 dst=r1 src=r0 offset=0 imm=25966
@@ -776,7 +776,7 @@ func(void* context)
     if ((func_helpers[0].tail_call) && (r0 == 0))
 #line 48 "sample/printk.c"
         return 0;
-    // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_ADD64_REG pc=168 dst=r6 src=r0 offset=0 imm=0
 #line 48 "sample/printk.c"
     r6 += r0;
     // EBPF_OP_MOV64_REG pc=169 dst=r0 src=r6 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/reflect_packet_dll.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_dll.c
@@ -98,7 +98,7 @@ reflect_packet(void* context)
     if (r3 > r2)
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=56 imm=56710
@@ -106,12 +106,12 @@ reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 34 "sample/reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
 #line 34 "sample/reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 35 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -122,7 +122,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 35 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=195 imm=17
@@ -130,12 +130,12 @@ reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
 #line 41 "sample/reflect_packet.c"
-    r4 <<= IMMEDIATE(2);
+    r4 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=16 dst=r4 src=r0 offset=0 imm=60
 #line 41 "sample/reflect_packet.c"
     r4 &= IMMEDIATE(60);
@@ -153,7 +153,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
 #line 47 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=186 imm=7459
@@ -161,12 +161,12 @@ reflect_packet(void* context)
     if (r2 != IMMEDIATE(7459))
 #line 47 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=4 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
@@ -181,7 +181,7 @@ reflect_packet(void* context)
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=29 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=30 dst=r3 src=r1 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
@@ -193,7 +193,7 @@ reflect_packet(void* context)
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=33 dst=r3 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=34 dst=r4 src=r1 offset=2 imm=0
 #line 15 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
@@ -202,7 +202,7 @@ reflect_packet(void* context)
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=36 dst=r3 src=r0 offset=0 imm=16
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=37 dst=r3 src=r2 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 |= r2;
@@ -235,7 +235,7 @@ reflect_packet(void* context)
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=47 dst=r3 src=r0 offset=0 imm=16
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=48 dst=r1 src=r3 offset=8 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint8_t)r3;
@@ -244,7 +244,7 @@ reflect_packet(void* context)
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=50 dst=r3 src=r0 offset=0 imm=24
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=51 dst=r1 src=r3 offset=9 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(9)) = (uint8_t)r3;
@@ -253,7 +253,7 @@ reflect_packet(void* context)
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(6)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=53 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=54 dst=r1 src=r2 offset=7 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(7)) = (uint8_t)r2;
@@ -265,7 +265,7 @@ reflect_packet(void* context)
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(10)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=57 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=58 dst=r1 src=r2 offset=11 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(11)) = (uint8_t)r2;
@@ -296,7 +296,7 @@ label_1:
     if (r3 > r2)
 #line 55 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
 #line 55 "sample/reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
@@ -307,7 +307,7 @@ label_1:
     if (r3 > r2)
 #line 61 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
 #line 61 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
@@ -315,7 +315,7 @@ label_1:
     if (r2 != IMMEDIATE(17))
 #line 61 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 67 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=73 dst=r2 src=r0 offset=135 imm=7459
@@ -323,12 +323,12 @@ label_1:
     if (r2 != IMMEDIATE(7459))
 #line 67 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=75 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=76 dst=r3 src=r1 offset=4 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
@@ -343,7 +343,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=81 dst=r3 src=r1 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
@@ -355,7 +355,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=84 dst=r3 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=85 dst=r4 src=r1 offset=2 imm=0
 #line 15 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
@@ -364,7 +364,7 @@ label_1:
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=87 dst=r3 src=r0 offset=0 imm=16
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=88 dst=r3 src=r2 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 |= r2;
@@ -397,7 +397,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=98 dst=r3 src=r0 offset=0 imm=16
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=99 dst=r1 src=r3 offset=8 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint8_t)r3;
@@ -406,7 +406,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=101 dst=r3 src=r0 offset=0 imm=24
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=102 dst=r1 src=r3 offset=9 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(9)) = (uint8_t)r3;
@@ -415,7 +415,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(6)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=104 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=105 dst=r1 src=r2 offset=7 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(7)) = (uint8_t)r2;
@@ -427,7 +427,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(10)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=108 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=109 dst=r1 src=r2 offset=11 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(11)) = (uint8_t)r2;
@@ -436,7 +436,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_LSH64_IMM pc=111 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=112 dst=r2 src=r1 offset=46 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
@@ -448,7 +448,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_LSH64_IMM pc=115 dst=r2 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=116 dst=r4 src=r1 offset=48 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
@@ -457,7 +457,7 @@ label_1:
     r2 |= r4;
     // EBPF_OP_LSH64_IMM pc=118 dst=r2 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=119 dst=r2 src=r3 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 |= r3;
@@ -466,7 +466,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_LSH64_IMM pc=121 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=122 dst=r3 src=r1 offset=50 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
@@ -478,7 +478,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_LSH64_IMM pc=125 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=126 dst=r5 src=r1 offset=52 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
@@ -487,13 +487,13 @@ label_1:
     r3 |= r5;
     // EBPF_OP_LSH64_IMM pc=128 dst=r3 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=129 dst=r3 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=130 dst=r3 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=131 dst=r3 src=r2 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 |= r2;
@@ -502,7 +502,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_LSH64_IMM pc=133 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=134 dst=r2 src=r1 offset=38 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
@@ -514,7 +514,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_LSH64_IMM pc=137 dst=r2 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=138 dst=r5 src=r1 offset=40 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
@@ -526,7 +526,7 @@ label_1:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r3;
     // EBPF_OP_LSH64_IMM pc=141 dst=r2 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=142 dst=r2 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 |= r4;
@@ -535,7 +535,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_LSH64_IMM pc=144 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=145 dst=r4 src=r1 offset=42 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
@@ -547,7 +547,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_LSH64_IMM pc=148 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=149 dst=r5 src=r1 offset=44 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
@@ -556,13 +556,13 @@ label_1:
     r4 |= r5;
     // EBPF_OP_LSH64_IMM pc=151 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=152 dst=r4 src=r3 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r3;
     // EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=154 dst=r4 src=r2 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r2;
@@ -601,7 +601,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=166 dst=r3 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(48);
+    r3 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=167 dst=r1 src=r3 offset=28 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(28)) = (uint8_t)r3;
@@ -610,7 +610,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=169 dst=r3 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(56);
+    r3 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=170 dst=r1 src=r3 offset=29 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(29)) = (uint8_t)r3;
@@ -619,7 +619,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=172 dst=r3 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(32);
+    r3 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=173 dst=r1 src=r3 offset=26 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(26)) = (uint8_t)r3;
@@ -628,7 +628,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=175 dst=r3 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(40);
+    r3 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=176 dst=r1 src=r3 offset=27 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(27)) = (uint8_t)r3;
@@ -637,7 +637,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=178 dst=r3 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=179 dst=r1 src=r3 offset=24 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(24)) = (uint8_t)r3;
@@ -646,7 +646,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=181 dst=r3 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=182 dst=r1 src=r3 offset=25 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(25)) = (uint8_t)r3;
@@ -655,7 +655,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(22)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=184 dst=r2 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=185 dst=r1 src=r2 offset=23 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(23)) = (uint8_t)r2;
@@ -667,7 +667,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=188 dst=r3 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(48);
+    r3 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=189 dst=r1 src=r3 offset=36 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(36)) = (uint8_t)r3;
@@ -676,7 +676,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(56);
+    r3 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=192 dst=r1 src=r3 offset=37 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(37)) = (uint8_t)r3;
@@ -685,7 +685,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(32);
+    r3 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=195 dst=r1 src=r3 offset=34 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(34)) = (uint8_t)r3;
@@ -694,7 +694,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=197 dst=r3 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(40);
+    r3 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=198 dst=r1 src=r3 offset=35 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(35)) = (uint8_t)r3;
@@ -703,7 +703,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=200 dst=r3 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=201 dst=r1 src=r3 offset=32 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(32)) = (uint8_t)r3;
@@ -712,7 +712,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=203 dst=r3 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=204 dst=r1 src=r3 offset=33 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(33)) = (uint8_t)r3;
@@ -721,7 +721,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(30)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=206 dst=r2 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=207 dst=r1 src=r2 offset=31 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(31)) = (uint8_t)r2;

--- a/tests/bpf2c_tests/expected/reflect_packet_raw.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_raw.c
@@ -72,7 +72,7 @@ reflect_packet(void* context)
     if (r3 > r2)
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=56 imm=56710
@@ -80,12 +80,12 @@ reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 34 "sample/reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
 #line 34 "sample/reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 35 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -96,7 +96,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 35 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=195 imm=17
@@ -104,12 +104,12 @@ reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
 #line 41 "sample/reflect_packet.c"
-    r4 <<= IMMEDIATE(2);
+    r4 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=16 dst=r4 src=r0 offset=0 imm=60
 #line 41 "sample/reflect_packet.c"
     r4 &= IMMEDIATE(60);
@@ -127,7 +127,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
 #line 47 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=186 imm=7459
@@ -135,12 +135,12 @@ reflect_packet(void* context)
     if (r2 != IMMEDIATE(7459))
 #line 47 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=4 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
@@ -155,7 +155,7 @@ reflect_packet(void* context)
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=29 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=30 dst=r3 src=r1 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
@@ -167,7 +167,7 @@ reflect_packet(void* context)
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=33 dst=r3 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=34 dst=r4 src=r1 offset=2 imm=0
 #line 15 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
@@ -176,7 +176,7 @@ reflect_packet(void* context)
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=36 dst=r3 src=r0 offset=0 imm=16
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=37 dst=r3 src=r2 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 |= r2;
@@ -209,7 +209,7 @@ reflect_packet(void* context)
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=47 dst=r3 src=r0 offset=0 imm=16
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=48 dst=r1 src=r3 offset=8 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint8_t)r3;
@@ -218,7 +218,7 @@ reflect_packet(void* context)
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=50 dst=r3 src=r0 offset=0 imm=24
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=51 dst=r1 src=r3 offset=9 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(9)) = (uint8_t)r3;
@@ -227,7 +227,7 @@ reflect_packet(void* context)
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(6)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=53 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=54 dst=r1 src=r2 offset=7 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(7)) = (uint8_t)r2;
@@ -239,7 +239,7 @@ reflect_packet(void* context)
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(10)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=57 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=58 dst=r1 src=r2 offset=11 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(11)) = (uint8_t)r2;
@@ -270,7 +270,7 @@ label_1:
     if (r3 > r2)
 #line 55 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
 #line 55 "sample/reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
@@ -281,7 +281,7 @@ label_1:
     if (r3 > r2)
 #line 61 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
 #line 61 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
@@ -289,7 +289,7 @@ label_1:
     if (r2 != IMMEDIATE(17))
 #line 61 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 67 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=73 dst=r2 src=r0 offset=135 imm=7459
@@ -297,12 +297,12 @@ label_1:
     if (r2 != IMMEDIATE(7459))
 #line 67 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=75 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=76 dst=r3 src=r1 offset=4 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
@@ -317,7 +317,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=81 dst=r3 src=r1 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
@@ -329,7 +329,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=84 dst=r3 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=85 dst=r4 src=r1 offset=2 imm=0
 #line 15 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
@@ -338,7 +338,7 @@ label_1:
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=87 dst=r3 src=r0 offset=0 imm=16
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=88 dst=r3 src=r2 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 |= r2;
@@ -371,7 +371,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=98 dst=r3 src=r0 offset=0 imm=16
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=99 dst=r1 src=r3 offset=8 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint8_t)r3;
@@ -380,7 +380,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=101 dst=r3 src=r0 offset=0 imm=24
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=102 dst=r1 src=r3 offset=9 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(9)) = (uint8_t)r3;
@@ -389,7 +389,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(6)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=104 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=105 dst=r1 src=r2 offset=7 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(7)) = (uint8_t)r2;
@@ -401,7 +401,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(10)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=108 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=109 dst=r1 src=r2 offset=11 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(11)) = (uint8_t)r2;
@@ -410,7 +410,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_LSH64_IMM pc=111 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=112 dst=r2 src=r1 offset=46 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
@@ -422,7 +422,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_LSH64_IMM pc=115 dst=r2 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=116 dst=r4 src=r1 offset=48 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
@@ -431,7 +431,7 @@ label_1:
     r2 |= r4;
     // EBPF_OP_LSH64_IMM pc=118 dst=r2 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=119 dst=r2 src=r3 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 |= r3;
@@ -440,7 +440,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_LSH64_IMM pc=121 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=122 dst=r3 src=r1 offset=50 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
@@ -452,7 +452,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_LSH64_IMM pc=125 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=126 dst=r5 src=r1 offset=52 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
@@ -461,13 +461,13 @@ label_1:
     r3 |= r5;
     // EBPF_OP_LSH64_IMM pc=128 dst=r3 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=129 dst=r3 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=130 dst=r3 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=131 dst=r3 src=r2 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 |= r2;
@@ -476,7 +476,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_LSH64_IMM pc=133 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=134 dst=r2 src=r1 offset=38 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
@@ -488,7 +488,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_LSH64_IMM pc=137 dst=r2 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=138 dst=r5 src=r1 offset=40 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
@@ -500,7 +500,7 @@ label_1:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r3;
     // EBPF_OP_LSH64_IMM pc=141 dst=r2 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=142 dst=r2 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 |= r4;
@@ -509,7 +509,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_LSH64_IMM pc=144 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=145 dst=r4 src=r1 offset=42 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
@@ -521,7 +521,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_LSH64_IMM pc=148 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=149 dst=r5 src=r1 offset=44 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
@@ -530,13 +530,13 @@ label_1:
     r4 |= r5;
     // EBPF_OP_LSH64_IMM pc=151 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=152 dst=r4 src=r3 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r3;
     // EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=154 dst=r4 src=r2 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r2;
@@ -575,7 +575,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=166 dst=r3 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(48);
+    r3 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=167 dst=r1 src=r3 offset=28 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(28)) = (uint8_t)r3;
@@ -584,7 +584,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=169 dst=r3 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(56);
+    r3 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=170 dst=r1 src=r3 offset=29 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(29)) = (uint8_t)r3;
@@ -593,7 +593,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=172 dst=r3 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(32);
+    r3 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=173 dst=r1 src=r3 offset=26 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(26)) = (uint8_t)r3;
@@ -602,7 +602,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=175 dst=r3 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(40);
+    r3 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=176 dst=r1 src=r3 offset=27 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(27)) = (uint8_t)r3;
@@ -611,7 +611,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=178 dst=r3 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=179 dst=r1 src=r3 offset=24 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(24)) = (uint8_t)r3;
@@ -620,7 +620,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=181 dst=r3 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=182 dst=r1 src=r3 offset=25 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(25)) = (uint8_t)r3;
@@ -629,7 +629,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(22)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=184 dst=r2 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=185 dst=r1 src=r2 offset=23 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(23)) = (uint8_t)r2;
@@ -641,7 +641,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=188 dst=r3 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(48);
+    r3 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=189 dst=r1 src=r3 offset=36 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(36)) = (uint8_t)r3;
@@ -650,7 +650,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(56);
+    r3 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=192 dst=r1 src=r3 offset=37 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(37)) = (uint8_t)r3;
@@ -659,7 +659,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(32);
+    r3 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=195 dst=r1 src=r3 offset=34 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(34)) = (uint8_t)r3;
@@ -668,7 +668,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=197 dst=r3 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(40);
+    r3 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=198 dst=r1 src=r3 offset=35 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(35)) = (uint8_t)r3;
@@ -677,7 +677,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=200 dst=r3 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=201 dst=r1 src=r3 offset=32 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(32)) = (uint8_t)r3;
@@ -686,7 +686,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=203 dst=r3 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=204 dst=r1 src=r3 offset=33 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(33)) = (uint8_t)r3;
@@ -695,7 +695,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(30)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=206 dst=r2 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=207 dst=r1 src=r2 offset=31 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(31)) = (uint8_t)r2;

--- a/tests/bpf2c_tests/expected/reflect_packet_sys.c
+++ b/tests/bpf2c_tests/expected/reflect_packet_sys.c
@@ -233,7 +233,7 @@ reflect_packet(void* context)
     if (r3 > r2)
 #line 29 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
+        // EBPF_OP_LDXH pc=6 dst=r4 src=r1 offset=12 imm=0
 #line 34 "sample/reflect_packet.c"
     r4 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(12));
     // EBPF_OP_JEQ_IMM pc=7 dst=r4 src=r0 offset=56 imm=56710
@@ -241,12 +241,12 @@ reflect_packet(void* context)
     if (r4 == IMMEDIATE(56710))
 #line 34 "sample/reflect_packet.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
+        // EBPF_OP_JNE_IMM pc=8 dst=r4 src=r0 offset=200 imm=8
 #line 34 "sample/reflect_packet.c"
     if (r4 != IMMEDIATE(8))
 #line 34 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=9 dst=r4 src=r1 offset=0 imm=0
 #line 35 "sample/reflect_packet.c"
     r4 = r1;
     // EBPF_OP_ADD64_IMM pc=10 dst=r4 src=r0 offset=0 imm=34
@@ -257,7 +257,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 35 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
+        // EBPF_OP_LDXB pc=12 dst=r4 src=r1 offset=23 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
     // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=195 imm=17
@@ -265,12 +265,12 @@ reflect_packet(void* context)
     if (r4 != IMMEDIATE(17))
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
+        // EBPF_OP_LDXB pc=14 dst=r4 src=r1 offset=14 imm=0
 #line 41 "sample/reflect_packet.c"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
     // EBPF_OP_LSH64_IMM pc=15 dst=r4 src=r0 offset=0 imm=2
 #line 41 "sample/reflect_packet.c"
-    r4 <<= IMMEDIATE(2);
+    r4 <<= (IMMEDIATE(2) & 63);
     // EBPF_OP_AND64_IMM pc=16 dst=r4 src=r0 offset=0 imm=60
 #line 41 "sample/reflect_packet.c"
     r4 &= IMMEDIATE(60);
@@ -288,7 +288,7 @@ reflect_packet(void* context)
     if (r4 > r2)
 #line 41 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
+        // EBPF_OP_LDXH pc=21 dst=r2 src=r3 offset=2 imm=0
 #line 47 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r3 + OFFSET(2));
     // EBPF_OP_JNE_IMM pc=22 dst=r2 src=r0 offset=186 imm=7459
@@ -296,12 +296,12 @@ reflect_packet(void* context)
     if (r2 != IMMEDIATE(7459))
 #line 47 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=23 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=24 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=25 dst=r3 src=r1 offset=4 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
@@ -316,7 +316,7 @@ reflect_packet(void* context)
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=29 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=30 dst=r3 src=r1 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
@@ -328,7 +328,7 @@ reflect_packet(void* context)
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=33 dst=r3 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=34 dst=r4 src=r1 offset=2 imm=0
 #line 15 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
@@ -337,7 +337,7 @@ reflect_packet(void* context)
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=36 dst=r3 src=r0 offset=0 imm=16
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=37 dst=r3 src=r2 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 |= r2;
@@ -370,7 +370,7 @@ reflect_packet(void* context)
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=47 dst=r3 src=r0 offset=0 imm=16
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=48 dst=r1 src=r3 offset=8 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint8_t)r3;
@@ -379,7 +379,7 @@ reflect_packet(void* context)
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=50 dst=r3 src=r0 offset=0 imm=24
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=51 dst=r1 src=r3 offset=9 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(9)) = (uint8_t)r3;
@@ -388,7 +388,7 @@ reflect_packet(void* context)
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(6)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=53 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=54 dst=r1 src=r2 offset=7 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(7)) = (uint8_t)r2;
@@ -400,7 +400,7 @@ reflect_packet(void* context)
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(10)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=57 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=58 dst=r1 src=r2 offset=11 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(11)) = (uint8_t)r2;
@@ -431,7 +431,7 @@ label_1:
     if (r3 > r2)
 #line 55 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=67 dst=r3 src=r1 offset=0 imm=0
 #line 55 "sample/reflect_packet.c"
     r3 = r1;
     // EBPF_OP_ADD64_IMM pc=68 dst=r3 src=r0 offset=0 imm=62
@@ -442,7 +442,7 @@ label_1:
     if (r3 > r2)
 #line 61 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
+        // EBPF_OP_LDXB pc=70 dst=r2 src=r1 offset=20 imm=0
 #line 61 "sample/reflect_packet.c"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
     // EBPF_OP_JNE_IMM pc=71 dst=r2 src=r0 offset=137 imm=17
@@ -450,7 +450,7 @@ label_1:
     if (r2 != IMMEDIATE(17))
 #line 61 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
+        // EBPF_OP_LDXH pc=72 dst=r2 src=r1 offset=56 imm=0
 #line 67 "sample/reflect_packet.c"
     r2 = *(uint16_t*)(uintptr_t)(r1 + OFFSET(56));
     // EBPF_OP_JNE_IMM pc=73 dst=r2 src=r0 offset=135 imm=7459
@@ -458,12 +458,12 @@ label_1:
     if (r2 != IMMEDIATE(7459))
 #line 67 "sample/reflect_packet.c"
         goto label_3;
-    // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
+        // EBPF_OP_LDXB pc=74 dst=r2 src=r1 offset=5 imm=0
 #line 15 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=75 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=76 dst=r3 src=r1 offset=4 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(4));
@@ -478,7 +478,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=80 dst=r2 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=81 dst=r3 src=r1 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(0));
@@ -490,7 +490,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=84 dst=r3 src=r0 offset=0 imm=8
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=85 dst=r4 src=r1 offset=2 imm=0
 #line 15 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(2));
@@ -499,7 +499,7 @@ label_1:
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=87 dst=r3 src=r0 offset=0 imm=16
 #line 15 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=88 dst=r3 src=r2 offset=0 imm=0
 #line 15 "sample/./xdp_common.h"
     r3 |= r2;
@@ -532,7 +532,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=98 dst=r3 src=r0 offset=0 imm=16
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=99 dst=r1 src=r3 offset=8 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint8_t)r3;
@@ -541,7 +541,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=101 dst=r3 src=r0 offset=0 imm=24
 #line 17 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=102 dst=r1 src=r3 offset=9 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(9)) = (uint8_t)r3;
@@ -550,7 +550,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(6)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=104 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=105 dst=r1 src=r2 offset=7 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(7)) = (uint8_t)r2;
@@ -562,7 +562,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(10)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=108 dst=r2 src=r0 offset=0 imm=8
 #line 17 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=109 dst=r1 src=r2 offset=11 imm=0
 #line 17 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(11)) = (uint8_t)r2;
@@ -571,7 +571,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(47));
     // EBPF_OP_LSH64_IMM pc=111 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=112 dst=r2 src=r1 offset=46 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(46));
@@ -583,7 +583,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(49));
     // EBPF_OP_LSH64_IMM pc=115 dst=r2 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=116 dst=r4 src=r1 offset=48 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
@@ -592,7 +592,7 @@ label_1:
     r2 |= r4;
     // EBPF_OP_LSH64_IMM pc=118 dst=r2 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=119 dst=r2 src=r3 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 |= r3;
@@ -601,7 +601,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(51));
     // EBPF_OP_LSH64_IMM pc=121 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=122 dst=r3 src=r1 offset=50 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(50));
@@ -613,7 +613,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(53));
     // EBPF_OP_LSH64_IMM pc=125 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=126 dst=r5 src=r1 offset=52 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(52));
@@ -622,13 +622,13 @@ label_1:
     r3 |= r5;
     // EBPF_OP_LSH64_IMM pc=128 dst=r3 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=129 dst=r3 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 |= r4;
     // EBPF_OP_LSH64_IMM pc=130 dst=r3 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(32);
+    r3 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=131 dst=r3 src=r2 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r3 |= r2;
@@ -637,7 +637,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
     // EBPF_OP_LSH64_IMM pc=133 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=134 dst=r2 src=r1 offset=38 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
@@ -649,7 +649,7 @@ label_1:
     r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
     // EBPF_OP_LSH64_IMM pc=137 dst=r2 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=138 dst=r5 src=r1 offset=40 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
@@ -661,7 +661,7 @@ label_1:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r3;
     // EBPF_OP_LSH64_IMM pc=141 dst=r2 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=142 dst=r2 src=r4 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r2 |= r4;
@@ -670,7 +670,7 @@ label_1:
     r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
     // EBPF_OP_LSH64_IMM pc=144 dst=r3 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=145 dst=r4 src=r1 offset=42 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
@@ -682,7 +682,7 @@ label_1:
     r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(45));
     // EBPF_OP_LSH64_IMM pc=148 dst=r4 src=r0 offset=0 imm=8
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=149 dst=r5 src=r1 offset=44 imm=0
 #line 32 "sample/./xdp_common.h"
     r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(44));
@@ -691,13 +691,13 @@ label_1:
     r4 |= r5;
     // EBPF_OP_LSH64_IMM pc=151 dst=r4 src=r0 offset=0 imm=16
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=152 dst=r4 src=r3 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r3;
     // EBPF_OP_LSH64_IMM pc=153 dst=r4 src=r0 offset=0 imm=32
 #line 32 "sample/./xdp_common.h"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=154 dst=r4 src=r2 offset=0 imm=0
 #line 32 "sample/./xdp_common.h"
     r4 |= r2;
@@ -736,7 +736,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=166 dst=r3 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(48);
+    r3 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=167 dst=r1 src=r3 offset=28 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(28)) = (uint8_t)r3;
@@ -745,7 +745,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=169 dst=r3 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(56);
+    r3 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=170 dst=r1 src=r3 offset=29 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(29)) = (uint8_t)r3;
@@ -754,7 +754,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=172 dst=r3 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(32);
+    r3 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=173 dst=r1 src=r3 offset=26 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(26)) = (uint8_t)r3;
@@ -763,7 +763,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=175 dst=r3 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(40);
+    r3 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=176 dst=r1 src=r3 offset=27 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(27)) = (uint8_t)r3;
@@ -772,7 +772,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=178 dst=r3 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=179 dst=r1 src=r3 offset=24 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(24)) = (uint8_t)r3;
@@ -781,7 +781,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=181 dst=r3 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=182 dst=r1 src=r3 offset=25 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(25)) = (uint8_t)r3;
@@ -790,7 +790,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(22)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=184 dst=r2 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=185 dst=r1 src=r2 offset=23 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(23)) = (uint8_t)r2;
@@ -802,7 +802,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=188 dst=r3 src=r0 offset=0 imm=48
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(48);
+    r3 >>= (IMMEDIATE(48) & 63);
     // EBPF_OP_STXB pc=189 dst=r1 src=r3 offset=36 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(36)) = (uint8_t)r3;
@@ -811,7 +811,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=191 dst=r3 src=r0 offset=0 imm=56
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(56);
+    r3 >>= (IMMEDIATE(56) & 63);
     // EBPF_OP_STXB pc=192 dst=r1 src=r3 offset=37 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(37)) = (uint8_t)r3;
@@ -820,7 +820,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=32
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(32);
+    r3 >>= (IMMEDIATE(32) & 63);
     // EBPF_OP_STXB pc=195 dst=r1 src=r3 offset=34 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(34)) = (uint8_t)r3;
@@ -829,7 +829,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=197 dst=r3 src=r0 offset=0 imm=40
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(40);
+    r3 >>= (IMMEDIATE(40) & 63);
     // EBPF_OP_STXB pc=198 dst=r1 src=r3 offset=35 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(35)) = (uint8_t)r3;
@@ -838,7 +838,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=200 dst=r3 src=r0 offset=0 imm=16
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(16);
+    r3 >>= (IMMEDIATE(16) & 63);
     // EBPF_OP_STXB pc=201 dst=r1 src=r3 offset=32 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(32)) = (uint8_t)r3;
@@ -847,7 +847,7 @@ label_1:
     r3 = r2;
     // EBPF_OP_RSH64_IMM pc=203 dst=r3 src=r0 offset=0 imm=24
 #line 34 "sample/./xdp_common.h"
-    r3 >>= IMMEDIATE(24);
+    r3 >>= (IMMEDIATE(24) & 63);
     // EBPF_OP_STXB pc=204 dst=r1 src=r3 offset=33 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(33)) = (uint8_t)r3;
@@ -856,7 +856,7 @@ label_1:
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(30)) = (uint8_t)r2;
     // EBPF_OP_RSH64_IMM pc=206 dst=r2 src=r0 offset=0 imm=8
 #line 34 "sample/./xdp_common.h"
-    r2 >>= IMMEDIATE(8);
+    r2 >>= (IMMEDIATE(8) & 63);
     // EBPF_OP_STXB pc=207 dst=r1 src=r2 offset=31 imm=0
 #line 34 "sample/./xdp_common.h"
     *(uint8_t*)(uintptr_t)(r1 + OFFSET(31)) = (uint8_t)r2;

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -139,12 +139,12 @@ connection_monitor(void* context)
     if (r2 == IMMEDIATE(0))
 #line 72 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+        // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
 #line 72 "sample/sockops.c"
     if (r2 == IMMEDIATE(2))
 #line 72 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 72 "sample/sockops.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=217 imm=1
@@ -152,7 +152,7 @@ connection_monitor(void* context)
     if (r2 != IMMEDIATE(1))
 #line 72 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
 #line 72 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -174,7 +174,7 @@ label_2:
     if (r2 != IMMEDIATE(2))
 #line 89 "sample/sockops.c"
         goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=15 dst=r10 src=r6 offset=-8 imm=0
@@ -212,7 +212,7 @@ label_2:
     if (r4 != IMMEDIATE(0))
 #line 24 "sample/sockops.c"
         goto label_3;
-    // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
+        // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
 #line 24 "sample/sockops.c"
     r5 = IMMEDIATE(28);
 label_3:
@@ -239,7 +239,7 @@ label_3:
     if (r4 != IMMEDIATE(0))
 #line 25 "sample/sockops.c"
         goto label_4;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
 #line 25 "sample/sockops.c"
     r3 = IMMEDIATE(44);
 label_4:
@@ -260,7 +260,7 @@ label_4:
     if (r4 != IMMEDIATE(0))
 #line 27 "sample/sockops.c"
         goto label_5;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
 #line 27 "sample/sockops.c"
     r0 = IMMEDIATE(24);
 label_5:
@@ -269,7 +269,7 @@ label_5:
     if (r4 != IMMEDIATE(0))
 #line 26 "sample/sockops.c"
         goto label_6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
 #line 26 "sample/sockops.c"
     r2 = IMMEDIATE(8);
 label_6:
@@ -333,12 +333,12 @@ label_6:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 33 "sample/sockops.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
+        // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
 #line 33 "sample/sockops.c"
     if (r0 == IMMEDIATE(0))
 #line 33 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
 #line 33 "sample/sockops.c"
     goto label_12;
 label_7:
@@ -389,7 +389,7 @@ label_7:
     if (r4 != IMMEDIATE(0))
 #line 47 "sample/sockops.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
 #line 47 "sample/sockops.c"
     r0 = r3;
 label_8:
@@ -398,7 +398,7 @@ label_8:
     r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(13));
     // EBPF_OP_LSH64_IMM pc=81 dst=r2 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=82 dst=r1 src=r0 offset=12 imm=0
 #line 48 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(12));
@@ -410,7 +410,7 @@ label_8:
     r8 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(15));
     // EBPF_OP_LSH64_IMM pc=85 dst=r8 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r8 <<= IMMEDIATE(8);
+    r8 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=86 dst=r5 src=r0 offset=14 imm=0
 #line 48 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(14));
@@ -422,7 +422,7 @@ label_8:
     r6 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(9));
     // EBPF_OP_LSH64_IMM pc=89 dst=r6 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r6 <<= IMMEDIATE(8);
+    r6 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 48 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(8));
@@ -434,7 +434,7 @@ label_8:
     r9 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(11));
     // EBPF_OP_LSH64_IMM pc=93 dst=r9 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r9 <<= IMMEDIATE(8);
+    r9 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=10 imm=0
 #line 48 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(10));
@@ -464,7 +464,7 @@ label_8:
     if (r4 != IMMEDIATE(0))
 #line 49 "sample/sockops.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
+        // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
 #line 49 "sample/sockops.c"
     r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120));
 label_9:
@@ -482,16 +482,16 @@ label_9:
     r6 |= r1;
     // EBPF_OP_LSH64_IMM pc=108 dst=r9 src=r0 offset=0 imm=16
 #line 49 "sample/sockops.c"
-    r9 <<= IMMEDIATE(16);
+    r9 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_LSH64_IMM pc=109 dst=r8 src=r0 offset=0 imm=16
 #line 49 "sample/sockops.c"
-    r8 <<= IMMEDIATE(16);
+    r8 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_LSH64_IMM pc=110 dst=r5 src=r0 offset=0 imm=8
 #line 49 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LSH64_IMM pc=111 dst=r7 src=r0 offset=0 imm=8
 #line 49 "sample/sockops.c"
-    r7 <<= IMMEDIATE(8);
+    r7 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=44
 #line 49 "sample/sockops.c"
     r1 = IMMEDIATE(44);
@@ -509,7 +509,7 @@ label_9:
     if (r4 != IMMEDIATE(0))
 #line 49 "sample/sockops.c"
         goto label_10;
-    // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
 #line 49 "sample/sockops.c"
     r1 = IMMEDIATE(44);
     // EBPF_OP_STXDW pc=118 dst=r10 src=r1 offset=-80 imm=0
@@ -539,7 +539,7 @@ label_10:
     if (r4 != IMMEDIATE(0))
 #line 52 "sample/sockops.c"
         goto label_11;
-    // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
 #line 52 "sample/sockops.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-88 imm=0
@@ -557,7 +557,7 @@ label_11:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
     // EBPF_OP_LSH64_IMM pc=131 dst=r8 src=r0 offset=0 imm=32
 #line 48 "sample/sockops.c"
-    r8 <<= IMMEDIATE(32);
+    r8 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=132 dst=r8 src=r9 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r8 |= r9;
@@ -566,7 +566,7 @@ label_11:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
     // EBPF_OP_LSH64_IMM pc=134 dst=r7 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
-    r7 <<= IMMEDIATE(16);
+    r7 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=135 dst=r7 src=r5 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r7 |= r5;
@@ -575,7 +575,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=137 dst=r1 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=138 dst=r2 src=r0 offset=4 imm=0
 #line 48 "sample/sockops.c"
     r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(4));
@@ -590,19 +590,19 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(7));
     // EBPF_OP_LSH64_IMM pc=142 dst=r4 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_OR64_REG pc=143 dst=r4 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r2;
     // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=145 dst=r4 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r1;
     // EBPF_OP_LSH64_IMM pc=146 dst=r4 src=r0 offset=0 imm=32
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=147 dst=r4 src=r7 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r7;
@@ -632,7 +632,7 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
     // EBPF_OP_LSH64_IMM pc=156 dst=r4 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=157 dst=r1 src=r3 offset=12 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
@@ -644,7 +644,7 @@ label_11:
     r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
     // EBPF_OP_LSH64_IMM pc=160 dst=r2 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=161 dst=r1 src=r3 offset=14 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
@@ -656,7 +656,7 @@ label_11:
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=164 dst=r5 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=165 dst=r1 src=r3 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
@@ -668,7 +668,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=169 dst=r0 src=r3 offset=2 imm=0
 #line 51 "sample/sockops.c"
     r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
@@ -677,13 +677,13 @@ label_11:
     r1 |= r0;
     // EBPF_OP_LSH64_IMM pc=171 dst=r1 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(16);
+    r1 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=172 dst=r1 src=r5 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r1 |= r5;
     // EBPF_OP_LSH64_IMM pc=173 dst=r2 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=174 dst=r2 src=r4 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r2 |= r4;
@@ -692,7 +692,7 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
     // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=177 dst=r5 src=r3 offset=8 imm=0
 #line 51 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
@@ -704,7 +704,7 @@ label_11:
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
     // EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=181 dst=r0 src=r3 offset=10 imm=0
 #line 51 "sample/sockops.c"
     r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
@@ -713,7 +713,7 @@ label_11:
     r5 |= r0;
     // EBPF_OP_LSH64_IMM pc=183 dst=r5 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(16);
+    r5 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=184 dst=r5 src=r4 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r5 |= r4;
@@ -731,7 +731,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=189 dst=r1 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=190 dst=r2 src=r3 offset=4 imm=0
 #line 51 "sample/sockops.c"
     r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
@@ -746,13 +746,13 @@ label_11:
     r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
     // EBPF_OP_LSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_OR64_REG pc=195 dst=r3 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r3 |= r2;
     // EBPF_OP_LSH64_IMM pc=196 dst=r3 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=197 dst=r3 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r3 |= r1;
@@ -810,7 +810,7 @@ label_11:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 58 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
 #line 58 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=216 dst=r0 src=r0 offset=8 imm=0
@@ -843,7 +843,7 @@ label_12:
     if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
 #line 58 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
 #line 58 "sample/sockops.c"
     r6 = r0;
 label_13:

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -113,12 +113,12 @@ connection_monitor(void* context)
     if (r2 == IMMEDIATE(0))
 #line 72 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+        // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
 #line 72 "sample/sockops.c"
     if (r2 == IMMEDIATE(2))
 #line 72 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 72 "sample/sockops.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=217 imm=1
@@ -126,7 +126,7 @@ connection_monitor(void* context)
     if (r2 != IMMEDIATE(1))
 #line 72 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
 #line 72 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -148,7 +148,7 @@ label_2:
     if (r2 != IMMEDIATE(2))
 #line 89 "sample/sockops.c"
         goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=15 dst=r10 src=r6 offset=-8 imm=0
@@ -186,7 +186,7 @@ label_2:
     if (r4 != IMMEDIATE(0))
 #line 24 "sample/sockops.c"
         goto label_3;
-    // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
+        // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
 #line 24 "sample/sockops.c"
     r5 = IMMEDIATE(28);
 label_3:
@@ -213,7 +213,7 @@ label_3:
     if (r4 != IMMEDIATE(0))
 #line 25 "sample/sockops.c"
         goto label_4;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
 #line 25 "sample/sockops.c"
     r3 = IMMEDIATE(44);
 label_4:
@@ -234,7 +234,7 @@ label_4:
     if (r4 != IMMEDIATE(0))
 #line 27 "sample/sockops.c"
         goto label_5;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
 #line 27 "sample/sockops.c"
     r0 = IMMEDIATE(24);
 label_5:
@@ -243,7 +243,7 @@ label_5:
     if (r4 != IMMEDIATE(0))
 #line 26 "sample/sockops.c"
         goto label_6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
 #line 26 "sample/sockops.c"
     r2 = IMMEDIATE(8);
 label_6:
@@ -307,12 +307,12 @@ label_6:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 33 "sample/sockops.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
+        // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
 #line 33 "sample/sockops.c"
     if (r0 == IMMEDIATE(0))
 #line 33 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
 #line 33 "sample/sockops.c"
     goto label_12;
 label_7:
@@ -363,7 +363,7 @@ label_7:
     if (r4 != IMMEDIATE(0))
 #line 47 "sample/sockops.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
 #line 47 "sample/sockops.c"
     r0 = r3;
 label_8:
@@ -372,7 +372,7 @@ label_8:
     r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(13));
     // EBPF_OP_LSH64_IMM pc=81 dst=r2 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=82 dst=r1 src=r0 offset=12 imm=0
 #line 48 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(12));
@@ -384,7 +384,7 @@ label_8:
     r8 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(15));
     // EBPF_OP_LSH64_IMM pc=85 dst=r8 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r8 <<= IMMEDIATE(8);
+    r8 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=86 dst=r5 src=r0 offset=14 imm=0
 #line 48 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(14));
@@ -396,7 +396,7 @@ label_8:
     r6 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(9));
     // EBPF_OP_LSH64_IMM pc=89 dst=r6 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r6 <<= IMMEDIATE(8);
+    r6 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 48 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(8));
@@ -408,7 +408,7 @@ label_8:
     r9 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(11));
     // EBPF_OP_LSH64_IMM pc=93 dst=r9 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r9 <<= IMMEDIATE(8);
+    r9 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=10 imm=0
 #line 48 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(10));
@@ -438,7 +438,7 @@ label_8:
     if (r4 != IMMEDIATE(0))
 #line 49 "sample/sockops.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
+        // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
 #line 49 "sample/sockops.c"
     r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120));
 label_9:
@@ -456,16 +456,16 @@ label_9:
     r6 |= r1;
     // EBPF_OP_LSH64_IMM pc=108 dst=r9 src=r0 offset=0 imm=16
 #line 49 "sample/sockops.c"
-    r9 <<= IMMEDIATE(16);
+    r9 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_LSH64_IMM pc=109 dst=r8 src=r0 offset=0 imm=16
 #line 49 "sample/sockops.c"
-    r8 <<= IMMEDIATE(16);
+    r8 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_LSH64_IMM pc=110 dst=r5 src=r0 offset=0 imm=8
 #line 49 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LSH64_IMM pc=111 dst=r7 src=r0 offset=0 imm=8
 #line 49 "sample/sockops.c"
-    r7 <<= IMMEDIATE(8);
+    r7 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=44
 #line 49 "sample/sockops.c"
     r1 = IMMEDIATE(44);
@@ -483,7 +483,7 @@ label_9:
     if (r4 != IMMEDIATE(0))
 #line 49 "sample/sockops.c"
         goto label_10;
-    // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
 #line 49 "sample/sockops.c"
     r1 = IMMEDIATE(44);
     // EBPF_OP_STXDW pc=118 dst=r10 src=r1 offset=-80 imm=0
@@ -513,7 +513,7 @@ label_10:
     if (r4 != IMMEDIATE(0))
 #line 52 "sample/sockops.c"
         goto label_11;
-    // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
 #line 52 "sample/sockops.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-88 imm=0
@@ -531,7 +531,7 @@ label_11:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
     // EBPF_OP_LSH64_IMM pc=131 dst=r8 src=r0 offset=0 imm=32
 #line 48 "sample/sockops.c"
-    r8 <<= IMMEDIATE(32);
+    r8 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=132 dst=r8 src=r9 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r8 |= r9;
@@ -540,7 +540,7 @@ label_11:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
     // EBPF_OP_LSH64_IMM pc=134 dst=r7 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
-    r7 <<= IMMEDIATE(16);
+    r7 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=135 dst=r7 src=r5 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r7 |= r5;
@@ -549,7 +549,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=137 dst=r1 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=138 dst=r2 src=r0 offset=4 imm=0
 #line 48 "sample/sockops.c"
     r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(4));
@@ -564,19 +564,19 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(7));
     // EBPF_OP_LSH64_IMM pc=142 dst=r4 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_OR64_REG pc=143 dst=r4 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r2;
     // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=145 dst=r4 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r1;
     // EBPF_OP_LSH64_IMM pc=146 dst=r4 src=r0 offset=0 imm=32
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=147 dst=r4 src=r7 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r7;
@@ -606,7 +606,7 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
     // EBPF_OP_LSH64_IMM pc=156 dst=r4 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=157 dst=r1 src=r3 offset=12 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
@@ -618,7 +618,7 @@ label_11:
     r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
     // EBPF_OP_LSH64_IMM pc=160 dst=r2 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=161 dst=r1 src=r3 offset=14 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
@@ -630,7 +630,7 @@ label_11:
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=164 dst=r5 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=165 dst=r1 src=r3 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
@@ -642,7 +642,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=169 dst=r0 src=r3 offset=2 imm=0
 #line 51 "sample/sockops.c"
     r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
@@ -651,13 +651,13 @@ label_11:
     r1 |= r0;
     // EBPF_OP_LSH64_IMM pc=171 dst=r1 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(16);
+    r1 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=172 dst=r1 src=r5 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r1 |= r5;
     // EBPF_OP_LSH64_IMM pc=173 dst=r2 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=174 dst=r2 src=r4 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r2 |= r4;
@@ -666,7 +666,7 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
     // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=177 dst=r5 src=r3 offset=8 imm=0
 #line 51 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
@@ -678,7 +678,7 @@ label_11:
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
     // EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=181 dst=r0 src=r3 offset=10 imm=0
 #line 51 "sample/sockops.c"
     r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
@@ -687,7 +687,7 @@ label_11:
     r5 |= r0;
     // EBPF_OP_LSH64_IMM pc=183 dst=r5 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(16);
+    r5 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=184 dst=r5 src=r4 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r5 |= r4;
@@ -705,7 +705,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=189 dst=r1 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=190 dst=r2 src=r3 offset=4 imm=0
 #line 51 "sample/sockops.c"
     r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
@@ -720,13 +720,13 @@ label_11:
     r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
     // EBPF_OP_LSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_OR64_REG pc=195 dst=r3 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r3 |= r2;
     // EBPF_OP_LSH64_IMM pc=196 dst=r3 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=197 dst=r3 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r3 |= r1;
@@ -784,7 +784,7 @@ label_11:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 58 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
 #line 58 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=216 dst=r0 src=r0 offset=8 imm=0
@@ -817,7 +817,7 @@ label_12:
     if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
 #line 58 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
 #line 58 "sample/sockops.c"
     r6 = r0;
 label_13:

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -274,12 +274,12 @@ connection_monitor(void* context)
     if (r2 == IMMEDIATE(0))
 #line 72 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
+        // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
 #line 72 "sample/sockops.c"
     if (r2 == IMMEDIATE(2))
 #line 72 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
+        // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
 #line 72 "sample/sockops.c"
     r6 = (uint64_t)4294967295;
     // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=217 imm=1
@@ -287,7 +287,7 @@ connection_monitor(void* context)
     if (r2 != IMMEDIATE(1))
 #line 72 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
 #line 72 "sample/sockops.c"
     r4 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
@@ -309,7 +309,7 @@ label_2:
     if (r2 != IMMEDIATE(2))
 #line 89 "sample/sockops.c"
         goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
 #line 89 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=15 dst=r10 src=r6 offset=-8 imm=0
@@ -347,7 +347,7 @@ label_2:
     if (r4 != IMMEDIATE(0))
 #line 24 "sample/sockops.c"
         goto label_3;
-    // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
+        // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
 #line 24 "sample/sockops.c"
     r5 = IMMEDIATE(28);
 label_3:
@@ -374,7 +374,7 @@ label_3:
     if (r4 != IMMEDIATE(0))
 #line 25 "sample/sockops.c"
         goto label_4;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
 #line 25 "sample/sockops.c"
     r3 = IMMEDIATE(44);
 label_4:
@@ -395,7 +395,7 @@ label_4:
     if (r4 != IMMEDIATE(0))
 #line 27 "sample/sockops.c"
         goto label_5;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
 #line 27 "sample/sockops.c"
     r0 = IMMEDIATE(24);
 label_5:
@@ -404,7 +404,7 @@ label_5:
     if (r4 != IMMEDIATE(0))
 #line 26 "sample/sockops.c"
         goto label_6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
+        // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
 #line 26 "sample/sockops.c"
     r2 = IMMEDIATE(8);
 label_6:
@@ -468,12 +468,12 @@ label_6:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 33 "sample/sockops.c"
         return 0;
-    // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
+        // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
 #line 33 "sample/sockops.c"
     if (r0 == IMMEDIATE(0))
 #line 33 "sample/sockops.c"
         goto label_13;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
+        // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
 #line 33 "sample/sockops.c"
     goto label_12;
 label_7:
@@ -524,7 +524,7 @@ label_7:
     if (r4 != IMMEDIATE(0))
 #line 47 "sample/sockops.c"
         goto label_8;
-    // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
 #line 47 "sample/sockops.c"
     r0 = r3;
 label_8:
@@ -533,7 +533,7 @@ label_8:
     r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(13));
     // EBPF_OP_LSH64_IMM pc=81 dst=r2 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=82 dst=r1 src=r0 offset=12 imm=0
 #line 48 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(12));
@@ -545,7 +545,7 @@ label_8:
     r8 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(15));
     // EBPF_OP_LSH64_IMM pc=85 dst=r8 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r8 <<= IMMEDIATE(8);
+    r8 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=86 dst=r5 src=r0 offset=14 imm=0
 #line 48 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(14));
@@ -557,7 +557,7 @@ label_8:
     r6 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(9));
     // EBPF_OP_LSH64_IMM pc=89 dst=r6 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r6 <<= IMMEDIATE(8);
+    r6 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=90 dst=r1 src=r0 offset=8 imm=0
 #line 48 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(8));
@@ -569,7 +569,7 @@ label_8:
     r9 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(11));
     // EBPF_OP_LSH64_IMM pc=93 dst=r9 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r9 <<= IMMEDIATE(8);
+    r9 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=10 imm=0
 #line 48 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(10));
@@ -599,7 +599,7 @@ label_8:
     if (r4 != IMMEDIATE(0))
 #line 49 "sample/sockops.c"
         goto label_9;
-    // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
+        // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
 #line 49 "sample/sockops.c"
     r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120));
 label_9:
@@ -617,16 +617,16 @@ label_9:
     r6 |= r1;
     // EBPF_OP_LSH64_IMM pc=108 dst=r9 src=r0 offset=0 imm=16
 #line 49 "sample/sockops.c"
-    r9 <<= IMMEDIATE(16);
+    r9 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_LSH64_IMM pc=109 dst=r8 src=r0 offset=0 imm=16
 #line 49 "sample/sockops.c"
-    r8 <<= IMMEDIATE(16);
+    r8 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_LSH64_IMM pc=110 dst=r5 src=r0 offset=0 imm=8
 #line 49 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LSH64_IMM pc=111 dst=r7 src=r0 offset=0 imm=8
 #line 49 "sample/sockops.c"
-    r7 <<= IMMEDIATE(8);
+    r7 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=44
 #line 49 "sample/sockops.c"
     r1 = IMMEDIATE(44);
@@ -644,7 +644,7 @@ label_9:
     if (r4 != IMMEDIATE(0))
 #line 49 "sample/sockops.c"
         goto label_10;
-    // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
+        // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
 #line 49 "sample/sockops.c"
     r1 = IMMEDIATE(44);
     // EBPF_OP_STXDW pc=118 dst=r10 src=r1 offset=-80 imm=0
@@ -674,7 +674,7 @@ label_10:
     if (r4 != IMMEDIATE(0))
 #line 52 "sample/sockops.c"
         goto label_11;
-    // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
+        // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
 #line 52 "sample/sockops.c"
     r1 = IMMEDIATE(24);
     // EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-88 imm=0
@@ -692,7 +692,7 @@ label_11:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
     // EBPF_OP_LSH64_IMM pc=131 dst=r8 src=r0 offset=0 imm=32
 #line 48 "sample/sockops.c"
-    r8 <<= IMMEDIATE(32);
+    r8 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=132 dst=r8 src=r9 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r8 |= r9;
@@ -701,7 +701,7 @@ label_11:
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
     // EBPF_OP_LSH64_IMM pc=134 dst=r7 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
-    r7 <<= IMMEDIATE(16);
+    r7 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=135 dst=r7 src=r5 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r7 |= r5;
@@ -710,7 +710,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=137 dst=r1 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=138 dst=r2 src=r0 offset=4 imm=0
 #line 48 "sample/sockops.c"
     r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(4));
@@ -725,19 +725,19 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(7));
     // EBPF_OP_LSH64_IMM pc=142 dst=r4 src=r0 offset=0 imm=8
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_OR64_REG pc=143 dst=r4 src=r2 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r2;
     // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(16);
+    r4 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=145 dst=r4 src=r1 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r1;
     // EBPF_OP_LSH64_IMM pc=146 dst=r4 src=r0 offset=0 imm=32
 #line 48 "sample/sockops.c"
-    r4 <<= IMMEDIATE(32);
+    r4 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_OR64_REG pc=147 dst=r4 src=r7 offset=0 imm=0
 #line 48 "sample/sockops.c"
     r4 |= r7;
@@ -767,7 +767,7 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
     // EBPF_OP_LSH64_IMM pc=156 dst=r4 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=157 dst=r1 src=r3 offset=12 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
@@ -779,7 +779,7 @@ label_11:
     r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
     // EBPF_OP_LSH64_IMM pc=160 dst=r2 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r2 <<= IMMEDIATE(8);
+    r2 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=161 dst=r1 src=r3 offset=14 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
@@ -791,7 +791,7 @@ label_11:
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
     // EBPF_OP_LSH64_IMM pc=164 dst=r5 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=165 dst=r1 src=r3 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
@@ -803,7 +803,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
     // EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=169 dst=r0 src=r3 offset=2 imm=0
 #line 51 "sample/sockops.c"
     r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
@@ -812,13 +812,13 @@ label_11:
     r1 |= r0;
     // EBPF_OP_LSH64_IMM pc=171 dst=r1 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(16);
+    r1 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=172 dst=r1 src=r5 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r1 |= r5;
     // EBPF_OP_LSH64_IMM pc=173 dst=r2 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r2 <<= IMMEDIATE(16);
+    r2 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=174 dst=r2 src=r4 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r2 |= r4;
@@ -827,7 +827,7 @@ label_11:
     r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
     // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r4 <<= IMMEDIATE(8);
+    r4 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=177 dst=r5 src=r3 offset=8 imm=0
 #line 51 "sample/sockops.c"
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
@@ -839,7 +839,7 @@ label_11:
     r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
     // EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(8);
+    r5 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=181 dst=r0 src=r3 offset=10 imm=0
 #line 51 "sample/sockops.c"
     r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
@@ -848,7 +848,7 @@ label_11:
     r5 |= r0;
     // EBPF_OP_LSH64_IMM pc=183 dst=r5 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r5 <<= IMMEDIATE(16);
+    r5 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=184 dst=r5 src=r4 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r5 |= r4;
@@ -866,7 +866,7 @@ label_11:
     r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
     // EBPF_OP_LSH64_IMM pc=189 dst=r1 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r1 <<= IMMEDIATE(8);
+    r1 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_LDXB pc=190 dst=r2 src=r3 offset=4 imm=0
 #line 51 "sample/sockops.c"
     r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
@@ -881,13 +881,13 @@ label_11:
     r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
     // EBPF_OP_LSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=8
 #line 51 "sample/sockops.c"
-    r3 <<= IMMEDIATE(8);
+    r3 <<= (IMMEDIATE(8) & 63);
     // EBPF_OP_OR64_REG pc=195 dst=r3 src=r2 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r3 |= r2;
     // EBPF_OP_LSH64_IMM pc=196 dst=r3 src=r0 offset=0 imm=16
 #line 51 "sample/sockops.c"
-    r3 <<= IMMEDIATE(16);
+    r3 <<= (IMMEDIATE(16) & 63);
     // EBPF_OP_OR64_REG pc=197 dst=r3 src=r1 offset=0 imm=0
 #line 51 "sample/sockops.c"
     r3 |= r1;
@@ -945,7 +945,7 @@ label_11:
     if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
 #line 58 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
 #line 58 "sample/sockops.c"
     r6 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=216 dst=r0 src=r0 offset=8 imm=0
@@ -978,7 +978,7 @@ label_12:
     if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
 #line 58 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
 #line 58 "sample/sockops.c"
     r6 = r0;
 label_13:


### PR DESCRIPTION
## Description

Shifts of >= 64 bits on 64-bit values and >= 32 bits on 32-bits values result in undefined behavior so we need to mask off the msb of the shift size.

## Testing

Ensure that all latest 'bpf_conformance' tests pass.

`bpf_conformance_runner.exe --test_file_directory D:\wrk\bpf_conformance\tests --exclude_regex lock* --plugin_path .\bpf2c_plugin.exe --plugin_options "--include d:\wrk\ebpf-for-windows\include"`

_Note: The above command-line refers to a local directory `D:\wrk\bpf_conformance\tests` cloned from the master bpf_conformance [repo](https://github.com/Alan-Jowett/bpf_conformance)._

## Documentation

_Is there any documentation impact for this change?_

No doc changes.

Fixes #2465