### PR TITLE
Remove DangerousAPI check from appverif

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -76,7 +76,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
       test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-x64


### PR DESCRIPTION
Fixes #2581
## Description

Remove `DangerousAPI` check from appverif for `unit_tests.exe`

## Testing

Existing CICD

## Documentation

NA
