### PR TITLE
Reduce reference set from bpf_object__open_file

### DIFF
--- a/include/ebpf_api.h
+++ b/include/ebpf_api.h
@@ -56,7 +56,6 @@ extern "C"
     {
         struct _ebpf_section_info* next;
         _Field_z_ const char* section_name;
-        _Field_z_ const char* program_type_name;
         _Field_z_ const char* program_name;
         ebpf_program_type_t program_type;
         ebpf_attach_type_t expected_attach_type;

--- a/libs/api/Verifier.cpp
+++ b/libs/api/Verifier.cpp
@@ -541,10 +541,6 @@ ebpf_api_elf_enumerate_sections(
             if (info->section_name == nullptr) {
                 throw std::runtime_error("Out of memory");
             }
-            info->program_type_name = ebpf_duplicate_string(raw_program.info.type.name.c_str());
-            if (info->program_type_name == nullptr) {
-                throw std::runtime_error("Out of memory");
-            }
 
             std::vector<uint8_t> raw_data = convert_ebpf_program_to_bytes(raw_program.prog);
             info->raw_data_size = raw_data.size();

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1923,7 +1923,6 @@ _ebpf_free_section_info(_In_ _Frees_ptr_ ebpf_section_info_t* info) noexcept
     }
     ebpf_free((void*)info->program_name);
     ebpf_free((void*)info->section_name);
-    ebpf_free((void*)info->program_type_name);
     ebpf_free(info->raw_data);
     ebpf_free(info);
     EBPF_LOG_EXIT();
@@ -2163,7 +2162,6 @@ _ebpf_pe_add_section(
         return 0;
     }
     ebpf_pe_context_t* pe_context = (ebpf_pe_context_t*)context;
-    const char* program_type_name = nullptr;
 
     // Get ELF section name.
     if (!pe_context->section_names.contains(pe_section_name)) {
@@ -2200,23 +2198,9 @@ _ebpf_pe_add_section(
     info->program_type = pe_context->section_program_types[pe_section_name];
     info->expected_attach_type = pe_context->section_attach_types[pe_section_name];
 
-    program_type_name = ebpf_get_program_type_name(&pe_context->section_program_types[pe_section_name]);
-    if (program_type_name == nullptr) {
-        pe_context->result = EBPF_NO_MEMORY;
-        return_value = 1;
-        goto Exit;
-    }
-
-    info->program_type_name = ebpf_duplicate_string(program_type_name);
-    if (info->program_type_name == nullptr) {
-        pe_context->result = EBPF_NO_MEMORY;
-        return_value = 1;
-        goto Exit;
-    }
-
     info->raw_data_size = section_header.Misc.VirtualSize;
     info->raw_data = (char*)ebpf_allocate(section_header.Misc.VirtualSize);
-    if (info->raw_data == nullptr || info->program_type_name == nullptr || info->section_name == nullptr) {
+    if (info->raw_data == nullptr || info->section_name == nullptr) {
         pe_context->result = EBPF_NO_MEMORY;
         return_value = 1;
         goto Exit;

--- a/libs/ebpfnetsh/elf.cpp
+++ b/libs/ebpfnetsh/elf.cpp
@@ -171,14 +171,17 @@ handle_ebpf_show_sections(
         if (!section.empty() && strcmp(current_section->section_name, section.c_str()) != 0) {
             continue;
         }
+        auto program_type_name = ebpf_get_program_type_name(&current_section->program_type);
+        if (program_type_name == nullptr) {
+            program_type_name = "unspec";
+        }
         if (level == VL_NORMAL) {
             std::cout << std::setw(20) << std::right << current_section->section_name << "  " << std::setw(9)
-                      << current_section->program_type_name << "  " << std::setw(7) << current_section->raw_data_size
-                      << "\n";
+                      << program_type_name << "  " << std::setw(7) << current_section->raw_data_size << "\n";
         } else {
             std::cout << "\n";
             std::cout << "Section      : " << current_section->section_name << "\n";
-            std::cout << "Program Type : " << current_section->program_type_name << "\n";
+            std::cout << "Program Type : " << program_type_name << "\n";
             std::cout << "Size         : " << current_section->raw_data_size << " bytes\n";
             for (auto stat = current_section->stats; stat != nullptr; stat = stat->next) {
                 std::cout << std::setw(13) << std::left << stat->key << ": " << stat->value << "\n";


### PR DESCRIPTION
## Description

The API bpf_object__open_file causes the provider data to be loaded to resolve program type to program type name. This is not needed for the actual load of the file and should be deferred until needed.

## Testing

CI/CD + WPR + WPA reference set analysis

## Documentation

No.
