### PR TITLE
(DRAFT - NOT FOR REVIEW): Remove KM Stress test runs from github ci/cd

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -428,37 +428,3 @@ jobs:
       leak_detection: false
       gather_dumps: true
       capture_etw: true
-
-  # Run multi-threaded stress tests against the kernel mode eBPF sub-system.
-  # The '-td' parameter specifies the run time per test, so the total run-time will be a multiple of the total number
-  # of tests, as each test is run sequentially.
-  kernel_mode_multi_threaded_stress_test:
-    needs: regular
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: kernel_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_km -tt=32 -td=10
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      leak_detection: false
-      gather_dumps: true
-      capture_etw: true
-
-  # Run multi-threaded stress tests against the kernel mode eBPF sub-system with extension restart enabled.
-  # The '-td' parameter specifies the run time per test, so the total run-time will be a multiple of the total number
-  # of tests, as each test is run sequentially.
-  kernel_mode_multi_threaded_stress_extension_restart_test:
-    needs: regular
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: kernel_mode_multi_threaded_stress_extension_restart
-      test_command: .\ebpf_stress_tests_km -tt=32 -td=10 -er=true -erd=250
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      leak_detection: false
-      gather_dumps: true
-      capture_etw: true


### PR DESCRIPTION
## Description

This PR removes the 'Kernel mode stress tests' jobs from the github ci/cd pipeline as they have been moved to the ADO pipeline. 

The github ci/cd jobs cannot be integrated with Dr. Watson and the other related support that's available on the ADO side, so a decision was made to move these specific jobs to the ADO side.

## Testing

Ensure Github CI/CD pipeline does not run these jobs anymore.

## Documentation

No documentation changes required.

Fixes #2510 
