### PR TITLE
Convert usersim to a DLL

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -218,6 +218,15 @@ SPDX-License-Identifier: MIT
 			<Component Id="EXPORT_PROGRAM_INFO.PDB" DiskId="1" Guid="{88356FE4-6247-4876-BA14-42EDA88CC5C7}">
 				<File Id="EXPORT_PROGRAM_INFO.PDB" Name="export_program_info.pdb" Source="$(var.export_program_info.TargetDir)export_program_info.pdb" />
 			</Component>
+			<!-- TODO(#2677): move usersim.dll down to the testing component.  Until that issue is addressed,
+			     export_program_info.exe requires it.
+			-->
+			<Component Id="USERSIM.DLL" DiskId="1" Guid="{739017F0-9E33-48FF-A33F-C1434AC757BE}">
+				<File Id="USERSIM.DLL" Name="usersim.dll" Source="$(var.SolutionDir)$(var.Platform)\$(var.Configuration)\usersim.dll" />
+			</Component>
+			<Component Id="USERSIM.PDB" DiskId="1" Guid="{BCE1BF99-6A3D-48A6-A382-4E87A2B20FB2}">
+				<File Id="USERSIM.PDB" Name="usersim.pdb" Source="$(var.SolutionDir)$(var.Platform)\$(var.Configuration)\usersim.pdb" />
+			</Component>
 		</ComponentGroup>
 
 		<!--Clear/Setup the eBPF store-->

--- a/libs/execution_context/unit/execution_context_unit_test.cpp
+++ b/libs/execution_context/unit/execution_context_unit_test.cpp
@@ -790,6 +790,7 @@ TEST_CASE("program", "[execution_context]")
     // Correct attach type, but wrong program type.
     {
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_XDP);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
         ebpf_link_t* local_link = nullptr;
         REQUIRE(ebpf_link_create(EBPF_ATTACH_TYPE_XDP, nullptr, 0, &local_link) == EBPF_SUCCESS);
         link.reset(local_link);
@@ -799,6 +800,7 @@ TEST_CASE("program", "[execution_context]")
     // Wrong attach type, but correct program type.
     {
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_BIND);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
         ebpf_link_t* local_link = nullptr;
         REQUIRE(ebpf_link_create(EBPF_ATTACH_TYPE_XDP, nullptr, 0, &local_link) == EBPF_SUCCESS);
         link.reset(local_link);
@@ -808,6 +810,7 @@ TEST_CASE("program", "[execution_context]")
     // Correct attach type and correct program type.
     {
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
         ebpf_link_t* local_link = nullptr;
         REQUIRE(ebpf_link_create(EBPF_ATTACH_TYPE_XDP, nullptr, 0, &local_link) == EBPF_SUCCESS);
         link.reset(local_link);

--- a/libs/platform/ebpf_platform.c
+++ b/libs/platform/ebpf_platform.c
@@ -559,3 +559,16 @@ ebpf_free_timer_work_item(_Frees_ptr_opt_ ebpf_timer_work_item_t* work_item)
     KeFlushQueuedDpcs();
     ebpf_free(work_item);
 }
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_platform_initiate()
+{
+    ebpf_initialize_cpu_count();
+    return EBPF_SUCCESS;
+}
+
+void
+ebpf_platform_terminate()
+{
+    KeFlushQueuedDpcs();
+}

--- a/libs/platform/kernel/ebpf_platform_kernel.c
+++ b/libs/platform/kernel/ebpf_platform_kernel.c
@@ -21,19 +21,6 @@ typedef struct _ebpf_ring_descriptor ebpf_ring_descriptor_t;
 static KDEFERRED_ROUTINE _ebpf_deferred_routine;
 static KDEFERRED_ROUTINE _ebpf_timer_routine;
 
-_Must_inspect_result_ ebpf_result_t
-ebpf_platform_initiate()
-{
-    ebpf_initialize_cpu_count();
-    return EBPF_SUCCESS;
-}
-
-void
-ebpf_platform_terminate()
-{
-    KeFlushQueuedDpcs();
-}
-
 __drv_allocatesMem(Mem) _Must_inspect_result_
     _Ret_writes_maybenull_(size) void* ebpf_allocate_cache_aligned_with_tag(size_t size, uint32_t tag)
 {

--- a/libs/platform/unit/platform_unit_test.cpp
+++ b/libs/platform/unit/platform_unit_test.cpp
@@ -450,9 +450,6 @@ TEST_CASE("epoch_test_stale_items", "[platform]")
         return;
     }
 
-    KIRQL old_irql;
-    KeRaiseIrql(DISPATCH_LEVEL, &old_irql);
-
     size_t const test_iterations = 100;
     for (size_t test_iteration = 0; test_iteration < test_iterations; test_iteration++) {
 
@@ -491,8 +488,6 @@ TEST_CASE("epoch_test_stale_items", "[platform]")
         REQUIRE(ebpf_epoch_is_free_list_empty(0));
         REQUIRE(ebpf_epoch_is_free_list_empty(1));
     }
-
-    KeLowerIrql(old_irql);
 }
 
 static auto provider_function = []() { return EBPF_SUCCESS; };

--- a/libs/platform/user/ebpf_platform_user.cpp
+++ b/libs/platform/user/ebpf_platform_user.cpp
@@ -24,29 +24,6 @@ bool _ebpf_platform_code_integrity_enabled = false;
 
 extern "C" size_t ebpf_fuzzing_memory_limit = MAXSIZE_T;
 
-static bool _usersim_platform_initiated = false;
-
-_Must_inspect_result_ ebpf_result_t
-ebpf_platform_initiate()
-{
-    ebpf_initialize_cpu_count();
-    if (!NT_SUCCESS(usersim_platform_initiate())) {
-        return EBPF_NO_MEMORY;
-    }
-    _usersim_platform_initiated = true;
-    return EBPF_SUCCESS;
-}
-
-void
-ebpf_platform_terminate()
-{
-    if (_usersim_platform_initiated) {
-        KeFlushQueuedDpcs();
-        usersim_platform_terminate();
-        _usersim_platform_initiated = false;
-    }
-}
-
 _Must_inspect_result_ ebpf_result_t
 ebpf_get_code_integrity_state(_Out_ ebpf_code_integrity_state_t* state)
 {

--- a/scripts/deploy-ebpf.ps1.in
+++ b/scripts/deploy-ebpf.ps1.in
@@ -7,6 +7,8 @@
 $source_directory="."
 
 # The following files should be installed on all platforms.
+# TODO(#2677): export_program_info.exe temporarily requires usersim.dll,
+# usersim.dll should get moved down to the test files list.
 [System.Collections.ArrayList]$built_runtime_files=@(
     "bpftool.exe",
     "bpftool.pdb",
@@ -24,7 +26,9 @@ $source_directory="."
     "NetEbpfExt.sys",
     "NetEbpfExt.pdb",
     "net-ebpf-ext.guid",
-    "ucrtbased.dll")
+    "ucrtbased.dll",
+    "usersim.dll",
+    "usersim.pdb")
 
 [System.Collections.ArrayList]$built_runtime_jit_files=@(
     "ebpfsvc.exe",

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -401,6 +401,7 @@ droppacket_test(ebpf_execution_type_t execution_type)
     bpf_link_ptr link;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -517,6 +518,7 @@ divide_by_zero_test_um(ebpf_execution_type_t execution_type)
     bpf_link_ptr link;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -559,6 +561,7 @@ bad_map_name_um(ebpf_execution_type_t execution_type)
     fd_t program_fd;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -690,6 +693,7 @@ bindmonitor_test(ebpf_execution_type_t execution_type)
     REQUIRE(audit_map_fd > 0);
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
 
     uint32_t ifindex = 0;
     REQUIRE(hook.attach_link(program_fd, &ifindex, sizeof(ifindex), &link) == EBPF_SUCCESS);
@@ -814,6 +818,7 @@ bindmonitor_tailcall_test(ebpf_execution_type_t execution_type)
     REQUIRE(outer_idx_map_fd > 0);
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
 
     uint32_t ifindex = 0;
     REQUIRE(hook.attach_link(program_fd, &ifindex, sizeof(ifindex), &link) == EBPF_SUCCESS);
@@ -901,6 +906,7 @@ bindmonitor_ring_buffer_test(ebpf_execution_type_t execution_type)
     REQUIRE(process_map_fd > 0);
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     REQUIRE(hook.attach_link(program_fd, nullptr, 0, &link) == EBPF_SUCCESS);
 
     // Create a list of fake app IDs and set it to event context.
@@ -934,6 +940,7 @@ _utility_helper_functions_test(ebpf_execution_type_t execution_type)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
     uint32_t ifindex = 0;
@@ -967,6 +974,7 @@ map_test(ebpf_execution_type_t execution_type)
     bpf_link_ptr link;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -1119,6 +1127,7 @@ _cgroup_load_test(
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(program_type, attach_type);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t program_info;
     REQUIRE(program_info.initialize(program_type) == EBPF_SUCCESS);
     bpf_object_ptr unique_object;
@@ -1272,6 +1281,7 @@ TEST_CASE("map_pinning_test", "[end_to_end]")
     REQUIRE(result == 0);
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
 
     std::string process_maps_name = "bindmonitor::process_map";
     std::string limit_maps_name = "bindmonitor::limits_map";
@@ -1419,6 +1429,7 @@ TEST_CASE("implicit_detach", "[end_to_end]")
     bpf_link* link = nullptr;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -1471,6 +1482,7 @@ TEST_CASE("implicit_detach_2", "[end_to_end]")
     bpf_link* link = nullptr;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -1524,6 +1536,7 @@ TEST_CASE("explicit_detach", "[end_to_end]")
     const char* error_message = nullptr;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -1572,6 +1585,7 @@ TEST_CASE("implicit_explicit_detach", "[end_to_end]")
     const char* error_message = nullptr;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -1676,6 +1690,7 @@ _xdp_reflect_packet_test(ebpf_execution_type_t execution_type, ADDRESS_FAMILY ad
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
     uint32_t ifindex = 0;
@@ -1720,6 +1735,7 @@ _xdp_encap_reflect_packet_test(ebpf_execution_type_t execution_type, ADDRESS_FAM
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
     uint32_t ifindex = 0;
@@ -1774,6 +1790,7 @@ TEST_CASE("printk", "[end_to_end]")
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t bind_program_info;
     REQUIRE(bind_program_info.initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
     uint32_t ifindex = 0;
@@ -1847,6 +1864,7 @@ _xdp_decapsulate_permit_packet_test(ebpf_execution_type_t execution_type, ADDRES
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
     uint32_t ifindex = 0;
@@ -1910,6 +1928,7 @@ TEST_CASE("link_tests", "[end_to_end]")
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
     uint32_t ifindex = 0;
@@ -1942,6 +1961,7 @@ _map_reuse_test(ebpf_execution_type_t execution_type)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -2024,6 +2044,7 @@ _wrong_map_reuse_test(ebpf_execution_type_t execution_type)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -2075,6 +2096,7 @@ _auto_pinned_maps_test(ebpf_execution_type_t execution_type)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -2132,6 +2154,7 @@ TEST_CASE("auto_pinned_maps_custom_path", "[end_to_end]")
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -2206,6 +2229,7 @@ _map_reuse_invalid_test(ebpf_execution_type_t execution_type)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -2249,6 +2273,7 @@ _map_reuse_2_test(ebpf_execution_type_t execution_type)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -2323,6 +2348,7 @@ _map_reuse_3_test(ebpf_execution_type_t execution_type)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -2589,6 +2615,7 @@ TEST_CASE("load_native_program_negative5", "[end_to_end]")
     fd_t program_fd;
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -2975,6 +3002,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
     // Load the program with the extension loaded.
     {
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
         program_info_provider_t xdp_program_info;
         REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -3005,6 +3033,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
     // Reload the extension provider with unchanged data.
     {
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
         program_info_provider_t xdp_program_info;
         REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -3028,6 +3057,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
             TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(changed_program_data), &changed_program_data};
 
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
         program_info_provider_t xdp_program_info;
         REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP, &changed_provider_data) == EBPF_SUCCESS);
 
@@ -3053,6 +3083,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
             TEST_NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(changed_program_data), &changed_program_data};
 
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
         program_info_provider_t xdp_program_info;
         REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP, &changed_provider_data) == EBPF_SUCCESS);
 
@@ -3112,6 +3143,7 @@ TEST_CASE("close_unload_test", "[close_cleanup]")
     REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     uint32_t ifindex = 0;
     REQUIRE(hook.attach_link(program_fd, &ifindex, sizeof(ifindex), &link) == EBPF_SUCCESS);
 
@@ -3203,6 +3235,7 @@ TEST_CASE("multiple_map_insert", "[close_cleanup]")
     REQUIRE(bpf_map_update_elem(prog_map_fd, &index, &callee1_fd, 0) == 0);
 
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     uint32_t ifindex = 0;
     REQUIRE(hook.attach_link(program_fd, &ifindex, sizeof(ifindex), &link) == EBPF_SUCCESS);
 

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -751,15 +751,18 @@ _test_helper_libbpf::initialize()
     xdp_program_info = new program_info_provider_t();
     REQUIRE(xdp_program_info->initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
     xdp_hook = new single_instance_hook_t(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(xdp_hook->initialize() == EBPF_SUCCESS);
 
     bind_program_info = new program_info_provider_t();
     REQUIRE(bind_program_info->initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
     bind_hook = new single_instance_hook_t(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(bind_hook->initialize() == EBPF_SUCCESS);
 
     cgroup_sock_addr_program_info = new program_info_provider_t();
     REQUIRE(cgroup_sock_addr_program_info->initialize(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR) == EBPF_SUCCESS);
     cgroup_inet4_connect_hook =
         new single_instance_hook_t(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR, EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT);
+    REQUIRE(cgroup_inet4_connect_hook->initialize() == EBPF_SUCCESS);
 
     test_helper_end_to_end.initialize();
 }

--- a/tests/netebpfext_unit/netebpf_ext_helper.cpp
+++ b/tests/netebpfext_unit/netebpf_ext_helper.cpp
@@ -91,7 +91,7 @@ _netebpf_ext_helper::_netebpf_ext_helper(
         nmr_hook_client_handle = std::make_unique<nmr_client_registration_t>(&hook_client, client_context);
     }
 
-    _fwp_engine::get()->set_sublayer_guids(
+    usersim_fwp_set_sublayer_guids(
         EBPF_DEFAULT_SUBLAYER, EBPF_HOOK_CGROUP_CONNECT_V4_SUBLAYER, EBPF_HOOK_CGROUP_CONNECT_V6_SUBLAYER);
 }
 

--- a/tests/netebpfext_unit/netebpf_ext_helper.h
+++ b/tests/netebpfext_unit/netebpf_ext_helper.h
@@ -13,11 +13,11 @@
     }
 #endif
 
-#include "..\..\external\usersim\src\fwp_um.h"
 #include "ebpf_extension_uuids.h"
 #include "ebpf_registry_helper.h"
 #include "net_ebpf_ext.h"
 #include "net_ebpf_ext_tracelog.h"
+#include "usersim\fwp_test.h"
 
 #include <iostream>
 #include <vector>
@@ -51,50 +51,41 @@ typedef class _netebpf_ext_helper
     FWP_ACTION_TYPE
     classify_test_packet(_In_ const GUID* layer_guid, NET_IFINDEX if_index)
     {
-        return _fwp_engine::get()->classify_test_packet(layer_guid, if_index);
+        return usersim_fwp_classify_packet(layer_guid, if_index);
     }
 
     FWP_ACTION_TYPE
-    test_bind_ipv4(_In_ fwp_classify_parameters_t* parameters)
-    {
-        return _fwp_engine::get()->test_bind_ipv4(parameters);
-    }
+    test_bind_ipv4(_In_ fwp_classify_parameters_t* parameters) { return usersim_fwp_bind_ipv4(parameters); }
 
     FWP_ACTION_TYPE
     test_cgroup_inet4_recv_accept(_In_ fwp_classify_parameters_t* parameters)
     {
-        return _fwp_engine::get()->test_cgroup_inet4_recv_accept(parameters);
+        return usersim_fwp_cgroup_inet4_recv_accept(parameters);
     }
 
     FWP_ACTION_TYPE
     test_cgroup_inet6_recv_accept(_In_ fwp_classify_parameters_t* parameters)
     {
-        return _fwp_engine::get()->test_cgroup_inet6_recv_accept(parameters);
+        return usersim_fwp_cgroup_inet6_recv_accept(parameters);
     }
 
     FWP_ACTION_TYPE
     test_cgroup_inet4_connect(_In_ fwp_classify_parameters_t* parameters)
     {
-        return _fwp_engine::get()->test_cgroup_inet4_connect(parameters);
+        return usersim_fwp_cgroup_inet4_connect(parameters);
     }
 
     FWP_ACTION_TYPE
     test_cgroup_inet6_connect(_In_ fwp_classify_parameters_t* parameters)
     {
-        return _fwp_engine::get()->test_cgroup_inet6_connect(parameters);
+        return usersim_fwp_cgroup_inet6_connect(parameters);
     }
 
     FWP_ACTION_TYPE
-    test_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters)
-    {
-        return _fwp_engine::get()->test_sock_ops_v4(parameters);
-    }
+    test_sock_ops_v4(_In_ fwp_classify_parameters_t* parameters) { return usersim_fwp_sock_ops_v4(parameters); }
 
     FWP_ACTION_TYPE
-    test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters)
-    {
-        return _fwp_engine::get()->test_sock_ops_v6(parameters);
-    }
+    test_sock_ops_v6(_In_ fwp_classify_parameters_t* parameters) { return usersim_fwp_sock_ops_v6(parameters); }
 
   private:
     bool trace_initiated = false;

--- a/tests/performance/performance_measure.h
+++ b/tests/performance/performance_measure.h
@@ -38,13 +38,8 @@ template <typename T> class _performance_measure
           preemptible(preemptible), test_name(test_name)
     {
         start_event = CreateEvent(nullptr, true, false, nullptr);
-        KeRaiseIrql(preemptible ? PASSIVE_LEVEL : DISPATCH_LEVEL, &old_irql);
     }
-    ~_performance_measure()
-    {
-        KeLowerIrql(old_irql);
-        CloseHandle(start_event);
-    }
+    ~_performance_measure() { CloseHandle(start_event); }
 
     /**
      * @brief Perform the measurement.
@@ -64,6 +59,10 @@ template <typename T> class _performance_measure
                 SetThreadAffinityMask(GetCurrentThread(), thread_mask);
                 ebpf_interlocked_increment_int32(&ready_count);
                 WaitForSingleObject(start_event, INFINITE);
+                KIRQL old_irql = PASSIVE_LEVEL;
+                if (!preemptible) {
+                    old_irql = KeRaiseIrqlToDpcLevel();
+                }
                 QueryPerformanceCounter(&this->counters[local_cpu_id].first);
                 for (size_t k = 0; k < iterations; k++) {
                     if constexpr (std::is_same<T, void(__cdecl*)(uint32_t)>::value) {
@@ -73,6 +72,9 @@ template <typename T> class _performance_measure
                     }
                 }
                 QueryPerformanceCounter(&this->counters[local_cpu_id].second);
+                if (!preemptible) {
+                    KeLowerIrql(old_irql);
+                }
             }));
         }
         // Wait for threads to spin up.
@@ -110,5 +112,4 @@ template <typename T> class _performance_measure
     HANDLE start_event;
     bool preemptible;
     const char* test_name;
-    KIRQL old_irql;
 };

--- a/tests/stress/um/stress_tests_um.cpp
+++ b/tests/stress/um/stress_tests_um.cpp
@@ -107,6 +107,7 @@ _bindmonitor_tailcall_stress_thread_function(const stress_test_thread_context& t
 
         // Attach and detach link.
         single_instance_hook_t hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+        REQUIRE(hook.initialize() == EBPF_SUCCESS);
         uint32_t ifindex = test_params.thread_index;
         bpf_link* link = nullptr;
         REQUIRE(hook.attach_link(local_program_object_info.fd, &ifindex, sizeof(ifindex), &link) == EBPF_SUCCESS);
@@ -128,6 +129,7 @@ static void
 _droppacket_stress_thread_function(const stress_test_thread_context& test_params)
 {
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     UNREFERENCED_PARAMETER(test_params);
     uint32_t count{0};
     using sc = std::chrono::steady_clock;

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1239,6 +1239,7 @@ _ebpf_test_tail_call(_In_z_ const char* filename, uint32_t expected_result)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -1353,6 +1354,7 @@ _multiple_tail_calls_test(ebpf_execution_type_t execution_type)
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -1671,6 +1673,7 @@ _array_of_maps_test(ebpf_execution_type_t execution_type, _In_ PCSTR dll_name, _
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
     single_instance_hook_t hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(hook.initialize() == EBPF_SUCCESS);
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
 
@@ -1883,7 +1886,9 @@ TEST_CASE("enumerate link IDs", "[libbpf]")
     program_info_provider_t bind_program_info;
     REQUIRE(bind_program_info.initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
     single_instance_hook_t xdp_hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(xdp_hook.initialize() == EBPF_SUCCESS);
     single_instance_hook_t bind_hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(bind_hook.initialize() == EBPF_SUCCESS);
 
     // Verify the enumeration is empty.
     uint32_t id1;
@@ -1928,7 +1933,9 @@ TEST_CASE("enumerate link IDs with bpf", "[libbpf]")
     program_info_provider_t bind_program_info;
     REQUIRE(bind_program_info.initialize(EBPF_PROGRAM_TYPE_BIND) == EBPF_SUCCESS);
     single_instance_hook_t xdp_hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(xdp_hook.initialize() == EBPF_SUCCESS);
     single_instance_hook_t bind_hook(EBPF_PROGRAM_TYPE_BIND, EBPF_ATTACH_TYPE_BIND);
+    REQUIRE(bind_hook.initialize() == EBPF_SUCCESS);
 
     // Verify the enumeration is empty.
     union bpf_attr attr;
@@ -2121,6 +2128,7 @@ TEST_CASE("bpf_obj_get_info_by_fd", "[libbpf]")
     program_info_provider_t xdp_program_info;
     REQUIRE(xdp_program_info.initialize(EBPF_PROGRAM_TYPE_XDP) == EBPF_SUCCESS);
     single_instance_hook_t xdp_hook(EBPF_PROGRAM_TYPE_XDP, EBPF_ATTACH_TYPE_XDP);
+    REQUIRE(xdp_hook.initialize() == EBPF_SUCCESS);
     uint32_t ifindex = 0;
     program_load_attach_helper_t xdp_helper;
     xdp_helper.initialize(
@@ -2229,6 +2237,7 @@ TEST_CASE("bpf_obj_get_info_by_fd_2", "[libbpf]")
     program_info_provider_t sock_addr_program_info;
     REQUIRE(sock_addr_program_info.initialize(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR) == EBPF_SUCCESS);
     single_instance_hook_t v4_connect_hook(EBPF_PROGRAM_TYPE_CGROUP_SOCK_ADDR, EBPF_ATTACH_TYPE_CGROUP_INET4_CONNECT);
+    REQUIRE(v4_connect_hook.initialize() == EBPF_SUCCESS);
 
     program_load_attach_helper_t sock_addr_helper;
     sock_addr_helper.initialize(

--- a/tools/export_program_info/CMakeLists.txt
+++ b/tools/export_program_info/CMakeLists.txt
@@ -43,6 +43,10 @@ set(export_program_info_log "${CMAKE_CURRENT_BINARY_DIR}/log.txt")
 
 add_custom_command(TARGET "export_program_info"
 POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy
+          ${CMAKE_BINARY_DIR}/x64/bin/$<CONFIG>/usersim.dll
+          ${CMAKE_BINARY_DIR}/x64/$<CONFIG>
+  COMMAND "$<TARGET_FILE:export_program_info>" --clear >> "${export_program_info_log}"
   COMMAND "$<TARGET_FILE:export_program_info>" >> "${export_program_info_log}"
   WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
   COMMENT "ebpf-for-windows - Running: export_program_info"

--- a/tools/export_program_info/export_program_info.vcxproj
+++ b/tools/export_program_info/export_program_info.vcxproj
@@ -142,6 +142,7 @@ $(OutputPath)export_program_info.exe</Command>
     </Link>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
+copy ..\Debug\usersim.dll .
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe</Command>
     </CustomBuildStep>
@@ -165,6 +166,7 @@ $(OutputPath)export_program_info.exe</Command>
     </Link>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
+copy ..\Debug\usersim.dll .
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe</Command>
     </CustomBuildStep>
@@ -190,6 +192,7 @@ $(OutputPath)export_program_info.exe</Command>
     </Link>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
+$(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe</Command>
     </CustomBuildStep>
     <CustomBuildStep>
@@ -214,6 +217,8 @@ $(OutputPath)export_program_info.exe</Command>
     </Link>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
+copy ..\Release\usersim.dll .
+$(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe</Command>
     </CustomBuildStep>
     <CustomBuildStep>

--- a/tools/export_program_info/export_program_info.vcxproj
+++ b/tools/export_program_info/export_program_info.vcxproj
@@ -143,6 +143,7 @@ $(OutputPath)export_program_info.exe</Command>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
 copy ..\Debug\usersim.dll .
+copy ..\Debug\usersim.pdb .
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe</Command>
     </CustomBuildStep>
@@ -167,6 +168,7 @@ $(OutputPath)export_program_info.exe</Command>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
 copy ..\Debug\usersim.dll .
+copy ..\Debug\usersim.pdb .
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe</Command>
     </CustomBuildStep>
@@ -218,6 +220,7 @@ $(OutputPath)export_program_info.exe</Command>
     <CustomBuildStep>
       <Command>cd /d $(OutputPath)
 copy ..\Release\usersim.dll .
+copy ..\Release\usersim.pdb .
 $(OutputPath)export_program_info.exe --clear
 $(OutputPath)export_program_info.exe</Command>
     </CustomBuildStep>

--- a/tools/nuget/ebpf-for-windows.nuspec.in
+++ b/tools/nuget/ebpf-for-windows.nuspec.in
@@ -28,6 +28,9 @@
 		<file src="ebpfapi.dll" target="build\native\bin"/>
 		<file src="ebpfapi.pdb" target="build\native\bin"/>
 		<file src="ebpfapi.lib" target="build\native\lib"/>
+		<!-- TODO(#2677): export_program_info.exe temporarily requires usersim.dll. -->
+		<file src="usersim.dll" target="build\native\bin"/>
+		<file src="usersim.pdb" target="build\native\bin"/>
 		<file src="..\..\include\**\*.*" target="build\native\include" />
 
 		<!--Cherry-pick files from external projects-->


### PR DESCRIPTION
## Description

* Convert usersim to a DLL
* Also make the cmake build clear program info state like the VS build does. (PR #1192 updated the vcxproj file but not the corresponding CMakeLists.txt file for export_program_info.)
* Update platform_unit_test.cpp to fix deadlock in epoch_test_stale_items hit by latest usersim fixes.  The main test thread can't run at `DISPATCH_LEVEL` or it can block execution of one of the two test threads if they are affinitized to the same processor as the main test thread.
* Update performance test to fix the same issue.
* Update `single_instance_hook_t` test class to not throw exceptions in unit tests, but rather allow using `REQUIRE()` so catch2 can correctly deal with fault injection

Fixes #2586 

## Testing

Covered by existing tests

## Documentation

No impact
