### PR TITLE
implementation of api_test

### DIFF
--- a/.azure/pipeline/azure-cicd.yml
+++ b/.azure/pipeline/azure-cicd.yml
@@ -1,0 +1,79 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+#################################################################################
+#                      OneBranch Pipelines - PR Build                           #
+# This pipeline was created by EasyStart from a sample located at:              #
+#   https://aka.ms/obpipelines/easystart/samples                                #
+# Documentation:  https://aka.ms/obpipelines                                    #
+# Yaml Schema:    https://aka.ms/obpipelines/yaml/schema                        #
+# Retail Tasks:   https://aka.ms/obpipelines/tasks                              #
+# Support:        https://aka.ms/onebranchsup                                   #
+#################################################################################
+
+# https://aka.ms/obpipelines/triggers
+trigger:
+  ## disable batching of changes when a push happens.
+  batch: false
+  branches:
+    include:
+    - main
+    - release/*
+
+pr:
+- main
+- release/*
+
+schedules:
+- cron: '0 21 * * *'
+  displayName: Schedule CI/CD
+  branches:
+    include:
+    - main
+    - release/*
+  always: true
+
+parameters: # parameters are shown up in ADO UI in a build queue time
+- name: 'debug'
+  displayName: 'Enable debug output'
+  type: boolean
+  default: false
+
+variables:
+  CDP_DEFINITION_BUILD_COUNT: $[counter('', 0)] # needed for onebranch.pipeline.version task https://aka.ms/obpipelines/versioning
+  system.debug: ${{ parameters.debug }}
+  ENABLE_PRS_DELAYSIGN: 0
+  ROOT: $(Build.SourcesDirectory)
+  REPOROOT: $(Build.SourcesDirectory)
+  OUTPUTROOT: $(REPOROOT)\out
+  NUGET_XMLDOC_MODE: none
+
+  WindowsContainerImage: 'cdpxwin1809.azurecr.io/global/vse2022:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
+
+jobs:
+
+# regular
+# Always run this job.
+- ${{ if in(variables['Build.Reason'], 'PullRequest', 'BatchedCI', 'IndividualCI', 'Schedule') }}:
+  - template: ./azure-reusable-build.yml
+    parameters:
+      name: regular
+      build_artifact: Build-x64
+      generate_release_package: true
+      build_nuget: true
+      build_options: /p:ReleaseJIT=True
+
+# api_test
+# Always run this job.
+- ${{ if in(variables['Build.Reason'], 'PullRequest', 'BatchedCI', 'IndividualCI', 'Schedule') }}:
+  - template: ./azure-reusable-test.yml
+    parameters:
+      name: api_test
+      test_command: '.\api_test.exe'
+      dependency: regular
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: false

--- a/.azure/pipeline/azure-cicd.yml
+++ b/.azure/pipeline/azure-cicd.yml
@@ -47,7 +47,6 @@ variables:
   REPOROOT: $(Build.SourcesDirectory)
   OUTPUTROOT: $(REPOROOT)\out
   NUGET_XMLDOC_MODE: none
-
   WindowsContainerImage: 'cdpxwin1809.azurecr.io/global/vse2022:latest' # Docker image which is used to build the project https://aka.ms/obpipelines/containers
 
 jobs:

--- a/.azure/pipeline/azure-reusable-build.yml
+++ b/.azure/pipeline/azure-reusable-build.yml
@@ -1,0 +1,160 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# This workflow performs a build of the project and uploads the result as a build artifact.
+
+parameters:
+  # Name associated with the output of this build.
+  - name: build_artifact
+    type: string
+  # Name of the job
+  - name: name
+    type: string
+  # Additional options passed to msbuild.
+  - name: build_options
+    type: string
+    default: ''
+  - name: generate_release_package
+    type: boolean
+    default: false
+  - name: build_codeql
+    type: boolean
+    default: false
+  - name: build_nuget
+    type: boolean
+    default: false
+  - name: cxx_flags
+    type: string
+    default: ''
+  - name: ld_flags
+    type: string
+    default: ''
+
+
+jobs:
+  - job: '${{parameters.name}}'
+    timeoutInMinutes: 90
+
+    strategy:
+      matrix:
+        Debug:
+          buildConfiguration: 'Debug'
+        Release:
+          buildConfiguration: 'Release'
+      maxParallel: 2
+
+    pool:
+      vmImage: 'windows-2022'
+      type: windows
+
+    variables:
+      # Path to the solution file relative to the root of the project.
+      SOLUTION_FILE_PATH: ebpf-for-windows.sln
+      BUILD_ARTIFACT_NAME: ${{parameters.build_artifact}}
+      BUILD_CONFIGURATION: $(buildConfiguration)
+      BUILD_PLATFORM: x64
+      BUILD_OPTIONS: ${{parameters.build_options}}
+      CXX_FLAGS: ${{parameters.cxx_flags}}
+      LD_FLAGS: ${{parameters.ld_flags}}
+      MSBUILD_PATH: 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\MSBuild\Current\Bin\amd64'
+      GDN_CODESIGN_TARGETDIRECTORY: '$(Build.SourcesDirectory)/$(BUILD_PLATFORM)/$(buildConfiguration)'
+
+    steps:
+      - checkout: self
+        displayName: 'Checkout Repo'
+        submodules: 'recursive'
+        fetchDepth: 0
+
+      - bash: |
+          echo "*** All environment variables ***"
+          env | sort
+        workingDirectory: $(Build.SourcesDirectory)
+        displayName: 'Dump Environment variables'
+
+      - bash: |
+          choco install -y llvm --version 11.0.1 --allow-downgrade
+          echo '##vso[task.prependpath]C:\Program Files\LLVM\bin'
+          choco install wixtoolset
+        workingDirectory: $(Build.SourcesDirectory)
+        displayName:  'Install tools'
+
+      - task: NuGetCommand@2
+        inputs:
+          command: 'restore'
+          restoreSolution: $(SOLUTION_FILE_PATH)
+        displayName: 'Restore Nuget Packages'
+
+      - bash: |
+          cmake -G "Visual Studio 17 2022" -S external/ebpf-verifier -B external/ebpf-verifier/build
+        env:
+          CXXFLAGS: '$(CXX_FLAGS) /ZH:SHA_256'
+          LDFLAGS: $(LD_FLAGS)
+        workingDirectory: $(Build.SourcesDirectory)
+        displayName: 'Create verifier project'
+
+      - bash: |
+          cmake -G "Visual Studio 17 2022" -S external/catch2 -B external/catch2/build -DBUILD_TESTING=OFF
+        env:
+          CXXFLAGS: '$(CXX_FLAGS) /ZH:SHA_256'
+          LDFLAGS: $(LD_FLAGS)
+        workingDirectory: $(Build.SourcesDirectory)
+        displayName: 'Create catch2 project'
+
+      - bash: |
+          cmake -G "Visual Studio 17 2022" -S external/ubpf -B external/ubpf/build
+        env:
+          CXXFLAGS: '$(CXX_FLAGS) /ZH:SHA_256'
+          LDFLAGS: $(LD_FLAGS)
+        workingDirectory: $(Build.SourcesDirectory)
+        displayName: 'Create ubpf project'
+
+      - script: |
+          "$(MSBUILD_PATH)\msbuild.exe" /m /p:Configuration=$(BUILD_CONFIGURATION) /p:Platform=$(BUILD_PLATFORM) $(SOLUTION_FILE_PATH) $(BUILD_OPTIONS)
+        workingDirectory: $(Build.SourcesDirectory)
+        displayName: 'Build'
+
+      - powershell: |
+          Invoke-WebRequest https://github.com/microsoft/ebpf-for-windows-demo/releases/download/v0.0.1/$(BUILD_PLATFORM)-$(BUILD_CONFIGURATION)-cilium-xdp.zip -OutFile x64-$(BUILD_CONFIGURATION)-cilium-xdp.zip
+        workingDirectory: $(Build.SourcesDirectory)
+        displayName: 'Download demo repository'
+
+      - script: |
+          tar -xf ..\..\x64-$(BUILD_CONFIGURATION)-cilium-xdp.zip
+        workingDirectory: $(Build.SourcesDirectory)/$(BUILD_PLATFORM)/$(buildConfiguration)
+        displayName: 'Extract artifacts to build path'
+
+      - publish: $(Build.SourcesDirectory)/$(BUILD_PLATFORM)/$(buildConfiguration)
+        artifact: "${{parameters.build_artifact}} $(buildConfiguration)"
+        displayName: 'Upload Build Output'
+
+      - publish: $(Build.SourcesDirectory)/$(BUILD_PLATFORM)/$(buildConfiguration)/ebpf-for-windows.msi
+        artifact: "ebpf-for-windows MSI installer $(buildConfiguration)"
+        condition: and(eq('${{parameters.build_artifact}}', 'Build-x64'), eq(variables.buildConfiguration, 'Debug'))
+        displayName: 'Upload the MSI package (Debug)'
+
+      - publish: $(Build.SourcesDirectory)/$(BUILD_PLATFORM)/$(buildConfiguration)/ebpf-for-windows.msi
+        artifact: "ebpf-for-windows MSI installer $(buildConfiguration)"
+        condition: and(eq('${{parameters.build_artifact}}', 'Build-x64'), eq(variables.buildConfiguration, 'Release'))
+        displayName: 'Upload the MSI package (Release)'
+
+      - script: |
+          "$(MSBUILD_PATH)\msbuild.exe" /m /p:Configuration="$(BUILD_CONFIGURATION)" /p:Platform="$(BUILD_PLATFORM)" "$(SOLUTION_FILE_PATH)" "$(BUILD_OPTIONS)" /t:tools\nuget
+        condition: and(eq(variables.buildConfiguration, 'Release'), eq('${{parameters.build_nuget}}', 'true'))
+        workingDirectory: $(Build.SourcesDirectory)
+        displayName: 'Build nuget package'
+
+      - bash: |
+          echo "##vso[task.setvariable variable=REL_NUGET_PACKAGE_PATH;isOutput=true]$(ls $(BUILD_PLATFORM)/$(BUILD_CONFIGURATION)/*.nupkg)"
+        condition: and(eq(variables.buildConfiguration, 'Release'), eq('${{parameters.build_nuget}}', 'true'))
+        name: nuget_packages
+        displayName: 'Locate the nuget package'
+
+      - publish: $(nuget_packages.REL_NUGET_PACKAGE_PATH)
+        artifact: 'ebpf-for-windows nuget'
+        condition: and(eq(variables.buildConfiguration, 'Release'), eq('${{parameters.build_nuget}}', 'true'), eq('${{parameters.build_artifact}}', 'Build-x64'))
+        displayName: 'Upload the nuget package'
+
+      - publish: $(nuget_packages.REL_NUGET_PACKAGE_PATH)
+        artifact: 'ebpf-for-windows-native nuget'
+        condition: and(eq(variables.buildConfiguration, 'Release'), eq('${{parameters.build_nuget}}', 'true'), eq('${{parameters.build_artifact}}', 'Build-x64-native-only'))
+        displayName: 'Upload the nuget package'

--- a/.azure/pipeline/azure-reusable-test.yml
+++ b/.azure/pipeline/azure-reusable-test.yml
@@ -1,0 +1,283 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# This workflow executes a single test, optionally gathering code coverage and logs.
+
+parameters:
+  - name: name
+    type: string
+  # Job dependency
+  - name: dependency
+    type: string
+  # The test command to invoke.
+  - name: test_command
+    type: string
+  # The name of the build artifact to download.
+  - name: build_artifact
+    type: string
+  # The environment to run this test on.
+  - name: environment
+    type: string
+  # Set to true to gather code coverage when this test runs.
+  - name: code_coverage
+    type: boolean
+    default: false
+  # Set to true to gather and upload memory dumps if a test process crashes.
+  - name: gather_dumps
+    type: boolean
+    default: false
+  - name: pre_test
+    type: string
+    default: ''
+  - name: post_test
+    type: string
+    default: ''
+  - name: capture_etw
+    type: boolean
+    default: false
+  # Set to true to use Visual Studio Developer command shell.
+  - name: vs_dev
+    type: boolean
+    default: false
+  - name: fault_injection
+    type: boolean
+    default: false
+  - name: leak_detection
+    type: boolean
+    default: false
+
+jobs:
+  - job: ${{parameters.name}}
+    dependsOn: ${{parameters.dependency}}
+    timeoutInMinutes: 90
+
+    strategy:
+      matrix:
+        Debug:
+          buildConfiguration: 'Debug'
+        Release:
+          buildConfiguration: 'Release'
+      maxParallel: 2
+
+    pool:
+      vmImage: ${{parameters.environment}}
+      type: windows
+
+    variables:
+      # Configuration type to build.
+      PROJECT_NAME: eBPFForWindows
+      NAME: ${{parameters.name}}
+      BUILD_CONFIGURATION: $(buildConfiguration)
+      BUILD_PLATFORM: x64
+      TEST_COMMAND: ${{parameters.test_command}}
+      PRE_COMMAND: ${{parameters.pre_test}}
+      POST_COMMAND: ${{parameters.post_test}}
+      EBPF_MEMORY_LEAK_DETECTION: ${{parameters.leak_detection}}
+      # Skip Codesign Validation task, as ths is a test job.
+      runCodesignValidationInjection: false
+
+    steps:
+      # Checking out the branch is needed to gather correct code coverage data.
+      - checkout: self
+        submodules: 'recursive'
+        fetchDepth: 0
+        # Only check out source code if code coverage is being gathered.
+        condition: eq('${{parameters.code_coverage}}', 'true')
+        displayName: 'Checkout Repo'
+
+      - bash: |
+          choco install -y --requirechecksum=true --checksum=2295A733DA39412C61E4F478677519DD0BB1893D88313CE56B468C9E50517888 --checksum-type=sha256 OpenCppCoverage
+          echo '##vso[task.prependpath]C:\Program Files\OpenCppCoverage'
+        condition: and(eq('${{parameters.code_coverage}}', 'true'), ne('${{parameters.environment}}', 'ebpf_cicd_tests'))
+        name: set_up_opencppcoverage
+        displayName:  'Set up OpenCppCoverage and add to PATH'
+
+      - powershell: |
+          mkdir c:\dumps\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)
+          New-Item -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -ErrorAction SilentlyContinue
+          New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpType" -Value 2 -PropertyType DWord -ErrorAction SilentlyContinue
+          New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "c:\dumps\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)" -PropertyType ExpandString -ErrorAction SilentlyContinue
+        condition: eq('${{parameters.gather_dumps}}', 'true')
+        name: configure_windows_error_reporting
+        displayName: 'Configure Windows Error Reporting to make a local copy of any crashes that occur'
+
+      - powershell: |
+          Remove-Item -Path $(Build.SourcesDirectory)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION) -Recurse -Force -ErrorAction SilentlyContinue
+        condition: eq('${{parameters.environment}}', 'ebpf_cicd_tests')
+        displayName: Remove existing artifacts
+
+      - download: current
+        artifact: "${{parameters.build_artifact}} $(buildConfiguration)"
+        condition: succeeded()
+        name: download_artifact
+        displayName: "Download build artifact"
+
+      - powershell: |
+          mkdir $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\
+          cd $(Build.ArtifactStagingDirectory)
+          cd ..
+          $source = ".\${{parameters.build_artifact}} $(buildConfiguration)"
+          $destination = "$(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)"
+          Get-ChildItem $source -exclude *140*.dll | Copy-Item -Destination $destination -Recurse -filter *.*
+        displayName: Copy build artifacts to correct path
+
+      - script: |
+          mkdir "$(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\Artifacts"
+        displayName: Create generated artifact folder
+
+      - script: |
+          mkdir $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\TestLogs
+          wpr.exe -start $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\ebpfforwindows.wprp -filemode
+        condition: eq('${{parameters.capture_etw}}', 'true')
+        name: start_etw_tracing
+        displayName: Start ETW tracing
+
+      - script: |
+          .\export_program_info.exe --clear
+          .\export_program_info.exe
+        workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)/$(BUILD_PLATFORM)/$(BUILD_CONFIGURATION)
+        name: configure_ebpf_store
+        displayName: Configure eBPF store
+
+      - powershell: |
+          Write-Host "Installing eBPF..."
+          Write-Host $pwd.ToString()
+          $LogFileName = "TestLog.log"
+          Import-Module .\install_ebpf.psm1 -Force -ArgumentList ($WorkingDirectory, $LogFileName)
+          Import-Module .\common.psm1 -Force -ArgumentList ($LogFileName)
+          Install-eBPFComponents
+        workingDirectory: $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)
+        displayName: Install eBPF components
+
+      - powershell: |
+          $ArifactVersionList = @("0.9.0")
+          $RegressionTestArtifactsPath = "$pwd\regression"
+          mkdir $RegressionTestArtifactsPath
+          foreach ($ArtifactVersion in $ArifactVersionList)
+          {
+            $DownloadPath = "$RegressionTestArtifactsPath\$ArtifactVersion"
+            mkdir $DownloadPath
+            $ArtifactName = "v$ArtifactVersion/Build-x64-native-only-Release.$ArtifactVersion.zip"
+            $ArtifactUrl = "https://github.com/microsoft/ebpf-for-windows/releases/download/" + $ArtifactName
+
+            $ProgressPreference = 'SilentlyContinue'
+            Invoke-WebRequest -Uri $ArtifactUrl -OutFile "$DownloadPath\artifact.zip"
+
+            Write-Host "Extracting $ArtifactName"
+            Expand-Archive -Path "$DownloadPath\artifact.zip" -DestinationPath $DownloadPath -Force
+            Expand-Archive -Path "$DownloadPath\build-Release.zip" -DestinationPath $DownloadPath -Force
+
+            Move-Item -Path "$DownloadPath\Release\cgroup_sock_addr2.sys" -Destination "$RegressionTestArtifactsPath\cgroup_sock_addr2_$ArtifactVersion.sys" -Force
+            Remove-Item -Path $DownloadPath -Force -Recurse
+          }
+        workingDirectory: $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)
+        displayName: Install regression components
+
+      - script: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
+          set EBPF_ENABLE_WER_REPORT=yes
+          OpenCppCoverage.exe -q --cover_children --sources $(Build.SourcesDirectory)\$(PROJECT_NAME) --excluded_sources $(Build.SourcesDirectory)\$(PROJECT_NAME)\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION) -- $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\$(TEST_COMMAND)
+        workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)
+        condition: and(eq('${{parameters.code_coverage}}', 'true'), eq('${{parameters.vs_dev}}', 'true'))
+        name: run_test_with_code_coverage_in_vs_dev
+        displayName: Run test with Code Coverage in VS Dev environment
+
+      - script: |
+          OpenCppCoverage.exe -q --cover_children --sources $(Build.SourcesDirectory)\$(PROJECT_NAME) --excluded_sources $(Build.SourcesDirectory)\$(PROJECT_NAME)\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION) -- powershell.exe .\Test-FaultInjection.ps1 $(TEST_COMMAND) 4
+        workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)
+        condition: and(eq('${{parameters.code_coverage}}', 'true'), eq('${{parameters.fault_injection}}', 'true'))
+        name: run_test_with_code_coverage_with_fault_injection
+        displayName: Run test with Code Coverage and low resource simulation
+
+      - script: |
+          powershell.exe .\Test-FaultInjection.ps1 $(TEST_COMMAND) 16
+        workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)/$(BUILD_PLATFORM)/$(BUILD_CONFIGURATION)
+        condition: and(ne('${{parameters.code_coverage}}', 'true'), eq('${{parameters.fault_injection}}', 'true'))
+        name: run_test_with_fault_injection
+        displayName: Run test with low resource simulation
+
+      - script: |
+          set EBPF_ENABLE_WER_REPORT=yes
+          OpenCppCoverage.exe -q --sources $(Build.SourcesDirectory)\$(PROJECT_NAME) --excluded_sources $(Build.SourcesDirectory)\$(PROJECT_NAME)\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION) -- $(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\$(TEST_COMMAND)
+        workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)
+        condition: and(eq('${{parameters.code_coverage}}', 'true'), ne('${{parameters.vs_dev}}', 'true'), ne('${{parameters.fault_injection}}', 'true'))
+        name: run_test_with_code_coverage
+        displayName: Run test with Code Coverage
+
+      - script: |
+          $(TEST_COMMAND)
+        workingDirectory: $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)
+        condition: eq('${{parameters.code_coverage}}', 'false')
+        name: run_test_without_code_coverage
+        displayName: Run test without Code Coverage
+
+      - script: |
+          $(POST_COMMAND)
+        condition: succeededOrFailed()
+        workingDirectory: $(Build.SourcesDirectory)/$(PROJECT_NAME)/$(BUILD_PLATFORM)/$(BUILD_CONFIGURATION)
+        name: run_post_test_command
+        displayName: Run post test command
+
+      - powershell: |
+          $fileExists = Test-Path -Path "$(Build.SourcesDirectory)\$(PROJECT_NAME)\ebpf_for_windows.xml"
+          Write-Output "##vso[task.setvariable variable=FileExists;isOutput=true]$fileExists"
+        name: check_coverage
+        displayName: Check for CodeCoverage
+
+      - task: PublishCodeCoverageResults@1
+        inputs:
+          codeCoverageTool: 'Cobertura'
+          summaryFileLocation: $(Build.SourcesDirectory)/$(PROJECT_NAME)/ebpf_for_windows.xml
+          pathToSources: $(Build.SourcesDirectory)/$(PROJECT_NAME)
+        condition: eq(variables['check_coverage.FileExists'], 'True')
+        displayName: Upload Code Coverage Report
+
+      - script: |
+          wpr.exe -stop $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\TestLogs\ebpfforwindows.etl
+        condition: eq('${{parameters.capture_etw}}', 'true')
+        displayName: Stop ETW tracing
+
+      - script: |
+          copy $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\*.log $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\TestLogs
+        condition: and(eq('${{parameters.name}}', 'bpf2c'), eq('${{parameters.capture_etw}}', 'true'))
+        displayName: Copy any bpf2c test logs to TestLogs
+
+      - powershell: |
+          $fileExists = Test-Path -Path "c:\dumps\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\*.dmp"
+          Write-Output "##vso[task.setvariable variable=FileExists;isOutput=true]$fileExists"
+        name: check_dumps
+        displayName: Check for crash dumps
+
+      - publish: 'c:/dumps/$(BUILD_PLATFORM)/$(buildConfiguration)'
+        artifact: 'Crash-Dumps-$(NAME)-$(BUILD_PLATFORM)-$(BUILD_CONFIGURATION)'
+        condition: and(succeededOrFailed(), eq('${{parameters.gather_dumps}}', 'true'), eq(variables['check_dumps.FileExists'], 'True'))
+        displayName: "Upload any crash dumps"
+
+      - powershell: |
+          $fileExists = Test-Path -Path "$(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\TestLogs\*"
+          Write-Output "##vso[task.setvariable variable=FileExists;isOutput=true]$fileExists"
+        condition: and(succeededOrFailed(), eq('${{parameters.capture_etw}}', 'true'))
+        name: check_logs
+        displayName: Check for TestLogs
+
+      - publish: $(Build.SourcesDirectory)/$(PROJECT_NAME)/$(BUILD_PLATFORM)/$(buildConfiguration)/TestLogs
+        artifact: 'Test-Logs-$(NAME)-$(BUILD_PLATFORM)-$(BUILD_CONFIGURATION)'
+        condition: and(succeededOrFailed(), eq(variables['check_logs.FileExists'], 'True'))
+        displayName: "Upload log files"
+
+      - powershell: |
+          $fileExists = Test-Path -Path "$(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)\Artifacts\*"
+          Write-Output "##vso[task.setvariable variable=FileExists;isOutput=true]$fileExists"
+        condition: succeededOrFailed()
+        name: check_artifacts
+        displayName: Check for generated artifacts
+
+      - publish: $(Build.SourcesDirectory)/$(BUILD_PLATFORM)/$(buildConfiguration)/Artifacts
+        artifact: 'Artifacts-$(NAME)-$(BUILD_PLATFORM)-$(BUILD_CONFIGURATION)'
+        condition: and(succeededOrFailed(), eq(variables['check_artifacts.FileExists'], 'True'))
+        displayName: "Upload log files"
+
+      - script: |
+          exit 1
+        condition: eq(variables['check_dumps.FileExists'], 'True')
+        displayName: Mark run as failed if crash dumps are found

--- a/.azure/pipeline/azure-reusable-test.yml
+++ b/.azure/pipeline/azure-reusable-test.yml
@@ -140,38 +140,14 @@ jobs:
         displayName: Configure eBPF store
 
       - powershell: |
-          Write-Host "Installing eBPF..."
-          Write-Host $pwd.ToString()
           $LogFileName = "TestLog.log"
           Import-Module .\install_ebpf.psm1 -Force -ArgumentList ($WorkingDirectory, $LogFileName)
           Import-Module .\common.psm1 -Force -ArgumentList ($LogFileName)
+          Import-module .\config_test_vm.psm1 -Force -ArgumentList ($WorkingDirectory, $LogFileName)
           Install-eBPFComponents
+          Get-RegressionTestArtifacts
         workingDirectory: $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)
-        displayName: Install eBPF components
-
-      - powershell: |
-          $ArifactVersionList = @("0.9.0")
-          $RegressionTestArtifactsPath = "$pwd\regression"
-          mkdir $RegressionTestArtifactsPath
-          foreach ($ArtifactVersion in $ArifactVersionList)
-          {
-            $DownloadPath = "$RegressionTestArtifactsPath\$ArtifactVersion"
-            mkdir $DownloadPath
-            $ArtifactName = "v$ArtifactVersion/Build-x64-native-only-Release.$ArtifactVersion.zip"
-            $ArtifactUrl = "https://github.com/microsoft/ebpf-for-windows/releases/download/" + $ArtifactName
-
-            $ProgressPreference = 'SilentlyContinue'
-            Invoke-WebRequest -Uri $ArtifactUrl -OutFile "$DownloadPath\artifact.zip"
-
-            Write-Host "Extracting $ArtifactName"
-            Expand-Archive -Path "$DownloadPath\artifact.zip" -DestinationPath $DownloadPath -Force
-            Expand-Archive -Path "$DownloadPath\build-Release.zip" -DestinationPath $DownloadPath -Force
-
-            Move-Item -Path "$DownloadPath\Release\cgroup_sock_addr2.sys" -Destination "$RegressionTestArtifactsPath\cgroup_sock_addr2_$ArtifactVersion.sys" -Force
-            Remove-Item -Path $DownloadPath -Force -Recurse
-          }
-        workingDirectory: $(Build.SourcesDirectory)\$(PROJECT_NAME)\$(BUILD_PLATFORM)\$(BUILD_CONFIGURATION)
-        displayName: Install regression components
+        displayName: Install eBPF components and regression artifacts
 
       - script: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"


### PR DESCRIPTION
closes #2535 

## Description
To achieve scalability and eliminate the need for GitHub runners in API testing, It is necessary to transfer CI/CD Kernel Tests from GitHub runners to Azure Pipeline.

1. builds the project and uploads the resulting artifacts.
2. supports different build configurations, such as Debug and Release,
3. steps for restoring NuGet packages, creating project files,
4. building the solution,
5. downloading a demo repository, and
6. uploading the build output. It also
7. handles the publishing of MSI and NuGet packages based on specified conditions.
 In the test yml file:

1. creates a generated artifact folder.
2. starts ETW tracing if specified.
3. configures the eBPF store and installs eBPF components.
4. installs regression components.
5. runs the test with code coverage in Visual Studio Developer Command Shell if specified.
6. runs the test with code coverage and low resource simulation if specified.
7. runs the test with/without code coverage if specified.
8. checks for crash dumps and uploads them if specified.
9. on board api_test
Create an automatic pipeline to consume the yml file from Github to trigger during the schedule, and PR to the main branch.

## Testing

a new CI/CD pipeline 

## Documentation

N/A
