### PR TITLE
Restore runner labels.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -149,7 +149,7 @@ jobs:
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       name: driver
       build_artifact: Build-x64
-      environment: self-hosted
+      environment: ebpf_cicd_tests
       # driver test copies dumps to testlog folder.
       gather_dumps: false
       # driver tests manually gather code coverage
@@ -168,7 +168,7 @@ jobs:
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       name: driver
       build_artifact: Build-x64-native-only
-      environment: self-hosted
+      environment: ebpf_cicd_tests
       # driver test copies dumps to testlog folder.
       gather_dumps: false
       # driver tests manually gather code coverage

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -100,7 +100,7 @@ jobs:
 
     # Perform shallow checkout for self-hosted runner.
     - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
-      if: (inputs.environment == 'self-hosted') && (steps.skip_check.outputs.should_skip != 'true')
+      if: (inputs.environment == 'ebpf_cicd_tests') && (steps.skip_check.outputs.should_skip != 'true')
       with:
         ref: ${{ github.event.workflow_run.head_branch }}
 
@@ -113,7 +113,7 @@ jobs:
 
     - name: Set up OpenCppCoverage and add to PATH
       id: set_up_opencppcoverage
-      if: (inputs.code_coverage == true) && (inputs.environment != 'self-hosted') && (steps.skip_check.outputs.should_skip != 'true')
+      if: (inputs.code_coverage == true) && (inputs.environment != 'ebpf_cicd_tests') && (steps.skip_check.outputs.should_skip != 'true')
       run: |
         choco install -y --requirechecksum=true --checksum=2295A733DA39412C61E4F478677519DD0BB1893D88313CE56B468C9E50517888 --checksum-type=sha256 OpenCppCoverage
         echo "C:\Program Files\OpenCppCoverage" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
@@ -130,7 +130,7 @@ jobs:
         New-ItemProperty -Path "HKLM:\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps" -Name "DumpFolder" -Value "$dump_path" -PropertyType ExpandString -ErrorAction SilentlyContinue
 
     - name: Remove existing artifacts
-      if: (inputs.environment == 'self-hosted') && (steps.skip_check.outputs.should_skip != 'true')
+      if: (inputs.environment == 'ebpf_cicd_tests') && (steps.skip_check.outputs.should_skip != 'true')
       run: |
         Remove-Item -Path ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -Recurse -Force -ErrorAction SilentlyContinue
 
@@ -171,14 +171,14 @@ jobs:
         .\export_program_info.exe
 
     - name: Run pre test command
-      if: steps.skip_check.outputs.should_skip != 'true' && (inputs.environment != 'self-hosted')
+      if: steps.skip_check.outputs.should_skip != 'true' && (inputs.environment != 'ebpf_cicd_tests')
       id: run_pre_test_command
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
         ${{env.PRE_COMMAND}}
 
     - name: Run pre test command on self-hosted runner
-      if: steps.skip_check.outputs.should_skip != 'true' && (inputs.environment == 'self-hosted')
+      if: steps.skip_check.outputs.should_skip != 'true' && (inputs.environment == 'ebpf_cicd_tests')
       id: run_pre_test_command_self_hosted
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
@@ -220,14 +220,14 @@ jobs:
           OpenCppCoverage.exe -q --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell .\Run-Test.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}}
 
     - name: Run test on self-hosted runner
-      if: (inputs.code_coverage == false) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment == 'self-hosted') && (inputs.fault_injection != true)
+      if: (inputs.code_coverage == false) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment == 'ebpf_cicd_tests') && (inputs.fault_injection != true)
       id: run_test_self_hosted
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
         ${{env.TEST_COMMAND}} -SelfHostedRunnerName ${{ runner.name }}
 
     - name: Run test without Code Coverage
-      if: (inputs.code_coverage == false) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment != 'self-hosted') && (inputs.fault_injection != true)
+      if: (inputs.code_coverage == false) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment != 'ebpf_cicd_tests') && (inputs.fault_injection != true)
       id: run_test_without_code_coverage
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       shell: cmd
@@ -237,7 +237,7 @@ jobs:
 
     - name: Run post test command
       # Run the post test command even if the workflow has failed.
-      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment != 'self-hosted')
+      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment != 'ebpf_cicd_tests')
       id: run_post_test_command
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
@@ -245,7 +245,7 @@ jobs:
 
     - name: Run post test command on self-hosted runner
       # Run the post test command even if the workflow has failed.
-      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment == 'self-hosted')
+      if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment == 'ebpf_cicd_tests')
       id: run_post_test_command_self_hosted
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |


### PR DESCRIPTION
## Description

Finish off impactless staged runner migration.
When introducing new runners, in order to allow PRs to continue flowing I relied on the below mechanism:
All runners have the` self-hosted` label, so can be picked up by all PRs.
For the new runners, I removed the ebpf_cicd_tests label, so they woudidn't pick up jobs for PRs other than the one introducting them. Otherwise all jobs failed. Then, all PRs could use all runners, since the code changed to use the `self-hosted `label

Now, we're restoring the labels to what they were, for all runners.