### PR TITLE
Remove barriers and spinlock in epoch_enter and epoch_exit

### DIFF
--- a/docs/EpochBasedMemoryManagement.md
+++ b/docs/EpochBasedMemoryManagement.md
@@ -42,87 +42,8 @@ can only be returned to the OS once no active execution context could be
 using that memory (i.e., when memory timestamp <=
 _ebpf_release_epoch).
 
-## Implementation details
 
-Each execution context maintains its own state in the form of:
-
-```
-typedef struct _ebpf_epoch_state
-{
-    int64_t epoch; // The highest epoch seen by this epoch state.
-} ebpf_epoch_state_t;
-```
-
-Each execution context must first call ebpf_epoch_enter prior to accessing any
-memory that is under epoch protection and then call ebpf_epoch_exit once it is
-done. The call to ebpf_epoch_enter returns a pointer to an ebpf_epoch_state_t
-object that must be passed to ebpf_epoch_exit. The epoch module maintains a
-table of per-CPU epoch states, with an epoch state being assigned to an
-execution context on ebpf_epoch_enter and returned on a call to ebpf_epoch_exit.
-Threads running at passive IRQL will block if there are no available epoch
-states and a thread running at dispatch IRQL will use a reserved epoch state.
-
-Memory is then allocated via calls to ebpf_epoch_allocate which returns
-memory with a private header and memory is freed via calls to
-ebpf_epoch_free. The private header is then used to track when the
-memory was freed as well as links. On free, the memory is stamped with
-the current epoch and the current epoch is atomically incremented. This
-ensures that the freed memory always maintains the correct epoch value.
-The memory is then enqueued on a per-CPU free list. On epoch exit, the
-free list is then scanned to locate entries whose timestamp is older than
-the release epoch. These entries are then returned to the OS.
-
-Note:
-A per-CPU free list is not necessary, but is instead an optimization to reduce
-cross-CPU contention.
-
-```
-// There are two possible actions that can be taken at the end of an epoch.
-// 1. Return a block of memory to the memory pool.
-// 2. Invoke a work item, which is used to free custom allocations.
-typedef enum _ebpf_epoch_allocation_type
-{
-    EBPF_EPOCH_ALLOCATION_MEMORY,
-    EBPF_EPOCH_ALLOCATION_WORK_ITEM,
-} ebpf_epoch_allocation_type_t;
-
-typedef struct _ebpf_epoch_allocation_header
-{
-    ebpf_list_entry_t list_entry;
-    int64_t freed_epoch;
-    ebpf_epoch_allocation_type_t entry_type;
-} ebpf_epoch_allocation_header_t;
-```
-
-Determining the release epoch is necessarily an expensive operation as
-it requires scanning the epoch of every active execution context, with
-execution contexts being protected by spinlocks. To limit the impact,
-the epoch module uses a one-shot timer to schedule a DPC that computes
-the release epoch by determining the minimum of all execution contexts'
-epochs. The timer is then re-armed when an execution context calls
-ebpf_epoch_exit. The result is that if no execution contexts are active,
-the timer will expire and will not be re-armed.
-
-## Exceptional cases
-
-There are a few exceptional cases handled in the epoch module.
-
-### Stale free lists
-
-Memory that has been enqueued to an execution context can become stale
-if the execution context calls ebpf_epoch_exit and there is memory in
-the free list that hasn't reached the release epoch yet. If no further
-calls are made to ebpf_epoch_enter/exit, then the memory will never be
-freed. To address this, the timer will set a "stale" flag on an epoch
-state each time it runs if there is memory in the free list and the
-ebpf_epoch_exit will clear the flag. If the timer observes that the
-epoch state is marked a stale (i.e., ebpf_epoch_exit hasn't been called
-since the last invocation of the timer), then it will schedule a one-off
-DPC to run in that execution context to flush the free list. The flush
-then performs an ebpf_epoch_enter/exit, which permits any expired
-entries in the free list to be freed.
-
-### Work items
+## Work items
 
 In some cases code that uses the epoch module requires more complex
 behavior than simply freeing memory on epoch expiry. To permit this
@@ -133,15 +54,10 @@ epoch). This is implemented as a special entry in the free list that
 causes a callback to be invoked instead of freeing the memory. The callback
 can then perform additional cleanup of state as needed.
 
-### Future investigations
+## Future investigations
 The use of a common clock leads to contention when the memory state changes
 (i.e., when memory is freed). One possible work around might be to move from a
 clock driven by state change to one derived from a hardware clock. Initial
 prototyping seems to indicate that the use of "QueryPerformanceCounter" and its
 kernel equivalent are more expensive than using a state driven clock, but more
 investigation is probably warranted.
-
-The per-CPU lock does raise the cost of every ebpf_epoch_enter/exit operations
-and it might be possible to implement a lock free schema for tracking epoch
-state, but current attempts have resulted in various bugs where edge conditions
-result in incorrect release epoch computations.

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -61,7 +61,7 @@ typedef struct _ebpf_attach_provider_data
  */
 typedef struct _ebpf_execution_context_state
 {
-    struct _ebpf_epoch_state* epoch_state;
+    uint64_t epoch_state[4];
     union
     {
         uint64_t thread;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -2391,7 +2391,8 @@ ebpf_core_invoke_protocol_handler(
     _In_opt_ void (*on_complete)(_Inout_ void*, size_t, ebpf_result_t))
 {
     ebpf_result_t retval;
-    ebpf_epoch_state_t* epoch_state = NULL;
+    ebpf_epoch_state_t epoch_state = {0};
+    bool in_epoch = false;
     ebpf_protocol_handler_t* handler = &_ebpf_protocol_handlers[operation_id];
     ebpf_operation_header_t* request = (ebpf_operation_header_t*)input_buffer;
     ebpf_operation_header_t* reply = (ebpf_operation_header_t*)output_buffer;
@@ -2468,7 +2469,8 @@ ebpf_core_invoke_protocol_handler(
         goto Done;
     }
 
-    epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_enter(&epoch_state);
+    in_epoch = true;
     retval = EBPF_SUCCESS;
 
     switch (handler->call_type) {
@@ -2531,8 +2533,8 @@ ebpf_core_invoke_protocol_handler(
     }
 
 Done:
-    if (epoch_state) {
-        ebpf_epoch_exit(epoch_state);
+    if (in_epoch) {
+        ebpf_epoch_exit(&epoch_state);
     }
     return retval;
 }
@@ -2540,9 +2542,10 @@ Done:
 bool
 ebpf_core_cancel_protocol_handler(_Inout_ void* async_context)
 {
-    ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_state_t epoch_state = {0};
+    ebpf_epoch_enter(&epoch_state);
     bool return_value = ebpf_async_cancel(async_context);
-    ebpf_epoch_exit(epoch_state);
+    ebpf_epoch_exit(&epoch_state);
     return return_value;
 }
 
@@ -2553,12 +2556,13 @@ ebpf_core_close_context(_In_opt_ void* context)
         return;
     }
 
-    ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_state_t epoch_state = {0};
+    ebpf_epoch_enter(&epoch_state);
 
     ebpf_core_object_t* object = (ebpf_core_object_t*)context;
     EBPF_OBJECT_RELEASE_REFERENCE_INDIRECT((&object->base));
 
-    ebpf_epoch_exit(epoch_state);
+    ebpf_epoch_exit(&epoch_state);
 }
 
 _Must_inspect_result_ ebpf_result_t

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -474,11 +474,11 @@ static ebpf_result_t
 _ebpf_link_instance_invoke_batch_begin(
     _In_ const void* client_binding_context, size_t state_size, _Out_writes_(state_size) void* state)
 {
+    ebpf_execution_context_state_t* execution_context_state = (ebpf_execution_context_state_t*)state;
     bool epoch_entered = false;
     bool provider_reference_held = false;
     ebpf_result_t return_value;
     ebpf_link_t* link = (ebpf_link_t*)client_binding_context;
-    ebpf_execution_context_state_t* execution_context_state = (ebpf_execution_context_state_t*)state;
 
     if (state_size < sizeof(ebpf_execution_context_state_t)) {
         return_value = EBPF_INVALID_ARGUMENT;
@@ -491,7 +491,7 @@ _ebpf_link_instance_invoke_batch_begin(
         goto Done;
     }
 
-    ((ebpf_execution_context_state_t*)state)->epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_enter((ebpf_epoch_state_t*)(execution_context_state->epoch_state));
     epoch_entered = true;
 
     return_value = ebpf_program_reference_providers(link->program);
@@ -511,7 +511,7 @@ Done:
     }
 
     if (return_value != EBPF_SUCCESS && epoch_entered) {
-        ebpf_epoch_exit(((ebpf_execution_context_state_t*)state)->epoch_state);
+        ebpf_epoch_exit((ebpf_epoch_state_t*)(execution_context_state->epoch_state));
     }
 
     return return_value;
@@ -524,7 +524,7 @@ _ebpf_link_instance_invoke_batch_end(_In_ const void* extension_client_binding_c
     ebpf_link_t* link = (ebpf_link_t*)extension_client_binding_context;
     ebpf_assert_success(ebpf_state_store(ebpf_program_get_state_index(), 0, execution_context_state));
     ebpf_program_dereference_providers(link->program);
-    ebpf_epoch_exit(execution_context_state->epoch_state);
+    ebpf_epoch_exit((ebpf_epoch_state_t*)(execution_context_state->epoch_state));
     return EBPF_SUCCESS;
 }
 

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -71,18 +71,21 @@ typedef enum _ebpf_epoch_cpu_message_type
                                                        ///< thread linked to this CPU and sets the proposed release
                                                        ///< epoch in the message to the minimum of the local minima and
                                                        ///< the minima in the message. The message is then forwarded to
-                                                       ///< the next CPU. The last CPU then sends an epoch commit message
-                                                       ///< to CPU 0 with the final proposed release epoch.
+                                                       ///< the next CPU. The last CPU then sends an epoch commit
+                                                       ///< message to CPU 0 with the final proposed release epoch.
 
     EBPF_EPOCH_CPU_MESSAGE_TYPE_COMMIT_RELEASE_EPOCH, ///< This message is sent to CPU 0 to commit the proposed release
                                                       ///< epoch.
                                                       ///< Each CPU then:
                                                       ///< 1. Clears the timer-armed flag.
-                                                      ///< 2. Sets the released epoch to the proposed release epoch minus 1.
-                                                      ///< 3. Releases any items in the free list that are eligible for reclamation.
+                                                      ///< 2. Sets the released epoch to the proposed release epoch
+                                                      ///< minus 1.
+                                                      ///< 3. Releases any items in the free list that are eligible for
+                                                      ///< reclamation.
                                                       ///< 4. Rearms the timer if need.
                                                       ///< 5. Forwards the message to the next CPU.
-                                                      ///< The last CPU then sends a epoch computation complete message to CPU 0.
+                                                      ///< The last CPU then sends a epoch computation complete message
+                                                      ///< to CPU 0.
     EBPF_EPOCH_CPU_MESSAGE_TYPE_PROPOSE_EPOCH_COMPLETE, ///< This message is sent only to CPU 0 to signal that epoch
                                                         ///< computation is complete.
     EBPF_EPOCH_CPU_MESSAGE_TYPE_EXIT_EPOCH, ///< This message is used when a thread running with IRQL < DISPATCH calls
@@ -661,14 +664,13 @@ typedef void (*ebpf_epoch_messenger_worker_t)(
  * CPU != 0 sets current epoch to the new current epoch.
  * Each CPU then queries the epoch for each thread queued on that CPU and sets the proposed release epoch in the message
  * to the minimum of the local minima and the minima in the message. The message is then forwarded to the next CPU. Non
- * last CPU forwards the message to the next CPU. The last CPU then sends a
+ * last CPU forwards the message to the next CPU. The last CPU then sends an
  * EBPF_EPOCH_CPU_MESSAGE_TYPE_COMMIT_RELEASE_EPOCH message to CPU 0 with the final proposed release epoch.
  *
  * @param[in] dpc DPC that triggered this function.
  * @param[in] cpu_entry CPU entry to compute the epoch for.
  * @param[in] message Message to process.
  * @param[in] current_cpu Current CPU.
- * @param[out] next_cpu Next CPU to send the message to.
  */
 void
 _ebpf_epoch_messenger_propose_release_epoch(
@@ -741,7 +743,6 @@ _ebpf_epoch_messenger_propose_release_epoch(
  * @param[in] cpu_entry CPU entry to rearm the timer for.
  * @param[in] message Message to process.
  * @param[in] current_cpu Current CPU.
- * @param[out] next_cpu Next CPU to send the message to.
  */
 void
 _ebpf_epoch_messenger_commit_release_epoch(
@@ -782,9 +783,6 @@ _ebpf_epoch_messenger_commit_release_epoch(
  * @param[in] cpu_entry CPU entry to mark the computation as complete for.
  * @param[in] message Message to process.
  * @param[in] current_cpu Current CPU.
- * @param[out] next_cpu Next CPU to send the message to.
- * @retval true Forward the message to the next CPU.
- * @retval false Do not forward the message to the next CPU.
  */
 void
 _ebpf_epoch_messenger_compute_epoch_complete(
@@ -814,9 +812,6 @@ _ebpf_epoch_messenger_compute_epoch_complete(
  * @param[in] cpu_entry CPU entry to call ebpf_epoch_exit() for.
  * @param[in] message Message to process.
  * @param[in] current_cpu Current CPU.
- * @param[out] next_cpu Next CPU to send the message to.
- * @retval true Forward the message to the next CPU.
- * @retval false Do not forward the message to the next CPU.
  */
 void
 _ebpf_epoch_messenger_exit_epoch(
@@ -843,9 +838,6 @@ _ebpf_epoch_messenger_exit_epoch(
  * @param[in] cpu_entry CPU entry to set the flag for.
  * @param[in] message Message to process.
  * @param[in] current_cpu Current CPU.
- * @param[out] next_cpu Next CPU to send the message to.
- * @retval true Forward the message to the next CPU.
- * @retval false Do not forward the message to the next CPU.
  */
 void
 _ebpf_epoch_messenger_rundown_in_progress(
@@ -883,9 +875,6 @@ _ebpf_epoch_messenger_rundown_in_progress(
  * @param[in] cpu_entry CPU entry to check.
  * @param[in] message Message to process.
  * @param[in] current_cpu Current CPU.
- * @param[out] next_cpu Next CPU to send the message to.
- * @retval true Forward the message to the next CPU.
- * @retval false Do not forward the message to the next CPU.
  */
 void
 _ebpf_epoch_messenger_is_free_list_empty(

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -78,11 +78,11 @@ typedef enum _ebpf_epoch_cpu_message_type
                                                       ///< epoch.
                                                       ///< Each CPU then:
                                                       ///< 1. Clears the timer-armed flag.
-    ///< 2. Sets the released epoch to the proposed release epoch minus 1.
-    ///< 3. Releases any items in the free list that are eligible for reclamation.
-    ///< 4. Rearms the timer if need.
-    ///< 5. Forwards the message to the next CPU.
-    ///< The last CPU then sends a epoch computation complete message to CPU 0.
+                                                      ///< 2. Sets the released epoch to the proposed release epoch minus 1.
+                                                      ///< 3. Releases any items in the free list that are eligible for reclamation.
+                                                      ///< 4. Rearms the timer if need.
+                                                      ///< 5. Forwards the message to the next CPU.
+                                                      ///< The last CPU then sends a epoch computation complete message to CPU 0.
     EBPF_EPOCH_CPU_MESSAGE_TYPE_PROPOSE_EPOCH_COMPLETE, ///< This message is sent only to CPU 0 to signal that epoch
                                                         ///< computation is complete.
     EBPF_EPOCH_CPU_MESSAGE_TYPE_EXIT_EPOCH, ///< This message is used when a thread running with IRQL < DISPATCH calls
@@ -353,9 +353,8 @@ ebpf_epoch_exit(_In_ ebpf_epoch_state_t* epoch_state)
 
     // Special case: Thread has moved to a different CPU since entering the epoch.
     if (cpu_id != epoch_state->cpu_id) {
-        // Assert that the IRQL is < DISPATCH_LEVEL. If it is DISPATCH_LEVEL, then
-        // then the thread moved to a different CPU (by dropping below DISPATCH_LEVEL)
-        // and then called ebpf_epoch_exit(). This is not allowed.
+        // Assert that the IRQL is < DISPATCH_LEVEL. If it is DISPATCH_LEVEL, then the thread moved to a different CPU
+        // (by dropping below DISPATCH_LEVEL) and calling ebpf_epoch_exit(). This is not allowed.
         ebpf_assert(epoch_state->irql_at_enter < DISPATCH_LEVEL);
 
         // Signal the other CPU to remove the thread entry.

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -8,8 +8,7 @@
  * @brief Epoch Base Memory Reclamation.
  * Each thread that accesses memory that needs to be reclaimed is associated with an epoch via ebpf_epoch_enter() and
  * ebpf_epoch_exit(). Each CPU maintains a list of threads that are currently in an epoch. When a thread enters an
- * epoch, it is added to the per-CPU list. When a thread exits an epoch, it is removed from the per-CPU list. When a
- * thread exits an epoch, the CPU checks if the per-CPU list is empty. If it is empty, then the CPU checks if the
+ * epoch, it is added to the per-CPU list. When a thread exits an epoch, it is removed from the per-CPU list and the CPU checks if the per-CPU list is empty. If it is empty, then the CPU checks if the
  * timer is armed. If the timer is not armed, then the CPU arms the timer. When the timer expires, the release epoch
  * computation is initiated. The release epoch computation is a two-phase process. First, each CPU determines the
  * minimum epoch of all threads on the CPU. Second, the minimum epoch is committed as the release epoch and any memory
@@ -18,7 +17,7 @@
  * the message to the minimum of the local minima and the minima in the message. The message is then forwarded to the
  * next CPU. The last CPU then sends an epoch commit message to CPU 0 with the final proposed release epoch. CPU 0 then
  * commits the proposed release epoch and releases any memory that is older than the release epoch and forwards the
- * message to the next CPU. The last CPU then sends a epoch computation complete message to CPU 0 which permits the
+ * message to the next CPU. The last CPU then sends an epoch computation complete message to CPU 0 which permits the
  * timer to be submit another release epoch computation.
  */
 
@@ -84,7 +83,7 @@ typedef enum _ebpf_epoch_cpu_message_type
                                                       ///< reclamation.
                                                       ///< 4. Rearms the timer if need.
                                                       ///< 5. Forwards the message to the next CPU.
-                                                      ///< The last CPU then sends a epoch computation complete message
+                                                      ///< The last CPU then sends an epoch computation complete message
                                                       ///< to CPU 0.
     EBPF_EPOCH_CPU_MESSAGE_TYPE_PROPOSE_EPOCH_COMPLETE, ///< This message is sent only to CPU 0 to signal that epoch
                                                         ///< computation is complete.
@@ -869,7 +868,7 @@ _ebpf_epoch_messenger_rundown_in_progress(
 /**
  * @brief Message to query if the free list is empty.
  * EBPF_EPOCH_CPU_MESSAGE_TYPE_IS_FREE_LIST_EMPTY message:
- * Message is sent to each CPU to query if it's local free list is empty.
+ * Message is sent to each CPU to query if its local free list is empty.
  *
  * @param[in] dpc DPC that triggered this function.
  * @param[in] cpu_entry CPU entry to check.

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -14,9 +14,9 @@
  * computation is initiated. The release epoch computation is a two-phase process. First, each CPU determines the
  * minimum epoch of all threads on the CPU. Second, the minimum epoch is committed as the release epoch and any memory
  * that is older than the release epoch is released. The release epoch computation is initiated by sending a message
- * to CPU 0. Each CPU then queries the epoch for each thread linked to  this CPU and sets the proposed release epoch in
+ * to CPU 0. Each CPU then queries the epoch for each thread linked to this CPU and sets the proposed release epoch in
  * the message to the minimum of the local minima and the minima in the message. The message is then forwarded to the
- * next CPU. The last CPU then sends a epoch commit message to CPU 0 with the final proposed release epoch. CPU 0 then
+ * next CPU. The last CPU then sends an epoch commit message to CPU 0 with the final proposed release epoch. CPU 0 then
  * commits the proposed release epoch and releases any memory that is older than the release epoch and forwards the
  * message to the next CPU. The last CPU then sends a epoch computation complete message to CPU 0 which permits the
  * timer to be submit another release epoch computation.
@@ -71,7 +71,7 @@ typedef enum _ebpf_epoch_cpu_message_type
                                                        ///< thread linked to this CPU and sets the proposed release
                                                        ///< epoch in the message to the minimum of the local minima and
                                                        ///< the minima in the message. The message is then forwarded to
-                                                       ///< the next CPU. The last CPU then sends a epoch commit message
+                                                       ///< the next CPU. The last CPU then sends an epoch commit message
                                                        ///< to CPU 0 with the final proposed release epoch.
 
     EBPF_EPOCH_CPU_MESSAGE_TYPE_COMMIT_RELEASE_EPOCH, ///< This message is sent to CPU 0 to commit the proposed release
@@ -92,7 +92,7 @@ typedef enum _ebpf_epoch_cpu_message_type
     EBPF_EPOCH_CPU_MESSAGE_TYPE_RUNDOWN_IN_PROGRESS, ///< This message is sent to each CPU to notify it that epoch code
                                                      ///< is shutting down and that no future timers should be armed and
                                                      ///< future messages should be ignored.
-    EBPF_EPOCH_CPU_MESSAGE_TYPE_IS_FREE_LIST_EMPTY,  ///< This message is sent to each CPU to query if it's local free
+    EBPF_EPOCH_CPU_MESSAGE_TYPE_IS_FREE_LIST_EMPTY,  ///< This message is sent to each CPU to query if its local free
                                                      ///< list is empty.
 } ebpf_epoch_cpu_message_type_t;
 

--- a/libs/runtime/ebpf_epoch.h
+++ b/libs/runtime/ebpf_epoch.h
@@ -11,7 +11,13 @@ extern "C"
 #endif
 
     typedef struct _ebpf_epoch_work_item ebpf_epoch_work_item_t;
-    typedef struct _ebpf_epoch_state ebpf_epoch_state_t;
+    typedef struct _ebpf_epoch_state
+    {
+        LIST_ENTRY epoch_list_entry; /// List entry for the epoch list.
+        uint64_t epoch;              /// The epoch when this entry was added to the list.
+        uint32_t cpu_id;             /// The CPU on which this entry was added to the list.
+        KIRQL irql_at_enter;         /// The IRQL when this entry was added to the list.
+    } ebpf_epoch_state_t;
 
     /**
      * @brief Initialize the eBPF epoch tracking module.
@@ -32,10 +38,10 @@ extern "C"
 
     /**
      * @brief Called prior to touching memory with lifetime under epoch control.
-     * @returns Pointer to epoch state that must be passed to ebpf_epoch_exit.
+     * @param[in] epoch_state Pointer to epoch state to be filled in.
      */
-    ebpf_epoch_state_t*
-    ebpf_epoch_enter();
+    void
+    ebpf_epoch_enter(_Out_ ebpf_epoch_state_t* epoch_state);
 
     /**
      * @brief Called after touching memory with lifetime under epoch control.

--- a/libs/runtime/ebpf_epoch.h
+++ b/libs/runtime/ebpf_epoch.h
@@ -40,14 +40,14 @@ extern "C"
      * @brief Called prior to touching memory with lifetime under epoch control.
      * @param[in] epoch_state Pointer to epoch state to be filled in.
      */
-    void
+    _IRQL_requires_same_ void
     ebpf_epoch_enter(_Out_ ebpf_epoch_state_t* epoch_state);
 
     /**
      * @brief Called after touching memory with lifetime under epoch control.
      * @param[in] epoch_state Pointer to epoch state returned by ebpf_epoch_enter.
      */
-    void
+    _IRQL_requires_same_ void
     ebpf_epoch_exit(_In_ ebpf_epoch_state_t* epoch_state);
 
     /**

--- a/tests/performance/ExecutionContext.cpp
+++ b/tests/performance/ExecutionContext.cpp
@@ -79,10 +79,11 @@ typedef class _ebpf_program_test_state
     {
         uint32_t result;
         ebpf_execution_context_state_t state = {0};
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         ebpf_get_execution_context_state(&state);
         ebpf_program_invoke(program, context, &result, &state);
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
 
   private:
@@ -124,11 +125,12 @@ typedef class _ebpf_map_test_state
         uint32_t key = cpu_id;
         volatile uint64_t* value = nullptr;
 
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         (void)ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
         uint64_t local = *value;
         UNREFERENCED_PARAMETER(local);
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
 
     void
@@ -136,10 +138,11 @@ typedef class _ebpf_map_test_state
     {
         uint32_t key = cpu_id;
         uint64_t* value = nullptr;
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         (void)ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER);
         (*value)++;
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
 
     void
@@ -147,9 +150,10 @@ typedef class _ebpf_map_test_state
     {
         uint32_t key = cpu_id;
         uint64_t value = 0;
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         (void)ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
 
     void
@@ -157,9 +161,10 @@ typedef class _ebpf_map_test_state
     {
         uint32_t key = ebpf_random_uint32();
         uint64_t value = 0;
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         (void)ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
 
     void
@@ -175,7 +180,8 @@ typedef class _ebpf_map_test_state
             }
         }
         uint32_t key = lru_key_base + (ebpf_random_uint32() % lru_key_range);
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         // Check if the current key is present.
         if (ebpf_map_find_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_MAP_FLAG_HELPER) == EBPF_SUCCESS) {
             // Cache hit.
@@ -183,7 +189,7 @@ typedef class _ebpf_map_test_state
             // Cache miss. Add it to the LRU map.
             (void)ebpf_map_update_entry(map, 0, (uint8_t*)&key, 0, (uint8_t*)&value, EBPF_ANY, EBPF_MAP_FLAG_HELPER);
         }
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
 
   private:
@@ -235,11 +241,12 @@ typedef class _ebpf_map_lpm_trie_test_state
         std::vector<uint8_t> key(prefix.size() + sizeof(length));
         memcpy(key.data(), &length, sizeof(length));
         std::copy(prefix.begin(), prefix.end(), key.begin() + sizeof(length));
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         REQUIRE(
             ebpf_map_update_entry(map, key.size(), key.data(), value.size(), value.data(), EBPF_ANY, 0) ==
             EBPF_SUCCESS);
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
 
     void
@@ -252,10 +259,11 @@ typedef class _ebpf_map_lpm_trie_test_state
         } ipv4_key = {32, ipv4_routes[ebpf_random_uint32() % ipv4_routes.size()].second};
         volatile uint64_t* value = nullptr;
 
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         (void)ebpf_map_find_entry(map, sizeof(ipv4_key), (uint8_t*)&ipv4_key, sizeof(value), (uint8_t*)&value, 0);
         UNREFERENCED_PARAMETER(value);
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
 
     ~_ebpf_map_lpm_trie_test_state()

--- a/tests/performance/platform.cpp
+++ b/tests/performance/platform.cpp
@@ -8,14 +8,16 @@
 static void
 _perf_epoch_enter_exit()
 {
-    ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
-    ebpf_epoch_exit(epoch_state);
+    ebpf_epoch_state_t epoch_state;
+    ebpf_epoch_enter(&epoch_state);
+    ebpf_epoch_exit(&epoch_state);
 }
 
 static void
 _perf_epoch_enter_alloc_free_exit()
 {
-    ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_state_t epoch_state;
+    ebpf_epoch_enter(&epoch_state);
     void* p = ebpf_epoch_allocate(10);
     if (p != NULL) {
         ebpf_epoch_free(p);
@@ -26,41 +28,45 @@ _perf_epoch_enter_alloc_free_exit()
         memset(p, 0xAA, 10);
 #pragma warning(pop)
     }
-    ebpf_epoch_exit(epoch_state);
+    ebpf_epoch_exit(&epoch_state);
 }
 
 static void
 _perf_bpf_get_prandom_u32()
 {
-    ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_state_t epoch_state;
+    ebpf_epoch_enter(&epoch_state);
     ebpf_random_uint32();
-    ebpf_epoch_exit(epoch_state);
+    ebpf_epoch_exit(&epoch_state);
 }
 
 static void
 _perf_bpf_ktime_get_boot_ns()
 {
     uint64_t time;
-    ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_state_t epoch_state;
+    ebpf_epoch_enter(&epoch_state);
     time = ebpf_query_time_since_boot(true) * EBPF_NS_PER_FILETIME;
-    ebpf_epoch_exit(epoch_state);
+    ebpf_epoch_exit(&epoch_state);
 }
 
 static void
 _perf_bpf_ktime_get_ns()
 {
     uint64_t time;
-    ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_state_t epoch_state;
+    ebpf_epoch_enter(&epoch_state);
     time = ebpf_query_time_since_boot(false) * EBPF_NS_PER_FILETIME;
-    ebpf_epoch_exit(epoch_state);
+    ebpf_epoch_exit(&epoch_state);
 }
 
 static void
 _perf_bpf_get_smp_processor_id()
 {
-    ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+    ebpf_epoch_state_t epoch_state;
+    ebpf_epoch_enter(&epoch_state);
     ebpf_get_current_cpu();
-    ebpf_epoch_exit(epoch_state);
+    ebpf_epoch_exit(&epoch_state);
 }
 
 /**
@@ -79,7 +85,8 @@ typedef class _ebpf_hash_table_test_state
         REQUIRE(ebpf_epoch_initiate() == EBPF_SUCCESS);
         epoch_initiated = true;
 
-        ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+        ebpf_epoch_state_t epoch_state;
+        ebpf_epoch_enter(&epoch_state);
         keys.resize(static_cast<size_t>(cpu_count) * 4ull);
         const ebpf_hash_table_creation_options_t options = {
             .key_size = sizeof(uint32_t),
@@ -98,7 +105,7 @@ typedef class _ebpf_hash_table_test_state
                     reinterpret_cast<uint8_t*>(&value),
                     EBPF_HASH_TABLE_OPERATION_ANY) == EBPF_SUCCESS);
         }
-        ebpf_epoch_exit(epoch_state);
+        ebpf_epoch_exit(&epoch_state);
     }
     ~_ebpf_hash_table_test_state()
     {
@@ -118,10 +125,11 @@ typedef class _ebpf_hash_table_test_state
     {
         uint8_t* value;
         for (auto& key : keys) {
-            ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+            ebpf_epoch_state_t epoch_state;
+            ebpf_epoch_enter(&epoch_state);
             // Expected to fail.
             (void)ebpf_hash_table_find(table, reinterpret_cast<uint8_t*>(&key), &value);
-            ebpf_epoch_exit(epoch_state);
+            ebpf_epoch_exit(&epoch_state);
         }
     }
 
@@ -130,11 +138,12 @@ typedef class _ebpf_hash_table_test_state
     {
         uint32_t next_key;
         for (auto& key : keys) {
-            ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+            ebpf_epoch_state_t epoch_state;
+            ebpf_epoch_enter(&epoch_state);
             // Expected to fail.
             (void)ebpf_hash_table_next_key(
                 table, reinterpret_cast<uint8_t*>(&key), reinterpret_cast<uint8_t*>(&next_key));
-            ebpf_epoch_exit(epoch_state);
+            ebpf_epoch_exit(&epoch_state);
         }
     }
 
@@ -147,14 +156,15 @@ typedef class _ebpf_hash_table_test_state
             uint32_t start = current_cpu * 4;
             uint32_t end = start + 4;
             for (uint32_t index = start; index < end; index++) {
-                ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+                ebpf_epoch_state_t epoch_state;
+                ebpf_epoch_enter(&epoch_state);
                 // Expected to fail.
                 (void)ebpf_hash_table_update(
                     table,
                     reinterpret_cast<uint8_t*>(&keys[index]),
                     reinterpret_cast<uint8_t*>(&value),
                     EBPF_HASH_TABLE_OPERATION_REPLACE);
-                ebpf_epoch_exit(epoch_state);
+                ebpf_epoch_exit(&epoch_state);
             }
         }
     }
@@ -165,14 +175,15 @@ typedef class _ebpf_hash_table_test_state
         uint64_t value = 12345678;
         // Update conflicting keys
         for (auto& key : keys) {
-            ebpf_epoch_state_t* epoch_state = ebpf_epoch_enter();
+            ebpf_epoch_state_t epoch_state;
+            ebpf_epoch_enter(&epoch_state);
             // Expected to fail.
             (void)ebpf_hash_table_update(
                 table,
                 reinterpret_cast<uint8_t*>(&key),
                 reinterpret_cast<uint8_t*>(&value),
                 EBPF_HASH_TABLE_OPERATION_REPLACE);
-            ebpf_epoch_exit(epoch_state);
+            ebpf_epoch_exit(&epoch_state);
         }
     }
 


### PR DESCRIPTION
## Description

Switch epoch logic from relying on spin-lock for protecting to relying on running at IRQL == DISPATCH_LEVEL.

Batching == 1

Before:
```cmd
C:\bpf_perf>RelWithDebInfo\bpf_performance_runner.exe -i tests.yml -e .sys -t "Baseline" -b 1 -c  50000000
Test,CPU 0,CPU 1,CPU 2,CPU 3,CPU 4,CPU 5
Baseline,119,119,115,117,116,118
```

After:
```cmd
C:\bpf_perf>RelWithDebInfo\bpf_performance_runner.exe -i tests.yml -e .sys -t "Baseline" -b 1 -c  50000000
Test,CPU 0,CPU 1,CPU 2,CPU 3,CPU 4,CPU 5
Baseline,31,30,31,31,31,33
```

Batching == 64

Before:
```cmd
C:\bpf_perf>RelWithDebInfo\bpf_performance_runner.exe -i tests.yml -e .sys -t "Baseline" -c  50000000
Test,CPU 0,CPU 1,CPU 2,CPU 3,CPU 4,CPU 5
Baseline,10,11,10,9,10,10
```

After:
```cmd
C:\bpf_perf>RelWithDebInfo\bpf_performance_runner.exe -i tests.yml -e .sys -t "Baseline" -c  50000000
Test,CPU 0,CPU 1,CPU 2,CPU 3,CPU 4,CPU 5
Baseline,8,7,7,8,8,8
```


## Testing

CI/CD + performance + stress.

## Documentation

Yes.

## Installation

No.

Resolves: #2787