### PR TITLE
Correctly capture the exit code

### DIFF
--- a/scripts/Run-Test.ps1
+++ b/scripts/Run-Test.ps1
@@ -7,17 +7,31 @@
 # the <output folder> with the name of the test executable and the current date
 # and time.
 
-if ($args.Count -eq 0) {
+# Modifying $args directly is can cause issues, so copy it to a new variable.
+$arguments = $args
+
+# Check that the correct number of arguments have been provided.
+if ($arguments.Count -eq 0) {
     Write-Output "Usage: Run-Test.ps1 <output folder> <timeout in seconds> <test command> <test arguments>"
     exit 1
 }
 
-$OutputFolder = $args[0]
-$args = $args[1..($args.Length - 1)]
-$Timeout = [int]$args[0]
-$args = $args[1..($args.Length - 1)]
+# Extract the output folder and timeout from the arguments.
+$OutputFolder = $arguments[0]
+$arguments = $arguments[1..($arguments.Length - 1)]
+$Timeout = [int]$arguments[0]
+$arguments = $arguments[1..($arguments.Length - 1)]
 
-$process = Start-Process -PassThru -NoNewWindow -FilePath $args[0] -ArgumentList $args[1..($args.Length - 1)]
+# Start the test process using the provided command and arguments.
+# This can't use Start-Process as that doesn't save exit code and always returns 0.
+$processInfo = New-Object System.Diagnostics.ProcessStartInfo
+$processInfo.UseShellExecute = $false
+$processInfo.FileName = $arguments[0]
+$processInfo.Arguments = $arguments[1..($arguments.Length - 1)] -join ' '
+
+$process = New-Object System.Diagnostics.Process
+$process.StartInfo = $processInfo
+$process.Start() | Out-Null
 
 if (!$process.WaitForExit($Timeout * 1000)) {
     $dumpFileName = "$($process.ProcessName)_$(Get-Date -Format 'yyyy-MM-dd_HH-mm-ss').dmp"
@@ -30,4 +44,5 @@ if (!$process.WaitForExit($Timeout * 1000)) {
     }
 }
 
+Write-Output "Test $($process.ProcessName) exited with code $($process.ExitCode)"
 exit $process.ExitCode


### PR DESCRIPTION
## Description

Work around bug in PowerShell where "Start-Process" doesn't correctly preserve and report the exit code of the process. 

## Testing

CI/CD

## Documentation

No.
