### PR TITLE
fix: minor typo in bpf2c.exe help text

### DIFF
--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -189,7 +189,7 @@ main(int argc, char** argv)
               [&]() {
                   std::cerr << argv[0]
                             << " is a tool to generate C code"
-                               "from an ELF file containing BPF byte code."
+                               " from an ELF file containing BPF byte code."
                             << std::endl;
                   std::cerr << "Options are:" << std::endl;
                   for (auto [option, tuple] : options) {


### PR DESCRIPTION
fixes #1905

## Description

This PR fixes a minor typo that is in the help text generated by `bpf2c.exe --help`. There is a space that was left out.

## Testing

N/A

## Documentation

N/A
