### PR TITLE
clean up native NMR handle only if not null

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -393,13 +393,15 @@ ebpf_native_terminate()
 
     // ebpf_provider_unload is blocking call until all the
     // native modules have been detached.
-    NTSTATUS status = NmrDeregisterProvider(_ebpf_native_nmr_provider_handle);
-    if (status == STATUS_PENDING) {
-        NmrWaitForProviderDeregisterComplete(_ebpf_native_nmr_provider_handle);
-    } else {
-        ebpf_assert(status == STATUS_SUCCESS);
+    if (_ebpf_native_nmr_provider_handle) {
+        NTSTATUS status = NmrDeregisterProvider(_ebpf_native_nmr_provider_handle);
+        if (status == STATUS_PENDING) {
+            NmrWaitForProviderDeregisterComplete(_ebpf_native_nmr_provider_handle);
+        } else {
+            ebpf_assert(status == STATUS_SUCCESS);
+        }
+        _ebpf_native_nmr_provider_handle = NULL;
     }
-    _ebpf_native_nmr_provider_handle = NULL;
 
     // All native modules should be cleaned up by now.
     ebpf_assert(!_ebpf_native_client_table || ebpf_hash_table_key_count(_ebpf_native_client_table) == 0);


### PR DESCRIPTION
## Description

Resolves #2529.

## Testing

Tested locally using XDP stress test. I highly recommend that eBPF enable driver verifier with fault injection to catch these kinds of bugs. That's all XDP does to repro. I've filed a feature request to add this coverage to eBPF: #2531.

## Documentation

N/A.
