### PR TITLE
Use full key width when computing array index

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -383,7 +383,7 @@ _update_array_map_entry(
         return EBPF_INVALID_ARGUMENT;
     }
 
-    uint8_t* entry = &map->data[*key * map->ebpf_map_definition.value_size];
+    uint8_t* entry = &map->data[key_value * map->ebpf_map_definition.value_size];
     if (data) {
         memcpy(entry, data, map->ebpf_map_definition.value_size);
     } else {


### PR DESCRIPTION
## Description

The function _update_array_map_entry incorrectly uses only the first 8bits of the key to find the location in the map array.

## Testing

Added test to catch this.

## Documentation

No.

## Installation

No.

Resolves: #2779