### PR TITLE
Support compiling even without clang installed

### DIFF
--- a/cmake/process_bpf_source_file.cmake
+++ b/cmake/process_bpf_source_file.cmake
@@ -32,6 +32,13 @@ function(add_bpftonative_command file_name kernel_mode unsafe_program)
 endfunction()
 
 function(build_bpf_samples unsafe_program)
+
+    find_program(clang_path "clang" NO_CACHE)
+    if (${clang_path} STREQUAL "clang_path-NOTFOUND")
+      message(WARNING "Could not find clang on the system -- not building bpf samples from high-level source code.")
+      return()
+    endif()
+
     file(GLOB files *.c)
 
     get_filename_component(target_name ${CMAKE_CURRENT_SOURCE_DIR} NAME)
@@ -57,7 +64,6 @@ function(build_bpf_samples unsafe_program)
 
     foreach(file ${files})
       get_filename_component(file_name ${file} NAME_WE)
-      find_program(clang_path "clang" REQUIRED)
       add_custom_command(
         OUTPUT
           ${output_dir}/${file_name}.o
@@ -69,5 +75,4 @@ function(build_bpf_samples unsafe_program)
       add_bpftonative_command(${file_name} "$true" ${unsafe_program})
       add_bpftonative_command(${file_name} "$false" ${unsafe_program})
     endforeach()
-
   endfunction()

--- a/tests/sample/CMakeLists.txt
+++ b/tests/sample/CMakeLists.txt
@@ -5,4 +5,4 @@ add_subdirectory("ext")
 add_subdirectory("unsafe")
 
 # build eBPF Samples.
-build_bpf_samples(0)
+build_bpf_samples(FALSE)

--- a/tests/sample/unsafe/CMakeLists.txt
+++ b/tests/sample/unsafe/CMakeLists.txt
@@ -2,4 +2,4 @@
 # SPDX-License-Identifier: MIT
 
 # build eBPF Samples but skip verification.
-build_bpf_samples(1)
+build_bpf_samples(TRUE)


### PR DESCRIPTION
## Description

If the user does not have clang installed, it is impossible to build any of the pieces of the project.

## Testing

No

## Documentation

No -- a new CMake warning message has been added. 
