### PR TITLE
Fix tcphdr layout

### DIFF
--- a/include/net/tcp.h
+++ b/include/net/tcp.h
@@ -6,22 +6,26 @@ struct tcphdr
 {
     uint16_t source;
     uint16_t dest;
-    uint32_t sequence_number;
-    uint32_t ack_number;
-    uint16_t data_offset : 4;
-    uint16_t reserved : 3;
+    uint32_t seq;     // Sequence Number
+    uint32_t ack_seq; // Acknowledgement Number
+
+    // List bits in each byte from right (low) to left (high).
     uint16_t ns : 1;
-    uint16_t cwr : 1;
-    uint16_t ece : 1;
-    uint16_t urg : 1;
-    uint16_t ack : 1;
-    uint16_t psh : 1;
-    uint16_t rst : 1;
-    uint16_t syn : 1;
+    uint16_t reserved : 3;
+    uint16_t doff : 4; // Data Offset
+
     uint16_t fin : 1;
-    uint16_t window_size;
-    uint16_t checksum;
-    uint16_t urgent_pointer;
+    uint16_t syn : 1;
+    uint16_t rst : 1;
+    uint16_t psh : 1;
+    uint16_t ack : 1;
+    uint16_t urg : 1;
+    uint16_t ece : 1;
+    uint16_t cwr : 1;
+
+    uint16_t window;  // Window Size
+    uint16_t check;   // Checksum
+    uint16_t urg_ptr; // Urgent Pointer
 };
 
 // Verify the bit fields give the correct header size.


### PR DESCRIPTION
## Description

Verified field names in BPF samples such as Cilium BPF programs

Fixes #2643 

## Testing

Static asserts don't work with bitfields so cannot be tested that way.
Manually tested with a C program using both clang and MSVC:

```
#include <assert.h>
#include <stdint.h>
#include "..\..\..\include\net\tcp.h"

// Test packet:
// Source Port            = 0x0102
// Destination Port       = 0x0304
// Sequence Number        = 0x05060708
// Acknolwedgement Number = 0x090a0b0c
// Data Offset            = 0xd
// Reserved + flags       = 0x07f
// Window                 = 0x1011
const char test_packet[] = {0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0xd0, 0x7f, 0x10, 0x11};

int main(int argc, char** argv)
{
    assert(((struct tcphdr*)test_packet)->source == 0x0201);
    assert(((struct tcphdr*)test_packet)->dest == 0x0403);
    assert(((struct tcphdr*)test_packet)->seq == 0x08070605);
    assert(((struct tcphdr*)test_packet)->ack_seq == 0x0c0b0a09);
    assert(((struct tcphdr*)test_packet)->window == 0x1110);
    assert(((struct tcphdr*)test_packet)->doff == 0xd);
    assert(((struct tcphdr*)test_packet)->reserved == 0);
    assert(((struct tcphdr*)test_packet)->ns == 0);
    assert(((struct tcphdr*)test_packet)->cwr == 0);
    assert(((struct tcphdr*)test_packet)->ece == 1);
    assert(((struct tcphdr*)test_packet)->urg == 1);
    assert(((struct tcphdr*)test_packet)->ack == 1);
    assert(((struct tcphdr*)test_packet)->psh == 1);
    assert(((struct tcphdr*)test_packet)->rst == 1);
    assert(((struct tcphdr*)test_packet)->syn == 1);
    assert(((struct tcphdr*)test_packet)->fin == 1);
    return 0;
}
```

## Documentation

No impact.
