### PR TITLE
Always end tool install with where command

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -123,6 +123,7 @@ jobs:
       run: |
         choco install -y llvm --version 11.0.1 --allow-downgrade
         echo "C:\Program Files\LLVM\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        where clang.exe
 
     - name: Cache nuget packages
       if: steps.skip_check.outputs.should_skip != 'true'

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -117,6 +117,7 @@ jobs:
       run: |
         choco install -y --requirechecksum=true --checksum=2295A733DA39412C61E4F478677519DD0BB1893D88313CE56B468C9E50517888 --checksum-type=sha256 OpenCppCoverage
         echo "C:\Program Files\OpenCppCoverage" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+        where OpenCppCoverage.exe
 
     - name: Configure Windows Error Reporting to make a local copy of any crashes that occur.
       id: configure_windows_error_reporting


### PR DESCRIPTION
## Description

Tool install commands should validate that the tool is installed and is present in the path via the where command.

## Testing

CI/CD

## Documentation

No.
