### PR TITLE
Fix build failures with latest MSVC (main)

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -124,7 +124,7 @@ jobs:
         cache-name: cache-nuget-modules
       with:
         path: packages
-        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('**/packages.config') }}-v2
+        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('**/packages.config') }}-v3
 
     - name: Restore NuGet packages
       if: steps.skip_check.outputs.should_skip != 'true'
@@ -139,7 +139,7 @@ jobs:
         cache-name: cache-verifier-project
       with:
         path: external/ebpf-verifier/build
-        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('.git/modules/external/ebpf-verifier/HEAD') }}-${{ hashFiles('external/Directory.Build.props')}}-v2
+        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('.git/modules/external/ebpf-verifier/HEAD') }}-${{ hashFiles('external/Directory.Build.props')}}-v3
 
     - name: Create verifier project
       if: steps.skip_check.outputs.should_skip != 'true'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -176,7 +176,10 @@ jobs:
     - name: Copy LLVM libs for Fuzzing & Address Sanitizing
       if: steps.skip_check.outputs.should_skip != 'true'
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-      run: copy "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.36.32532\bin\Hostx64\x64\clang*" .
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        copy "%VCToolsInstallDir%\bin\Hostx64\x64\clang*" .
 
     - name: Download demo Debug repository
       if: steps.skip_check.outputs.should_skip != 'true' && (matrix.configurations == 'Debug' || matrix.configurations == 'NativeOnlyDebug')

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -68,6 +68,13 @@ jobs:
         cancel_others: 'false'
         paths_ignore: '["**.md", "**/docs/**"]'
 
+    - name: Set MSVC Environment Variables
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+        powershell.exe "echo 'msvc_tools_path=%VCToolsInstallDir%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
+        powershell.exe "echo 'msvc_tools_version=%VCToolsVersion%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
+
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
       if: steps.skip_check.outputs.should_skip != 'true'
       with:
@@ -124,7 +131,7 @@ jobs:
         cache-name: cache-nuget-modules
       with:
         path: packages
-        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('**/packages.config') }}-v3
+        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('**/packages.config') }}-${{env.msvc_tools_version}}
 
     - name: Restore NuGet packages
       if: steps.skip_check.outputs.should_skip != 'true'
@@ -139,7 +146,7 @@ jobs:
         cache-name: cache-verifier-project
       with:
         path: external/ebpf-verifier/build
-        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('.git/modules/external/ebpf-verifier/HEAD') }}-${{ hashFiles('external/Directory.Build.props')}}-v3
+        key: ${{ runner.os }}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}-${{env.BUILD_ARTIFACT_NAME}}-${{ hashFiles('.git/modules/external/ebpf-verifier/HEAD') }}-${{ hashFiles('external/Directory.Build.props')}}-${{env.msvc_tools_version}}
 
     - name: Create verifier project
       if: steps.skip_check.outputs.should_skip != 'true'
@@ -178,8 +185,7 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-        copy "%VCToolsInstallDir%\bin\Hostx64\x64\clang*" .
+        copy "${{env.msvc_tools_path}}\bin\Hostx64\x64\clang*" .
 
     - name: Download demo Debug repository
       if: steps.skip_check.outputs.should_skip != 'true' && (matrix.configurations == 'Debug' || matrix.configurations == 'NativeOnlyDebug')

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -176,7 +176,7 @@ jobs:
     - name: Copy LLVM libs for Fuzzing & Address Sanitizing
       if: steps.skip_check.outputs.should_skip != 'true'
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
-      run: copy "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.35.32215\bin\Hostx64\x64\clang*" .
+      run: copy "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.36.32532\bin\Hostx64\x64\clang*" .
 
     - name: Download demo Debug repository
       if: steps.skip_check.outputs.should_skip != 'true' && (matrix.configurations == 'Debug' || matrix.configurations == 'NativeOnlyDebug')

--- a/libs/api/libbpf_internal.h
+++ b/libs/api/libbpf_internal.h
@@ -5,8 +5,6 @@
 #define PATH_MAX MAX_PATH
 #define strdup _strdup
 
-#define TEST_LINE 0
-
 static inline int
 libbpf_err(int ret)
 {

--- a/libs/api/libbpf_internal.h
+++ b/libs/api/libbpf_internal.h
@@ -5,6 +5,8 @@
 #define PATH_MAX MAX_PATH
 #define strdup _strdup
 
+#define TEST_LINE 0
+
 static inline int
 libbpf_err(int ret)
 {

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -876,9 +876,9 @@ TEST_CASE("ring_buffer_async_query", "[execution_context]")
 
     struct _completion
     {
-        uint8_t* buffer;
+        uint8_t* buffer = nullptr;
         ebpf_ring_buffer_map_async_query_result_t async_query_result = {};
-        uint64_t value;
+        uint64_t value{};
     } completion;
 
     REQUIRE(ebpf_ring_buffer_map_query_buffer(map.get(), &completion.buffer) == EBPF_SUCCESS);

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -63,9 +63,9 @@ typedef struct _service_context
         sizeof(NPI_MODULEID),
         MIT_GUID,
     };
-    HMODULE dll;
-    bool loaded;
-    HANDLE nmr_client_handle;
+    HMODULE dll{};
+    bool loaded = false;
+    HANDLE nmr_client_handle{};
     NPI_CLIENT_CHARACTERISTICS nmr_client_characteristics = {
         0,
         sizeof(NPI_CLIENT_CHARACTERISTICS),

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -127,7 +127,7 @@ _base_socket::get_received_message(_Out_ uint32_t& message_size, _Outref_result_
 }
 
 _client_socket::_client_socket(int _sock_type, int _protocol, uint16_t _port, socket_family_t _family)
-    : _base_socket{_sock_type, _protocol, _port, _family}, overlapped{}
+    : _base_socket{_sock_type, _protocol, _port, _family}, overlapped{}, receive_posted(false)
 {}
 
 void
@@ -368,6 +368,7 @@ _server_socket::_server_socket(int _sock_type, int _protocol, uint16_t _port)
     : _base_socket{_sock_type, _protocol, _port, Dual}, overlapped{}
 {
     overlapped.hEvent = INVALID_HANDLE_VALUE;
+    receive_message = nullptr;
 
     GUID guid = WSAID_WSARECVMSG;
     uint32_t bytes;


### PR DESCRIPTION
## Description

Looks like the MSVC version has again changed from `14.35.32215` to `14.36.32532` and broke the build for the `main` branch. This PR fixes the build failures and contains the following changes:

1. Use `vcvars64` and set the environment variables for `VCToolsInstallDir` and `VCToolsVersion`, so that we dont hardcode path in the yml.
2. Fixes for new analysis failures flagged by new MSVC version.

## Testing

Existing CICD

## Documentation

NA
