### PR TITLE
Sort programs to match bpf2c

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1751,9 +1751,15 @@ _initialize_ebpf_object_from_native_file(
     }
 
     // The bpf2c tool orders programs by section name, so we need to sort the programs
-    // vector to match.
+    // vector to match. If there are multiple programs per section, sort by program name.
     std::sort(object.programs.begin(), object.programs.end(), [](const ebpf_program_t* a, const ebpf_program_t* b) {
-        return strcmp(a->section_name, b->section_name) < 0;
+        int section_name_comparison = strcmp(a->section_name, b->section_name);
+        int program_name_comparison = strcmp(a->program_name, b->program_name);
+        if (section_name_comparison != 0) {
+            return section_name_comparison < 0;
+        } else {
+            return program_name_comparison < 0;
+        }
     });
 
 Exit:

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1750,10 +1750,10 @@ _initialize_ebpf_object_from_native_file(
         program = nullptr;
     }
 
-    // The bpf2c tool orders programs by name, so we need to sort the programs
+    // The bpf2c tool orders programs by section name, so we need to sort the programs
     // vector to match.
     std::sort(object.programs.begin(), object.programs.end(), [](const ebpf_program_t* a, const ebpf_program_t* b) {
-        return strcmp(a->program_name, b->program_name) < 0;
+        return strcmp(a->section_name, b->section_name) < 0;
     });
 
 Exit:

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -36,6 +36,7 @@ typedef unsigned char boolean;
 #include "utilities.hpp"
 #include "windows_platform_common.hpp"
 
+#include <algorithm>
 #include <codecvt>
 #include <fcntl.h>
 #include <io.h>
@@ -1748,6 +1749,12 @@ _initialize_ebpf_object_from_native_file(
         object.programs.emplace_back(program);
         program = nullptr;
     }
+
+    // The bpf2c tool orders programs by name, so we need to sort the programs
+    // vector to match.
+    std::sort(object.programs.begin(), object.programs.end(), [](const ebpf_program_t* a, const ebpf_program_t* b) {
+        return strcmp(a->program_name, b->program_name) < 0;
+    });
 
 Exit:
     if (result != EBPF_SUCCESS) {

--- a/tests/end_to_end/helpers.h
+++ b/tests/end_to_end/helpers.h
@@ -331,12 +331,12 @@ typedef class _single_instance_hook : public _hook_helper
     };
     HANDLE nmr_provider_handle;
 
-    PNPI_REGISTRATION_INSTANCE client_registration_instance;
-    const void* client_binding_context;
-    const ebpf_extension_data_t* client_data;
-    const ebpf_extension_dispatch_table_t* client_dispatch_table;
-    HANDLE nmr_binding_handle;
-    bpf_link* link_object;
+    PNPI_REGISTRATION_INSTANCE client_registration_instance = nullptr;
+    const void* client_binding_context = nullptr;
+    const ebpf_extension_data_t* client_data = nullptr;
+    const ebpf_extension_dispatch_table_t* client_dispatch_table = nullptr;
+    HANDLE nmr_binding_handle = nullptr;
+    bpf_link* link_object = nullptr;
 } single_instance_hook_t;
 
 typedef class xdp_md_helper : public xdp_md_t


### PR DESCRIPTION
Resolves: #2781

## Description

The bpf2c tool populates the _programs array sorted by the section name for each program. This then defines the order in which program handles are returned from kernel to user mode. The function _ebpf_enumerate_native_sections returns programs in the order in which they occur in the PE file (which doesn't always match). The net result is that libbpf programs -> kernel handles sometimes don't match.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
