### PR TITLE
Fix for failing 'Full fault injection' test.

### DIFF
--- a/libs/platform/CMakeLists.txt
+++ b/libs/platform/CMakeLists.txt
@@ -88,6 +88,7 @@ target_compile_definitions("platform_user" PRIVATE
 
 wdk_add_library("platform_kernel" STATIC WINVER "${EBPFFORWINDOWS_WDK_WINVER}"
   ${platform_sources}
+  kernel/ebpf_fault_injection_kernel.c
   kernel/ebpf_handle_kernel.c
   kernel/ebpf_platform_kernel.c
   kernel/ebpf_native_kernel.c

--- a/libs/platform/ebpf_object.c
+++ b/libs/platform/ebpf_object.c
@@ -228,8 +228,8 @@ void
 ebpf_object_tracking_terminate()
 {
     for (int index = 0; index < EBPF_COUNT_OF(_ebpf_id_table); index++) {
-        ebpf_assert(_ebpf_id_table[index].object == NULL || ebpf_fuzzing_enabled);
-        ebpf_assert(_ebpf_id_table[index].reference_count == 0 || ebpf_fuzzing_enabled);
+        ebpf_assert(_ebpf_id_table[index].object == NULL || usersim_fault_injection_is_enabled());
+        ebpf_assert(_ebpf_id_table[index].reference_count == 0 || usersim_fault_injection_is_enabled());
     }
 }
 

--- a/libs/platform/ebpf_platform.c
+++ b/libs/platform/ebpf_platform.c
@@ -4,8 +4,6 @@
 #include "ebpf_platform.h"
 #include "ebpf_tracelog.h"
 
-bool ebpf_fuzzing_enabled = false;
-
 static uint32_t _ebpf_platform_maximum_processor_count = 0;
 
 _Ret_range_(>, 0) uint32_t ebpf_get_cpu_count() { return _ebpf_platform_maximum_processor_count; }

--- a/libs/platform/ebpf_platform.h
+++ b/libs/platform/ebpf_platform.h
@@ -100,8 +100,6 @@ extern "C"
 
     typedef struct _ebpf_helper_function_addresses ebpf_helper_function_addresses_t;
 
-    extern bool ebpf_fuzzing_enabled;
-
     /**
      * @brief Initialize the eBPF platform abstraction layer.
      * @retval EBPF_SUCCESS The operation was successful.
@@ -1075,6 +1073,18 @@ extern "C"
      */
     ebpf_result_t
     ebpf_utf8_string_to_unicode(_In_ const ebpf_utf8_string_t* input, _Outptr_ wchar_t** output);
+
+    /**
+     * @brief Check if fault injection is enabled. (Fault injection
+     *        is not supported in kernel mode.)
+     *
+     * TODO(#2677): move this prototype to another project.
+     *
+     * @retval TRUE Fault injection is enabled. (User mode *ONLY*)
+     * @retval FALSE Fault injection is not enabled.
+     */
+    BOOLEAN
+    usersim_fault_injection_is_enabled();
 
 #ifdef __cplusplus
 }

--- a/libs/platform/kernel/ebpf_fault_injection_kernel.c
+++ b/libs/platform/kernel/ebpf_fault_injection_kernel.c
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "ebpf_platform.h"
+
+// TODO(#2677): Update this prototype.
+BOOLEAN
+usersim_fault_injection_is_enabled(void)
+{
+    // Kernel mode replacement (for call from usersim).
+    // As of now, fault injection is not supported in kernel mode.
+    return FALSE;
+}

--- a/libs/platform/kernel/platform_kernel.vcxproj
+++ b/libs/platform/kernel/platform_kernel.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="..\ebpf_serialize.c" />
     <ClCompile Include="..\ebpf_state.c" />
     <ClCompile Include="..\ebpf_trampoline.c" />
+    <ClCompile Include="ebpf_fault_injection_kernel.c" />
     <ClCompile Include="ebpf_handle_kernel.c" />
     <ClCompile Include="ebpf_native_kernel.c" />
     <ClCompile Include="ebpf_platform_kernel.c" />

--- a/libs/platform/kernel/platform_kernel.vcxproj.filters
+++ b/libs/platform/kernel/platform_kernel.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClCompile Include="..\ebpf_platform.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include=".\ebpf_fault_injection_kernel.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ebpf_epoch.h">

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -10,7 +10,6 @@
 #include "netsh_test_helper.h"
 #include "platform.h"
 #include "test_helper.hpp"
-#include "usersim/../../src/fault_injection.h"
 
 #include <winsock2.h>
 #include <windows.h>

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -6,7 +6,6 @@
 #include "catch_wrapper.hpp"
 #include "netebpf_ext_helper.h"
 #include "passed_test_log.h"
-#include "usersim/../../src/fault_injection.h"
 #include "watchdog.h"
 
 #include <map>


### PR DESCRIPTION
## Description

Fixes in this PR:
1. Replace the global 'fault injection state' flag with a call to a `usersim` function that returns this state.
2. Fix a post-crash memory leak in test code.

## Testing
CI/CD

## Documentation
No documentation changes needed.

## Installation

No

Fixes #2557
