### PR TITLE
Validate program type in ebpf_program_create

### DIFF
--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -648,12 +648,22 @@ ebpf_program_create(_In_ const ebpf_program_parameters_t* program_parameters, _O
 {
     EBPF_LOG_ENTRY();
     ebpf_result_t retval;
-    ebpf_program_t* local_program;
+    ebpf_program_t* local_program = NULL;
     ebpf_utf8_string_t local_program_name = {NULL, 0};
     ebpf_utf8_string_t local_section_name = {NULL, 0};
     ebpf_utf8_string_t local_file_name = {NULL, 0};
     ebpf_utf8_string_t local_hash_type_name = {NULL, 0};
     uint8_t* local_program_info_hash = NULL;
+
+    if (IsEqualGUID(&program_parameters->program_type, &EBPF_PROGRAM_TYPE_UNSPECIFIED)) {
+        EBPF_LOG_MESSAGE_GUID(
+            EBPF_TRACELOG_LEVEL_ERROR,
+            EBPF_TRACELOG_KEYWORD_PROGRAM,
+            "Program type must be specified.",
+            &program_parameters->program_type);
+        retval = EBPF_INVALID_ARGUMENT;
+        goto Done;
+    }
 
     local_program = (ebpf_program_t*)ebpf_allocate_with_tag(sizeof(ebpf_program_t), EBPF_POOL_TAG_PROGRAM);
     if (!local_program) {

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -791,6 +791,12 @@ ebpf_program_create(_In_ const ebpf_program_parameters_t* program_parameters, _O
     }
 
     if (local_program->general_helper_provider_data == NULL || local_program->info_extension_provider_data == NULL) {
+        EBPF_LOG_MESSAGE_GUID_GUID(
+            EBPF_TRACELOG_LEVEL_INFO,
+            EBPF_TRACELOG_KEYWORD_PROGRAM,
+            "Program type and Attach type:",
+            &program_parameters->program_type,
+            &program_parameters->expected_attach_type);
         retval = EBPF_EXTENSION_FAILED_TO_LOAD;
         goto Done;
     }

--- a/libs/execution_context/ebpf_program.h
+++ b/libs/execution_context/ebpf_program.h
@@ -68,6 +68,8 @@ extern "C"
      * @retval EBPF_SUCCESS The operation was successful.
      * @retval EBPF_NO_MEMORY Unable to allocate resources for this
      *  program instance.
+     * @retval EBPF_INVALID_ARGUMENT Program type was not set or Program name length was greater than BPF_OBJ_NAME_LEN.
+     * @retval EBPF_EXTENSION_FAILED_TO_LOAD The program extension failed to load.
      */
     _Must_inspect_result_ ebpf_result_t
     ebpf_program_create(_In_ const ebpf_program_parameters_t* program_parameters, _Outptr_ ebpf_program_t** program);

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -1680,7 +1680,7 @@ TEST_CASE("EBPF_OPERATION_GET_PROGRAM_INFO", "[execution_context][negative]")
     // Invalid program handle and type.
     request.program_handle = ebpf_handle_invalid;
     request.program_type = {0};
-    REQUIRE(invoke_protocol(EBPF_OPERATION_GET_PROGRAM_INFO, request, reply) == EBPF_EXTENSION_FAILED_TO_LOAD);
+    REQUIRE(invoke_protocol(EBPF_OPERATION_GET_PROGRAM_INFO, request, reply) == EBPF_INVALID_ARGUMENT);
 
     // Reply too small.
     request.program_handle = program_handles[0];


### PR DESCRIPTION
## Description

__ebpf_program_parameters had program_type not set. Hence the ebpf program failed to load and attach.

Behavior change in return value:
If the program type guid is 0, the new return value is changed 
    From:  EBPF_EXTENSION_FAILED_TO_LOAD
    To: EBPF_INVALID_ARGUMENT

Trace Addition:
1. This PR adds a trace for debugging where program type is 0.
2. This PR adds a trace for debugging to print the guid for program type and attach type. There can be cases when the extension can fail to load/attach:
    - Program type is valid but incorrect attach type (For eg, Program type is EBPF_PROGRAM_TYPE_BIND, Attach type is  EBPF_ATTACH_TYPE_XDP)
    - Attach type is valid but incorrect program type (For eg, EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_BIND)

## Testing

_Do any existing tests cover this change? Yes
Are new tests needed? No

Manual testing was done from ebpf-for-windows-demo using ebpf-for-window's ebpfcore changes, and collected the traces to verify.

PS C:\ebpf-for-windows-demo\Debug>  .\cilium_based_agent.exe --bpf-lb-mode=snat --device=ethernet
Initializing daemon with mode = snat
Using interface:
  name         = ethernet
  mtu          = 1500
  ifindex      = 8
  IPv4 address = 172.29.163.18

Cleaning up previous configuration ...
Compiling XDP eBPF program for SNAT ...
Verifying the program ...
Loading and attaching the program to XDP hook ...
bpf_object__load failed with error=-22
Failed to load and attach the XDP program, error = -22
PS C:\ebpf-for-windows-demo\Debug>
```
Logman trace:

{"Entry":"_ebpf_core_protocol_create_program","meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericMessage","time":"2023-06-24T02:45:16.3382364Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":5,"opcode":1,"keywords":"0x1"}}
[1]1C10.1B78::2023/06/23-19:45:16.338237300 [EbpfForWindowsProvider]{"Entry":"ebpf_program_create_and_initialize","meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericMessage","time":"2023-06-24T02:45:16.3382373Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":5,"opcode":1,"keywords":"0x1"}}
[1]1C10.1B78::2023/06/23-19:45:16.338238000 [EbpfForWindowsProvider]{"Entry":"ebpf_program_create","meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericMessage","time":"2023-06-24T02:45:16.3382380Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":5,"opcode":1,"keywords":"0x1"}}
[1]1C10.1B78::2023/06/23-19:45:16.338239400 [EbpfForWindowsProvider]{"Message":"Program type must be specified.","*guid":"{00000000-0000-0000-0000-000000000000}","meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericMessage","time":"2023-06-24T02:45:16.3382394Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":2,"keywords":"0x80"}}
[1]1C10.1B78::2023/06/23-19:45:16.338240300 [EbpfForWindowsProvider]{"ErrorMessage":"ebpf_program_create returned error","Error":6,"meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericError","time":"2023-06-24T02:45:16.3382403Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":2,"keywords":"0x2"}}
[1]1C10.1B78::2023/06/23-19:45:16.338245500 [EbpfForWindowsProvider]{"ErrorMessage":"ebpf_program_create_and_initialize returned error","Error":6,"meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericError","time":"2023-06-24T02:45:16.3382455Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":2,"keywords":"0x2"}}
[1]1C10.1B78::2023/06/23-19:45:16.338246200 [EbpfForWindowsProvider]{"ErrorMessage":"_ebpf_core_protocol_create_program returned error","Error":6,"meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericError","time":"2023-06-24T02:45:16.3382462Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":2,"keywords":"0x2"}}
[1]1C10.1B78::2023/06/23-19:45:16.338253800 [EbpfForWindowsProvider]{"Api":"\"ebpf_core_invoke_protocol_handler\"","status":"0xC000000D(NT=An invalid parameter was passed to a service or function.)","meta":{"provider":"EbpfForWindowsProvider","event":"EbpfApiError","time":"2023-06-24T02:45:16.3382538Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":2,"keywords":"0x4"}}
[1]1C10.1B78::2023/06/23-19:45:16.338286400 [EbpfForWindowsProvider]{"Api":"DeviceIoControl","last_error":"87(WIN=The parameter is incorrect.)","meta":{"provider":"EbpfForWindowsProvider","event":"EbpfApiError","time":"2023-06-24T02:45:16.3382864Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":2,"keywords":"0x100"}}
[1]1C10.1B78::2023/06/23-19:45:16.338287200 [EbpfForWindowsProvider]{"ErrorMessage":"invoke_ioctl returned error","Error":87,"meta":{"provider":"EbpfForWindowsProvider","event":"EbpfGenericError","time":"2023-06-24T02:45:16.3382872Z","cpu":1,"pid":7184,"tid":7032,"channel":11,"level":2,"keywords":"0x4"}}
```


## Documentation

_Is there any documentation impact for this change? TSG (Trouble Shooting Guide) needs an addition of this trace. It will be addressed in #2625 
