### PR TITLE
revert changes

### DIFF
--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -17,6 +17,7 @@
 #include "ebpf_structs.h"
 #include "misc_helper.h"
 #include "native_helper.hpp"
+#include "socket_helper.h"
 #include "socket_tests_common.h"
 #include "watchdog.h"
 
@@ -35,14 +36,42 @@ static std::string _remote_ip_v6;
 static std::string _user_name;
 static std::string _password;
 static std::string _user_type_string;
+typedef enum _user_type
+{
+    ADMINISTRATOR,
+    STANDARD_USER
+} user_type_t;
+
+typedef struct _test_addresses
+{
+    struct sockaddr_storage loopback_address;
+    struct sockaddr_storage remote_address;
+    struct sockaddr_storage local_address;
+    struct sockaddr_storage vip_address;
+} test_addresses_t;
+
+typedef struct _test_globals
+{
+    user_type_t user_type = STANDARD_USER;
+    HANDLE user_token = nullptr;
+    ADDRESS_FAMILY family = 0;
+    IPPROTO protocol = IPPROTO_IPV4;
+    uint16_t destination_port = 4444;
+    uint16_t proxy_port = 4443;
+    test_addresses_t addresses[socket_family_t::Max] = {0};
+    bool attach_v4_program = false;
+    bool attach_v6_program = false;
+    bpf_object_ptr bpf_object;
+} test_globals_t;
+
+static test_globals_t _globals;
 static volatile bool _globals_initialized = false;
 
 static void
 _impersonate_user()
 {
-    test_globals_t globals;
     printf("Impersonating user [%s].\n", _user_name.c_str());
-    bool result = ImpersonateLoggedOnUser(globals.user_token);
+    bool result = ImpersonateLoggedOnUser(_globals.user_token);
     REQUIRE(result == true);
 }
 
@@ -102,9 +131,8 @@ typedef class _impersonation_helper
 static HANDLE
 _log_on_user(std::string& user_name, std::string& password)
 {
-    test_globals_t globals;
     HANDLE token = 0;
-    if (globals.user_type != user_type_t::ADMINISTRATOR) {
+    if (_globals.user_type != user_type_t::ADMINISTRATOR) {
         bool result = LogonUserA(
             user_name.c_str(), nullptr, password.c_str(), LOGON32_LOGON_INTERACTIVE, LOGON32_PROVIDER_DEFAULT, &token);
         if (result == false) {
@@ -154,38 +182,37 @@ _initialize_test_globals()
     ADDRESS_FAMILY family;
     uint32_t v4_addresses = 0;
     uint32_t v6_addresses = 0;
-    test_globals_t globals;
 
     printf("Initializing test globals.\n");
 
     // Read v4 addresses.
     if (_remote_ip_v4 != "") {
         get_address_from_string(
-            _remote_ip_v4, globals.addresses[socket_family_t::IPv4].remote_address, false, &family);
+            _remote_ip_v4, _globals.addresses[socket_family_t::IPv4].remote_address, false, &family);
         REQUIRE(family == AF_INET);
-        get_address_from_string(_remote_ip_v4, globals.addresses[socket_family_t::Dual].remote_address, true, &family);
+        get_address_from_string(_remote_ip_v4, _globals.addresses[socket_family_t::Dual].remote_address, true, &family);
         REQUIRE(family == AF_INET);
         v4_addresses++;
     }
     if (_local_ip_v4 != "") {
-        get_address_from_string(_local_ip_v4, globals.addresses[socket_family_t::IPv4].local_address, false, &family);
+        get_address_from_string(_local_ip_v4, _globals.addresses[socket_family_t::IPv4].local_address, false, &family);
         REQUIRE(family == AF_INET);
-        get_address_from_string(_local_ip_v4, globals.addresses[socket_family_t::Dual].local_address, true, &family);
+        get_address_from_string(_local_ip_v4, _globals.addresses[socket_family_t::Dual].local_address, true, &family);
         REQUIRE(family == AF_INET);
         v4_addresses++;
     }
     if (_vip_v4 != "") {
-        get_address_from_string(_vip_v4, globals.addresses[socket_family_t::IPv4].vip_address, false, &family);
+        get_address_from_string(_vip_v4, _globals.addresses[socket_family_t::IPv4].vip_address, false, &family);
         REQUIRE(family == AF_INET);
-        get_address_from_string(_vip_v4, globals.addresses[socket_family_t::Dual].vip_address, true, &family);
+        get_address_from_string(_vip_v4, _globals.addresses[socket_family_t::Dual].vip_address, true, &family);
         REQUIRE(family == AF_INET);
         v4_addresses++;
     }
     REQUIRE((v4_addresses == 0 || v4_addresses == 3));
-    globals.attach_v4_program = (v4_addresses != 0);
-    IN4ADDR_SETLOOPBACK((PSOCKADDR_IN)&globals.addresses[socket_family_t::IPv4].loopback_address);
+    _globals.attach_v4_program = (v4_addresses != 0);
+    IN4ADDR_SETLOOPBACK((PSOCKADDR_IN)&_globals.addresses[socket_family_t::IPv4].loopback_address);
     IN6ADDR_SETV4MAPPED(
-        (PSOCKADDR_IN6)&globals.addresses[socket_family_t::Dual].loopback_address,
+        (PSOCKADDR_IN6)&_globals.addresses[socket_family_t::Dual].loopback_address,
         &in4addr_loopback,
         scopeid_unspecified,
         0);
@@ -193,48 +220,48 @@ _initialize_test_globals()
     // Read v6 addresses.
     if (_remote_ip_v6 != "") {
         get_address_from_string(
-            _remote_ip_v6, globals.addresses[socket_family_t::IPv6].remote_address, false, &family);
+            _remote_ip_v6, _globals.addresses[socket_family_t::IPv6].remote_address, false, &family);
         REQUIRE(family == AF_INET6);
         v6_addresses++;
     }
     if (_local_ip_v6 != "") {
-        get_address_from_string(_local_ip_v6, globals.addresses[socket_family_t::IPv6].local_address, false, &family);
+        get_address_from_string(_local_ip_v6, _globals.addresses[socket_family_t::IPv6].local_address, false, &family);
         REQUIRE(family == AF_INET6);
         v6_addresses++;
     }
     if (_vip_v6 != "") {
-        get_address_from_string(_vip_v6, globals.addresses[socket_family_t::IPv6].vip_address, false, &family);
+        get_address_from_string(_vip_v6, _globals.addresses[socket_family_t::IPv6].vip_address, false, &family);
         REQUIRE(family == AF_INET6);
         v6_addresses++;
     }
     REQUIRE((v6_addresses == 0 || v6_addresses == 3));
-    globals.attach_v6_program = (v6_addresses != 0);
-    IN6ADDR_SETLOOPBACK((PSOCKADDR_IN6)&globals.addresses[socket_family_t::IPv6].loopback_address);
+    _globals.attach_v6_program = (v6_addresses != 0);
+    IN6ADDR_SETLOOPBACK((PSOCKADDR_IN6)&_globals.addresses[socket_family_t::IPv6].loopback_address);
 
     // Load the user token.
-    globals.user_type = _get_user_type(_user_type_string);
-    globals.user_token = _log_on_user(_user_name, _password);
+    _globals.user_type = _get_user_type(_user_type_string);
+    _globals.user_token = _log_on_user(_user_name, _password);
 
     // Load and attach the programs.
     native_module_helper_t helper;
     helper.initialize("cgroup_sock_addr2");
-    globals.bpf_object.reset(bpf_object__open(helper.get_file_name().c_str()));
-    REQUIRE(globals.bpf_object.get() != nullptr);
-    REQUIRE(bpf_object__load(globals.bpf_object.get()) == 0);
-    if (globals.attach_v4_program) {
+    _globals.bpf_object.reset(bpf_object__open(helper.get_file_name().c_str()));
+    REQUIRE(_globals.bpf_object.get() != nullptr);
+    REQUIRE(bpf_object__load(_globals.bpf_object.get()) == 0);
+    if (_globals.attach_v4_program) {
         printf("Attaching IPv4 program\n");
         bpf_program* connect_program_v4 =
-            bpf_object__find_program_by_name(globals.bpf_object.get(), "connect_redirect4");
+            bpf_object__find_program_by_name(_globals.bpf_object.get(), "connect_redirect4");
         REQUIRE(connect_program_v4 != nullptr);
 
         result = bpf_prog_attach(
             bpf_program__fd(const_cast<const bpf_program*>(connect_program_v4)), 0, BPF_CGROUP_INET4_CONNECT, 0);
         REQUIRE(result == 0);
     }
-    if (globals.attach_v6_program) {
+    if (_globals.attach_v6_program) {
         printf("Attaching IPv6 program\n");
         bpf_program* connect_program_v6 =
-            bpf_object__find_program_by_name(globals.bpf_object.get(), "connect_redirect6");
+            bpf_object__find_program_by_name(_globals.bpf_object.get(), "connect_redirect6");
         REQUIRE(connect_program_v6 != nullptr);
 
         result = bpf_prog_attach(
@@ -249,8 +276,7 @@ _initialize_test_globals()
 static void
 _validate_audit_map_entry(uint64_t authentication_id)
 {
-    test_globals_t globals;
-    bpf_map* audit_map = bpf_object__find_map_by_name(globals.bpf_object.get(), "audit_map");
+    bpf_map* audit_map = bpf_object__find_map_by_name(_globals.bpf_object.get(), "audit_map");
     REQUIRE(audit_map != nullptr);
 
     fd_t map_fd = bpf_map__fd(audit_map);
@@ -266,7 +292,7 @@ _validate_audit_map_entry(uint64_t authentication_id)
     result = LsaGetLogonSessionData((PLUID)&entry.logon_id, &data);
     REQUIRE(result == ERROR_SUCCESS);
 
-    if (globals.user_type == user_type_t::ADMINISTRATOR) {
+    if (_globals.user_type == user_type_t::ADMINISTRATOR) {
         REQUIRE(entry.is_admin == 1);
     } else {
         REQUIRE(entry.is_admin == 0);
@@ -287,8 +313,7 @@ _update_policy_map(
     bool dual_stack,
     bool add)
 {
-    test_globals_t globals;
-    bpf_map* policy_map = bpf_object__find_map_by_name(globals.bpf_object.get(), "policy_map");
+    bpf_map* policy_map = bpf_object__find_map_by_name(_globals.bpf_object.get(), "policy_map");
     REQUIRE(policy_map != nullptr);
 
     fd_t map_fd = bpf_map__fd(policy_map);
@@ -297,7 +322,7 @@ _update_policy_map(
     destination_entry_t key = {0};
     destination_entry_t value = {0};
 
-    if (globals.family == AF_INET && dual_stack) {
+    if (_globals.family == AF_INET && dual_stack) {
         struct sockaddr_in6* v6_destination = (struct sockaddr_in6*)&destination;
         struct sockaddr_in6* v6_proxy = (struct sockaddr_in6*)&proxy;
 
@@ -306,8 +331,8 @@ _update_policy_map(
         INET_SET_ADDRESS(
             AF_INET6, (PUCHAR)&value.destination_ip, IN6_GET_ADDR_V4MAPPED((IN6_ADDR*)&v6_proxy->sin6_addr));
     } else {
-        INET_SET_ADDRESS(globals.family, (PUCHAR)&key.destination_ip, INETADDR_ADDRESS((PSOCKADDR)&destination));
-        INET_SET_ADDRESS(globals.family, (PUCHAR)&value.destination_ip, INETADDR_ADDRESS((PSOCKADDR)&proxy));
+        INET_SET_ADDRESS(_globals.family, (PUCHAR)&key.destination_ip, INETADDR_ADDRESS((PSOCKADDR)&destination));
+        INET_SET_ADDRESS(_globals.family, (PUCHAR)&value.destination_ip, INETADDR_ADDRESS((PSOCKADDR)&proxy));
     }
 
     key.destination_port = htons(destination_port);
@@ -334,19 +359,18 @@ connect_redirect_test(
     uint32_t bytes_received = 0;
     char* received_message = nullptr;
     uint64_t authentication_id;
-    test_globals_t globals;
 
     // Update policy in the map to redirect the connection to the proxy.
-    _update_policy_map(destination, proxy, destination_port, proxy_port, globals.protocol, dual_stack, add_policy);
+    _update_policy_map(destination, proxy, destination_port, proxy_port, _globals.protocol, dual_stack, add_policy);
 
     {
-        impersonation_helper_t helper(globals.user_type);
+        impersonation_helper_t helper(_globals.user_type);
 
         authentication_id = _get_current_thread_authentication_id();
         REQUIRE(authentication_id != 0);
 
         // Try to send and receive message to "destination". It should succeed.
-        sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, globals.destination_port);
+        sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, _globals.destination_port);
         sender_socket->complete_async_send(1000, expected_result_t::SUCCESS);
 
         sender_socket->post_async_receive();
@@ -363,24 +387,23 @@ connect_redirect_test(
 
     // Remove entry from policy map.
     add_policy = false;
-    _update_policy_map(destination, proxy, destination_port, proxy_port, globals.protocol, dual_stack, add_policy);
+    _update_policy_map(destination, proxy, destination_port, proxy_port, _globals.protocol, dual_stack, add_policy);
 }
 
 void
 authorize_test(_In_ client_socket_t* sender_socket, _Inout_ sockaddr_storage& destination, bool dual_stack)
 {
-    test_globals_t globals;
     uint64_t authentication_id;
     // Default behavior of the eBPF program is to block the connection.
 
     // Send should fail as the connection is blocked.
     {
-        impersonation_helper_t helper(globals.user_type);
+        impersonation_helper_t helper(_globals.user_type);
 
         authentication_id = _get_current_thread_authentication_id();
         REQUIRE(authentication_id != 0);
 
-        sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, globals.destination_port);
+        sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, _globals.destination_port);
         sender_socket->complete_async_send(1000, expected_result_t::FAILURE);
 
         // Receive should time out as connection is blocked.
@@ -392,21 +415,20 @@ authorize_test(_In_ client_socket_t* sender_socket, _Inout_ sockaddr_storage& de
 
     // Now update the policy map to allow the connection and test again.
     connect_redirect_test(
-        sender_socket, destination, destination, globals.destination_port, globals.destination_port, dual_stack);
+        sender_socket, destination, destination, _globals.destination_port, _globals.destination_port, dual_stack);
 }
 
 void
 get_client_socket(bool dual_stack, _Inout_ client_socket_t** sender_socket)
 {
-    test_globals_t globals;
-    impersonation_helper_t helper(globals.user_type);
+    impersonation_helper_t helper(_globals.user_type);
 
     client_socket_t* old_socket = *sender_socket;
     client_socket_t* new_socket = nullptr;
     socket_family_t family = dual_stack
                                  ? socket_family_t::Dual
-                                 : ((globals.family == AF_INET) ? socket_family_t::IPv4 : socket_family_t::IPv6);
-    if (globals.protocol == IPPROTO_TCP) {
+                                 : ((_globals.family == AF_INET) ? socket_family_t::IPv4 : socket_family_t::IPv6);
+    if (_globals.protocol == IPPROTO_TCP) {
         new_socket = (client_socket_t*)new stream_client_socket_t(SOCK_STREAM, IPPROTO_TCP, 0, family);
     } else {
         new_socket = (client_socket_t*)new datagram_client_socket_t(SOCK_DGRAM, IPPROTO_UDP, 0, family);
@@ -432,12 +454,11 @@ void
 connect_redirect_test_wrapper(
     _Inout_ sockaddr_storage& destination, _In_ const sockaddr_storage& proxy, bool dual_stack)
 {
-    test_globals_t globals;
     client_socket_t* sender_socket = nullptr;
 
     get_client_socket(dual_stack, &sender_socket);
     connect_redirect_test(
-        sender_socket, destination, proxy, globals.destination_port, globals.proxy_port, dual_stack);
+        sender_socket, destination, proxy, _globals.destination_port, _globals.proxy_port, dual_stack);
     delete sender_socket;
 }
 
@@ -445,12 +466,11 @@ connect_redirect_test_wrapper(
     void connection_authorization_tests_##destination##(                                                         \
         ADDRESS_FAMILY family, IPPROTO protocol, bool dual_stack, _In_ test_addresses_t& addresses)              \
     {                                                                                                            \
-        test_globals_t globals;                                                                                  \
         _initialize_test_globals();                                                                              \
-        globals.family = family;                                                                                \
-        globals.protocol = protocol;                                                                            \
-        const char* protocol_string = (globals.protocol == IPPROTO_TCP) ? "TCP" : "UDP";                        \
-        const char* family_string = (globals.family == AF_INET) ? "IPv4" : "IPv6";                              \
+        _globals.family = family;                                                                                \
+        _globals.protocol = protocol;                                                                            \
+        const char* protocol_string = (_globals.protocol == IPPROTO_TCP) ? "TCP" : "UDP";                        \
+        const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";                              \
         const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";                             \
         printf("CONNECT: " #destination " | %s | %s | %s\n", protocol_string, family_string, dual_stack_string); \
         authorize_test_wrapper(dual_stack, addresses.##destination##);                                           \
@@ -472,9 +492,8 @@ DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(remote_address)
     socket_family_name, socket_family_type, dual_stack, protocol, destination)                            \
     TEST_CASE(socket_family_name "_" #destination "_" #protocol, "[connect_authorize_redirect_tests_v4]") \
     {                                                                                                     \
-        test_globals_t globals;                                                                           \
         connection_authorization_tests_##destination##(                                                   \
-            AF_INET, protocol, (dual_stack), globals.addresses[##socket_family_type##]);                 \
+            AF_INET, protocol, (dual_stack), _globals.addresses[##socket_family_type##]);                 \
     }
 
 #define DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, protocol) \
@@ -489,9 +508,8 @@ DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(remote_address)
     socket_family_name, socket_family_type, dual_stack, protocol, destination)                            \
     TEST_CASE(socket_family_name "_" #destination "_" #protocol, "[connect_authorize_redirect_tests_v6]") \
     {                                                                                                     \
-        test_globals_t globals;                                                                           \
         connection_authorization_tests_##destination##(                                                   \
-            AF_INET6, protocol, (dual_stack), globals.addresses[##socket_family_type##]);                \
+            AF_INET6, protocol, (dual_stack), _globals.addresses[##socket_family_type##]);                \
     }
 
 #define DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, protocol) \
@@ -532,12 +550,11 @@ DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv
     void connection_redirection_tests_##original_destination##_##new_destination##(                                   \
         ADDRESS_FAMILY family, IPPROTO protocol, bool dual_stack, _In_ test_addresses_t& addresses)                   \
     {                                                                                                                 \
-        test_globals_t globals;                                                                                       \
         _initialize_test_globals();                                                                                   \
-        globals.family = family;                                                                                     \
-        globals.protocol = protocol;                                                                                 \
-        const char* protocol_string = (globals.protocol == IPPROTO_TCP) ? "TCP" : "UDP";                             \
-        const char* family_string = (globals.family == AF_INET) ? "IPv4" : "IPv6";                                   \
+        _globals.family = family;                                                                                     \
+        _globals.protocol = protocol;                                                                                 \
+        const char* protocol_string = (_globals.protocol == IPPROTO_TCP) ? "TCP" : "UDP";                             \
+        const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";                                   \
         const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";                                  \
         printf(                                                                                                       \
             "REDIRECT: " #original_destination " -> " #new_destination " | %s | %s | %s\n",                           \
@@ -577,9 +594,8 @@ DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(local_address, loopback_address)
         socket_family_name "_" #original_destination "_" #new_destination "_" #protocol,                 \
         "[connect_authorize_redirect_tests_v4]")                                                         \
     {                                                                                                    \
-        test_globals_t globals;                                                                          \
         connection_redirection_tests_##original_destination##_##new_destination##(                       \
-            AF_INET, protocol, (dual_stack), globals.addresses[##socket_family_type##]);                \
+            AF_INET, protocol, (dual_stack), _globals.addresses[##socket_family_type##]);                \
     }
 
 #define DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, protocol) \
@@ -604,9 +620,8 @@ DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(local_address, loopback_address)
         socket_family_name "_" #original_destination "_" #new_destination "_" #protocol,                 \
         "[connect_authorize_redirect_tests_v6]")                                                         \
     {                                                                                                    \
-        test_globals_t globals;                                                                          \
         connection_redirection_tests_##original_destination##_##new_destination##(                       \
-            AF_INET6, protocol, (dual_stack), globals.addresses[##socket_family_type##]);               \
+            AF_INET6, protocol, (dual_stack), _globals.addresses[##socket_family_type##]);               \
     }
 
 #define DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, protocol) \
@@ -654,7 +669,6 @@ DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6,
 int
 main(int argc, char* argv[])
 {
-    test_globals_t _globals;
     Catch::Session session;
 
     // Use Catch's composite command line parser.

--- a/tests/libs/common/common_tests.h
+++ b/tests/libs/common/common_tests.h
@@ -11,7 +11,6 @@
 #include "bpf/libbpf.h"
 #include "ebpf_api.h"
 #include "ebpf_result.h"
-#include "socket_helper.h"
 
 #include <windows.h>
 #include <future>
@@ -19,19 +18,6 @@
 
 #define RING_BUFFER_TEST_EVENT_COUNT 10
 
-typedef enum _user_type
-{
-    ADMINISTRATOR,
-    STANDARD_USER
-} user_type_t;
-
-typedef struct _test_addresses
-{
-    struct sockaddr_storage loopback_address;
-    struct sockaddr_storage remote_address;
-    struct sockaddr_storage local_address;
-    struct sockaddr_storage vip_address;
-} test_addresses_t;
 typedef struct _close_bpf_object
 {
     void
@@ -44,19 +30,6 @@ typedef struct _close_bpf_object
 } close_bpf_object_t;
 typedef std::unique_ptr<bpf_object, close_bpf_object_t> bpf_object_ptr;
 
-typedef struct _test_globals
-{
-    user_type_t user_type = STANDARD_USER;
-    HANDLE user_token = nullptr;
-    ADDRESS_FAMILY family = 0;
-    IPPROTO protocol = IPPROTO_IPV4;
-    uint16_t destination_port = 4444;
-    uint16_t proxy_port = 4443;
-    test_addresses_t addresses[socket_family_t::Max] = {0};
-    bool attach_v4_program = false;
-    bool attach_v6_program = false;
-    bpf_object_ptr bpf_object;
-} test_globals_t;
 void
 ebpf_test_pinned_map_enum();
 void

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -18,6 +18,7 @@
 #include "ebpf_nethooks.h"
 #include "ebpf_structs.h"
 #include "native_helper.hpp"
+#include "socket_helper.h"
 #include "socket_tests_common.h"
 #include "watchdog.h"
 
@@ -163,19 +164,18 @@ TEST_CASE("connection_test_tcp_v6", "[sock_addr_tests]")
 
 TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
 {
-    test_globals_t globals;
     bpf_prog_info program_info = {};
     uint32_t program_info_size = sizeof(program_info);
 
     native_module_helper_t helper;
     helper.initialize("cgroup_sock_addr");
 
-    globals.bpf_object.reset(bpf_object__open(helper.get_file_name().c_str()));
-    REQUIRE(globals.bpf_object.get() != nullptr);
+    struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
+    REQUIRE(object != nullptr);
     // Load the programs.
-    REQUIRE(bpf_object__load(globals.bpf_object.get()) == 0);
+    REQUIRE(bpf_object__load(object) == 0);
 
-    bpf_program* connect4_program = bpf_object__find_program_by_name(globals.bpf_object.get(), "authorize_connect4");
+    bpf_program* connect4_program = bpf_object__find_program_by_name(object, "authorize_connect4");
     REQUIRE(connect4_program != nullptr);
 
     int result = bpf_prog_attach(
@@ -201,8 +201,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
             bpf_program__fd(const_cast<const bpf_program*>(connect4_program)), &program_info, &program_info_size) == 0);
     REQUIRE(program_info.link_count == 0);
 
-    bpf_program* recv_accept4_program =
-        bpf_object__find_program_by_name(globals.bpf_object.get(), "authorize_recv_accept4");
+    bpf_program* recv_accept4_program = bpf_object__find_program_by_name(object, "authorize_recv_accept4");
     REQUIRE(recv_accept4_program != nullptr);
 
     result = bpf_prog_attach(
@@ -231,7 +230,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
         0);
     REQUIRE(program_info.link_count == 0);
 
-    bpf_program* connect6_program = bpf_object__find_program_by_name(globals.bpf_object.get(), "authorize_connect6");
+    bpf_program* connect6_program = bpf_object__find_program_by_name(object, "authorize_connect6");
     REQUIRE(connect6_program != nullptr);
 
     result = bpf_prog_attach(
@@ -241,8 +240,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
         0);
     REQUIRE(result == 0);
 
-    bpf_program* recv_accept6_program =
-        bpf_object__find_program_by_name(globals.bpf_object.get(), "authorize_recv_accept6");
+    bpf_program* recv_accept6_program = bpf_object__find_program_by_name(object, "authorize_recv_accept6");
     REQUIRE(recv_accept6_program != nullptr);
 
     result = bpf_prog_attach(
@@ -251,6 +249,7 @@ TEST_CASE("attach_sock_addr_programs", "[sock_addr_tests]")
         BPF_CGROUP_INET6_RECV_ACCEPT,
         0);
     REQUIRE(result == 0);
+    bpf_object__close(object);
 }
 
 void
@@ -442,20 +441,20 @@ TEST_CASE("connection_monitor_test_disconnect_tcp_v6", "[sock_ops_tests]")
 
 TEST_CASE("attach_sockops_programs", "[sock_ops_tests]")
 {
-    test_globals_t globals;
     native_module_helper_t helper;
     helper.initialize("sockops");
-    globals.bpf_object.reset(bpf_object__open(helper.get_file_name().c_str()));
-    REQUIRE(globals.bpf_object.get() != nullptr);
-
+    struct bpf_object* object = bpf_object__open(helper.get_file_name().c_str());
+    REQUIRE(object != nullptr);
     // Load the programs.
-    REQUIRE(bpf_object__load(globals.bpf_object.get()) == 0);
+    REQUIRE(bpf_object__load(object) == 0);
 
-    bpf_program* _program = bpf_object__find_program_by_name(globals.bpf_object.get(), "connection_monitor");
+    bpf_program* _program = bpf_object__find_program_by_name(object, "connection_monitor");
     REQUIRE(_program != nullptr);
 
     int result = bpf_prog_attach(bpf_program__fd(const_cast<const bpf_program*>(_program)), 0, BPF_CGROUP_SOCK_OPS, 0);
     REQUIRE(result == 0);
+
+    bpf_object__close(object);
 }
 
 int


### PR DESCRIPTION
## Description
Revert the changes from #2669
PR on #2669 was first introduced with sockets tests and connect redirect tests with global variables.  However, a comment on the PR raised the concern that usersim will detect the global declaration as a memory leak, or at the very least, result in a leak occurring in an incorrect context, or even lead to the absence of a leak despite its presence. The suggestion was to have it be a local variable on the stack of each test case. However, this caused connect redirect test to fail. CICD would show that the tests are passing and merged the PR although the test was failing due to [this issue ](https://github.com/microsoft/ebpf-for-windows/issues/2707). 
This PR will revert the changes in PR #2669, and a new PR will be raised after a discussion with the team members is concluded. Reopened issue #2203. 

## Testing

CICD


