### PR TITLE
Ensure correct params are passed for CI/CD km mt stress test jobs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -448,7 +448,7 @@ jobs:
     with:
       name: km_mt_stress_tests
       pre_test: .\setup_ebpf_cicd_stress_tests.ps1
-      test_command: .\execute_ebpf_cicd_tests.ps1 -RunKmStressTests $true
+      test_command: .\execute_ebpf_cicd_tests.ps1 -RunKmStressTestsOnly $true
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       build_artifact: Build-x64
       environment: ebpf_cicd_tests
@@ -465,7 +465,7 @@ jobs:
     with:
       name: km_mt_stress_tests_restart_extension
       pre_test: .\setup_ebpf_cicd_stress_tests.ps1
-      test_command: .\execute_ebpf_cicd_stress_tests.ps1 -RunKmStressTests $true -RestartExtension $true
+      test_command: .\execute_ebpf_cicd_stress_tests.ps1 -RunKmStressTestsOnly $true -RestartExtension $true
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       build_artifact: Build-x64
       environment: ebpf_cicd_tests

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -20,10 +20,10 @@ function Invoke-CICDTestsOnVM
     param([parameter(Mandatory=$true)] [string] $VMName,
           [parameter(Mandatory=$false)] [bool] $VerboseLogs = $false,
           [parameter(Mandatory=$false)] [bool] $Coverage = $false,
-          [parameter(Mandatory=$false)][bool] $RunKmStressTests = $false,
+          [parameter(Mandatory=$false)][bool] $RunKmStressTestsOnly = $false,
           [parameter(Mandatory=$false)][bool] $RestartExtension = $false)
 
-    if ($RunKmStressTests -eq $true) {
+    if ($RunKmStressTestsOnly -eq $true) {
         Write-Log "Executing eBPF kernel mode multi-threaded stress tests on $VMName"
     } else {
         Write-Log "Running eBPF CI/CD tests on $VMName"
@@ -34,19 +34,22 @@ function Invoke-CICDTestsOnVM
         param([Parameter(Mandatory=$True)] [string] $WorkingDirectory,
               [Parameter(Mandatory=$True)] [string] $LogFileName,
               [Parameter(Mandatory=$True)] [bool] $VerboseLogs,
-              [Parameter(Mandatory=$True)] [bool] $Coverage)
+              [Parameter(Mandatory=$True)] [bool] $Coverage,
+              [parameter(Mandatory=$True)][bool] $RunKmStressTestsOnly,
+              [parameter(Mandatory=$True)][bool] $RestartExtension)
+
         $WorkingDirectory = "$Env:SystemDrive\$WorkingDirectory"
         Import-Module $WorkingDirectory\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
         Import-Module $WorkingDirectory\run_driver_tests.psm1 -ArgumentList ($WorkingDirectory, $LogFileName) -Force -WarningAction SilentlyContinue
 
-        if ($RunKmStressTests -eq $true) {
+        if ($RunKmStressTestsOnly -eq $true) {
             Invoke-CICDStressTests -VerboseLogs $VerboseLogs -Coverage $Coverage `
                 -RestartExtension $RestartExtension 2>&1 | Write-Log
         } else {
             Invoke-CICDTests -VerboseLogs $VerboseLogs -Coverage $Coverage 2>&1 | Write-Log
         }
 
-    } -ArgumentList ("eBPF", $LogFileName, $VerboseLogs, $Coverage) -ErrorAction Stop
+    } -ArgumentList ("eBPF", $LogFileName, $VerboseLogs, $Coverage, $RunKmStressTestsOnly, $RestartExtension) -ErrorAction Stop
 }
 
 function Add-eBPFProgramOnVM


### PR DESCRIPTION
## Description

Fixes runtime parameter handling to ensure correct and exclusive execution of the scheduled km stress tests. 

## Testing

CI/CD Scheduled Run

## Documentation

No doc changes.

## Installation

No installation changes.

Fixes: #2771 
Fixes: #2772 

