### PR TITLE
Switch from mod to and for computing bucket index

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -858,7 +858,7 @@ _create_hash_map_internal(
     const ebpf_hash_table_creation_options_t options = {
         .key_size = local_map->ebpf_map_definition.key_size,
         .value_size = local_map->ebpf_map_definition.value_size,
-        .bucket_count = local_map->ebpf_map_definition.max_entries,
+        .minimum_bucket_count = local_map->ebpf_map_definition.max_entries,
         .max_entries = local_map->ebpf_map_definition.max_entries,
         .extract_function = extract_function,
         .supplemental_value_size = supplemental_value_size,

--- a/libs/runtime/ebpf_hash_table.c
+++ b/libs/runtime/ebpf_hash_table.c
@@ -591,7 +591,8 @@ ebpf_hash_table_create(_Out_ ebpf_hash_table_t** hash_table, _In_ const ebpf_has
     ebpf_hash_table_t* table = NULL;
     size_t table_size = 0;
     // Select default values for the hash table.
-    size_t bucket_count = options->bucket_count ? options->bucket_count : EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT;
+    size_t bucket_count =
+        options->minimum_bucket_count ? options->minimum_bucket_count : EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT;
     void* (*allocate)(size_t size) = options->allocate ? options->allocate : ebpf_epoch_allocate;
     void (*free)(void* memory) = options->free ? options->free : ebpf_epoch_free;
 

--- a/libs/runtime/ebpf_hash_table.h
+++ b/libs/runtime/ebpf_hash_table.h
@@ -58,7 +58,7 @@ extern "C"
         ebpf_hash_table_extract_function extract_function; //< Function to extract key from stored value.
         ebpf_hash_table_allocate allocate; //< Function to allocate memory - defaults to ebpf_epoch_allocate.
         ebpf_hash_table_free free;         //< Function to free memory - defaults to ebpf_epoch_free.
-        size_t bucket_count; //< Number of buckets to use - defaults to EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT.
+        size_t bucket_count; //< Minimum number of buckets to use - defaults to EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT.
         size_t max_entries;  //< Maximum number of entries in the hash table - defaults to EBPF_HASH_TABLE_NO_LIMIT.
         size_t supplemental_value_size; //< Size of supplemental value to store in each entry - defaults to 0.
         void* notification_context;     //< Context to pass to notification functions.

--- a/libs/runtime/ebpf_hash_table.h
+++ b/libs/runtime/ebpf_hash_table.h
@@ -58,8 +58,9 @@ extern "C"
         ebpf_hash_table_extract_function extract_function; //< Function to extract key from stored value.
         ebpf_hash_table_allocate allocate; //< Function to allocate memory - defaults to ebpf_epoch_allocate.
         ebpf_hash_table_free free;         //< Function to free memory - defaults to ebpf_epoch_free.
-        size_t bucket_count; //< Minimum number of buckets to use - defaults to EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT.
-        size_t max_entries;  //< Maximum number of entries in the hash table - defaults to EBPF_HASH_TABLE_NO_LIMIT.
+        size_t minimum_bucket_count;       //< Minimum number of buckets to use - defaults to
+                                           // EBPF_HASH_TABLE_DEFAULT_BUCKET_COUNT.
+        size_t max_entries; //< Maximum number of entries in the hash table - defaults to EBPF_HASH_TABLE_NO_LIMIT.
         size_t supplemental_value_size; //< Size of supplemental value to store in each entry - defaults to 0.
         void* notification_context;     //< Context to pass to notification functions.
         ebpf_hash_table_notification_function

--- a/libs/runtime/ebpf_state.c
+++ b/libs/runtime/ebpf_state.c
@@ -43,7 +43,7 @@ ebpf_state_initiate()
     const ebpf_hash_table_creation_options_t options = {
         .key_size = sizeof(uint64_t),
         .value_size = sizeof(ebpf_state_entry_t),
-        .bucket_count = ebpf_get_cpu_count(),
+        .minimum_bucket_count = ebpf_get_cpu_count(),
     };
 
     return_value = ebpf_hash_table_create(&_ebpf_state_thread_table, &options);

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -148,7 +148,7 @@ TEST_CASE("hash_table_test", "[platform]")
         .value_size = data_1.size(),
         .allocate = ebpf_allocate,
         .free = ebpf_free,
-        .bucket_count = 1,
+        .minimum_bucket_count = 1,
     };
 
     ebpf_hash_table_t* raw_ptr = nullptr;
@@ -292,7 +292,7 @@ TEST_CASE("hash_table_stress_test", "[platform]")
     const ebpf_hash_table_creation_options_t options = {
         .key_size = sizeof(uint32_t),
         .value_size = sizeof(uint64_t),
-        .bucket_count = static_cast<size_t>(worker_threads) * static_cast<size_t>(key_count),
+        .minimum_bucket_count = static_cast<size_t>(worker_threads) * static_cast<size_t>(key_count),
     };
     REQUIRE(ebpf_hash_table_create(&table, &options) == EBPF_SUCCESS);
     auto worker = [table, iterations, key_count, load_factor, &cpu_id]() {

--- a/tests/performance/platform.cpp
+++ b/tests/performance/platform.cpp
@@ -84,7 +84,7 @@ typedef class _ebpf_hash_table_test_state
         const ebpf_hash_table_creation_options_t options = {
             .key_size = sizeof(uint32_t),
             .value_size = sizeof(uint64_t),
-            .bucket_count = keys.size(),
+            .minimum_bucket_count = keys.size(),
         };
         REQUIRE(ebpf_hash_table_create(&table, &options) == EBPF_SUCCESS);
         for (auto& key : keys) {


### PR DESCRIPTION
## Description

Hash tables use MOD in computing the bucket index from the hash.
Two changes:
1) Expand bucket count to power of 2.
2) Use AND mask to compute bucket index.

## Testing

CI/CD and performance testing.

## Documentation

No.

## Installation

No.

```cmd
Baseline:
C:\bpf_perf>Debug\bpf_performance_runner.exe -i tests.yml -e .sys -t "BPF_MAP_TYPE_HASH read" -c 100000000 -p 6
BPF_MAP_TYPE_HASH read,86,85,86,83,85,84

No mod hash:
C:\bpf_perf>Debug\bpf_performance_runner.exe -i tests.yml -e .sys -t "BPF_MAP_TYPE_HASH read" -c 100000000 -p 6
BPF_MAP_TYPE_HASH read,73,71,72,73,71,71
```