### PR TITLE
Exclude sample and generated code from codecov.io

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -30,3 +30,9 @@ coverage:
     project:
       default:
         threshold: 2%
+
+ignore:
+  # Ignore generated files.
+  - "x64/"
+  # Ignore sample code.
+  - "tests/sample"


### PR DESCRIPTION
## Description

Codecov.io coverage numbers include both generated code and sample code in the total code coverage numbers, which doesn't accurately represent the state of the project.

## Testing

CI/CD

## Documentation

No.
