### PR TITLE
Fix bindmonitor_tail_call_invoke_program_test test case with 31 MAX tail calls

### DIFF
--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_dll.c
@@ -45,7 +45,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         32,                      // Maximum number of entries allowed in the map.
+         31,                      // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.
@@ -109,37 +109,49 @@ BindMonitor_Caller(void* context)
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
 #line 31 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
-    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
+    // EBPF_OP_LDDW pc=1 dst=r1 src=r0 offset=0 imm=544761188
 #line 31 "sample/bindmonitor_mt_tailcall.c"
-    r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
+    r1 = (uint64_t)2924860388435300;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-8 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=1818321696
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
+    r1 = (uint64_t)7955925866773570336;
+    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-16 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=540701285
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
+    r1 = (uint64_t)7811882042596684389;
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-24 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1601335156
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7812726395573006196;
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-32 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1684957506
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7597131999608727874;
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-40 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=16 dst=r1 src=r10 offset=0 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
+    // EBPF_OP_ADD64_IMM pc=17 dst=r1 src=r0 offset=0 imm=-40
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
+    r1 += IMMEDIATE(-40);
+    // EBPF_OP_MOV64_IMM pc=18 dst=r2 src=r0 offset=0 imm=40
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=0
+    r2 = IMMEDIATE(40);
+    // EBPF_OP_MOV64_IMM pc=19 dst=r3 src=r0 offset=0 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
+    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=13
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Caller_helpers[0].address
 #line 33 "sample/bindmonitor_mt_tailcall.c"
@@ -148,16 +160,16 @@ BindMonitor_Caller(void* context)
     if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0))
 #line 33 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=22 dst=r2 src=r0 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=24 dst=r3 src=r0 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
+    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=5
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Caller_helpers[1].address
 #line 34 "sample/bindmonitor_mt_tailcall.c"
@@ -166,10 +178,10 @@ BindMonitor_Caller(void* context)
     if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0))
 #line 34 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     return r0;
 #line 36 "sample/bindmonitor_mt_tailcall.c"
@@ -193,101 +205,157 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[0].address
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[1].address
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee0_helpers[0].address
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -308,101 +376,157 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=2
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=2
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[1].address
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=2
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee1_helpers[0].address
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -423,101 +547,157 @@ static uint16_t BindMonitor_Callee10_maps[] = {
 #pragma code_seg(push, "bind/10")
 static uint64_t
 BindMonitor_Callee10(void* context)
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=11
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee10_helpers[0].address
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=11
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee10_helpers[1].address
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0))
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=11
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee10_helpers[0].address
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -538,101 +718,157 @@ static uint16_t BindMonitor_Callee11_maps[] = {
 #pragma code_seg(push, "bind/11")
 static uint64_t
 BindMonitor_Callee11(void* context)
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=12
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee11_helpers[0].address
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=12
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee11_helpers[1].address
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0))
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=12
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee11_helpers[0].address
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -653,101 +889,157 @@ static uint16_t BindMonitor_Callee12_maps[] = {
 #pragma code_seg(push, "bind/12")
 static uint64_t
 BindMonitor_Callee12(void* context)
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee12_helpers[0].address
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee12_helpers[1].address
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0))
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=13
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee12_helpers[0].address
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -768,101 +1060,157 @@ static uint16_t BindMonitor_Callee13_maps[] = {
 #pragma code_seg(push, "bind/13")
 static uint64_t
 BindMonitor_Callee13(void* context)
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=14
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee13_helpers[0].address
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=14
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee13_helpers[1].address
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0))
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=14
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee13_helpers[0].address
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -883,101 +1231,157 @@ static uint16_t BindMonitor_Callee14_maps[] = {
 #pragma code_seg(push, "bind/14")
 static uint64_t
 BindMonitor_Callee14(void* context)
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=15
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee14_helpers[0].address
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=15
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee14_helpers[1].address
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0))
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=15
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee14_helpers[0].address
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -998,101 +1402,157 @@ static uint16_t BindMonitor_Callee15_maps[] = {
 #pragma code_seg(push, "bind/15")
 static uint64_t
 BindMonitor_Callee15(void* context)
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=16
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee15_helpers[0].address
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=16
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee15_helpers[1].address
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0))
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=16
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee15_helpers[0].address
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1113,101 +1573,157 @@ static uint16_t BindMonitor_Callee16_maps[] = {
 #pragma code_seg(push, "bind/16")
 static uint64_t
 BindMonitor_Callee16(void* context)
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=17
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee16_helpers[0].address
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=17
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee16_helpers[1].address
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0))
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=17
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee16_helpers[0].address
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1228,101 +1744,157 @@ static uint16_t BindMonitor_Callee17_maps[] = {
 #pragma code_seg(push, "bind/17")
 static uint64_t
 BindMonitor_Callee17(void* context)
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=18
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee17_helpers[0].address
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=18
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee17_helpers[1].address
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0))
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=18
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee17_helpers[0].address
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1343,101 +1915,157 @@ static uint16_t BindMonitor_Callee18_maps[] = {
 #pragma code_seg(push, "bind/18")
 static uint64_t
 BindMonitor_Callee18(void* context)
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=19
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee18_helpers[0].address
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=19
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee18_helpers[1].address
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0))
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=19
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee18_helpers[0].address
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1458,101 +2086,157 @@ static uint16_t BindMonitor_Callee19_maps[] = {
 #pragma code_seg(push, "bind/19")
 static uint64_t
 BindMonitor_Callee19(void* context)
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee19_helpers[0].address
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee19_helpers[1].address
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0))
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=20
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee19_helpers[0].address
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1573,101 +2257,157 @@ static uint16_t BindMonitor_Callee2_maps[] = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 BindMonitor_Callee2(void* context)
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=3
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee2_helpers[0].address
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=3
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee2_helpers[1].address
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0))
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=3
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee2_helpers[0].address
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1688,101 +2428,157 @@ static uint16_t BindMonitor_Callee20_maps[] = {
 #pragma code_seg(push, "bind/20")
 static uint64_t
 BindMonitor_Callee20(void* context)
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=21
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee20_helpers[0].address
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=21
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee20_helpers[1].address
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0))
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=21
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee20_helpers[0].address
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1803,101 +2599,157 @@ static uint16_t BindMonitor_Callee21_maps[] = {
 #pragma code_seg(push, "bind/21")
 static uint64_t
 BindMonitor_Callee21(void* context)
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=22
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee21_helpers[0].address
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=22
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee21_helpers[1].address
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0))
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=22
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee21_helpers[0].address
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1918,101 +2770,157 @@ static uint16_t BindMonitor_Callee22_maps[] = {
 #pragma code_seg(push, "bind/22")
 static uint64_t
 BindMonitor_Callee22(void* context)
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=23
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee22_helpers[0].address
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=23
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee22_helpers[1].address
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0))
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=23
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee22_helpers[0].address
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2033,101 +2941,157 @@ static uint16_t BindMonitor_Callee23_maps[] = {
 #pragma code_seg(push, "bind/23")
 static uint64_t
 BindMonitor_Callee23(void* context)
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee23_helpers[0].address
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee23_helpers[1].address
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0))
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=24
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee23_helpers[0].address
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2148,101 +3112,157 @@ static uint16_t BindMonitor_Callee24_maps[] = {
 #pragma code_seg(push, "bind/24")
 static uint64_t
 BindMonitor_Callee24(void* context)
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=25
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee24_helpers[0].address
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=25
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee24_helpers[1].address
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0))
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=25
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee24_helpers[0].address
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2263,101 +3283,157 @@ static uint16_t BindMonitor_Callee25_maps[] = {
 #pragma code_seg(push, "bind/25")
 static uint64_t
 BindMonitor_Callee25(void* context)
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=26
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee25_helpers[0].address
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=26
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee25_helpers[1].address
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0))
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=26
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee25_helpers[0].address
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2378,101 +3454,157 @@ static uint16_t BindMonitor_Callee26_maps[] = {
 #pragma code_seg(push, "bind/26")
 static uint64_t
 BindMonitor_Callee26(void* context)
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=27
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee26_helpers[0].address
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=27
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee26_helpers[1].address
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0))
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=27
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee26_helpers[0].address
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2493,101 +3625,157 @@ static uint16_t BindMonitor_Callee27_maps[] = {
 #pragma code_seg(push, "bind/27")
 static uint64_t
 BindMonitor_Callee27(void* context)
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=28
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee27_helpers[0].address
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=28
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee27_helpers[1].address
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0))
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=28
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee27_helpers[0].address
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2608,101 +3796,157 @@ static uint16_t BindMonitor_Callee28_maps[] = {
 #pragma code_seg(push, "bind/28")
 static uint64_t
 BindMonitor_Callee28(void* context)
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=29
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee28_helpers[0].address
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=29
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee28_helpers[1].address
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0))
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=29
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee28_helpers[0].address
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2723,101 +3967,157 @@ static uint16_t BindMonitor_Callee29_maps[] = {
 #pragma code_seg(push, "bind/29")
 static uint64_t
 BindMonitor_Callee29(void* context)
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=30
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee29_helpers[0].address
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=30
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee29_helpers[1].address
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0))
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=30
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee29_helpers[0].address
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2838,252 +4138,193 @@ static uint16_t BindMonitor_Callee3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 BindMonitor_Callee3(void* context)
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=4
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee3_helpers[0].address
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=4
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee3_helpers[1].address
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0))
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=4
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee3_helpers[0].address
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
-
-static helper_function_entry_t BindMonitor_Callee30_helpers[] = {
-    {NULL, 13, "helper_id_13"},
-    {NULL, 5, "helper_id_5"},
-};
 
 static GUID BindMonitor_Callee30_program_type_guid = {
     0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID BindMonitor_Callee30_attach_type_guid = {
     0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-static uint16_t BindMonitor_Callee30_maps[] = {
-    0,
-};
-
 #pragma code_seg(push, "bind/30")
 static uint64_t
 BindMonitor_Callee30(void* context)
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r2 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r3 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r4 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r5 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r6 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
-
-    // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r6 = r1;
-    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=31
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r3 = IMMEDIATE(31);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=31
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r3 = IMMEDIATE(31);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[1].address
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0))
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-        return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    return r0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-}
-#pragma code_seg(pop)
-#line __LINE__ __FILE__
-
-static GUID BindMonitor_Callee31_program_type_guid = {
-    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
-static GUID BindMonitor_Callee31_attach_type_guid = {
-    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-#pragma code_seg(push, "bind/31")
-static uint64_t
-BindMonitor_Callee31(void* context)
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-{
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    // Prologue
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r0 = 0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r1 = 0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r10 = 0;
-
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uintptr_t)context;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=0
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=1 dst=r0 src=r0 offset=0 imm=0
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3104,101 +4345,157 @@ static uint16_t BindMonitor_Callee4_maps[] = {
 #pragma code_seg(push, "bind/4")
 static uint64_t
 BindMonitor_Callee4(void* context)
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee4_helpers[0].address
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee4_helpers[1].address
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0))
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=5
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee4_helpers[0].address
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3219,101 +4516,157 @@ static uint16_t BindMonitor_Callee5_maps[] = {
 #pragma code_seg(push, "bind/5")
 static uint64_t
 BindMonitor_Callee5(void* context)
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=6
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee5_helpers[0].address
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=6
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee5_helpers[1].address
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0))
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=6
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee5_helpers[0].address
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3334,101 +4687,157 @@ static uint16_t BindMonitor_Callee6_maps[] = {
 #pragma code_seg(push, "bind/6")
 static uint64_t
 BindMonitor_Callee6(void* context)
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=7
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee6_helpers[0].address
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=7
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee6_helpers[1].address
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0))
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=7
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee6_helpers[0].address
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3449,101 +4858,157 @@ static uint16_t BindMonitor_Callee7_maps[] = {
 #pragma code_seg(push, "bind/7")
 static uint64_t
 BindMonitor_Callee7(void* context)
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee7_helpers[0].address
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee7_helpers[1].address
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0))
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee7_helpers[0].address
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3564,101 +5029,157 @@ static uint16_t BindMonitor_Callee8_maps[] = {
 #pragma code_seg(push, "bind/8")
 static uint64_t
 BindMonitor_Callee8(void* context)
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=9
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee8_helpers[0].address
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=9
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee8_helpers[1].address
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0))
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=9
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee8_helpers[0].address
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3679,101 +5200,159 @@ static uint16_t BindMonitor_Callee9_maps[] = {
 #pragma code_seg(push, "bind/9")
 static uint64_t
 BindMonitor_Callee9(void* context)
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r8 = 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r8 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_MOV64_IMM pc=12 dst=r2 src=r0 offset=0 imm=20
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=10
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=13 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(10);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=13
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee9_helpers[0].address
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_LDDW pc=16 dst=r2 src=r0 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=10
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=18 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(10);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=5
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee9_helpers[1].address
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0))
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-8 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=23 dst=r1 src=r0 offset=0 imm=544497952
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=25 dst=r10 src=r1 offset=-16 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=26 dst=r1 src=r0 offset=0 imm=1634082924
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-24 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r7 offset=-32 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_STXH pc=30 dst=r10 src=r8 offset=-4 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee9_helpers[0].address
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3790,7 +5369,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Caller_helpers,
         2,
-        21,
+        28,
         &BindMonitor_Caller_program_type_guid,
         &BindMonitor_Caller_attach_type_guid,
     },
@@ -3804,7 +5383,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee0_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee0_program_type_guid,
         &BindMonitor_Callee0_attach_type_guid,
     },
@@ -3818,7 +5397,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee1_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee1_program_type_guid,
         &BindMonitor_Callee1_attach_type_guid,
     },
@@ -3832,7 +5411,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee10_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee10_program_type_guid,
         &BindMonitor_Callee10_attach_type_guid,
     },
@@ -3846,7 +5425,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee11_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee11_program_type_guid,
         &BindMonitor_Callee11_attach_type_guid,
     },
@@ -3860,7 +5439,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee12_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee12_program_type_guid,
         &BindMonitor_Callee12_attach_type_guid,
     },
@@ -3874,7 +5453,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee13_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee13_program_type_guid,
         &BindMonitor_Callee13_attach_type_guid,
     },
@@ -3888,7 +5467,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee14_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee14_program_type_guid,
         &BindMonitor_Callee14_attach_type_guid,
     },
@@ -3902,7 +5481,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee15_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee15_program_type_guid,
         &BindMonitor_Callee15_attach_type_guid,
     },
@@ -3916,7 +5495,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee16_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee16_program_type_guid,
         &BindMonitor_Callee16_attach_type_guid,
     },
@@ -3930,7 +5509,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee17_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee17_program_type_guid,
         &BindMonitor_Callee17_attach_type_guid,
     },
@@ -3944,7 +5523,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee18_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee18_program_type_guid,
         &BindMonitor_Callee18_attach_type_guid,
     },
@@ -3958,7 +5537,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee19_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee19_program_type_guid,
         &BindMonitor_Callee19_attach_type_guid,
     },
@@ -3972,7 +5551,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee2_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee2_program_type_guid,
         &BindMonitor_Callee2_attach_type_guid,
     },
@@ -3986,7 +5565,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee20_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee20_program_type_guid,
         &BindMonitor_Callee20_attach_type_guid,
     },
@@ -4000,7 +5579,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee21_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee21_program_type_guid,
         &BindMonitor_Callee21_attach_type_guid,
     },
@@ -4014,7 +5593,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee22_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee22_program_type_guid,
         &BindMonitor_Callee22_attach_type_guid,
     },
@@ -4028,7 +5607,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee23_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee23_program_type_guid,
         &BindMonitor_Callee23_attach_type_guid,
     },
@@ -4042,7 +5621,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee24_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee24_program_type_guid,
         &BindMonitor_Callee24_attach_type_guid,
     },
@@ -4056,7 +5635,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee25_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee25_program_type_guid,
         &BindMonitor_Callee25_attach_type_guid,
     },
@@ -4070,7 +5649,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee26_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee26_program_type_guid,
         &BindMonitor_Callee26_attach_type_guid,
     },
@@ -4084,7 +5663,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee27_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee27_program_type_guid,
         &BindMonitor_Callee27_attach_type_guid,
     },
@@ -4098,7 +5677,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee28_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee28_program_type_guid,
         &BindMonitor_Callee28_attach_type_guid,
     },
@@ -4112,7 +5691,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee29_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee29_program_type_guid,
         &BindMonitor_Callee29_attach_type_guid,
     },
@@ -4126,7 +5705,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee3_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee3_program_type_guid,
         &BindMonitor_Callee3_attach_type_guid,
     },
@@ -4136,27 +5715,13 @@ static program_entry_t _programs[] = {
         "bind/30",
         "bind/30",
         "BindMonitor_Callee30",
-        BindMonitor_Callee30_maps,
-        1,
-        BindMonitor_Callee30_helpers,
+        NULL,
+        0,
+        NULL,
+        0,
         2,
-        21,
         &BindMonitor_Callee30_program_type_guid,
         &BindMonitor_Callee30_attach_type_guid,
-    },
-    {
-        0,
-        BindMonitor_Callee31,
-        "bind/31",
-        "bind/31",
-        "BindMonitor_Callee31",
-        NULL,
-        0,
-        NULL,
-        0,
-        2,
-        &BindMonitor_Callee31_program_type_guid,
-        &BindMonitor_Callee31_attach_type_guid,
     },
     {
         0,
@@ -4168,7 +5733,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee4_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee4_program_type_guid,
         &BindMonitor_Callee4_attach_type_guid,
     },
@@ -4182,7 +5747,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee5_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee5_program_type_guid,
         &BindMonitor_Callee5_attach_type_guid,
     },
@@ -4196,7 +5761,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee6_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee6_program_type_guid,
         &BindMonitor_Callee6_attach_type_guid,
     },
@@ -4210,7 +5775,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee7_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee7_program_type_guid,
         &BindMonitor_Callee7_attach_type_guid,
     },
@@ -4224,7 +5789,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee8_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee8_program_type_guid,
         &BindMonitor_Callee8_attach_type_guid,
     },
@@ -4238,7 +5803,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee9_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee9_program_type_guid,
         &BindMonitor_Callee9_attach_type_guid,
     },
@@ -4249,7 +5814,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 33;
+    *count = 32;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_raw.c
@@ -19,7 +19,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         32,                      // Maximum number of entries allowed in the map.
+         31,                      // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.
@@ -83,37 +83,49 @@ BindMonitor_Caller(void* context)
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
 #line 31 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
-    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
+    // EBPF_OP_LDDW pc=1 dst=r1 src=r0 offset=0 imm=544761188
 #line 31 "sample/bindmonitor_mt_tailcall.c"
-    r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
+    r1 = (uint64_t)2924860388435300;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-8 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=1818321696
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
+    r1 = (uint64_t)7955925866773570336;
+    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-16 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=540701285
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
+    r1 = (uint64_t)7811882042596684389;
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-24 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1601335156
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7812726395573006196;
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-32 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1684957506
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7597131999608727874;
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-40 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=16 dst=r1 src=r10 offset=0 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
+    // EBPF_OP_ADD64_IMM pc=17 dst=r1 src=r0 offset=0 imm=-40
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
+    r1 += IMMEDIATE(-40);
+    // EBPF_OP_MOV64_IMM pc=18 dst=r2 src=r0 offset=0 imm=40
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=0
+    r2 = IMMEDIATE(40);
+    // EBPF_OP_MOV64_IMM pc=19 dst=r3 src=r0 offset=0 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
+    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=13
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Caller_helpers[0].address
 #line 33 "sample/bindmonitor_mt_tailcall.c"
@@ -122,16 +134,16 @@ BindMonitor_Caller(void* context)
     if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0))
 #line 33 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=22 dst=r2 src=r0 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=24 dst=r3 src=r0 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
+    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=5
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Caller_helpers[1].address
 #line 34 "sample/bindmonitor_mt_tailcall.c"
@@ -140,10 +152,10 @@ BindMonitor_Caller(void* context)
     if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0))
 #line 34 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     return r0;
 #line 36 "sample/bindmonitor_mt_tailcall.c"
@@ -167,101 +179,157 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[0].address
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[1].address
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee0_helpers[0].address
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -282,101 +350,157 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=2
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=2
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[1].address
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=2
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee1_helpers[0].address
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -397,101 +521,157 @@ static uint16_t BindMonitor_Callee10_maps[] = {
 #pragma code_seg(push, "bind/10")
 static uint64_t
 BindMonitor_Callee10(void* context)
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=11
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee10_helpers[0].address
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=11
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee10_helpers[1].address
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0))
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=11
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee10_helpers[0].address
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -512,101 +692,157 @@ static uint16_t BindMonitor_Callee11_maps[] = {
 #pragma code_seg(push, "bind/11")
 static uint64_t
 BindMonitor_Callee11(void* context)
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=12
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee11_helpers[0].address
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=12
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee11_helpers[1].address
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0))
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=12
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee11_helpers[0].address
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -627,101 +863,157 @@ static uint16_t BindMonitor_Callee12_maps[] = {
 #pragma code_seg(push, "bind/12")
 static uint64_t
 BindMonitor_Callee12(void* context)
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee12_helpers[0].address
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee12_helpers[1].address
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0))
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=13
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee12_helpers[0].address
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -742,101 +1034,157 @@ static uint16_t BindMonitor_Callee13_maps[] = {
 #pragma code_seg(push, "bind/13")
 static uint64_t
 BindMonitor_Callee13(void* context)
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=14
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee13_helpers[0].address
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=14
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee13_helpers[1].address
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0))
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=14
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee13_helpers[0].address
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -857,101 +1205,157 @@ static uint16_t BindMonitor_Callee14_maps[] = {
 #pragma code_seg(push, "bind/14")
 static uint64_t
 BindMonitor_Callee14(void* context)
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=15
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee14_helpers[0].address
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=15
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee14_helpers[1].address
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0))
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=15
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee14_helpers[0].address
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -972,101 +1376,157 @@ static uint16_t BindMonitor_Callee15_maps[] = {
 #pragma code_seg(push, "bind/15")
 static uint64_t
 BindMonitor_Callee15(void* context)
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=16
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee15_helpers[0].address
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=16
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee15_helpers[1].address
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0))
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=16
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee15_helpers[0].address
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1087,101 +1547,157 @@ static uint16_t BindMonitor_Callee16_maps[] = {
 #pragma code_seg(push, "bind/16")
 static uint64_t
 BindMonitor_Callee16(void* context)
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=17
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee16_helpers[0].address
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=17
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee16_helpers[1].address
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0))
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=17
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee16_helpers[0].address
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1202,101 +1718,157 @@ static uint16_t BindMonitor_Callee17_maps[] = {
 #pragma code_seg(push, "bind/17")
 static uint64_t
 BindMonitor_Callee17(void* context)
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=18
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee17_helpers[0].address
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=18
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee17_helpers[1].address
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0))
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=18
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee17_helpers[0].address
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1317,101 +1889,157 @@ static uint16_t BindMonitor_Callee18_maps[] = {
 #pragma code_seg(push, "bind/18")
 static uint64_t
 BindMonitor_Callee18(void* context)
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=19
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee18_helpers[0].address
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=19
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee18_helpers[1].address
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0))
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=19
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee18_helpers[0].address
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1432,101 +2060,157 @@ static uint16_t BindMonitor_Callee19_maps[] = {
 #pragma code_seg(push, "bind/19")
 static uint64_t
 BindMonitor_Callee19(void* context)
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee19_helpers[0].address
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee19_helpers[1].address
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0))
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=20
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee19_helpers[0].address
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1547,101 +2231,157 @@ static uint16_t BindMonitor_Callee2_maps[] = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 BindMonitor_Callee2(void* context)
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=3
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee2_helpers[0].address
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=3
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee2_helpers[1].address
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0))
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=3
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee2_helpers[0].address
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1662,101 +2402,157 @@ static uint16_t BindMonitor_Callee20_maps[] = {
 #pragma code_seg(push, "bind/20")
 static uint64_t
 BindMonitor_Callee20(void* context)
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=21
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee20_helpers[0].address
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=21
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee20_helpers[1].address
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0))
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=21
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee20_helpers[0].address
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1777,101 +2573,157 @@ static uint16_t BindMonitor_Callee21_maps[] = {
 #pragma code_seg(push, "bind/21")
 static uint64_t
 BindMonitor_Callee21(void* context)
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=22
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee21_helpers[0].address
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=22
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee21_helpers[1].address
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0))
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=22
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee21_helpers[0].address
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1892,101 +2744,157 @@ static uint16_t BindMonitor_Callee22_maps[] = {
 #pragma code_seg(push, "bind/22")
 static uint64_t
 BindMonitor_Callee22(void* context)
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=23
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee22_helpers[0].address
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=23
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee22_helpers[1].address
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0))
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=23
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee22_helpers[0].address
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2007,101 +2915,157 @@ static uint16_t BindMonitor_Callee23_maps[] = {
 #pragma code_seg(push, "bind/23")
 static uint64_t
 BindMonitor_Callee23(void* context)
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee23_helpers[0].address
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee23_helpers[1].address
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0))
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=24
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee23_helpers[0].address
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2122,101 +3086,157 @@ static uint16_t BindMonitor_Callee24_maps[] = {
 #pragma code_seg(push, "bind/24")
 static uint64_t
 BindMonitor_Callee24(void* context)
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=25
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee24_helpers[0].address
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=25
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee24_helpers[1].address
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0))
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=25
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee24_helpers[0].address
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2237,101 +3257,157 @@ static uint16_t BindMonitor_Callee25_maps[] = {
 #pragma code_seg(push, "bind/25")
 static uint64_t
 BindMonitor_Callee25(void* context)
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=26
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee25_helpers[0].address
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=26
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee25_helpers[1].address
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0))
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=26
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee25_helpers[0].address
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2352,101 +3428,157 @@ static uint16_t BindMonitor_Callee26_maps[] = {
 #pragma code_seg(push, "bind/26")
 static uint64_t
 BindMonitor_Callee26(void* context)
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=27
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee26_helpers[0].address
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=27
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee26_helpers[1].address
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0))
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=27
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee26_helpers[0].address
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2467,101 +3599,157 @@ static uint16_t BindMonitor_Callee27_maps[] = {
 #pragma code_seg(push, "bind/27")
 static uint64_t
 BindMonitor_Callee27(void* context)
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=28
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee27_helpers[0].address
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=28
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee27_helpers[1].address
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0))
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=28
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee27_helpers[0].address
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2582,101 +3770,157 @@ static uint16_t BindMonitor_Callee28_maps[] = {
 #pragma code_seg(push, "bind/28")
 static uint64_t
 BindMonitor_Callee28(void* context)
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=29
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee28_helpers[0].address
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=29
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee28_helpers[1].address
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0))
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=29
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee28_helpers[0].address
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2697,101 +3941,157 @@ static uint16_t BindMonitor_Callee29_maps[] = {
 #pragma code_seg(push, "bind/29")
 static uint64_t
 BindMonitor_Callee29(void* context)
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=30
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee29_helpers[0].address
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=30
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee29_helpers[1].address
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0))
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=30
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee29_helpers[0].address
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2812,252 +4112,193 @@ static uint16_t BindMonitor_Callee3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 BindMonitor_Callee3(void* context)
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=4
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee3_helpers[0].address
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=4
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee3_helpers[1].address
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0))
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=4
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee3_helpers[0].address
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
-
-static helper_function_entry_t BindMonitor_Callee30_helpers[] = {
-    {NULL, 13, "helper_id_13"},
-    {NULL, 5, "helper_id_5"},
-};
 
 static GUID BindMonitor_Callee30_program_type_guid = {
     0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID BindMonitor_Callee30_attach_type_guid = {
     0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-static uint16_t BindMonitor_Callee30_maps[] = {
-    0,
-};
-
 #pragma code_seg(push, "bind/30")
 static uint64_t
 BindMonitor_Callee30(void* context)
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r2 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r3 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r4 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r5 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r6 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
-
-    // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r6 = r1;
-    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=31
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r3 = IMMEDIATE(31);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=31
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r3 = IMMEDIATE(31);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[1].address
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0))
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-        return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    return r0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-}
-#pragma code_seg(pop)
-#line __LINE__ __FILE__
-
-static GUID BindMonitor_Callee31_program_type_guid = {
-    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
-static GUID BindMonitor_Callee31_attach_type_guid = {
-    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-#pragma code_seg(push, "bind/31")
-static uint64_t
-BindMonitor_Callee31(void* context)
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-{
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    // Prologue
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r0 = 0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r1 = 0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r10 = 0;
-
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uintptr_t)context;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=0
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=1 dst=r0 src=r0 offset=0 imm=0
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3078,101 +4319,157 @@ static uint16_t BindMonitor_Callee4_maps[] = {
 #pragma code_seg(push, "bind/4")
 static uint64_t
 BindMonitor_Callee4(void* context)
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee4_helpers[0].address
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee4_helpers[1].address
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0))
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=5
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee4_helpers[0].address
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3193,101 +4490,157 @@ static uint16_t BindMonitor_Callee5_maps[] = {
 #pragma code_seg(push, "bind/5")
 static uint64_t
 BindMonitor_Callee5(void* context)
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=6
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee5_helpers[0].address
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=6
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee5_helpers[1].address
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0))
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=6
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee5_helpers[0].address
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3308,101 +4661,157 @@ static uint16_t BindMonitor_Callee6_maps[] = {
 #pragma code_seg(push, "bind/6")
 static uint64_t
 BindMonitor_Callee6(void* context)
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=7
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee6_helpers[0].address
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=7
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee6_helpers[1].address
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0))
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=7
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee6_helpers[0].address
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3423,101 +4832,157 @@ static uint16_t BindMonitor_Callee7_maps[] = {
 #pragma code_seg(push, "bind/7")
 static uint64_t
 BindMonitor_Callee7(void* context)
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee7_helpers[0].address
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee7_helpers[1].address
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0))
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee7_helpers[0].address
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3538,101 +5003,157 @@ static uint16_t BindMonitor_Callee8_maps[] = {
 #pragma code_seg(push, "bind/8")
 static uint64_t
 BindMonitor_Callee8(void* context)
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=9
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee8_helpers[0].address
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=9
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee8_helpers[1].address
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0))
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=9
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee8_helpers[0].address
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3653,101 +5174,159 @@ static uint16_t BindMonitor_Callee9_maps[] = {
 #pragma code_seg(push, "bind/9")
 static uint64_t
 BindMonitor_Callee9(void* context)
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r8 = 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r8 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_MOV64_IMM pc=12 dst=r2 src=r0 offset=0 imm=20
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=10
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=13 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(10);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=13
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee9_helpers[0].address
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_LDDW pc=16 dst=r2 src=r0 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=10
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=18 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(10);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=5
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee9_helpers[1].address
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0))
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-8 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=23 dst=r1 src=r0 offset=0 imm=544497952
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=25 dst=r10 src=r1 offset=-16 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=26 dst=r1 src=r0 offset=0 imm=1634082924
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-24 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r7 offset=-32 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_STXH pc=30 dst=r10 src=r8 offset=-4 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee9_helpers[0].address
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3764,7 +5343,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Caller_helpers,
         2,
-        21,
+        28,
         &BindMonitor_Caller_program_type_guid,
         &BindMonitor_Caller_attach_type_guid,
     },
@@ -3778,7 +5357,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee0_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee0_program_type_guid,
         &BindMonitor_Callee0_attach_type_guid,
     },
@@ -3792,7 +5371,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee1_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee1_program_type_guid,
         &BindMonitor_Callee1_attach_type_guid,
     },
@@ -3806,7 +5385,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee10_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee10_program_type_guid,
         &BindMonitor_Callee10_attach_type_guid,
     },
@@ -3820,7 +5399,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee11_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee11_program_type_guid,
         &BindMonitor_Callee11_attach_type_guid,
     },
@@ -3834,7 +5413,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee12_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee12_program_type_guid,
         &BindMonitor_Callee12_attach_type_guid,
     },
@@ -3848,7 +5427,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee13_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee13_program_type_guid,
         &BindMonitor_Callee13_attach_type_guid,
     },
@@ -3862,7 +5441,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee14_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee14_program_type_guid,
         &BindMonitor_Callee14_attach_type_guid,
     },
@@ -3876,7 +5455,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee15_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee15_program_type_guid,
         &BindMonitor_Callee15_attach_type_guid,
     },
@@ -3890,7 +5469,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee16_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee16_program_type_guid,
         &BindMonitor_Callee16_attach_type_guid,
     },
@@ -3904,7 +5483,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee17_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee17_program_type_guid,
         &BindMonitor_Callee17_attach_type_guid,
     },
@@ -3918,7 +5497,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee18_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee18_program_type_guid,
         &BindMonitor_Callee18_attach_type_guid,
     },
@@ -3932,7 +5511,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee19_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee19_program_type_guid,
         &BindMonitor_Callee19_attach_type_guid,
     },
@@ -3946,7 +5525,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee2_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee2_program_type_guid,
         &BindMonitor_Callee2_attach_type_guid,
     },
@@ -3960,7 +5539,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee20_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee20_program_type_guid,
         &BindMonitor_Callee20_attach_type_guid,
     },
@@ -3974,7 +5553,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee21_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee21_program_type_guid,
         &BindMonitor_Callee21_attach_type_guid,
     },
@@ -3988,7 +5567,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee22_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee22_program_type_guid,
         &BindMonitor_Callee22_attach_type_guid,
     },
@@ -4002,7 +5581,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee23_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee23_program_type_guid,
         &BindMonitor_Callee23_attach_type_guid,
     },
@@ -4016,7 +5595,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee24_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee24_program_type_guid,
         &BindMonitor_Callee24_attach_type_guid,
     },
@@ -4030,7 +5609,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee25_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee25_program_type_guid,
         &BindMonitor_Callee25_attach_type_guid,
     },
@@ -4044,7 +5623,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee26_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee26_program_type_guid,
         &BindMonitor_Callee26_attach_type_guid,
     },
@@ -4058,7 +5637,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee27_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee27_program_type_guid,
         &BindMonitor_Callee27_attach_type_guid,
     },
@@ -4072,7 +5651,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee28_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee28_program_type_guid,
         &BindMonitor_Callee28_attach_type_guid,
     },
@@ -4086,7 +5665,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee29_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee29_program_type_guid,
         &BindMonitor_Callee29_attach_type_guid,
     },
@@ -4100,7 +5679,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee3_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee3_program_type_guid,
         &BindMonitor_Callee3_attach_type_guid,
     },
@@ -4110,27 +5689,13 @@ static program_entry_t _programs[] = {
         "bind/30",
         "bind/30",
         "BindMonitor_Callee30",
-        BindMonitor_Callee30_maps,
-        1,
-        BindMonitor_Callee30_helpers,
+        NULL,
+        0,
+        NULL,
+        0,
         2,
-        21,
         &BindMonitor_Callee30_program_type_guid,
         &BindMonitor_Callee30_attach_type_guid,
-    },
-    {
-        0,
-        BindMonitor_Callee31,
-        "bind/31",
-        "bind/31",
-        "BindMonitor_Callee31",
-        NULL,
-        0,
-        NULL,
-        0,
-        2,
-        &BindMonitor_Callee31_program_type_guid,
-        &BindMonitor_Callee31_attach_type_guid,
     },
     {
         0,
@@ -4142,7 +5707,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee4_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee4_program_type_guid,
         &BindMonitor_Callee4_attach_type_guid,
     },
@@ -4156,7 +5721,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee5_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee5_program_type_guid,
         &BindMonitor_Callee5_attach_type_guid,
     },
@@ -4170,7 +5735,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee6_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee6_program_type_guid,
         &BindMonitor_Callee6_attach_type_guid,
     },
@@ -4184,7 +5749,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee7_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee7_program_type_guid,
         &BindMonitor_Callee7_attach_type_guid,
     },
@@ -4198,7 +5763,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee8_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee8_program_type_guid,
         &BindMonitor_Callee8_attach_type_guid,
     },
@@ -4212,7 +5777,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee9_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee9_program_type_guid,
         &BindMonitor_Callee9_attach_type_guid,
     },
@@ -4223,7 +5788,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 33;
+    *count = 32;
 }
 
 static void

--- a/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
+++ b/tests/bpf2c_tests/expected/bindmonitor_mt_tailcall_sys.c
@@ -180,7 +180,7 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_PROG_ARRAY, // Type of map.
          4,                       // Size in bytes of a map key.
          4,                       // Size in bytes of a map value.
-         32,                      // Maximum number of entries allowed in the map.
+         31,                      // Maximum number of entries allowed in the map.
          0,                       // Inner map index.
          PIN_NONE,                // Pinning type for the map.
          0,                       // Identifier for a map template.
@@ -244,37 +244,49 @@ BindMonitor_Caller(void* context)
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
 #line 31 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
-    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
+    // EBPF_OP_LDDW pc=1 dst=r1 src=r0 offset=0 imm=544761188
 #line 31 "sample/bindmonitor_mt_tailcall.c"
-    r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
+    r1 = (uint64_t)2924860388435300;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r1 offset=-8 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=1818321696
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
+    r1 = (uint64_t)7955925866773570336;
+    // EBPF_OP_STXDW pc=6 dst=r10 src=r1 offset=-16 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=540701285
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
+    r1 = (uint64_t)7811882042596684389;
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-24 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1601335156
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7812726395573006196;
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-32 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1684957506
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7597131999608727874;
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-40 imm=0
+#line 33 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=16 dst=r1 src=r10 offset=0 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
+    // EBPF_OP_ADD64_IMM pc=17 dst=r1 src=r0 offset=0 imm=-40
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
+    r1 += IMMEDIATE(-40);
+    // EBPF_OP_MOV64_IMM pc=18 dst=r2 src=r0 offset=0 imm=40
 #line 33 "sample/bindmonitor_mt_tailcall.c"
-    r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=0
+    r2 = IMMEDIATE(40);
+    // EBPF_OP_MOV64_IMM pc=19 dst=r3 src=r0 offset=0 imm=0
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
+    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=13
 #line 33 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Caller_helpers[0].address
 #line 33 "sample/bindmonitor_mt_tailcall.c"
@@ -283,16 +295,16 @@ BindMonitor_Caller(void* context)
     if ((BindMonitor_Caller_helpers[0].tail_call) && (r0 == 0))
 #line 33 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=21 dst=r1 src=r6 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=22 dst=r2 src=r0 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=24 dst=r3 src=r0 offset=0 imm=0
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
+    // EBPF_OP_CALL pc=25 dst=r0 src=r0 offset=0 imm=5
 #line 34 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Caller_helpers[1].address
 #line 34 "sample/bindmonitor_mt_tailcall.c"
@@ -301,10 +313,10 @@ BindMonitor_Caller(void* context)
     if ((BindMonitor_Caller_helpers[1].tail_call) && (r0 == 0))
 #line 34 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=26 dst=r0 src=r0 offset=0 imm=1
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0
 #line 36 "sample/bindmonitor_mt_tailcall.c"
     return r0;
 #line 36 "sample/bindmonitor_mt_tailcall.c"
@@ -328,101 +340,157 @@ static uint16_t BindMonitor_Callee0_maps[] = {
 #pragma code_seg(push, "bind/0")
 static uint64_t
 BindMonitor_Callee0(void* context)
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 50 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[0].address
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(1);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee0_helpers[1].address
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee0_helpers[1].tail_call) && (r0 == 0))
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee0_helpers[0].address
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee0_helpers[0].tail_call) && (r0 == 0))
+#line 53 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 53 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 50 "sample/bindmonitor_mt_tailcall.c"
+#line 53 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -443,101 +511,157 @@ static uint16_t BindMonitor_Callee1_maps[] = {
 #pragma code_seg(push, "bind/1")
 static uint64_t
 BindMonitor_Callee1(void* context)
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 51 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=2
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[0].address
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=2
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(2);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee1_helpers[1].address
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee1_helpers[1].tail_call) && (r0 == 0))
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=2
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(2);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee1_helpers[0].address
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee1_helpers[0].tail_call) && (r0 == 0))
+#line 54 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 54 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 51 "sample/bindmonitor_mt_tailcall.c"
+#line 54 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -558,101 +682,157 @@ static uint16_t BindMonitor_Callee10_maps[] = {
 #pragma code_seg(push, "bind/10")
 static uint64_t
 BindMonitor_Callee10(void* context)
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 60 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=11
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee10_helpers[0].address
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=11
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(11);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee10_helpers[1].address
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee10_helpers[1].tail_call) && (r0 == 0))
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=11
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(11);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee10_helpers[0].address
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee10_helpers[0].tail_call) && (r0 == 0))
+#line 63 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 63 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 60 "sample/bindmonitor_mt_tailcall.c"
+#line 63 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -673,101 +853,157 @@ static uint16_t BindMonitor_Callee11_maps[] = {
 #pragma code_seg(push, "bind/11")
 static uint64_t
 BindMonitor_Callee11(void* context)
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 61 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=12
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee11_helpers[0].address
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=12
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(12);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee11_helpers[1].address
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee11_helpers[1].tail_call) && (r0 == 0))
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=12
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(12);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee11_helpers[0].address
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee11_helpers[0].tail_call) && (r0 == 0))
+#line 64 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 64 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 61 "sample/bindmonitor_mt_tailcall.c"
+#line 64 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -788,101 +1024,157 @@ static uint16_t BindMonitor_Callee12_maps[] = {
 #pragma code_seg(push, "bind/12")
 static uint64_t
 BindMonitor_Callee12(void* context)
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 62 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee12_helpers[0].address
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=13
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(13);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee12_helpers[1].address
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee12_helpers[1].tail_call) && (r0 == 0))
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=13
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(13);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee12_helpers[0].address
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee12_helpers[0].tail_call) && (r0 == 0))
+#line 65 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 65 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 62 "sample/bindmonitor_mt_tailcall.c"
+#line 65 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -903,101 +1195,157 @@ static uint16_t BindMonitor_Callee13_maps[] = {
 #pragma code_seg(push, "bind/13")
 static uint64_t
 BindMonitor_Callee13(void* context)
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 63 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=14
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee13_helpers[0].address
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=14
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(14);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee13_helpers[1].address
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee13_helpers[1].tail_call) && (r0 == 0))
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=14
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(14);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee13_helpers[0].address
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee13_helpers[0].tail_call) && (r0 == 0))
+#line 66 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 66 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 63 "sample/bindmonitor_mt_tailcall.c"
+#line 66 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1018,101 +1366,157 @@ static uint16_t BindMonitor_Callee14_maps[] = {
 #pragma code_seg(push, "bind/14")
 static uint64_t
 BindMonitor_Callee14(void* context)
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 64 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=15
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee14_helpers[0].address
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=15
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(15);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee14_helpers[1].address
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee14_helpers[1].tail_call) && (r0 == 0))
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=15
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(15);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee14_helpers[0].address
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee14_helpers[0].tail_call) && (r0 == 0))
+#line 67 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 67 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 64 "sample/bindmonitor_mt_tailcall.c"
+#line 67 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1133,101 +1537,157 @@ static uint16_t BindMonitor_Callee15_maps[] = {
 #pragma code_seg(push, "bind/15")
 static uint64_t
 BindMonitor_Callee15(void* context)
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 65 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=16
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee15_helpers[0].address
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=16
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(16);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee15_helpers[1].address
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee15_helpers[1].tail_call) && (r0 == 0))
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=16
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(16);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee15_helpers[0].address
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee15_helpers[0].tail_call) && (r0 == 0))
+#line 68 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 68 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 65 "sample/bindmonitor_mt_tailcall.c"
+#line 68 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1248,101 +1708,157 @@ static uint16_t BindMonitor_Callee16_maps[] = {
 #pragma code_seg(push, "bind/16")
 static uint64_t
 BindMonitor_Callee16(void* context)
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 66 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=17
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee16_helpers[0].address
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=17
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(17);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee16_helpers[1].address
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee16_helpers[1].tail_call) && (r0 == 0))
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=17
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(17);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee16_helpers[0].address
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee16_helpers[0].tail_call) && (r0 == 0))
+#line 69 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 69 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 66 "sample/bindmonitor_mt_tailcall.c"
+#line 69 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1363,101 +1879,157 @@ static uint16_t BindMonitor_Callee17_maps[] = {
 #pragma code_seg(push, "bind/17")
 static uint64_t
 BindMonitor_Callee17(void* context)
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 67 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=18
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee17_helpers[0].address
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=18
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(18);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee17_helpers[1].address
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee17_helpers[1].tail_call) && (r0 == 0))
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=18
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(18);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee17_helpers[0].address
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee17_helpers[0].tail_call) && (r0 == 0))
+#line 70 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 70 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 67 "sample/bindmonitor_mt_tailcall.c"
+#line 70 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1478,101 +2050,157 @@ static uint16_t BindMonitor_Callee18_maps[] = {
 #pragma code_seg(push, "bind/18")
 static uint64_t
 BindMonitor_Callee18(void* context)
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 68 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=19
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee18_helpers[0].address
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=19
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(19);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee18_helpers[1].address
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee18_helpers[1].tail_call) && (r0 == 0))
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=19
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(19);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee18_helpers[0].address
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee18_helpers[0].tail_call) && (r0 == 0))
+#line 71 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 71 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 68 "sample/bindmonitor_mt_tailcall.c"
+#line 71 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1593,101 +2221,157 @@ static uint16_t BindMonitor_Callee19_maps[] = {
 #pragma code_seg(push, "bind/19")
 static uint64_t
 BindMonitor_Callee19(void* context)
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 69 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee19_helpers[0].address
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=20
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(20);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee19_helpers[1].address
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee19_helpers[1].tail_call) && (r0 == 0))
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=20
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(20);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee19_helpers[0].address
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee19_helpers[0].tail_call) && (r0 == 0))
+#line 72 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 72 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 69 "sample/bindmonitor_mt_tailcall.c"
+#line 72 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1708,101 +2392,157 @@ static uint16_t BindMonitor_Callee2_maps[] = {
 #pragma code_seg(push, "bind/2")
 static uint64_t
 BindMonitor_Callee2(void* context)
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 52 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=3
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee2_helpers[0].address
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=3
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(3);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee2_helpers[1].address
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee2_helpers[1].tail_call) && (r0 == 0))
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=3
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(3);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee2_helpers[0].address
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee2_helpers[0].tail_call) && (r0 == 0))
+#line 55 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 55 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 52 "sample/bindmonitor_mt_tailcall.c"
+#line 55 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1823,101 +2563,157 @@ static uint16_t BindMonitor_Callee20_maps[] = {
 #pragma code_seg(push, "bind/20")
 static uint64_t
 BindMonitor_Callee20(void* context)
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 70 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=21
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee20_helpers[0].address
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=21
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(21);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee20_helpers[1].address
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee20_helpers[1].tail_call) && (r0 == 0))
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=21
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(21);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee20_helpers[0].address
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee20_helpers[0].tail_call) && (r0 == 0))
+#line 73 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 73 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 70 "sample/bindmonitor_mt_tailcall.c"
+#line 73 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1938,101 +2734,157 @@ static uint16_t BindMonitor_Callee21_maps[] = {
 #pragma code_seg(push, "bind/21")
 static uint64_t
 BindMonitor_Callee21(void* context)
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 71 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=22
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee21_helpers[0].address
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=22
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(22);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee21_helpers[1].address
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee21_helpers[1].tail_call) && (r0 == 0))
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=22
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(22);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee21_helpers[0].address
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee21_helpers[0].tail_call) && (r0 == 0))
+#line 74 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 74 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 71 "sample/bindmonitor_mt_tailcall.c"
+#line 74 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2053,101 +2905,157 @@ static uint16_t BindMonitor_Callee22_maps[] = {
 #pragma code_seg(push, "bind/22")
 static uint64_t
 BindMonitor_Callee22(void* context)
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 72 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=23
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee22_helpers[0].address
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=23
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(23);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee22_helpers[1].address
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee22_helpers[1].tail_call) && (r0 == 0))
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=23
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(23);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee22_helpers[0].address
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee22_helpers[0].tail_call) && (r0 == 0))
+#line 75 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 75 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 72 "sample/bindmonitor_mt_tailcall.c"
+#line 75 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2168,101 +3076,157 @@ static uint16_t BindMonitor_Callee23_maps[] = {
 #pragma code_seg(push, "bind/23")
 static uint64_t
 BindMonitor_Callee23(void* context)
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee23_helpers[0].address
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=24
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(24);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee23_helpers[1].address
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee23_helpers[1].tail_call) && (r0 == 0))
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=24
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(24);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee23_helpers[0].address
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee23_helpers[0].tail_call) && (r0 == 0))
+#line 76 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 76 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 73 "sample/bindmonitor_mt_tailcall.c"
+#line 76 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2283,101 +3247,157 @@ static uint16_t BindMonitor_Callee24_maps[] = {
 #pragma code_seg(push, "bind/24")
 static uint64_t
 BindMonitor_Callee24(void* context)
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 74 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=25
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee24_helpers[0].address
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=25
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(25);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee24_helpers[1].address
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee24_helpers[1].tail_call) && (r0 == 0))
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=25
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(25);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee24_helpers[0].address
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee24_helpers[0].tail_call) && (r0 == 0))
+#line 77 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 77 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 74 "sample/bindmonitor_mt_tailcall.c"
+#line 77 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2398,101 +3418,157 @@ static uint16_t BindMonitor_Callee25_maps[] = {
 #pragma code_seg(push, "bind/25")
 static uint64_t
 BindMonitor_Callee25(void* context)
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 75 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=26
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee25_helpers[0].address
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=26
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(26);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee25_helpers[1].address
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee25_helpers[1].tail_call) && (r0 == 0))
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=26
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(26);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee25_helpers[0].address
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee25_helpers[0].tail_call) && (r0 == 0))
+#line 78 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 78 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 75 "sample/bindmonitor_mt_tailcall.c"
+#line 78 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2513,101 +3589,157 @@ static uint16_t BindMonitor_Callee26_maps[] = {
 #pragma code_seg(push, "bind/26")
 static uint64_t
 BindMonitor_Callee26(void* context)
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 76 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=27
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee26_helpers[0].address
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=27
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee26_helpers[1].address
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee26_helpers[1].tail_call) && (r0 == 0))
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=27
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee26_helpers[0].address
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee26_helpers[0].tail_call) && (r0 == 0))
+#line 79 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 79 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 76 "sample/bindmonitor_mt_tailcall.c"
+#line 79 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2628,101 +3760,157 @@ static uint16_t BindMonitor_Callee27_maps[] = {
 #pragma code_seg(push, "bind/27")
 static uint64_t
 BindMonitor_Callee27(void* context)
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 77 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=28
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee27_helpers[0].address
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=28
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(28);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee27_helpers[1].address
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee27_helpers[1].tail_call) && (r0 == 0))
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=28
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(28);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee27_helpers[0].address
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee27_helpers[0].tail_call) && (r0 == 0))
+#line 80 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 80 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 77 "sample/bindmonitor_mt_tailcall.c"
+#line 80 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2743,101 +3931,157 @@ static uint16_t BindMonitor_Callee28_maps[] = {
 #pragma code_seg(push, "bind/28")
 static uint64_t
 BindMonitor_Callee28(void* context)
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 78 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=29
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee28_helpers[0].address
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=29
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(29);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee28_helpers[1].address
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee28_helpers[1].tail_call) && (r0 == 0))
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=29
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(29);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee28_helpers[0].address
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee28_helpers[0].tail_call) && (r0 == 0))
+#line 81 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 81 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 78 "sample/bindmonitor_mt_tailcall.c"
+#line 81 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2858,101 +4102,157 @@ static uint16_t BindMonitor_Callee29_maps[] = {
 #pragma code_seg(push, "bind/29")
 static uint64_t
 BindMonitor_Callee29(void* context)
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 79 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=30
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee29_helpers[0].address
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=30
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(30);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee29_helpers[1].address
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee29_helpers[1].tail_call) && (r0 == 0))
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=30
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(30);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee29_helpers[0].address
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee29_helpers[0].tail_call) && (r0 == 0))
+#line 82 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 82 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 79 "sample/bindmonitor_mt_tailcall.c"
+#line 82 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -2973,252 +4273,193 @@ static uint16_t BindMonitor_Callee3_maps[] = {
 #pragma code_seg(push, "bind/3")
 static uint64_t
 BindMonitor_Callee3(void* context)
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 53 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=4
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee3_helpers[0].address
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=4
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(4);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee3_helpers[1].address
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee3_helpers[1].tail_call) && (r0 == 0))
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=4
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(4);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee3_helpers[0].address
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee3_helpers[0].tail_call) && (r0 == 0))
+#line 56 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 56 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 53 "sample/bindmonitor_mt_tailcall.c"
+#line 56 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
-
-static helper_function_entry_t BindMonitor_Callee30_helpers[] = {
-    {NULL, 13, "helper_id_13"},
-    {NULL, 5, "helper_id_5"},
-};
 
 static GUID BindMonitor_Callee30_program_type_guid = {
     0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
 static GUID BindMonitor_Callee30_attach_type_guid = {
     0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-static uint16_t BindMonitor_Callee30_maps[] = {
-    0,
-};
-
 #pragma code_seg(push, "bind/30")
 static uint64_t
 BindMonitor_Callee30(void* context)
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r2 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r3 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r4 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r5 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r6 = 0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 80 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
-
-    // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r6 = r1;
-    // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
-    // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=31
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r3 = IMMEDIATE(31);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[0].address
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[0].tail_call) && (r0 == 0))
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-        return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=31
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r3 = IMMEDIATE(31);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = BindMonitor_Callee30_helpers[1].address
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    if ((BindMonitor_Callee30_helpers[1].tail_call) && (r0 == 0))
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-        return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-    return r0;
-#line 80 "sample/bindmonitor_mt_tailcall.c"
-}
-#pragma code_seg(pop)
-#line __LINE__ __FILE__
-
-static GUID BindMonitor_Callee31_program_type_guid = {
-    0x608c517c, 0x6c52, 0x4a26, {0xb6, 0x77, 0xbb, 0x1c, 0x34, 0x42, 0x5a, 0xdf}};
-static GUID BindMonitor_Callee31_attach_type_guid = {
-    0xb9707e04, 0x8127, 0x4c72, {0x83, 0x3e, 0x05, 0xb1, 0xfb, 0x43, 0x94, 0x96}};
-#pragma code_seg(push, "bind/31")
-static uint64_t
-BindMonitor_Callee31(void* context)
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-{
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    // Prologue
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r0 = 0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r1 = 0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    register uint64_t r10 = 0;
-
-#line 93 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uintptr_t)context;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_IMM pc=0 dst=r0 src=r0 offset=0 imm=0
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(0);
     // EBPF_OP_EXIT pc=1 dst=r0 src=r0 offset=0 imm=0
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 93 "sample/bindmonitor_mt_tailcall.c"
+#line 95 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3239,101 +4480,157 @@ static uint16_t BindMonitor_Callee4_maps[] = {
 #pragma code_seg(push, "bind/4")
 static uint64_t
 BindMonitor_Callee4(void* context)
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 54 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee4_helpers[0].address
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(5);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee4_helpers[1].address
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee4_helpers[1].tail_call) && (r0 == 0))
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=5
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(5);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee4_helpers[0].address
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee4_helpers[0].tail_call) && (r0 == 0))
+#line 57 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 57 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 54 "sample/bindmonitor_mt_tailcall.c"
+#line 57 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3354,101 +4651,157 @@ static uint16_t BindMonitor_Callee5_maps[] = {
 #pragma code_seg(push, "bind/5")
 static uint64_t
 BindMonitor_Callee5(void* context)
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 55 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=6
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee5_helpers[0].address
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=6
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(6);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee5_helpers[1].address
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee5_helpers[1].tail_call) && (r0 == 0))
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=6
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(6);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee5_helpers[0].address
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee5_helpers[0].tail_call) && (r0 == 0))
+#line 58 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 58 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 55 "sample/bindmonitor_mt_tailcall.c"
+#line 58 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3469,101 +4822,157 @@ static uint16_t BindMonitor_Callee6_maps[] = {
 #pragma code_seg(push, "bind/6")
 static uint64_t
 BindMonitor_Callee6(void* context)
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 56 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=7
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee6_helpers[0].address
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=7
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(7);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee6_helpers[1].address
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee6_helpers[1].tail_call) && (r0 == 0))
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=7
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(7);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee6_helpers[0].address
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee6_helpers[0].tail_call) && (r0 == 0))
+#line 59 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 59 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 56 "sample/bindmonitor_mt_tailcall.c"
+#line 59 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3584,101 +4993,157 @@ static uint16_t BindMonitor_Callee7_maps[] = {
 #pragma code_seg(push, "bind/7")
 static uint64_t
 BindMonitor_Callee7(void* context)
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 57 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee7_helpers[0].address
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=8
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(8);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee7_helpers[1].address
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee7_helpers[1].tail_call) && (r0 == 0))
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(8);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee7_helpers[0].address
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee7_helpers[0].tail_call) && (r0 == 0))
+#line 60 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 60 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 57 "sample/bindmonitor_mt_tailcall.c"
+#line 60 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3699,101 +5164,157 @@ static uint16_t BindMonitor_Callee8_maps[] = {
 #pragma code_seg(push, "bind/8")
 static uint64_t
 BindMonitor_Callee8(void* context)
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 58 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
     // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
     // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=9
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee8_helpers[0].address
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
     // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
     // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=9
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(9);
     // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee8_helpers[1].address
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee8_helpers[1].tail_call) && (r0 == 0))
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=19 dst=r0 src=r0 offset=16 imm=-1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=20 dst=r1 src=r0 offset=0 imm=10
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(10);
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-4 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=22 dst=r1 src=r0 offset=0 imm=1680154744
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-8 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=24 dst=r1 src=r0 offset=0 imm=544497952
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=27 dst=r1 src=r0 offset=0 imm=1634082924
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r1 offset=-24 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=30 dst=r10 src=r7 offset=-32 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=9
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(9);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee8_helpers[0].address
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee8_helpers[0].tail_call) && (r0 == 0))
+#line 61 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 61 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 58 "sample/bindmonitor_mt_tailcall.c"
+#line 61 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3814,101 +5335,159 @@ static uint16_t BindMonitor_Callee9_maps[] = {
 #pragma code_seg(push, "bind/9")
 static uint64_t
 BindMonitor_Callee9(void* context)
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
 {
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     // Prologue
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r0 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r1 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r2 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r3 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r4 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r5 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r6 = 0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r7 = 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    register uint64_t r8 = 0;
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     register uint64_t r10 = 0;
 
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uintptr_t)context;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r1 src=r0 offset=0 imm=680997
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = IMMEDIATE(680997);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-8 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_STXW pc=2 dst=r10 src=r1 offset=-16 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r1;
     // EBPF_OP_LDDW pc=3 dst=r1 src=r0 offset=0 imm=1852383340
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = (uint64_t)2339731488442490988;
-    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-16 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=6 dst=r1 src=r0 offset=0 imm=1818845524
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    r1 = (uint64_t)7809632219746099540;
-    // EBPF_OP_STXDW pc=8 dst=r10 src=r1 offset=-24 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_STXDW pc=5 dst=r10 src=r1 offset=-24 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=6 dst=r7 src=r0 offset=0 imm=1818845524
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r7 = (uint64_t)7809632219746099540;
+    // EBPF_OP_STXDW pc=8 dst=r10 src=r7 offset=-32 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_REG pc=9 dst=r1 src=r10 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-24
-#line 59 "sample/bindmonitor_mt_tailcall.c"
-    r1 += IMMEDIATE(-24);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=20
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_ADD64_IMM pc=10 dst=r1 src=r0 offset=0 imm=-32
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r8 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r8 = IMMEDIATE(10);
+    // EBPF_OP_MOV64_IMM pc=12 dst=r2 src=r0 offset=0 imm=20
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r2 = IMMEDIATE(20);
-    // EBPF_OP_MOV64_IMM pc=12 dst=r3 src=r0 offset=0 imm=10
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=13 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(10);
-    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=13
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_CALL pc=14 dst=r0 src=r0 offset=0 imm=13
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee9_helpers[0].address
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_REG pc=15 dst=r1 src=r6 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r1 = r6;
-    // EBPF_OP_LDDW pc=15 dst=r2 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_LDDW pc=16 dst=r2 src=r0 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r2 = POINTER(_maps[0].address);
-    // EBPF_OP_MOV64_IMM pc=17 dst=r3 src=r0 offset=0 imm=10
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_MOV64_IMM pc=18 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r3 = IMMEDIATE(10);
-    // EBPF_OP_CALL pc=18 dst=r0 src=r0 offset=0 imm=5
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_CALL pc=19 dst=r0 src=r0 offset=0 imm=5
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = BindMonitor_Callee9_helpers[1].address
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
          (r1, r2, r3, r4, r5);
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     if ((BindMonitor_Callee9_helpers[1].tail_call) && (r0 == 0))
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
         return 0;
-        // EBPF_OP_MOV64_IMM pc=19 dst=r0 src=r0 offset=0 imm=1
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_JSGT_IMM pc=20 dst=r0 src=r0 offset=15 imm=-1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((int64_t)r0 > IMMEDIATE(-1))
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+        goto label_1;
+    // EBPF_OP_MOV64_IMM pc=21 dst=r1 src=r0 offset=0 imm=1680154744
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = IMMEDIATE(1680154744);
+    // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-8 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r1;
+    // EBPF_OP_LDDW pc=23 dst=r1 src=r0 offset=0 imm=544497952
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7306085893296906528;
+    // EBPF_OP_STXDW pc=25 dst=r10 src=r1 offset=-16 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=26 dst=r1 src=r0 offset=0 imm=1634082924
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = (uint64_t)7234307576302018668;
+    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-24 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_STXDW pc=29 dst=r10 src=r7 offset=-32 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_STXH pc=30 dst=r10 src=r8 offset=-4 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-4)) = (uint16_t)r8;
+    // EBPF_OP_MOV64_REG pc=31 dst=r1 src=r10 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=32 dst=r1 src=r0 offset=0 imm=-32
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r1 += IMMEDIATE(-32);
+    // EBPF_OP_MOV64_IMM pc=33 dst=r2 src=r0 offset=0 imm=30
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r2 = IMMEDIATE(30);
+    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=10
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r3 = IMMEDIATE(10);
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=13
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    r0 = BindMonitor_Callee9_helpers[0].address
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+         (r1, r2, r3, r4, r5);
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+    if ((BindMonitor_Callee9_helpers[0].tail_call) && (r0 == 0))
+#line 62 "sample/bindmonitor_mt_tailcall.c"
+        return 0;
+label_1:
+    // EBPF_OP_MOV64_IMM pc=36 dst=r0 src=r0 offset=0 imm=1
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     r0 = IMMEDIATE(1);
-    // EBPF_OP_EXIT pc=20 dst=r0 src=r0 offset=0 imm=0
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+    // EBPF_OP_EXIT pc=37 dst=r0 src=r0 offset=0 imm=0
+#line 62 "sample/bindmonitor_mt_tailcall.c"
     return r0;
-#line 59 "sample/bindmonitor_mt_tailcall.c"
+#line 62 "sample/bindmonitor_mt_tailcall.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -3925,7 +5504,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Caller_helpers,
         2,
-        21,
+        28,
         &BindMonitor_Caller_program_type_guid,
         &BindMonitor_Caller_attach_type_guid,
     },
@@ -3939,7 +5518,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee0_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee0_program_type_guid,
         &BindMonitor_Callee0_attach_type_guid,
     },
@@ -3953,7 +5532,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee1_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee1_program_type_guid,
         &BindMonitor_Callee1_attach_type_guid,
     },
@@ -3967,7 +5546,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee10_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee10_program_type_guid,
         &BindMonitor_Callee10_attach_type_guid,
     },
@@ -3981,7 +5560,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee11_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee11_program_type_guid,
         &BindMonitor_Callee11_attach_type_guid,
     },
@@ -3995,7 +5574,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee12_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee12_program_type_guid,
         &BindMonitor_Callee12_attach_type_guid,
     },
@@ -4009,7 +5588,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee13_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee13_program_type_guid,
         &BindMonitor_Callee13_attach_type_guid,
     },
@@ -4023,7 +5602,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee14_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee14_program_type_guid,
         &BindMonitor_Callee14_attach_type_guid,
     },
@@ -4037,7 +5616,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee15_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee15_program_type_guid,
         &BindMonitor_Callee15_attach_type_guid,
     },
@@ -4051,7 +5630,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee16_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee16_program_type_guid,
         &BindMonitor_Callee16_attach_type_guid,
     },
@@ -4065,7 +5644,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee17_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee17_program_type_guid,
         &BindMonitor_Callee17_attach_type_guid,
     },
@@ -4079,7 +5658,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee18_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee18_program_type_guid,
         &BindMonitor_Callee18_attach_type_guid,
     },
@@ -4093,7 +5672,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee19_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee19_program_type_guid,
         &BindMonitor_Callee19_attach_type_guid,
     },
@@ -4107,7 +5686,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee2_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee2_program_type_guid,
         &BindMonitor_Callee2_attach_type_guid,
     },
@@ -4121,7 +5700,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee20_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee20_program_type_guid,
         &BindMonitor_Callee20_attach_type_guid,
     },
@@ -4135,7 +5714,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee21_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee21_program_type_guid,
         &BindMonitor_Callee21_attach_type_guid,
     },
@@ -4149,7 +5728,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee22_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee22_program_type_guid,
         &BindMonitor_Callee22_attach_type_guid,
     },
@@ -4163,7 +5742,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee23_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee23_program_type_guid,
         &BindMonitor_Callee23_attach_type_guid,
     },
@@ -4177,7 +5756,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee24_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee24_program_type_guid,
         &BindMonitor_Callee24_attach_type_guid,
     },
@@ -4191,7 +5770,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee25_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee25_program_type_guid,
         &BindMonitor_Callee25_attach_type_guid,
     },
@@ -4205,7 +5784,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee26_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee26_program_type_guid,
         &BindMonitor_Callee26_attach_type_guid,
     },
@@ -4219,7 +5798,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee27_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee27_program_type_guid,
         &BindMonitor_Callee27_attach_type_guid,
     },
@@ -4233,7 +5812,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee28_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee28_program_type_guid,
         &BindMonitor_Callee28_attach_type_guid,
     },
@@ -4247,7 +5826,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee29_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee29_program_type_guid,
         &BindMonitor_Callee29_attach_type_guid,
     },
@@ -4261,7 +5840,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee3_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee3_program_type_guid,
         &BindMonitor_Callee3_attach_type_guid,
     },
@@ -4271,27 +5850,13 @@ static program_entry_t _programs[] = {
         "bind/30",
         "bind/30",
         "BindMonitor_Callee30",
-        BindMonitor_Callee30_maps,
-        1,
-        BindMonitor_Callee30_helpers,
+        NULL,
+        0,
+        NULL,
+        0,
         2,
-        21,
         &BindMonitor_Callee30_program_type_guid,
         &BindMonitor_Callee30_attach_type_guid,
-    },
-    {
-        0,
-        BindMonitor_Callee31,
-        "bind/31",
-        "bind/31",
-        "BindMonitor_Callee31",
-        NULL,
-        0,
-        NULL,
-        0,
-        2,
-        &BindMonitor_Callee31_program_type_guid,
-        &BindMonitor_Callee31_attach_type_guid,
     },
     {
         0,
@@ -4303,7 +5868,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee4_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee4_program_type_guid,
         &BindMonitor_Callee4_attach_type_guid,
     },
@@ -4317,7 +5882,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee5_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee5_program_type_guid,
         &BindMonitor_Callee5_attach_type_guid,
     },
@@ -4331,7 +5896,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee6_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee6_program_type_guid,
         &BindMonitor_Callee6_attach_type_guid,
     },
@@ -4345,7 +5910,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee7_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee7_program_type_guid,
         &BindMonitor_Callee7_attach_type_guid,
     },
@@ -4359,7 +5924,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee8_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee8_program_type_guid,
         &BindMonitor_Callee8_attach_type_guid,
     },
@@ -4373,7 +5938,7 @@ static program_entry_t _programs[] = {
         1,
         BindMonitor_Callee9_helpers,
         2,
-        21,
+        38,
         &BindMonitor_Callee9_program_type_guid,
         &BindMonitor_Callee9_attach_type_guid,
     },
@@ -4384,7 +5949,7 @@ static void
 _get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
 {
     *programs = _programs;
-    *count = 33;
+    *count = 32;
 }
 
 static void

--- a/tests/stress/km/stress_tests_km.cpp
+++ b/tests/stress/km/stress_tests_km.cpp
@@ -1126,7 +1126,7 @@ _set_up_tailcall_program(bpf_object* object, const std::string& map_name)
     LOG_VERBOSE("({}) Opened fd:{} for map:{}", __func__, prog_map_fd, map_name.c_str());
 
     // Set up tail calls.
-    for (int index = 0; index < MAX_TAIL_CALL_CNT; index++) {
+    for (int index = 0; index < MAX_TAIL_CALL_CNT - 1; index++) {
         try {
             std::string bind_program_name{"BindMonitor_Callee"};
             bind_program_name += std::to_string(index);

--- a/tests/stress/readme.md
+++ b/tests/stress/readme.md
@@ -104,7 +104,7 @@ Sample command line invocations:
 - Delay of 250 ms between successive extension restarts.
 
 ## 1.6. bindmonitor_tail_call_invoke_program_test
-This test first loads a specific native eBPF program. It then loads all the MAX_TAIL_CALL_CNT tail call programs and updates the program array map. It then creates the specified number of threads where each thread attempts a TCP 'bind' to the same port continuously in a loop. The test setup guarantees that the `thread_index` passed in each `thread_context` is unique to that thread, so that each thread gets a unique port (base_port + thread_index).
+This test first loads a specific native eBPF program. It then loads all the MAX_TAIL_CALL_CNT-1 tail call programs and updates the program array map. It then creates the specified number of threads where each thread attempts a TCP 'bind' to the same port continuously in a loop. The test setup guarantees that the `thread_index` passed in each `thread_context` is unique to that thread, so that each thread gets a unique port (base_port + thread_index).
 
 This causes the invocation of the in-kernel eBPF tail call programs to be executed in sequence. The last tail call program returns a PERMIT verdict.
 


### PR DESCRIPTION
## Description

bindmonitor_tail_call_invoke_program_test test case fails with MAX tail calls 32. The max does not include top-level caller.
Solution:
 - Reduce the number of tail calls to 31 in bindmonitor_mt_tailcalls.sys ebpf program, to onboard kernel stress in CICD.

Note: 
- This test case needs to pass to onboard kernel stress in CICD.
- The behavior of processing up to 31 (MAX TAIL CALL CNT - 1) was done in https://github.com/microsoft/ebpf-for-windows/pull/2504/files.
- Linux behavior of 33 MAX TAIL CALL CNT (provided in https://www.man7.org/linux/man-pages/man7/bpf-helpers.7.html) is pending to verify in https://github.com/microsoft/ebpf-for-windows/issues/2794

## Testing

_Do any existing tests cover this change? Yes.
Are new tests needed? No

Manual testing:
```
PS C:\Temp> .\ebpf_stress_tests_km.exe -tt=32 -td=2  -er=true bindmonitor_tail_call_invoke_program_tes
t
Filters: "bindmonitor_tail_call_invoke_program_test"
Randomness seeded to: 287414023

Starting test *** bindmonitor_tailcall_invoke_program_test ***
test threads per program    : 32
test duration (in minutes)  : 2
test verbose output         : false
test extension restart      : true
test extension restart delay: 1000 ms
waiting on 32 test threads...
waiting on 1 extension restart threads...
**** Extension restart thread done. Exiting. ****
===============================================================================
All tests passed (566334 assertions in 1 test case)

PS C:\Temp>
```
## Documentation

_Is there any documentation impact for this change? Yes. Done.

## Installation

_Is there any installer impact for this change? No
