### PR TITLE
Don't throw exceptions from ~_single_instance_hook

### DIFF
--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -129,7 +129,9 @@ typedef class _single_instance_hook : public _hook_helper
     }
     ~_single_instance_hook()
     {
-        detach();
+        // Best effort cleanup. Ignore errors.
+        (void)ebpf_link_detach(link_object);
+        (void)ebpf_link_close(link_object);
         NTSTATUS status = NmrDeregisterProvider(nmr_provider_handle);
         if (status == STATUS_PENDING) {
             NmrWaitForProviderDeregisterComplete(nmr_provider_handle);

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -130,8 +130,10 @@ typedef class _single_instance_hook : public _hook_helper
     ~_single_instance_hook()
     {
         // Best effort cleanup. Ignore errors.
-        (void)ebpf_link_detach(link_object);
-        (void)ebpf_link_close(link_object);
+        if (link_object) {
+            (void)ebpf_link_detach(link_object);
+            (void)ebpf_link_close(link_object);
+        }
         NTSTATUS status = NmrDeregisterProvider(nmr_provider_handle);
         if (status == STATUS_PENDING) {
             NmrWaitForProviderDeregisterComplete(nmr_provider_handle);


### PR DESCRIPTION
Resolves: #2511 

## Description

C++ destructors are noexcept by definition. Throwing from a destructor is a noexcept violation which results in abort. Avoid this by making best effort to cleanup in destructors.

## Testing

CI/CD

## Documentation

No.
