### PR TITLE
Fix driver job failure due to log file contention.

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -182,7 +182,7 @@ jobs:
       id: run_pre_test_command_self_hosted
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        ${{env.PRE_COMMAND}} -SelfHostedRunnerName ${{ runner.name }}
+        ${{env.PRE_COMMAND}} -LogFileName ${{ runner.name }}.log -SelfHostedRunnerName ${{ runner.name }}
 
     # TODO: Clean up the combination of options: https://github.com/microsoft/ebpf-for-windows/issues/1590
     - name: Run test with Code Coverage in VS Dev environment
@@ -224,7 +224,7 @@ jobs:
       id: run_test_self_hosted
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        ${{env.TEST_COMMAND}} -SelfHostedRunnerName ${{ runner.name }}
+        ${{env.TEST_COMMAND}} -LogFileName ${{ runner.name }}.log -SelfHostedRunnerName ${{ runner.name }}
 
     - name: Run test without Code Coverage
       if: (inputs.code_coverage == false) && (steps.skip_check.outputs.should_skip != 'true') && (inputs.environment != 'ebpf_cicd_tests') && (inputs.fault_injection != true)
@@ -249,7 +249,7 @@ jobs:
       id: run_post_test_command_self_hosted
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        ${{env.POST_COMMAND}} -SelfHostedRunnerName ${{ runner.name }}
+        ${{env.POST_COMMAND}} -LogFileName ${{ runner.name }}.log -SelfHostedRunnerName ${{ runner.name }}
 
     - name: Check for CodeCoverage
       if: steps.skip_check.outputs.should_skip != 'true'

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -273,11 +273,12 @@ function Import-ResultsFromVM
         } -ArgumentList ("eBPF", $LogFileName, $EtlFile) -ErrorAction Ignore
 
         # Copy ETL from Test VM.
-        Write-Log ("Copy $EtlFile from eBPF on $VMName to $pwd\TestLogs")
+        Write-Log ("Copy $EtlFile from eBPF on $VMName to $pwd\TestLogs\$VMName\Logs")
         Copy-Item -FromSession $VMSession -Path "$VMSystemDrive\eBPF\$EtlFile" -Destination ".\TestLogs\$VMName\Logs" -Recurse -Force -ErrorAction Ignore 2>&1 | Write-Log
     }
     # Move runner test logs to TestLogs folder.
-    Move-Item $LogFileName -Destination ".\TestLogs" -Force -ErrorAction Ignore 2>&1 | Write-Log
+    Write-Host ("Copy $LogFileName from $env:TEMP on host runner to $pwd\TestLogs")
+    Move-Item "$env:TEMP\$LogFileName" -Destination ".\TestLogs" -Force -ErrorAction Ignore 2>&1 | Write-Log
 }
 
 function Install-eBPFComponentsOnVM


### PR DESCRIPTION
## Description
Fixes #2736 
Missed one instance of state leakage in #2722.

Tthe `driver` job generates almost all its logs on the VM where the tests are executed.
However, the few log lines from the runner deploying the test collateral on the VMs are persisted in a file in the host's TEMP directory.
We never overwrote the default file name, so the 2 runner processes hit a race condition, when writing to this file.

Due to an existing bug, we never collected this file anyway, fixed now, confimed in the respective artifact file.