### PR TITLE
Misc. code clean-up fixes, add some critical traces.

### DIFF
--- a/netebpfext/net_ebpf_ext_tracelog.h
+++ b/netebpfext/net_ebpf_ext_tracelog.h
@@ -379,12 +379,12 @@ net_ebpf_ext_log_message_uint64_uint64_uint64(
         }                                                                                                             \
     } while (false);
 
-#define NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(keyword, ptr, ptr_name, result)                                     \
+#define NET_EBPF_EXT_BAIL_ON_ALLOC_FAILURE_STATUS(keyword, ptr, ptr_name, status)                                     \
     do {                                                                                                              \
         if ((ptr) == NULL) {                                                                                          \
             NET_EBPF_EXT_LOG_MESSAGE(                                                                                 \
                 NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, ##keyword##, "Failed to allocate " #ptr_name " in " __FUNCTION__); \
-            (result) = STATUS_INSUFFICIENT_RESOURCES;                                                                 \
+            (status) = STATUS_INSUFFICIENT_RESOURCES;                                                                 \
             goto Exit;                                                                                                \
         }                                                                                                             \
     } while (false);


### PR DESCRIPTION
## Description

Issues fixed:
- Check nmr binding handle validity prior to calling NmrDeregisterProvider
- Add some critical traces.

_Note: The `NetEbpfExt` extension can certainly use some more traces.  That task will be addressed in a subsequent PR._

## Testing

CI/CD run.

## Documentation

No doc changes required.

Fixes #2583 

