### PR TITLE
Exclude netsh show processes test from sanitize job

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -338,7 +338,8 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
-      test_command: .\unit_tests.exe -d yes
+      # Exclude [processes] test that ASAN can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-x64-Sanitize
       environment: windows-2022
       code_coverage: false


### PR DESCRIPTION
## Description

ASAN apparently takes its own lock inside NtQueryObject so if TerminateThread gets called on that thread because of NtQueryObject hanging, the ASAN lock may not get released and ASAN can hang in the next CreateThread call.

We had similar issues with codecov so apply the same solution here in excluding `[processes]` from a sanitize run.

Fixes #2650

## Testing

Covered by existing CI/CD tests, since this was found by CI/CD runs.

## Documentation

No impact.
