### PR TITLE
Fix build artifact circular dependency

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -198,13 +198,11 @@ jobs:
       working-directory: ${{env.GITHUB_WORKSPACE}}
       run: Invoke-WebRequest https://github.com/microsoft/ebpf-for-windows-demo/releases/download/v0.0.1/${{env.BUILD_PLATFORM}}-Release-cilium-xdp.zip -OutFile x64-${{env.BUILD_CONFIGURATION}}-cilium-xdp.zip
 
+    # Download the bpf_performance repository artifacts for the Release build.
     - name: Download bpf_performance repository artifacts
       if: steps.skip_check.outputs.should_skip != 'true' && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease')
-      working-directory: ${{env.GITHUB_WORKSPACE}}
-      env:
-        GH_TOKEN: ${{ github.token }}
-      run: |
-        scripts\Fetch-LatestArtifacts.ps1 -ArtifactName "build-RelWithDebInfo-windows-2022" -OutputPath "${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\performance" -Owner alan-jowett -repo bpf_performance
+      working-directory: ${{env.GITHUB_WORKSPACE}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}
+      run: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_performance/releases/download/v0.0.1/build-RelWithDebInfo-windows-2022.zip -OutFile bpf_performance.zip
 
     - name: Extract artifacts to build path
       if: steps.skip_check.outputs.should_skip != 'true' && matrix.configurations != 'FuzzerDebug'

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -201,8 +201,10 @@ jobs:
     # Download the bpf_performance repository artifacts for the Release build.
     - name: Download bpf_performance repository artifacts
       if: steps.skip_check.outputs.should_skip != 'true' && (matrix.configurations == 'Release' || matrix.configurations == 'NativeOnlyRelease')
-      working-directory: ${{env.GITHUB_WORKSPACE}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}
-      run: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_performance/releases/download/v0.0.1/build-RelWithDebInfo-windows-2022.zip -OutFile bpf_performance.zip
+      working-directory: ${{env.GITHUB_WORKSPACE}}
+      run: |
+        cd ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
+        Invoke-WebRequest https://github.com/Alan-Jowett/bpf_performance/releases/download/v0.0.1/build-RelWithDebInfo-windows-2022.zip -OutFile bpf_performance.zip
 
     - name: Extract artifacts to build path
       if: steps.skip_check.outputs.should_skip != 'true' && matrix.configurations != 'FuzzerDebug'


### PR DESCRIPTION
## Description

The bpf_performance repo depends on artifacts from ebpf-for-windows repo to build.
The ebpf-for-windows repo depends on artifacts from bpf_performance to build.

Net effect is that both builds now fail and there is no way to recover.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
