### PR TITLE
Fix incorrect LRU algorithm

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1063,6 +1063,7 @@ _insert_into_hot_list(_Inout_ ebpf_core_lru_map_t* map, _Inout_ ebpf_lru_entry_t
     ebpf_list_remove_entry(&entry->list_entry);
     ebpf_list_insert_tail(&map->hot_list, &entry->list_entry);
     map->hot_list_size++;
+    entry->generation = map->current_generation;
 
     _merge_hot_into_cold_list_if_needed(map);
 

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1055,6 +1055,7 @@ _insert_into_hot_list(_Inout_ ebpf_core_lru_map_t* map, _Inout_ ebpf_lru_entry_t
     state = ebpf_lock_lock(&map->lock);
     lock_held = true;
 
+    key_state = _get_key_state(map, entry);
     if (key_state != EBPF_LRU_KEY_COLD) {
         goto Exit;
     }


### PR DESCRIPTION
## Description

When keys are moved to the hot-list, they should be also moved to the current generation. This allows subsequent key usages to take the hot-path and not re-acquire the lock.

## Testing

CI/CD + Perf

## Documentation

No.

## Installation

No,

Resolves: #2777 

Note: This also contains the fix for #2765 as it is needed to test this.
