### PR TITLE
Reduce code pages touched during ebpf_api_initiate

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -204,10 +204,6 @@ ebpf_api_initiate() noexcept
     // it will be re-attempted before an IOCTL call is made.
     (void)initialize_device_handle();
 
-    // Load provider data from ebpf store. This is best effort
-    // as there may be no data present in the store.
-    (void)load_ebpf_provider_data();
-
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
 

--- a/libs/api_common/windows_platform_common.hpp
+++ b/libs/api_common/windows_platform_common.hpp
@@ -40,9 +40,6 @@ get_attach_type_windows(const std::string& section);
 _Ret_maybenull_z_ const char*
 get_attach_type_name(_In_ const ebpf_attach_type_t* attach_type);
 
-_Must_inspect_result_ ebpf_result_t
-load_ebpf_provider_data();
-
 void
 clear_ebpf_provider_data();
 

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -11,6 +11,7 @@
 #include "ebpf_program.h"
 #include "ebpf_ring_buffer.h"
 #include "helpers.h"
+#include "test_helper.hpp"
 
 #include <optional>
 #include <set>
@@ -659,8 +660,9 @@ test_function()
 
 TEST_CASE("program", "[execution_context]")
 {
-    _ebpf_core_initializer core;
-    core.initialize();
+    // single_instance_hook_t call ebpapi functions, which requires calling ebpf_api_initiate/ebpf_api_terminate.
+    _test_helper_end_to_end end_to_end;
+    end_to_end.initialize();
 
     program_info_provider_t program_info_provider;
     REQUIRE(program_info_provider.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);


### PR DESCRIPTION
## Description

Eliminate 5 pages from ebpf_api_initiate.

## Testing

CI/CD + WPR + WPA comparative analysis (shows pages no longer being touched).

## Documentation

No.

Notes:
The API load_ebpf_provider_data is best effort, so removing the result.
