### PR TITLE
enable explicit clean-up prior to process exit for user mode stress test app.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -367,6 +367,21 @@ jobs:
       fault_injection: true
       leak_detection: true
 
+  # Run a fast multi-threaded stress test pass against the usersim user-mode 'mock' framework.
+  # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
+  quick_user_mode_multi_threaded_stress_test:
+    needs: regular
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: quick_user_mode_multi_threaded_stress
+      test_command: .\ebpf_stress_tests_um -tt=8 -td=2
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      leak_detection: false
+      gather_dumps: true
+      capture_etw: true
+
   # Additional jobs to run on a schedule only (skip push and pull request).
   # ---------------------------------------------------------------------------
   codeql:
@@ -416,7 +431,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: user_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_um -tt=32 -td=10
+      test_command: .\ebpf_stress_tests_um -tt=8 -td=10
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: false

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -115,7 +115,7 @@ typedef class _single_instance_hook : public _hook_helper
     _single_instance_hook(ebpf_program_type_t program_type, ebpf_attach_type_t attach_type)
         : _hook_helper{attach_type}, client_binding_context(nullptr), client_data(nullptr),
           client_dispatch_table(nullptr), link_object(nullptr), client_registration_instance(nullptr),
-          nmr_binding_handle(nullptr)
+          nmr_binding_handle(nullptr), nmr_provider_handle(nullptr)
     {
         attach_provider_data.supported_program_type = program_type;
         attach_provider_data.bpf_attach_type = get_bpf_attach_type(&attach_type);

--- a/tests/stress/ebpf_mt_stress.h
+++ b/tests/stress/ebpf_mt_stress.h
@@ -104,3 +104,7 @@ get_jit_program_attributes(const std::string& program_name);
 // The query_supported_program_names() call is 'exported' by both the user and kernel mode test suites.
 const std::vector<std::string>
 query_supported_program_names();
+
+// The test_process_cleanup() call is 'exported' by both the user and kernel mode test suites.
+void
+test_process_cleanup();

--- a/tests/stress/ebpf_stress_tests.cpp
+++ b/tests/stress/ebpf_stress_tests.cpp
@@ -153,4 +153,9 @@ main(int argc, char* argv[])
     }
 
     session.run();
+
+    // Tests that run against the 'usersim' framework need explicit clean-up before process
+    // termination. This clean-up is handled by the OS and/or the in-kernel eBPF components for
+    // tests that run against the kernel components.
+    test_process_cleanup();
 }

--- a/tests/stress/km/stress_tests_km.cpp
+++ b/tests/stress/km/stress_tests_km.cpp
@@ -44,6 +44,14 @@ query_supported_program_names()
     return program_names;
 }
 
+// This function is called by the common test initialization code to perform the requisite clean-up as the last action
+// prior to process termination.
+void
+test_process_cleanup()
+{
+    // As of now, we don't need to do anything here for kernel mode tests.
+}
+
 // Test thread control parameters (# of threads, run duration etc.).
 static test_control_info _global_test_control_info{0};
 


### PR DESCRIPTION
## Description

This PR fixes the user mode ('usersim') multi-threaded stress test application to ensure that allocated 'mock' resources are explicitly free'd prior to process termination.

## Testing

Existing CI/CD test.

## Documentation

No doc changes required.

## Installation

No installer changes required.

Fixes: #2222 
