### PR TITLE
Switch calls into ebpf_core to static dispatch table

### DIFF
--- a/include/ebpf_proxy.h
+++ b/include/ebpf_proxy.h
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+#pragma once
+
+#include "ebpf_protocol.h"
+#include "ebpf_result.h"
+#include "ebpf_structs.h"
+#include "ebpf_windows.h"
+#include "framework.h"
+
+/// @brief Proxy to driver dispatch table.
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * @brief Initialize the eBPF core execution context.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  operation.
+     */
+    _Must_inspect_result_ ebpf_result_t typedef (*ebpf_core_initiate_t)();
+
+    /**
+     * @brief Uninitialize the eBPF core execution context.
+     *
+     */
+    typedef void (*ebpf_core_terminate_t)();
+
+    /**
+     * @brief Invoke an operations on the eBPF execution context that was issued
+     *  by the user mode library.
+     *
+     * @param[in] operation_id Identifier of the operation to execute.
+     * @param[in] input_buffer Encoded buffer containing parameters for this
+     *  operation.
+     * @param[out] output_buffer Pointer to memory that will contain the
+     *  encoded result parameters for this operation.
+     * @param[in] output_buffer_length Length of the output buffer.
+     * @param[in, out] async_context Async context to be passed to on_complete.
+     * @param[in] on_complete Callback to be invoked when the operation is complete.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  operation.
+     */
+    typedef _Must_inspect_result_ ebpf_result_t (*ebpf_core_invoke_protocol_handler_t)(
+        ebpf_operation_id_t operation_id,
+        _In_reads_bytes_(input_buffer_length) const void* input_buffer,
+        uint16_t input_buffer_length,
+        _Out_writes_bytes_opt_(output_buffer_length) void* output_buffer,
+        uint16_t output_buffer_length,
+        _Inout_opt_ void* async_context,
+        _In_opt_ void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t));
+
+    /**
+     * @brief Query properties about an operation.
+     *
+     * @param[in] operation_id Identifier of the operation to query.
+     * @param[out] minimum_request_size Minimum size of a request buffer for
+     *  this operation.
+     * @param[out] minimum_reply_size Minimum size of the reply buffer for this
+     *  operation.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NOT_SUPPORTED The operation id is not valid.
+     */
+    typedef _Must_inspect_result_ ebpf_result_t (*ebpf_core_get_protocol_handler_properties_t)(
+        ebpf_operation_id_t operation_id,
+        _Out_ size_t* minimum_request_size,
+        _Out_ size_t* minimum_reply_size,
+        _Out_ bool* async);
+
+    /**
+     * @brief Cancel an async protocol operation that returned EBPF_PENDING from
+     * ebpf_core_dispatch_table.invoke_protocol_handler.
+     *
+     * @param[in, out] async_context Async context passed to ebpf_core_dispatch_table.invoke_protocol_handler.
+     * @retval true Operation was canceled.
+     * @retval false Operation was already completed.
+     */
+    typedef bool (*ebpf_core_cancel_protocol_handler_t)(_Inout_ void* async_context);
+
+    /**
+     * @brief Close the FsContext2 from a file object.
+     *
+     * @param[in] context The FsContext2 from a fileobject to close.
+     */
+    typedef void (*ebpf_core_close_context_t)(_In_opt_ void* context);
+
+    typedef struct _ebpf_core_dispatch_table
+    {
+        uint32_t size;
+        uint32_t version;
+        ebpf_core_initiate_t initiate;
+        ebpf_core_terminate_t terminate;
+        ebpf_core_invoke_protocol_handler_t invoke_protocol_handler;
+        ebpf_core_get_protocol_handler_properties_t get_protocol_handler_properties;
+        ebpf_core_cancel_protocol_handler_t cancel_protocol_handler;
+        ebpf_core_close_context_t close_context;
+    } ebpf_core_dispatch_table_t;
+
+    extern ebpf_core_dispatch_table_t ebpf_core_dispatch_table;
+
+#ifdef __cplusplus
+} // extern "C"
+#endif

--- a/libs/execution_context/ebpf_core.h
+++ b/libs/execution_context/ebpf_core.h
@@ -22,77 +22,6 @@ extern "C"
     typedef uint32_t(__stdcall* ebpf_hook_function)(uint8_t*);
 
     /**
-     * @brief Initialize the eBPF core execution context.
-     *
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
-     *  operation.
-     */
-    _Must_inspect_result_ ebpf_result_t
-    ebpf_core_initiate();
-
-    /**
-     * @brief Uninitialize the eBPF core execution context.
-     *
-     */
-    void
-    ebpf_core_terminate();
-
-    /**
-     * @brief Invoke an operations on the eBPF execution context that was issued
-     *  by the user mode library.
-     *
-     * @param[in] operation_id Identifier of the operation to execute.
-     * @param[in] input_buffer Encoded buffer containing parameters for this
-     *  operation.
-     * @param[out] output_buffer Pointer to memory that will contain the
-     *  encoded result parameters for this operation.
-     * @param[in] output_buffer_length Length of the output buffer.
-     * @param[in, out] async_context Async context to be passed to on_complete.
-     * @param[in] on_complete Callback to be invoked when the operation is complete.
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
-     *  operation.
-     */
-    _Must_inspect_result_ ebpf_result_t
-    ebpf_core_invoke_protocol_handler(
-        ebpf_operation_id_t operation_id,
-        _In_reads_bytes_(input_buffer_length) const void* input_buffer,
-        uint16_t input_buffer_length,
-        _Out_writes_bytes_opt_(output_buffer_length) void* output_buffer,
-        uint16_t output_buffer_length,
-        _Inout_opt_ void* async_context,
-        _In_opt_ void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t));
-
-    /**
-     * @brief Query properties about an operation.
-     *
-     * @param[in] operation_id Identifier of the operation to query.
-     * @param[out] minimum_request_size Minimum size of a request buffer for
-     *  this operation.
-     * @param[out] minimum_reply_size Minimum size of the reply buffer for this
-     *  operation.
-     * @retval EBPF_SUCCESS The operation was successful.
-     * @retval EBPF_NOT_SUPPORTED The operation id is not valid.
-     */
-    _Must_inspect_result_ ebpf_result_t
-    ebpf_core_get_protocol_handler_properties(
-        ebpf_operation_id_t operation_id,
-        _Out_ size_t* minimum_request_size,
-        _Out_ size_t* minimum_reply_size,
-        _Out_ bool* async);
-
-    /**
-     * @brief Cancel an async protocol operation that returned EBPF_PENDING from ebpf_core_invoke_protocol_handler.
-     *
-     * @param[in, out] async_context Async context passed to ebpf_core_invoke_protocol_handler.
-     * @retval true Operation was canceled.
-     * @retval false Operation was already completed.
-     */
-    bool
-    ebpf_core_cancel_protocol_handler(_Inout_ void* async_context);
-
-    /**
      * @brief Computes difference of checksum values for two input raw buffers using 1's complement arithmetic.
      *
      * @param[in] from Pointer to first raw buffer.
@@ -235,14 +164,6 @@ extern "C"
         const size_t count_of_helpers,
         _In_reads_(count_of_helpers) const uint32_t* helper_function_ids,
         _Out_writes_(count_of_helpers) uint64_t* helper_function_addresses);
-
-    /**
-     * @brief Close the FsContext2 from a file object.
-     *
-     * @param[in] context The FsContext2 from a fileobject to close.
-     */
-    void
-    ebpf_core_close_context(_In_opt_ void* context);
 
 #ifdef __cplusplus
 }

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -9,6 +9,7 @@
 #include "ebpf_maps.h"
 #include "ebpf_object.h"
 #include "ebpf_program.h"
+#include "ebpf_proxy.h"
 #include "ebpf_ring_buffer.h"
 #include "helpers.h"
 
@@ -93,8 +94,8 @@ typedef class _ebpf_async_wrapper
 class _ebpf_core_initializer
 {
   public:
-    _ebpf_core_initializer() { REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS); }
-    ~_ebpf_core_initializer() { ebpf_core_terminate(); }
+    _ebpf_core_initializer() { REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS); }
+    ~_ebpf_core_initializer() { ebpf_core_dispatch_table.terminate(); }
 };
 
 template <typename T> class ebpf_object_deleter
@@ -1151,7 +1152,7 @@ invoke_protocol(
 
     auto completion = [](void*, size_t, ebpf_result_t) {};
 
-    return ebpf_core_invoke_protocol_handler(
+    return ebpf_core_dispatch_table.invoke_protocol_handler(
         operation_id,
         request_ptr,
         static_cast<uint16_t>(request_size),
@@ -1628,7 +1629,7 @@ TEST_CASE("EBPF_OPERATION_GET_PINNED_OBJECT short header", "[execution_context][
     auto completion = [](void*, size_t, ebpf_result_t) {};
 
     REQUIRE(
-        ebpf_core_invoke_protocol_handler(
+        ebpf_core_dispatch_table.invoke_protocol_handler(
             EBPF_OPERATION_GET_PINNED_OBJECT,
             request_ptr,
             static_cast<uint16_t>(request_size),
@@ -1761,7 +1762,7 @@ TEST_CASE("EBPF_OPERATION_LOAD_NATIVE_MODULE short header", "[execution_context]
     auto completion = [](void*, size_t, ebpf_result_t) {};
 
     REQUIRE(
-        ebpf_core_invoke_protocol_handler(
+        ebpf_core_dispatch_table.invoke_protocol_handler(
             EBPF_OPERATION_LOAD_NATIVE_MODULE,
             request_ptr,
             static_cast<uint16_t>(request_size),

--- a/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
+++ b/tests/libfuzzer/core_helper_fuzzer/libfuzz_harness.cpp
@@ -7,6 +7,7 @@
 #include "ebpf_handle.h"
 #include "ebpf_object.h"
 #include "ebpf_program.h"
+#include "ebpf_proxy.h"
 #include "helpers.h"
 #include "libfuzzer.h"
 #include "netebpf_ext_helper.h"
@@ -160,9 +161,9 @@ class fuzz_wrapper
   public:
     fuzz_wrapper()
     {
-        ebpf_result_t result = ebpf_core_initiate();
+        ebpf_result_t result = ebpf_core_dispatch_table.initiate();
         if (result != EBPF_SUCCESS) {
-            throw std::runtime_error("ebpf_core_initiate failed");
+            throw std::runtime_error("ebpf_core_dispatch_table.initiate failed");
         }
     }
     void
@@ -212,7 +213,7 @@ class fuzz_wrapper
             (void)ebpf_handle_close(handle);
         };
         program_information_providers.clear();
-        ebpf_core_terminate();
+        ebpf_core_dispatch_table.terminate();
     }
 
     ebpf_handle_t

--- a/tests/performance/ExecutionContext.cpp
+++ b/tests/performance/ExecutionContext.cpp
@@ -22,10 +22,10 @@ typedef class _ebpf_program_test_state
         : byte_code(byte_code), program_info_provider(nullptr)
     {
         ebpf_program_parameters_t parameters = {EBPF_PROGRAM_TYPE_XDP};
-        REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+        REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS);
 
         // Create the program info provider.  We can only do this after calling
-        // ebpf_core_initiate() since that initializes the interface GUID.
+        // ebpf_core_dispatch_table.initiate() since that initializes the interface GUID.
         program_info_provider = new _program_info_provider(EBPF_PROGRAM_TYPE_XDP);
 
         REQUIRE(ebpf_program_create(&parameters, &program) == EBPF_SUCCESS);
@@ -34,7 +34,7 @@ typedef class _ebpf_program_test_state
     {
         EBPF_OBJECT_RELEASE_REFERENCE(reinterpret_cast<ebpf_core_object_t*>(program));
         delete program_info_provider;
-        ebpf_core_terminate();
+        ebpf_core_dispatch_table.terminate();
     }
 
 #if !defined(CONFIG_BPF_JIT_DISABLED) || !defined(CONFIG_BPF_INTERPRETER_DISABLED)
@@ -96,7 +96,7 @@ typedef class _ebpf_map_test_state
     _ebpf_map_test_state(ebpf_map_type_t type, std::optional<uint32_t> map_size = {})
     {
         ebpf_utf8_string_t name{(uint8_t*)"test", 4};
-        REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+        REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS);
         ebpf_map_definition_in_memory_t definition{
             type, sizeof(uint32_t), sizeof(uint64_t), map_size.has_value() ? map_size.value() : ebpf_get_cpu_count()};
 
@@ -114,7 +114,7 @@ typedef class _ebpf_map_test_state
     ~_ebpf_map_test_state()
     {
         EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
-        ebpf_core_terminate();
+        ebpf_core_dispatch_table.terminate();
     }
 
     void
@@ -195,7 +195,7 @@ typedef class _ebpf_map_test_state
 typedef class _ebpf_map_lpm_trie_test_state
 {
   public:
-    _ebpf_map_lpm_trie_test_state() : map(nullptr) { REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS); }
+    _ebpf_map_lpm_trie_test_state() : map(nullptr) { REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS); }
 
     void
     populate_ipv4_routes(size_t route_count)
@@ -260,7 +260,7 @@ typedef class _ebpf_map_lpm_trie_test_state
     ~_ebpf_map_lpm_trie_test_state()
     {
         EBPF_OBJECT_RELEASE_REFERENCE((ebpf_core_object_t*)map);
-        ebpf_core_terminate();
+        ebpf_core_dispatch_table.terminate();
     }
 
   private:

--- a/tests/performance/performance.h
+++ b/tests/performance/performance.h
@@ -10,6 +10,7 @@
 #include "ebpf_maps.h"
 #include "ebpf_object.h"
 #include "ebpf_program.h"
+#include "ebpf_proxy.h"
 #include "helpers.h"
 #include "performance_measure.h"
 

--- a/tests/performance/platform.cpp
+++ b/tests/performance/platform.cpp
@@ -218,61 +218,61 @@ _ebpf_hash_table_test_replace_value_overlap()
 void
 test_bpf_get_prandom_u32(bool preemptible)
 {
-    REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+    REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS);
     size_t iterations = PERFORMANCE_MEASURE_ITERATION_COUNT;
     _performance_measure measure(__FUNCTION__, preemptible, _perf_bpf_get_prandom_u32, iterations);
     measure.run_test();
-    ebpf_core_terminate();
+    ebpf_core_dispatch_table.terminate();
 }
 
 void
 test_bpf_ktime_get_boot_ns(bool preemptible)
 {
-    REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+    REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS);
     size_t iterations = PERFORMANCE_MEASURE_ITERATION_COUNT;
     _performance_measure measure(__FUNCTION__, preemptible, _perf_bpf_ktime_get_boot_ns, iterations);
     measure.run_test();
-    ebpf_core_terminate();
+    ebpf_core_dispatch_table.terminate();
 }
 
 void
 test_bpf_ktime_get_ns(bool preemptible)
 {
-    REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+    REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS);
     size_t iterations = PERFORMANCE_MEASURE_ITERATION_COUNT;
     _performance_measure measure(__FUNCTION__, preemptible, _perf_bpf_ktime_get_ns, iterations);
     measure.run_test();
-    ebpf_core_terminate();
+    ebpf_core_dispatch_table.terminate();
 }
 
 void
 test_bpf_get_smp_processor_id(bool preemptible)
 {
-    REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+    REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS);
     size_t iterations = PERFORMANCE_MEASURE_ITERATION_COUNT;
     _performance_measure measure(__FUNCTION__, preemptible, _perf_bpf_get_smp_processor_id, iterations);
     measure.run_test();
-    ebpf_core_terminate();
+    ebpf_core_dispatch_table.terminate();
 }
 
 void
 test_epoch_enter_exit(bool preemptible)
 {
-    REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+    REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS);
     size_t iterations = PERFORMANCE_MEASURE_ITERATION_COUNT * 10;
     _performance_measure measure(__FUNCTION__, preemptible, _perf_epoch_enter_exit, iterations);
     measure.run_test();
-    ebpf_core_terminate();
+    ebpf_core_dispatch_table.terminate();
 }
 
 void
 test_epoch_enter_exit_alloc_free(bool preemptible)
 {
-    REQUIRE(ebpf_core_initiate() == EBPF_SUCCESS);
+    REQUIRE(ebpf_core_dispatch_table.initiate() == EBPF_SUCCESS);
     size_t iterations = PERFORMANCE_MEASURE_ITERATION_COUNT * 10;
     _performance_measure measure(__FUNCTION__, preemptible, _perf_epoch_enter_alloc_free_exit, iterations);
     measure.run_test();
-    ebpf_core_terminate();
+    ebpf_core_dispatch_table.terminate();
 }
 
 void


### PR DESCRIPTION
## Description

Long term goal is to permit reloading of portions of the eBPF For Windows code for servicing.
As a step on that path, this PR decouples the eBPF driver from the eBPF execution context via a static dispatch table.

## Testing

CI/CD

## Documentation

No.
