### PR TITLE
Remove double free of ebpf_map_t

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1592,11 +1592,6 @@ _initialize_ebpf_maps_native(
 
 Exit:
     if (result != EBPF_SUCCESS) {
-        if (map != nullptr) {
-            clean_up_ebpf_map(map);
-            map = nullptr;
-        }
-
         clean_up_ebpf_maps(maps);
     }
     EBPF_RETURN_RESULT(result);


### PR DESCRIPTION
Resolves: #2512 

## Description

The function _initialize_ebpf_maps_native double frees the map entry on failure.

## Testing

CI/CD + fault injection.

## Documentation

No.
