### PR TITLE
Add GitHub workflow for scheduling releases.

### DIFF
--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -21,7 +21,7 @@ jobs:
           TITLE: "Scheduled eBPF release is due"
           LABELS: 'release'
           BODY: |
-            A new release for eBPF must be issued:
+            This is an automated reminder that a new release for eBPF must be created:
 
             1. Follow instructions in [ReleaseProcess.md](https://github.com/microsoft/ebpf-for-windows/blob/main/docs/ReleaseProcess.md).
             1. Sync the internal `mscodehub` and follow the internal release instructions in `\.internal\docs\ReleaseEbpfRedistProcess.md`.

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -21,7 +21,7 @@ jobs:
           TITLE: "Scheduled eBPF release is due"
           LABELS: 'release'
           BODY: |
-            This is an automated reminder that a new release for eBPF must be created:
+            This is an automated reminder that a new release for eBPF is scheduled to be created:
 
             1. Follow instructions in [ReleaseProcess.md](https://github.com/microsoft/ebpf-for-windows/blob/main/docs/ReleaseProcess.md).
             1. Sync the internal `mscodehub` and follow the internal release instructions in `\.internal\docs\ReleaseEbpfRedistProcess.md`.

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation
 # SPDX-License-Identifier: MIT
 
-# This workflow is triggered on the first day of every month, and creates an issue for realeasing eBPF.
+# This workflow is triggered on the first day of every month, and creates an issue for releasing eBPF for Windows.
 
 name: Release scheduler
 on:

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -1,0 +1,43 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# This workflow is triggered on the first day of every month, and creates an issue for realeasing eBPF.
+
+name: Release scheduler
+on:
+  schedule:
+    - cron: 0 0 1 * *
+
+jobs:
+  create_release_issue:
+    name: Create release task
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create release task
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
+        env:
+          TITLE: "Scheduled eBPF release is due"
+          LABELS: 'release'
+          BODY: |
+            A new release for eBPF must be issued:
+
+            1. Follow instructions in [ReleaseProcess.md](https://github.com/microsoft/ebpf-for-windows/blob/main/docs/ReleaseProcess.md).
+            1. Sync the internal `mscodehub` and follow the internal release instructions in `\.internal\docs\ReleaseEbpfRedistProcess.md`.
+        with:
+          script: |
+            const owner = process.env.GITHUB_REPOSITORY.split('/')[0]
+            const repo = process.env.GITHUB_REPOSITORY.split('/')[1]
+            const body = process.env.BODY;
+            const title = process.env.TITLE;
+            const labels = process.env.LABELS;
+            const label_array = labels ? labels.split(',') : [];
+            console.log(`Creating issue ${title}`);
+            await github.rest.issues.create({
+              owner: owner,
+              repo: repo,
+              title: title,
+              body: body,
+              labels: label_array,
+            });

--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -18,8 +18,8 @@ jobs:
       - name: Create release task
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410
         env:
-          TITLE: "Scheduled eBPF release is due"
-          LABELS: 'release'
+          TITLE: Scheduled eBPF release is due
+          LABELS: release
           BODY: |
             This is an automated reminder that a new release for eBPF is scheduled to be created:
 


### PR DESCRIPTION
Closes #2710

## Description

Adds GitHub workflow for scheduling releases.

## Testing

Local.

## Documentation

n.a.

## Installation

no
