### PR TITLE
fix stress test script file name

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -465,7 +465,7 @@ jobs:
     with:
       name: km_mt_stress_tests_restart_extension
       pre_test: .\setup_ebpf_cicd_stress_tests.ps1
-      test_command: .\execute_ebpf_cicd_stress_tests.ps1 -RunKmStressTestsOnly $true -RestartExtension $true
+      test_command: .\execute_ebpf_cicd_tests.ps1 -RunKmStressTestsOnly $true -RestartExtension $true
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       build_artifact: Build-x64
       environment: ebpf_cicd_tests


### PR DESCRIPTION
## Description

This PR corrects the stress test execution script name in one of the newly onboarded scheduled km stress test jobs.

## Testing

CI/CD Scheduled run

## Documentation

No doc changes.

## Installation

No installation impact.