### PR TITLE
Fix closing native program / maps handles in system worker thread. 

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -311,7 +311,6 @@ _Requires_exclusive_lock_held_(module->lock) static void _ebpf_native_acquire_re
 void
 ebpf_native_acquire_reference(_Inout_ ebpf_native_module_t* module)
 {
-    EBPF_LOG_ENTRY();
     ebpf_lock_state_t state = 0;
 
     state = ebpf_lock_lock(&module->lock);
@@ -322,7 +321,6 @@ ebpf_native_acquire_reference(_Inout_ ebpf_native_module_t* module)
 void
 ebpf_native_release_reference(_In_opt_ _Post_invalid_ ebpf_native_module_t* module)
 {
-    EBPF_LOG_ENTRY();
     int64_t new_ref_count;
     ebpf_lock_state_t module_lock_state = 0;
     bool lock_acquired = false;

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1314,10 +1314,10 @@ _ebpf_native_clean_up_handle_cleanup_context(_Inout_ ebpf_native_handle_cleanup_
         ebpf_free(cleanup_context->handle_information->map_handles);
         ebpf_free(cleanup_context->handle_information->program_handles);
         ebpf_free(cleanup_context->handle_information->process_state);
-    }
 
-    if (cleanup_context->handle_information->process_handle != 0) {
-        ebpf_platform_dereference_process(cleanup_context->handle_information->process_handle);
+        if (cleanup_context->handle_information->process_handle != 0) {
+            ebpf_platform_dereference_process(cleanup_context->handle_information->process_handle);
+        }
     }
 
     if (cleanup_context->handle_cleanup_work_item != NULL) {

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1293,15 +1293,15 @@ _ebpf_native_close_handles_work_item(_In_opt_ const void* context)
         }
     }
 
-    ebpf_free(handle_info->program_handles);
-    ebpf_free(handle_info->map_handles);
-
     // Detach process from this worker thread.
     ebpf_platform_detach_process(handle_info->process_state);
-    ebpf_free(handle_info->process_state);
 
     // Release the reference on the process object.
     ebpf_platform_dereference_process(handle_info->process_handle);
+
+    ebpf_free(handle_info->process_state);
+    ebpf_free(handle_info->program_handles);
+    ebpf_free(handle_info->map_handles);
 }
 
 static void

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1298,6 +1298,7 @@ _ebpf_native_close_handles_work_item(_In_opt_ const void* context)
 
     // Detach process from this worker thread.
     ebpf_platform_detach_process(handle_info->process_state);
+    ebpf_free(handle_info->process_state);
 
     // Release the reference on the process object.
     ebpf_platform_dereference_process(handle_info->process_handle);

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -1794,6 +1794,7 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_program_create_and_initialize(
     _In_ const ebpf_program_parameters_t* parameters, _Out_ ebpf_handle_t* program_handle)
 {
+    EBPF_LOG_ENTRY();
     ebpf_result_t retval;
     ebpf_program_t* program = NULL;
 
@@ -1809,7 +1810,7 @@ ebpf_program_create_and_initialize(
 
 Done:
     EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)program);
-    return retval;
+    EBPF_RETURN_RESULT(retval);
 }
 
 typedef struct _ebpf_helper_id_to_index

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -95,6 +95,8 @@ extern "C"
     typedef uintptr_t ebpf_lock_t;
     typedef uint8_t ebpf_lock_state_t;
 
+    typedef struct _ebpf_process_state ebpf_process_state_t;
+
     // A self-relative security descriptor.
     typedef struct _SECURITY_DESCRIPTOR ebpf_security_descriptor_t;
     typedef struct _GENERIC_MAPPING ebpf_security_generic_mapping_t;
@@ -1053,6 +1055,48 @@ extern "C"
     uint32_t
     ebpf_platform_thread_id();
 
+    /**
+     * @brief Allocate memory for process state. Caller needs to call ebpf_free()
+     *  to free the memory.
+     *
+     * @return Pointer to the process state.
+     */
+    _Ret_maybenull_ ebpf_process_state_t*
+    ebpf_allocate_process_state();
+
+    /**
+     * @brief Get a handle to the current process.
+     *
+     * @return Handle to the current process.
+     */
+    intptr_t
+    ebpf_platform_reference_process();
+
+    /**
+     * @brief Dereference a handle to a process.
+     *
+     * @param[in] process_handle to the process.
+     */
+    void
+    ebpf_platform_dereference_process(intptr_t process_handle);
+
+    /**
+     * @brief Attach to the specified process.
+     *
+     * @param[in] handle to the process.
+     * @param[in,out] state Pointer to the process state.
+     */
+    void
+    ebpf_platform_attach_process(intptr_t process_handle, _Inout_ ebpf_process_state_t* state);
+
+    /**
+     * @brief Detach from the current process.
+     *
+     * @param[in] state Pointer to the process state.
+     */
+    void
+    ebpf_platform_detach_process(_In_ ebpf_process_state_t* state);
+
     TRACELOGGING_DECLARE_PROVIDER(ebpf_tracelog_provider);
 
     _Must_inspect_result_ ebpf_result_t
@@ -1286,7 +1330,7 @@ extern "C"
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                      \
         TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT), \
         TraceLoggingOpcode(WINEVENT_OPCODE_START),                      \
-        TraceLoggingString(__FUNCTION__, "<=="));
+        TraceLoggingString(__FUNCTION__, "==>"));
 
 #define EBPF_LOG_EXIT()                                                 \
     TraceLoggingWrite(                                                  \
@@ -1295,7 +1339,7 @@ extern "C"
         TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                      \
         TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT), \
         TraceLoggingOpcode(WINEVENT_OPCODE_STOP),                       \
-        TraceLoggingString(__FUNCTION__, "==>"));
+        TraceLoggingString(__FUNCTION__, "<=="));
 
 #define EBPF_RETURN_ERROR(error)                   \
     do {                                           \

--- a/libs/platform/kernel/ebpf_handle_kernel.c
+++ b/libs/platform/kernel/ebpf_handle_kernel.c
@@ -67,6 +67,10 @@ ebpf_handle_create(_Out_ ebpf_handle_t* handle, _Inout_ ebpf_base_object_t* obje
     *handle = (ebpf_handle_t)file_handle;
     file_handle = 0;
     return_value = EBPF_SUCCESS;
+
+    EBPF_LOG_MESSAGE_UINT64(
+        EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_CORE, "ebpf_handle_create: returning handle", *handle);
+
 Done:
     if (file_object) {
         ObDereferenceObject(file_object);
@@ -83,6 +87,10 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_handle_close(ebpf_handle_t handle)
 {
     EBPF_LOG_ENTRY();
+
+    EBPF_LOG_MESSAGE_UINT64(
+        EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_CORE, "ebpf_handle_close: closing handle", (uint64_t)handle);
+
     NTSTATUS status = ObCloseHandle((HANDLE)handle, UserMode);
     if (!NT_SUCCESS(status)) {
         EBPF_LOG_NTSTATUS_API_FAILURE(EBPF_TRACELOG_KEYWORD_BASE, ObCloseHandle, status);

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -15,6 +15,11 @@ static uint32_t _ebpf_platform_maximum_processor_count = 0;
 extern DEVICE_OBJECT*
 ebpf_driver_get_device_object();
 
+typedef struct _ebpf_process_state
+{
+    KAPC_STATE state;
+} ebpf_process_state_t;
+
 typedef struct _ebpf_memory_descriptor
 {
     MDL memory_descriptor_list;
@@ -919,4 +924,37 @@ ebpf_utf8_string_to_unicode(_In_ const ebpf_utf8_string_t* input, _Outptr_ wchar
 Done:
     ebpf_free(unicode_string);
     return retval;
+}
+
+intptr_t
+ebpf_platform_reference_process()
+{
+    PEPROCESS process = PsGetCurrentProcess();
+    ObReferenceObject(process);
+    return (intptr_t)process;
+}
+
+_Ret_maybenull_ ebpf_process_state_t*
+ebpf_allocate_process_state()
+{
+    ebpf_process_state_t* state = ebpf_allocate(sizeof(ebpf_process_state_t));
+    return state;
+}
+
+void
+ebpf_platform_dereference_process(intptr_t process_handle)
+{
+    ObDereferenceObject((PEPROCESS)process_handle);
+}
+
+void
+ebpf_platform_attach_process(intptr_t process_handle, _Inout_ ebpf_process_state_t* state)
+{
+    KeStackAttachProcess((PEPROCESS)process_handle, &state->state);
+}
+
+void
+ebpf_platform_detach_process(_In_ ebpf_process_state_t* state)
+{
+    KeUnstackDetachProcess(&state->state);
 }

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -937,6 +937,7 @@ ebpf_platform_reference_process()
 _Ret_maybenull_ ebpf_process_state_t*
 ebpf_allocate_process_state()
 {
+    // Skipping fault injection as call to ebpf_allocate() covers it.
     ebpf_process_state_t* state = ebpf_allocate(sizeof(ebpf_process_state_t));
     return state;
 }

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -37,6 +37,11 @@ static EX_RUNDOWN_REF _ebpf_platform_preemptible_work_items_rundown;
 
 ebpf_leak_detector_ptr _ebpf_leak_detector_ptr;
 
+typedef struct _ebpf_process_state
+{
+    uint8_t unused;
+} ebpf_process_state_t;
+
 /**
  * @brief Environment variable to enable fault injection testing.
  *
@@ -1407,4 +1412,38 @@ ebpf_utf8_string_to_unicode(_In_ const ebpf_utf8_string_t* input, _Outptr_ wchar
 Done:
     ebpf_free(unicode_string);
     return retval;
+}
+
+_Ret_maybenull_ ebpf_process_state_t*
+ebpf_allocate_process_state()
+{
+    ebpf_process_state_t* state = (ebpf_process_state_t*)ebpf_allocate(sizeof(ebpf_process_state_t));
+    return state;
+}
+
+intptr_t
+ebpf_platform_reference_process()
+{
+
+    HANDLE process = GetCurrentProcess();
+    return (intptr_t)process;
+}
+
+void
+ebpf_platform_dereference_process(intptr_t process_handle)
+{
+    UNREFERENCED_PARAMETER(process_handle);
+}
+
+void
+ebpf_platform_attach_process(intptr_t process_handle, _Inout_ ebpf_process_state_t* state)
+{
+    UNREFERENCED_PARAMETER(process_handle);
+    UNREFERENCED_PARAMETER(state);
+}
+
+void
+ebpf_platform_detach_process(_In_ ebpf_process_state_t* state)
+{
+    UNREFERENCED_PARAMETER(state);
 }

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -1417,6 +1417,7 @@ Done:
 _Ret_maybenull_ ebpf_process_state_t*
 ebpf_allocate_process_state()
 {
+    // Skipping fault injection as call to ebpf_allocate() covers it.
     ebpf_process_state_t* state = (ebpf_process_state_t*)ebpf_allocate(sizeof(ebpf_process_state_t));
     return state;
 }
@@ -1432,12 +1433,14 @@ ebpf_platform_reference_process()
 void
 ebpf_platform_dereference_process(intptr_t process_handle)
 {
+    // This is a no-op for the user mode implementation.
     UNREFERENCED_PARAMETER(process_handle);
 }
 
 void
 ebpf_platform_attach_process(intptr_t process_handle, _Inout_ ebpf_process_state_t* state)
 {
+    // This is a no-op for the user mode implementation.
     UNREFERENCED_PARAMETER(process_handle);
     UNREFERENCED_PARAMETER(state);
 }
@@ -1445,5 +1448,6 @@ ebpf_platform_attach_process(intptr_t process_handle, _Inout_ ebpf_process_state
 void
 ebpf_platform_detach_process(_In_ ebpf_process_state_t* state)
 {
+    // This is a no-op for the user mode implementation.
     UNREFERENCED_PARAMETER(state);
 }

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1002,6 +1002,11 @@ _load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execut
     }
 }
 
+// The below tests try to load native drivers for invalid programs (that will fail verification).
+// Since verification can be skipped in bpf2c for only Debug builds, these tests are applicable
+// only for Debug build.
+#ifdef _DEBUG
+
 TEST_CASE("load_native_program_invalid1", "[native][negative]")
 {
     _load_invalid_program("invalid_maps1.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
@@ -1022,3 +1027,5 @@ TEST_CASE("load_native_program_invalid5", "[native][negative]")
 {
     _load_invalid_program("invalid_maps3.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
 }
+
+#endif

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -984,6 +984,11 @@ test_sock_addr_native_program_load_attach(const char* file_name)
 
 DECLARE_REGRESSION_TEST_CASE("0.9.0")
 
+// The below tests try to load native drivers for invalid programs (that will fail verification).
+// Since verification can be skipped in bpf2c for only Debug builds, these tests are applicable
+// only for Debug build.
+#ifdef _DEBUG
+
 static void
 _load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execution_type, int expected_result)
 {
@@ -1001,11 +1006,6 @@ _load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execut
         REQUIRE(bpf_prog_get_next_id(0, &next_id) == -ENOENT);
     }
 }
-
-// The below tests try to load native drivers for invalid programs (that will fail verification).
-// Since verification can be skipped in bpf2c for only Debug builds, these tests are applicable
-// only for Debug build.
-#ifdef _DEBUG
 
 TEST_CASE("load_native_program_invalid1", "[native][negative]")
 {

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -983,3 +983,42 @@ test_sock_addr_native_program_load_attach(const char* file_name)
     }
 
 DECLARE_REGRESSION_TEST_CASE("0.9.0")
+
+static void
+_load_invalid_program(_In_z_ const char* file_name, ebpf_execution_type_t execution_type, int expected_result)
+{
+    int result;
+    bpf_object* object = nullptr;
+    fd_t program_fd;
+    uint32_t next_id;
+
+    result = _program_load_helper(file_name, BPF_PROG_TYPE_UNSPEC, execution_type, &object, &program_fd);
+    REQUIRE(result == expected_result);
+
+    if (result != 0) {
+        // If load failed, no programs or maps should be loaded.
+        REQUIRE(bpf_map_get_next_id(0, &next_id) == -ENOENT);
+        REQUIRE(bpf_prog_get_next_id(0, &next_id) == -ENOENT);
+    }
+}
+
+TEST_CASE("load_native_program_invalid1", "[native][negative]")
+{
+    _load_invalid_program("invalid_maps1.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
+}
+TEST_CASE("load_native_program_invalid2", "[native][negative]")
+{
+    _load_invalid_program("invalid_maps2.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
+}
+TEST_CASE("load_native_program_invalid3", "[native][negative]")
+{
+    _load_invalid_program("invalid_helpers.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
+}
+TEST_CASE("load_native_program_invalid4", "[native][negative]")
+{
+    _load_invalid_program("empty.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
+}
+TEST_CASE("load_native_program_invalid5", "[native][negative]")
+{
+    _load_invalid_program("invalid_maps3.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
+}


### PR DESCRIPTION
Fixes #2457

## Description

Earlier fix done in PR #2395 was incomplete. The previous fix queued a workitem to close the program and map handles in the case of native module load failure. Closing the handles in system worker thread fails with `INVALID_HANDLE` as the handle is created for type `UserMode`, and the worker thread is running in system context.

The fix is to attach the current process to the worker thread to be able to close the handles. The new fix does the following:
1. take reference on the current process, and pass process info to the worker thread.
2. worker thread attaches process, closes handles, detaches process and release process reference.

## Testing

Added new kernel tests.

## Documentation

NA
