### PR TITLE
Timeout during fault injection

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -192,7 +192,7 @@ jobs:
       shell: cmd
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
-          OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell.exe .\Test-FaultInjection.ps1 ${{env.TEST_COMMAND}} 4
+          OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 4
 
     - name: Run test with low resource simulation
       if: (inputs.code_coverage != true) && (inputs.fault_injection == true) && (steps.skip_check.outputs.should_skip != 'true')
@@ -201,7 +201,7 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
-          powershell.exe .\Test-FaultInjection.ps1 ${{env.TEST_COMMAND}} 16
+          powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 16
 
     - name: Run test with Code Coverage
       if: (inputs.code_coverage == true) && (inputs.vs_dev != true) && (inputs.fault_injection != true) && (steps.skip_check.outputs.should_skip != 'true')

--- a/tests/libs/common/passed_test_log.h
+++ b/tests/libs/common/passed_test_log.h
@@ -30,16 +30,16 @@ class _passed_test_log : public Catch::EventListenerBase
             GetModuleFileNameA(nullptr, process_name, MAX_PATH);
             std::string log_file = process_name;
             log_file += ".passed.log";
-            passed_tests.open(log_file, std::ios::app);
+            passed_tests = std::make_unique<std::ofstream>(log_file, std::ios::app);
         }
         if (testCaseStats.totals.assertions.failed == 0) {
-            passed_tests << testCaseStats.testInfo->name << std::endl;
-            passed_tests.flush();
+            *passed_tests << testCaseStats.testInfo->name << std::endl;
+            passed_tests->flush();
         }
     }
 
   private:
-    static std::ofstream passed_tests;
+    static std::unique_ptr<std::ofstream> passed_tests;
 };
 
-std::ofstream _passed_test_log::passed_tests;
+std::unique_ptr<std::ofstream> _passed_test_log::passed_tests;


### PR DESCRIPTION
## Description

Add timeout logic to fault injection to permit capturing dumps for hung tests.
Fix intermittent bug in _passed_test_log that prevented logging.

## Testing

CI/CD

## Documentation

No.
