### PR TITLE
Uniform trace logging

### DIFF
--- a/libs/platform/ebpf_tracelog.h
+++ b/libs/platform/ebpf_tracelog.h
@@ -126,6 +126,34 @@ extern "C"
         return local_result;                       \
     } while (false);
 
+#define EBPF_RETURN_VOID() \
+    do {                   \
+        EBPF_LOG_EXIT();   \
+        return;            \
+    } while (false);
+
+#define EBPF_RETURN_RESULT(status)                 \
+    do {                                           \
+        ebpf_result_t local_result = (status);     \
+        if (local_result == EBPF_SUCCESS) {        \
+            EBPF_LOG_FUNCTION_SUCCESS();           \
+        } else {                                   \
+            EBPF_LOG_FUNCTION_ERROR(local_result); \
+        }                                          \
+        return local_result;                       \
+    } while (false);
+
+#define EBPF_RETURN_NTSTATUS(status)               \
+    do {                                           \
+        NTSTATUS local_status = (status);          \
+        if (NT_SUCCESS(local_status)) {            \
+            EBPF_LOG_FUNCTION_SUCCESS();           \
+        } else {                                   \
+            EBPF_LOG_FUNCTION_ERROR(local_status); \
+        }                                          \
+        return local_status;                       \
+    } while (false);
+
 #define EBPF_RETURN_POINTER(type, pointer)                                                                         \
     do {                                                                                                           \
         type local_result = (type)(pointer);                                                                       \
@@ -377,38 +405,6 @@ extern "C"
             TraceLoggingString(#api, "Api"),                                                                         \
             TraceLoggingWinError(last_error));                                                                       \
     }
-
-    /////////////////////////////////////////////////////////
-    // Macros built on top of the above primary trace macros.
-    /////////////////////////////////////////////////////////
-
-#define EBPF_RETURN_VOID() \
-    do {                   \
-        EBPF_LOG_EXIT();   \
-        return;            \
-    } while (false);
-
-#define EBPF_RETURN_RESULT(status)                 \
-    do {                                           \
-        ebpf_result_t local_result = (status);     \
-        if (local_result == EBPF_SUCCESS) {        \
-            EBPF_LOG_FUNCTION_SUCCESS();           \
-        } else {                                   \
-            EBPF_LOG_FUNCTION_ERROR(local_result); \
-        }                                          \
-        return local_result;                       \
-    } while (false);
-
-#define EBPF_RETURN_NTSTATUS(status)               \
-    do {                                           \
-        NTSTATUS local_status = (status);          \
-        if (NT_SUCCESS(local_status)) {            \
-            EBPF_LOG_FUNCTION_SUCCESS();           \
-        } else {                                   \
-            EBPF_LOG_FUNCTION_ERROR(local_status); \
-        }                                          \
-        return local_status;                       \
-    } while (false);
 
 #ifdef __cplusplus
 }

--- a/libs/platform/ebpf_tracelog.h
+++ b/libs/platform/ebpf_tracelog.h
@@ -327,57 +327,55 @@ extern "C"
             TraceLoggingUInt32((enum), (#enum)));                                    \
     }
 
-#define EBPF_LOG_WIN32_STRING_API_FAILURE(keyword, message, api)                                                       \
-    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_ERROR)) { \
-        unsigned long last_error = GetLastError();                                                                     \
-        TraceLoggingWrite(                                                                                             \
-            ebpf_tracelog_provider,                                                                                    \
-            EBPF_TRACELOG_EVENT_API_ERROR,                                                                             \
-            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                              \
-            TraceLoggingKeyword((keyword)),                                                                            \
-            TraceLoggingString(message, "Message"),                                                                    \
-            TraceLoggingString(#api, "Api"),                                                                           \
-            TraceLoggingWinError(last_error));                                                                         \
+#define EBPF_LOG_WIN32_STRING_API_FAILURE(keyword, message, api)                                                     \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API)) { \
+        unsigned long last_error = GetLastError();                                                                   \
+        TraceLoggingWrite(                                                                                           \
+            ebpf_tracelog_provider,                                                                                  \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                                           \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                            \
+            TraceLoggingKeyword((keyword)),                                                                          \
+            TraceLoggingString(message, "Message"),                                                                  \
+            TraceLoggingString(#api, "Api"),                                                                         \
+            TraceLoggingWinError(last_error));                                                                       \
     }
 
-#define EBPF_LOG_WIN32_WSTRING_API_FAILURE(keyword, wstring, api)                                                      \
-    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_ERROR)) { \
-        unsigned long last_error = GetLastError();                                                                     \
-        TraceLoggingWrite(                                                                                             \
-            ebpf_tracelog_provider,                                                                                    \
-            EBPF_TRACELOG_EVENT_API_ERROR,                                                                             \
-            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                              \
-            TraceLoggingKeyword((keyword)),                                                                            \
-            TraceLoggingWideString(wstring, "Message"),                                                                \
-            TraceLoggingString(#api, "Api"),                                                                           \
-            TraceLoggingWinError(last_error));                                                                         \
+#define EBPF_LOG_WIN32_WSTRING_API_FAILURE(keyword, wstring, api)                                                    \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API)) { \
+        unsigned long last_error = GetLastError();                                                                   \
+        TraceLoggingWrite(                                                                                           \
+            ebpf_tracelog_provider,                                                                                  \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                                           \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                            \
+            TraceLoggingKeyword((keyword)),                                                                          \
+            TraceLoggingWideString(wstring, "Message"),                                                              \
+            TraceLoggingString(#api, "Api"),                                                                         \
+            TraceLoggingWinError(last_error));                                                                       \
     }
 
-#define EBPF_LOG_WIN32_GUID_API_FAILURE(keyword, guid, api)                                                            \
-    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_ERROR)) { \
-        unsigned long last_error = GetLastError();                                                                     \
-        TraceLoggingWrite(                                                                                             \
-            ebpf_tracelog_provider,                                                                                    \
-            EBPF_TRACELOG_EVENT_API_ERROR,                                                                             \
-            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                              \
-            TraceLoggingKeyword((keyword)),                                                                            \
-            TraceLoggingGuid((*guid), (#guid)),                                                                        \
-            TraceLoggingString(#api, "Api"),                                                                           \
-            TraceLoggingWinError(last_error));                                                                         \
-    }                                                                                                                  \
-    while (false)                                                                                                      \
-        ;
+#define EBPF_LOG_WIN32_GUID_API_FAILURE(keyword, guid, api)                                                          \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API)) { \
+        unsigned long last_error = GetLastError();                                                                   \
+        TraceLoggingWrite(                                                                                           \
+            ebpf_tracelog_provider,                                                                                  \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                                           \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                            \
+            TraceLoggingKeyword((keyword)),                                                                          \
+            TraceLoggingGuid((*guid), (#guid)),                                                                      \
+            TraceLoggingString(#api, "Api"),                                                                         \
+            TraceLoggingWinError(last_error));                                                                       \
+    }
 
-#define EBPF_LOG_WIN32_API_FAILURE(keyword, api)                                                                       \
-    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_ERROR)) { \
-        unsigned long last_error = GetLastError();                                                                     \
-        TraceLoggingWrite(                                                                                             \
-            ebpf_tracelog_provider,                                                                                    \
-            EBPF_TRACELOG_EVENT_API_ERROR,                                                                             \
-            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                              \
-            TraceLoggingKeyword((keyword)),                                                                            \
-            TraceLoggingString(#api, "Api"),                                                                           \
-            TraceLoggingWinError(last_error));                                                                         \
+#define EBPF_LOG_WIN32_API_FAILURE(keyword, api)                                                                     \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API)) { \
+        unsigned long last_error = GetLastError();                                                                   \
+        TraceLoggingWrite(                                                                                           \
+            ebpf_tracelog_provider,                                                                                  \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                                           \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                            \
+            TraceLoggingKeyword((keyword)),                                                                          \
+            TraceLoggingString(#api, "Api"),                                                                         \
+            TraceLoggingWinError(last_error));                                                                       \
     }
 
     /////////////////////////////////////////////////////////

--- a/libs/platform/ebpf_tracelog.h
+++ b/libs/platform/ebpf_tracelog.h
@@ -154,52 +154,52 @@ extern "C"
         return local_status;                       \
     } while (false);
 
-#define EBPF_RETURN_POINTER(type, pointer)                                                                         \
-    do {                                                                                                           \
-        type local_result = (type)(pointer);                                                                       \
-        if (TraceLoggingProviderEnabled(                                                                           \
-                ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT)) { \
-            TraceLoggingWrite(                                                                                     \
-                ebpf_tracelog_provider,                                                                            \
-                EBPF_TRACELOG_EVENT_RETURN,                                                                        \
-                TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                                                         \
-                TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_BASE),                                                   \
-                TraceLoggingString(__FUNCTION__ " returned"),                                                      \
-                TraceLoggingPointer(local_result, #pointer));                                                      \
-        }                                                                                                          \
-        return local_result;                                                                                       \
+#define EBPF_RETURN_POINTER(type, pointer)                                                          \
+    do {                                                                                            \
+        type local_result = (type)(pointer);                                                        \
+        if (TraceLoggingProviderEnabled(                                                            \
+                ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_BASE)) { \
+            TraceLoggingWrite(                                                                      \
+                ebpf_tracelog_provider,                                                             \
+                EBPF_TRACELOG_EVENT_RETURN,                                                         \
+                TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                                          \
+                TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_BASE),                                    \
+                TraceLoggingString(__FUNCTION__ " returned"),                                       \
+                TraceLoggingPointer(local_result, #pointer));                                       \
+        }                                                                                           \
+        return local_result;                                                                        \
     } while (false);
 
-#define EBPF_RETURN_BOOL(flag)                                                                                     \
-    do {                                                                                                           \
-        bool local_result = (flag);                                                                                \
-        if (TraceLoggingProviderEnabled(                                                                           \
-                ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT)) { \
-            TraceLoggingWrite(                                                                                     \
-                ebpf_tracelog_provider,                                                                            \
-                EBPF_TRACELOG_EVENT_RETURN,                                                                        \
-                TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                                                         \
-                TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_BASE),                                                   \
-                TraceLoggingString(__FUNCTION__ " returned"),                                                      \
-                TraceLoggingBool(!!local_result, #flag));                                                          \
-        }                                                                                                          \
-        return local_result;                                                                                       \
+#define EBPF_RETURN_BOOL(flag)                                                                      \
+    do {                                                                                            \
+        bool local_result = (flag);                                                                 \
+        if (TraceLoggingProviderEnabled(                                                            \
+                ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_BASE)) { \
+            TraceLoggingWrite(                                                                      \
+                ebpf_tracelog_provider,                                                             \
+                EBPF_TRACELOG_EVENT_RETURN,                                                         \
+                TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                                          \
+                TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_BASE),                                    \
+                TraceLoggingString(__FUNCTION__ " returned"),                                       \
+                TraceLoggingBool(!!local_result, #flag));                                           \
+        }                                                                                           \
+        return local_result;                                                                        \
     } while (false);
 
-#define EBPF_RETURN_FD(fd)                                                                                         \
-    do {                                                                                                           \
-        fd_t local_fd = (fd);                                                                                      \
-        if (TraceLoggingProviderEnabled(                                                                           \
-                ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_FUNCTION_ENTRY_EXIT)) { \
-            TraceLoggingWrite(                                                                                     \
-                ebpf_tracelog_provider,                                                                            \
-                EBPF_TRACELOG_EVENT_RETURN,                                                                        \
-                TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                                                         \
-                TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_BASE),                                                   \
-                TraceLoggingString(__FUNCTION__ " returned"),                                                      \
-                TraceLoggingInt32(local_fd, #fd));                                                                 \
-        }                                                                                                          \
-        return local_fd;                                                                                           \
+#define EBPF_RETURN_FD(fd)                                                                          \
+    do {                                                                                            \
+        fd_t local_fd = (fd);                                                                       \
+        if (TraceLoggingProviderEnabled(                                                            \
+                ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_BASE)) { \
+            TraceLoggingWrite(                                                                      \
+                ebpf_tracelog_provider,                                                             \
+                EBPF_TRACELOG_EVENT_RETURN,                                                         \
+                TraceLoggingLevel(WINEVENT_LEVEL_VERBOSE),                                          \
+                TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_BASE),                                    \
+                TraceLoggingString(__FUNCTION__ " returned"),                                       \
+                TraceLoggingInt32(local_fd, #fd));                                                  \
+        }                                                                                           \
+        return local_fd;                                                                            \
     } while (false);
 
     void
@@ -355,55 +355,55 @@ extern "C"
             TraceLoggingUInt32((enum), (#enum)));                                    \
     }
 
-#define EBPF_LOG_WIN32_STRING_API_FAILURE(keyword, message, api)                                                     \
-    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API)) { \
-        unsigned long last_error = GetLastError();                                                                   \
-        TraceLoggingWrite(                                                                                           \
-            ebpf_tracelog_provider,                                                                                  \
-            EBPF_TRACELOG_EVENT_API_ERROR,                                                                           \
-            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                            \
-            TraceLoggingKeyword((keyword)),                                                                          \
-            TraceLoggingString(message, "Message"),                                                                  \
-            TraceLoggingString(#api, "Api"),                                                                         \
-            TraceLoggingWinError(last_error));                                                                       \
+#define EBPF_LOG_WIN32_STRING_API_FAILURE(keyword, message, api)                                   \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, keyword)) { \
+        unsigned long last_error = GetLastError();                                                 \
+        TraceLoggingWrite(                                                                         \
+            ebpf_tracelog_provider,                                                                \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                         \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                          \
+            TraceLoggingKeyword((keyword)),                                                        \
+            TraceLoggingString(message, "Message"),                                                \
+            TraceLoggingString(#api, "Api"),                                                       \
+            TraceLoggingWinError(last_error));                                                     \
     }
 
-#define EBPF_LOG_WIN32_WSTRING_API_FAILURE(keyword, wstring, api)                                                    \
-    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API)) { \
-        unsigned long last_error = GetLastError();                                                                   \
-        TraceLoggingWrite(                                                                                           \
-            ebpf_tracelog_provider,                                                                                  \
-            EBPF_TRACELOG_EVENT_API_ERROR,                                                                           \
-            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                            \
-            TraceLoggingKeyword((keyword)),                                                                          \
-            TraceLoggingWideString(wstring, "Message"),                                                              \
-            TraceLoggingString(#api, "Api"),                                                                         \
-            TraceLoggingWinError(last_error));                                                                       \
+#define EBPF_LOG_WIN32_WSTRING_API_FAILURE(keyword, wstring, api)                                  \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, keyword)) { \
+        unsigned long last_error = GetLastError();                                                 \
+        TraceLoggingWrite(                                                                         \
+            ebpf_tracelog_provider,                                                                \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                         \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                          \
+            TraceLoggingKeyword((keyword)),                                                        \
+            TraceLoggingWideString(wstring, "Message"),                                            \
+            TraceLoggingString(#api, "Api"),                                                       \
+            TraceLoggingWinError(last_error));                                                     \
     }
 
-#define EBPF_LOG_WIN32_GUID_API_FAILURE(keyword, guid, api)                                                          \
-    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API)) { \
-        unsigned long last_error = GetLastError();                                                                   \
-        TraceLoggingWrite(                                                                                           \
-            ebpf_tracelog_provider,                                                                                  \
-            EBPF_TRACELOG_EVENT_API_ERROR,                                                                           \
-            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                            \
-            TraceLoggingKeyword((keyword)),                                                                          \
-            TraceLoggingGuid((*guid), (#guid)),                                                                      \
-            TraceLoggingString(#api, "Api"),                                                                         \
-            TraceLoggingWinError(last_error));                                                                       \
+#define EBPF_LOG_WIN32_GUID_API_FAILURE(keyword, guid, api)                                        \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, keyword)) { \
+        unsigned long last_error = GetLastError();                                                 \
+        TraceLoggingWrite(                                                                         \
+            ebpf_tracelog_provider,                                                                \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                         \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                          \
+            TraceLoggingKeyword((keyword)),                                                        \
+            TraceLoggingGuid((*guid), (#guid)),                                                    \
+            TraceLoggingString(#api, "Api"),                                                       \
+            TraceLoggingWinError(last_error));                                                     \
     }
 
-#define EBPF_LOG_WIN32_API_FAILURE(keyword, api)                                                                     \
-    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API)) { \
-        unsigned long last_error = GetLastError();                                                                   \
-        TraceLoggingWrite(                                                                                           \
-            ebpf_tracelog_provider,                                                                                  \
-            EBPF_TRACELOG_EVENT_API_ERROR,                                                                           \
-            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                                            \
-            TraceLoggingKeyword((keyword)),                                                                          \
-            TraceLoggingString(#api, "Api"),                                                                         \
-            TraceLoggingWinError(last_error));                                                                       \
+#define EBPF_LOG_WIN32_API_FAILURE(keyword, api)                                                   \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, keyword)) { \
+        unsigned long last_error = GetLastError();                                                 \
+        TraceLoggingWrite(                                                                         \
+            ebpf_tracelog_provider,                                                                \
+            EBPF_TRACELOG_EVENT_API_ERROR,                                                         \
+            TraceLoggingLevel(EBPF_TRACELOG_LEVEL_ERROR),                                          \
+            TraceLoggingKeyword((keyword)),                                                        \
+            TraceLoggingString(#api, "Api"),                                                       \
+            TraceLoggingWinError(last_error));                                                     \
     }
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fixes #2651

## Description

This PR:

-  Adds checking for the availability of the `TraceLoggingProvider`, where not previously implemented, accounting also for the contextual tracing level and keyword.
- Refactors the macro functions' ordering in the source code.

## Testing

CI/CD, local

## Documentation

n.a.
