### PR TITLE
Add OneBranch Build Property Flags to Build Template

### DIFF
--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -40,6 +40,9 @@
     <RootNamespace>$(FileName)</RootNamespace>
     <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
     <ProjectName>$(FileName)_km</ProjectName>
+    <!-- Required for Microsoft internal OneBranch builds -->
+    <UseInternalMSUniCrtPackage>true</UseInternalMSUniCrtPackage>    
+    <UndockedKernelModeBuild>true</UndockedKernelModeBuild>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup>

--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -40,7 +40,7 @@
     <RootNamespace>$(FileName)</RootNamespace>
     <WindowsTargetPlatformVersion>$(LatestTargetPlatformVersion)</WindowsTargetPlatformVersion>
     <ProjectName>$(FileName)_km</ProjectName>
-    <!-- Required for Microsoft internal OneBranch builds -->
+    <!-- Required for Microsoft OneBranch builds -->
     <UseInternalMSUniCrtPackage>true</UseInternalMSUniCrtPackage>    
     <UndockedKernelModeBuild>true</UndockedKernelModeBuild>
   </PropertyGroup>


### PR DESCRIPTION
## Description

These two build flags are required when using the internal "native compiler" builds from OneBranch that are used to produce "official" binaries that have all the correct compiler/linker flags required by Windows OS builds.

## Testing

Not yet. Requires going through the process to merge this PR, update XDP to consume, regenerate XDP VS projects, mirror internal XDP repo and run through internal build.

## Documentation

N/A

## Installation

N/A
