### PR TITLE
Add helper function to set redirect context

### DIFF
--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -178,6 +178,7 @@ EBPF_HELPER(uint64_t, bpf_sock_addr_get_current_pid_tgid, (bpf_sock_addr_t * ctx
 
 /**
  * @brief Set a context for consumption by a proxy application (sock_addr specific only).
+ * This function is not supported for the recv_accept hooks.
  *
  * @param[in] ctx Pointer to bpf_sock_addr_t context.
  * @param[in] data Pointer to data to store.

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -156,6 +156,7 @@ typedef struct bpf_sock_addr
 typedef enum
 {
     BPF_FUNC_sock_addr_get_current_pid_tgid = SOCK_ADDR_EXT_HELPER_FN_BASE + 1,
+    BPF_FUNC_sock_addr_set_redirect_context = SOCK_ADDR_EXT_HELPER_FN_BASE + 2,
 } ebpf_sock_addr_helper_id_t;
 
 /**
@@ -173,6 +174,20 @@ EBPF_HELPER(uint64_t, bpf_sock_addr_get_current_pid_tgid, (bpf_sock_addr_t * ctx
 #ifndef __doxygen
 #define bpf_sock_addr_get_current_pid_tgid \
     ((bpf_sock_addr_get_current_pid_tgid_t)BPF_FUNC_sock_addr_get_current_pid_tgid)
+#endif
+
+/**
+ * @brief Set a context for consumption by a proxy application (sock_addr specific only).
+ *
+ * @param[in] ctx Pointer to bpf_sock_addr_t context.
+ * @param[in] data Pointer to data to store.
+ * @param[in] data_size The size of the data to store.
+ *
+ */
+EBPF_HELPER(void, bpf_sock_addr_set_redirect_context, (bpf_sock_addr_t * ctx, char* data, uint32_t data_size));
+#ifndef __doxygen
+#define bpf_sock_addr_set_redirect_context \
+    ((bpf_sock_addr_set_redirect_context_t)BPF_FUNC_bpf_sock_addr_set_redirect_context)
 #endif
 
 /**

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -183,11 +183,13 @@ EBPF_HELPER(uint64_t, bpf_sock_addr_get_current_pid_tgid, (bpf_sock_addr_t * ctx
  * @param[in] data Pointer to data to store.
  * @param[in] data_size The size of the data to store.
  *
+ * @retval 0 The operation was successful.
+ * @retval <0 A failure occurred.
  */
-EBPF_HELPER(void, bpf_sock_addr_set_redirect_context, (bpf_sock_addr_t * ctx, char* data, uint32_t data_size));
+EBPF_HELPER(int, bpf_sock_addr_set_redirect_context, (bpf_sock_addr_t * ctx, void* data, uint32_t data_size));
 #ifndef __doxygen
 #define bpf_sock_addr_set_redirect_context \
-    ((bpf_sock_addr_set_redirect_context_t)BPF_FUNC_bpf_sock_addr_set_redirect_context)
+    ((bpf_sock_addr_set_redirect_context_t)BPF_FUNC_sock_addr_set_redirect_context)
 #endif
 
 /**

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -177,7 +177,7 @@ EBPF_HELPER(uint64_t, bpf_sock_addr_get_current_pid_tgid, (bpf_sock_addr_t * ctx
 #endif
 
 /**
- * @brief Set a context for consumption by a proxy application (sock_addr specific only).
+ * @brief Set a context for consumption by a user-mode application (sock_addr specific only).
  * This function is not supported for the recv_accept hooks.
  *
  * @param[in] ctx Pointer to bpf_sock_addr_t context.

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -47,7 +47,7 @@ static const ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_f
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
     {BPF_FUNC_sock_addr_set_redirect_context,
-     "bpf_func_sock_addr_set_redirect_context",
+     "bpf_sock_addr_set_redirect_context",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}}};
 

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -45,7 +45,11 @@ static const ebpf_helper_function_prototype_t _sock_addr_ebpf_extension_helper_f
     {BPF_FUNC_sock_addr_get_current_pid_tgid,
      "bpf_sock_addr_get_current_pid_tgid",
      EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}}};
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX}},
+    {BPF_FUNC_sock_addr_set_redirect_context,
+     "bpf_func_sock_addr_set_redirect_context",
+     EBPF_RETURN_TYPE_INTEGER,
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_PTR_TO_READABLE_MEM, EBPF_ARGUMENT_TYPE_CONST_SIZE}}};
 
 // CGROUP_SOCK_ADDR global helper function prototypes.
 static const ebpf_helper_function_prototype_t _ebpf_sock_addr_global_helper_function_prototype[] = {

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -179,7 +179,8 @@ typedef struct _net_ebpf_bpf_sock_addr
     TOKEN_ACCESS_INFORMATION* access_information;
     uint64_t process_id;
     uint32_t flags;
-    char* redirect_context;
+    net_ebpf_extension_hook_id_t hook_id;
+    void* redirect_context;
     uint32_t redirect_context_size;
 } net_ebpf_sock_addr_t;
 
@@ -260,12 +261,38 @@ _ebpf_sock_addr_get_current_logon_id(_In_ const bpf_sock_addr_t* ctx)
     return logon_id;
 }
 
-static void
-_ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ char* data, _In_ uint32_t data_size)
+static int
+_ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void* data, _In_ uint32_t data_size)
 {
+    int return_value = 0;
     net_ebpf_sock_addr_t* sock_addr_ctx = CONTAINING_RECORD(ctx, net_ebpf_sock_addr_t, base);
+    void* redirect_context = NULL;
+
+    // This function is only supported at the connect redirect layer
+    if (sock_addr_ctx->hook_id != EBPF_HOOK_ALE_CONNECT_REDIRECT_V4 &&
+        sock_addr_ctx->hook_id != EBPF_HOOK_ALE_CONNECT_REDIRECT_V6) {
+        return_value = -1;
+        goto Exit;
+    }
+
+    // Allocate buffer to store redirect context
+    redirect_context = ExAllocatePoolUninitialized(NonPagedPoolNx, data_size, NET_EBPF_EXTENSION_POOL_TAG);
+    if (redirect_context == NULL) {
+        return_value = -1;
+        goto Exit;
+    }
+    memcpy(redirect_context, data, data_size);
+
+    // Set redirect context
+    sock_addr_ctx->redirect_context = redirect_context;
     sock_addr_ctx->redirect_context_size = data_size;
-    sock_addr_ctx->redirect_context = data;
+
+Exit:
+    if (return_value == -1) {
+        NET_EBPF_EXT_LOG_FUNCTION_ERROR(return_value);
+    }
+
+    return return_value;
 }
 
 _IRQL_requires_max_(DISPATCH_LEVEL) static NTSTATUS _perform_access_check(
@@ -420,7 +447,8 @@ _ebpf_sock_addr_context_destroy(
 // SOCK_ADDR Program Information NPI Provider.
 //
 
-static const void* _ebpf_sock_addr_specific_helper_functions[] = {(void*)_ebpf_sock_addr_get_current_pid_tgid};
+static const void* _ebpf_sock_addr_specific_helper_functions[] = {
+    (void*)_ebpf_sock_addr_get_current_pid_tgid, (void*)_ebpf_sock_addr_set_redirect_context};
 
 static ebpf_helper_function_addresses_t _ebpf_sock_addr_specific_helper_function_address_table = {
     EBPF_COUNT_OF(_ebpf_sock_addr_specific_helper_functions), (uint64_t*)_ebpf_sock_addr_specific_helper_functions};
@@ -1063,6 +1091,8 @@ _net_ebpf_extension_sock_addr_copy_wfp_connection_fields(
 
     FWPS_INCOMING_VALUE0* incoming_values = incoming_fixed_values->incomingValue;
 
+    sock_addr_ctx->hook_id = hook_id;
+
     // Copy IP address fields.
     if ((hook_id == EBPF_HOOK_ALE_AUTH_CONNECT_V4) || (hook_id == EBPF_HOOK_ALE_AUTH_RECV_ACCEPT_V4) ||
         (hook_id == EBPF_HOOK_ALE_CONNECT_REDIRECT_V4)) {
@@ -1365,6 +1395,9 @@ _net_ebpf_ext_process_redirect_verdict(
 
         connect_request->localRedirectContext = sock_addr_ctx->redirect_context;
         connect_request->localRedirectContextSize = sock_addr_ctx->redirect_context_size;
+        // Ownership transferred to WFP
+        sock_addr_ctx->redirect_context = NULL;
+        sock_addr_ctx->redirect_context_size = 0;
     }
 
 Exit:
@@ -1660,6 +1693,10 @@ Exit:
 
     if (attached_client) {
         net_ebpf_extension_hook_client_leave_rundown(attached_client);
+    }
+
+    if (net_ebpf_sock_addr_ctx.redirect_context != NULL) {
+        ExFreePool(net_ebpf_sock_addr_ctx.redirect_context);
     }
 
     NET_EBPF_EXT_LOG_EXIT();

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -268,14 +268,14 @@ _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void*
     net_ebpf_sock_addr_t* sock_addr_ctx = CONTAINING_RECORD(ctx, net_ebpf_sock_addr_t, base);
     void* redirect_context = NULL;
 
-    // This function is only supported at the connect redirect layer
+    // This function is only supported at the connect redirect layer.
     if (sock_addr_ctx->hook_id != EBPF_HOOK_ALE_CONNECT_REDIRECT_V4 &&
         sock_addr_ctx->hook_id != EBPF_HOOK_ALE_CONNECT_REDIRECT_V6) {
         return_value = -1;
         goto Exit;
     }
 
-    // Allocate buffer to store redirect context
+    // Allocate buffer to store redirect context.
     redirect_context = ExAllocatePoolUninitialized(NonPagedPoolNx, data_size, NET_EBPF_EXTENSION_POOL_TAG);
     if (redirect_context == NULL) {
         return_value = -1;
@@ -283,7 +283,7 @@ _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void*
     }
     memcpy(redirect_context, data, data_size);
 
-    // Set redirect context
+    // Set redirect context.
     sock_addr_ctx->redirect_context = redirect_context;
     sock_addr_ctx->redirect_context_size = data_size;
 
@@ -1395,7 +1395,7 @@ _net_ebpf_ext_process_redirect_verdict(
 
         connect_request->localRedirectContext = sock_addr_ctx->redirect_context;
         connect_request->localRedirectContextSize = sock_addr_ctx->redirect_context_size;
-        // Ownership transferred to WFP
+        // Ownership transferred to WFP.
         sock_addr_ctx->redirect_context = NULL;
         sock_addr_ctx->redirect_context_size = 0;
     }

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -268,6 +268,12 @@ _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void*
     net_ebpf_sock_addr_t* sock_addr_ctx = CONTAINING_RECORD(ctx, net_ebpf_sock_addr_t, base);
     void* redirect_context = NULL;
 
+    // Check for invalid parameters.
+    if (data == NULL || data_size == 0) {
+        return_value = -1;
+        goto Exit;
+    }
+
     // This function is only supported at the connect redirect layer.
     if (sock_addr_ctx->hook_id != EBPF_HOOK_ALE_CONNECT_REDIRECT_V4 &&
         sock_addr_ctx->hook_id != EBPF_HOOK_ALE_CONNECT_REDIRECT_V6) {

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -277,6 +277,10 @@ _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void*
     // This function is only supported at the connect redirect layer.
     if (sock_addr_ctx->hook_id != EBPF_HOOK_ALE_CONNECT_REDIRECT_V4 &&
         sock_addr_ctx->hook_id != EBPF_HOOK_ALE_CONNECT_REDIRECT_V6) {
+        NET_EBPF_EXT_LOG_MESSAGE(
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
+            "_ebpf_sock_addr_set_redirect_context invoked at incorrect hook.");
         return_value = -1;
         goto Exit;
     }
@@ -284,6 +288,10 @@ _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void*
     // Allocate buffer to store redirect context.
     redirect_context = ExAllocatePoolUninitialized(NonPagedPoolNx, data_size, NET_EBPF_EXTENSION_POOL_TAG);
     if (redirect_context == NULL) {
+        NET_EBPF_EXT_LOG_MESSAGE(
+            NET_EBPF_EXT_TRACELOG_LEVEL_ERROR,
+            NET_EBPF_EXT_TRACELOG_KEYWORD_SOCK_ADDR,
+            "_ebpf_sock_addr_set_redirect_context failed to allocate memory for the redirect context.");
         return_value = -1;
         goto Exit;
     }

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -283,7 +283,12 @@ _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void*
     }
     memcpy(redirect_context, data, data_size);
 
-    // Set redirect context.
+    // If a redirect context already exists, free the existing buffer.
+    if (sock_addr_ctx->redirect_context != NULL) {
+        ExFreePool(sock_addr_ctx->redirect_context);
+    }
+
+    // Set the redirect context.
     sock_addr_ctx->redirect_context = redirect_context;
     sock_addr_ctx->redirect_context_size = data_size;
 

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1001,6 +1001,10 @@ test_sock_addr_native_program_load_attach(const char* file_name)
         test_sock_addr_native_program_load_attach((const char*)"cgroup_sock_addr2_"##version ".sys"); \
     }
 
+// Commenting the regression test for 0.9.0 as a breaking change was added.
+// This test needs to be enabled once v0.11.0 is released. Tracking issue #2839.
+// DECLARE_REGRESSION_TEST_CASE("0.9.0")
+
 // The below tests try to load native drivers for invalid programs (that will fail verification).
 // Since verification can be skipped in bpf2c for only Debug builds, these tests are applicable
 // only for Debug build.

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1001,8 +1001,6 @@ test_sock_addr_native_program_load_attach(const char* file_name)
         test_sock_addr_native_program_load_attach((const char*)"cgroup_sock_addr2_"##version ".sys"); \
     }
 
-DECLARE_REGRESSION_TEST_CASE("0.9.0")
-
 // The below tests try to load native drivers for invalid programs (that will fail verification).
 // Since verification can be skipped in bpf2c for only Debug builds, these tests are applicable
 // only for Debug build.

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -198,7 +198,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=67 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=71 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
@@ -207,12 +207,12 @@ label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=65 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=69 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
@@ -233,27 +233,30 @@ label_1:
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
 #line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
+        // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=35 dst=r7 src=r0 offset=57 imm=0
+    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=36 dst=r7 src=r0 offset=60 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
 #line 72 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=36 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=37 dst=r2 src=r0 offset=0 imm=-32
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
 #line 77 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=40 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
 #line 77 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
 #line 77 "sample/cgroup_sock_addr2.c"
@@ -262,69 +265,72 @@ label_1:
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
 #line 77 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=41 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r9 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=27 imm=0
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=27 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 78 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=44 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=45 dst=r10 src=r1 offset=-70 imm=0
+    // EBPF_OP_STXB pc=47 dst=r10 src=r1 offset=-70 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=29989
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=29989
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=540697973
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=540697973
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=2037544046
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=2037544046
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1869770784
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1869770784
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=57 dst=r1 src=r0 offset=0 imm=1853189958
+    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1853189958
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=59 dst=r10 src=r1 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-104 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=60 dst=r4 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=62 dst=r4 src=r8 offset=16 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=61 dst=r3 src=r8 offset=0 imm=0
+    // EBPF_OP_LDXW pc=63 dst=r3 src=r8 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=64 dst=r1 src=r10 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=63 dst=r1 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=65 dst=r1 src=r0 offset=0 imm=-104
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=64 dst=r2 src=r0 offset=0 imm=35
+    // EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=35
 #line 79 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=14
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=14
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
 #line 79 "sample/cgroup_sock_addr2.c"
@@ -333,29 +339,35 @@ label_1:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 79 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=66 dst=r1 src=r8 offset=0 imm=0
+        // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
 #line 80 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=67 dst=r6 src=r1 offset=24 imm=0
+    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
 #line 80 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=68 dst=r1 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=69 dst=r6 src=r1 offset=40 imm=0
+    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=70 dst=r7 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
 #line 81 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -364,16 +376,16 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -382,13 +394,13 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -397,37 +409,37 @@ label_2:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=85 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=86 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=87 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=88 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=89 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=91 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -437,10 +449,10 @@ label_2:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=93 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
 #line 136 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=94 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
 #line 136 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 136 "sample/cgroup_sock_addr2.c"
@@ -510,71 +522,77 @@ connect_redirect6(void* context)
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 95 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=25959
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
 #line 95 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=4 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=14 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=15 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
 #line 98 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=16 dst=r1 src=r0 offset=1 imm=17
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 98 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
 #line 98 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=84 imm=6
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
 #line 98 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 98 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=82 imm=23
+    // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=21 dst=r2 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
 #line 106 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r3 src=r0 offset=0 imm=27
+    // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
 #line 106 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=65537
+    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
 #line 106 "sample/cgroup_sock_addr2.c"
@@ -583,69 +601,72 @@ label_1:
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
 #line 106 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=25 dst=r0 src=r0 offset=0 imm=32
+        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=26 dst=r0 src=r0 offset=0 imm=32
+    // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=27 dst=r7 src=r0 offset=74 imm=0
+    // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
 #line 106 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=28 dst=r1 src=r6 offset=36 imm=0
+        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=29 dst=r1 src=r0 offset=0 imm=32
+    // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=30 dst=r2 src=r6 offset=32 imm=0
+    // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=31 dst=r1 src=r2 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
-    // EBPF_OP_STXDW pc=32 dst=r10 src=r1 offset=-24 imm=0
+    // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=33 dst=r1 src=r6 offset=28 imm=0
+    // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=34 dst=r1 src=r0 offset=0 imm=32
+    // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=35 dst=r2 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=36 dst=r1 src=r2 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
-    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=38 dst=r1 src=r6 offset=40 imm=0
+    // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=40 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-12 imm=0
+    // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-32
+    // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 118 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
 #line 118 "sample/cgroup_sock_addr2.c"
@@ -654,63 +675,66 @@ label_1:
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
 #line 118 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=47 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r9 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=49 dst=r8 src=r0 offset=30 imm=0
+    // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 119 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=50 dst=r7 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=51 dst=r7 src=r0 offset=0 imm=24
+    // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
 #line 119 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=52 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=53 dst=r10 src=r1 offset=-70 imm=0
+    // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=25973
+    // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=55 dst=r10 src=r1 offset=-72 imm=0
+    // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=2037544046
+    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1869770784
+    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=62 dst=r1 src=r0 offset=0 imm=1853189958
+    // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r1 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r1 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=67 dst=r2 src=r0 offset=0 imm=27
+    // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
 #line 120 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=12
+    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
 #line 120 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
 #line 120 "sample/cgroup_sock_addr2.c"
@@ -719,47 +743,53 @@ label_1:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 120 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=12 imm=0
+        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=70 dst=r7 src=r1 offset=12 imm=0
+    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=71 dst=r1 src=r8 offset=8 imm=0
+    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=72 dst=r7 src=r1 offset=8 imm=0
+    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=4 imm=0
+    // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=4 imm=0
+    // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=0 imm=0
+    // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=0 imm=0
+    // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=77 dst=r1 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=78 dst=r6 src=r1 offset=40 imm=0
+    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=79 dst=r7 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
 #line 122 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -768,16 +798,16 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -786,13 +816,13 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -801,37 +831,37 @@ label_2:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=93 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=94 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=95 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=96 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=97 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=98 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=100 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -841,10 +871,10 @@ label_2:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
 #line 143 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=103 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
 #line 143 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 143 "sample/cgroup_sock_addr2.c"
@@ -864,7 +894,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        95,
+        99,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -878,7 +908,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        104,
+        110,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -75,6 +75,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65536, "helper_id_65536"},
@@ -95,45 +96,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
 {
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -147,257 +148,308 @@ connect_redirect4(void* context)
     // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_LDXW pc=6 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=25959
+#line 57 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25959);
+    // EBPF_OP_STXH pc=7 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1299477349
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7022083122929103717;
+    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-48 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1953394499
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)6085621373624807235;
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-56 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=14 dst=r1 src=r0 offset=0 imm=1768187218
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)8386658473162859858;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-64 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+    // EBPF_OP_STXB pc=17 dst=r10 src=r7 offset=-38 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
+    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=24 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-32 imm=0
-#line 58 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=19 dst=r10 src=r1 offset=-32 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=8 dst=r1 src=r6 offset=40 imm=0
-#line 59 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=20 dst=r1 src=r6 offset=40 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=9 dst=r10 src=r1 offset=-16 imm=0
-#line 59 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r6 offset=44 imm=0
-#line 60 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=22 dst=r1 src=r6 offset=44 imm=0
+#line 62 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-12 imm=0
-#line 60 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-12 imm=0
+#line 62 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_JEQ_IMM pc=12 dst=r1 src=r0 offset=1 imm=17
-#line 62 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=24 dst=r1 src=r0 offset=1 imm=17
+#line 64 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 62 "sample/cgroup_sock_addr2.c"
+#line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
-#line 62 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=67 imm=6
+#line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 62 "sample/cgroup_sock_addr2.c"
+#line 64 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=60 imm=2
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=65 imm=2
+#line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
-#line 66 "sample/cgroup_sock_addr2.c"
+#line 68 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+#line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=17 dst=r2 src=r0 offset=0 imm=-32
-#line 71 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=18 dst=r1 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=1
-#line 71 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
+#line 72 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=31 dst=r3 src=r0 offset=0 imm=27
+#line 72 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=65537
+#line 72 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=22 dst=r9 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=23 dst=r7 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=24 dst=r8 src=r0 offset=27 imm=0
+    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=35 dst=r7 src=r0 offset=57 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=26 dst=r10 src=r1 offset=-38 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=29989
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=28 dst=r10 src=r1 offset=-40 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=29 dst=r1 src=r0 offset=0 imm=540697973
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-48 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=32 dst=r1 src=r0 offset=0 imm=2037544046
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=34 dst=r10 src=r1 offset=-56 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=35 dst=r1 src=r0 offset=0 imm=1869770784
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-64 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=1853189958
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-72 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=41 dst=r4 src=r8 offset=16 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=42 dst=r3 src=r8 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=43 dst=r1 src=r10 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=44 dst=r1 src=r0 offset=0 imm=-72
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-72);
-    // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=35
-#line 73 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=14
-#line 73 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 72 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+    // EBPF_OP_MOV64_REG pc=36 dst=r2 src=r10 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=37 dst=r2 src=r0 offset=0 imm=-32
+#line 77 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-32);
+    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=40 dst=r0 src=r0 offset=0 imm=1
+#line 77 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=41 dst=r8 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r8 = r0;
+    // EBPF_OP_MOV64_IMM pc=42 dst=r9 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r9 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=27 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    if (r8 == IMMEDIATE(0))
+#line 78 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+    // EBPF_OP_MOV64_IMM pc=44 dst=r1 src=r0 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=45 dst=r10 src=r1 offset=-70 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=29989
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=540697973
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=2037544046
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1869770784
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=57 dst=r1 src=r0 offset=0 imm=1853189958
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=59 dst=r10 src=r1 offset=-104 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=60 dst=r4 src=r8 offset=16 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=61 dst=r3 src=r8 offset=0 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r10 offset=0 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=63 dst=r1 src=r0 offset=0 imm=-104
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=64 dst=r2 src=r0 offset=0 imm=35
+#line 79 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=14
+#line 79 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 79 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 79 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 79 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_LDXW pc=66 dst=r1 src=r8 offset=0 imm=0
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=48 dst=r6 src=r1 offset=24 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=67 dst=r6 src=r1 offset=24 imm=0
+#line 80 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=49 dst=r1 src=r8 offset=16 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=68 dst=r1 src=r8 offset=16 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=50 dst=r6 src=r1 offset=40 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=69 dst=r6 src=r1 offset=40 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=51 dst=r7 src=r0 offset=0 imm=1
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=70 dst=r7 src=r0 offset=0 imm=1
+#line 81 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r9 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=71 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r9 offset=-64 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r9 offset=-72 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
+    r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[3].address
-#line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
-#line 45 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
-#line 45 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
-#line 46 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=21
-#line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
+#line 45 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 45 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+#line 45 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
+#line 46 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
+    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=65 dst=r1 src=r6 offset=20 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
+    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=66 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=67 dst=r10 src=r1 offset=-52 imm=0
+    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=68 dst=r2 src=r10 offset=0 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_REG pc=85 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=69 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=86 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=70 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=71 dst=r3 src=r0 offset=0 imm=-72
+    // EBPF_OP_ADD64_IMM pc=88 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
-    r3 += IMMEDIATE(-72);
-    // EBPF_OP_LDDW pc=72 dst=r1 src=r0 offset=0 imm=0
+    r3 += IMMEDIATE(-104);
+    // EBPF_OP_LDDW pc=89 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=74 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=91 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=75 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[5].address
+    r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 50 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=76 dst=r0 src=r7 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=93 dst=r0 src=r7 offset=0 imm=0
+#line 136 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=77 dst=r0 src=r0 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=94 dst=r0 src=r0 offset=0 imm=0
+#line 136 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 125 "sample/cgroup_sock_addr2.c"
+#line 136 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
 
 static helper_function_entry_t connect_redirect6_helpers[] = {
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
     {NULL, 65536, "helper_id_65536"},
@@ -418,337 +470,384 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
 {
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
-    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
-    // EBPF_OP_LDXW pc=5 dst=r1 src=r6 offset=44 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=25959
+#line 95 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25959);
+    // EBPF_OP_STXH pc=4 dst=r10 src=r1 offset=-40 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=1299477349
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7022083122929103717;
+    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1953394499
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)6085621373624807235;
+    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-56 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1768187218
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)8386658473162859858;
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-64 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+    // EBPF_OP_STXB pc=14 dst=r10 src=r7 offset=-38 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
+    // EBPF_OP_LDXW pc=15 dst=r1 src=r6 offset=44 imm=0
+#line 98 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=6 dst=r1 src=r0 offset=1 imm=17
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=16 dst=r1 src=r0 offset=1 imm=17
+#line 98 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 91 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=84 imm=6
+#line 98 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 91 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=8 dst=r2 src=r6 offset=0 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=76 imm=23
-#line 95 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
-#line 95 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=82 imm=23
+#line 102 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(23))
+#line 102 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
+    // EBPF_OP_MOV64_REG pc=20 dst=r2 src=r10 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=11 dst=r2 src=r0 offset=0 imm=32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=12 dst=r3 src=r6 offset=32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=13 dst=r2 src=r3 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=14 dst=r10 src=r2 offset=-24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_LDXW pc=15 dst=r2 src=r6 offset=28 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=17 dst=r3 src=r6 offset=24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=18 dst=r2 src=r3 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r2 offset=-32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_LDXH pc=20 dst=r2 src=r6 offset=40 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=21 dst=r10 src=r2 offset=-16 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
-    // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-12 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=23 dst=r2 src=r10 offset=0 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r2 src=r0 offset=0 imm=-32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=1
-#line 107 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=21 dst=r2 src=r0 offset=0 imm=-64
+#line 106 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=23 dst=r3 src=r0 offset=0 imm=27
+#line 106 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=65537
+#line 106 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=29 dst=r9 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=30 dst=r7 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=31 dst=r8 src=r0 offset=30 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=33 dst=r7 src=r0 offset=0 imm=24
-#line 108 "sample/cgroup_sock_addr2.c"
-    r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=34 dst=r1 src=r0 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=35 dst=r10 src=r1 offset=-38 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=25973
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=37 dst=r10 src=r1 offset=-40 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=2037544046
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-48 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=1869770784
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-56 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=1853189958
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-64 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=47 dst=r1 src=r10 offset=0 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=48 dst=r1 src=r0 offset=0 imm=-64
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_IMM pc=49 dst=r2 src=r0 offset=0 imm=27
-#line 109 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=12
-#line 109 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LSH64_IMM pc=25 dst=r0 src=r0 offset=0 imm=32
+#line 106 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=26 dst=r0 src=r0 offset=0 imm=32
+#line 106 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=27 dst=r7 src=r0 offset=74 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 106 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+    // EBPF_OP_LDXW pc=28 dst=r1 src=r6 offset=36 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=29 dst=r1 src=r0 offset=0 imm=32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=30 dst=r2 src=r6 offset=32 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=31 dst=r1 src=r2 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=32 dst=r10 src=r1 offset=-24 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDXW pc=33 dst=r1 src=r6 offset=28 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=34 dst=r1 src=r0 offset=0 imm=32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=35 dst=r2 src=r6 offset=24 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=36 dst=r1 src=r2 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-32 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=38 dst=r1 src=r6 offset=40 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-16 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
+    // EBPF_OP_LDXW pc=40 dst=r1 src=r6 offset=44 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-12 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-32);
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
+#line 118 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=47 dst=r8 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r8 = r0;
+    // EBPF_OP_MOV64_IMM pc=48 dst=r9 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r9 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=49 dst=r8 src=r0 offset=30 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    if (r8 == IMMEDIATE(0))
+#line 119 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+    // EBPF_OP_MOV64_REG pc=50 dst=r7 src=r6 offset=0 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    r7 = r6;
+    // EBPF_OP_ADD64_IMM pc=51 dst=r7 src=r0 offset=0 imm=24
+#line 119 "sample/cgroup_sock_addr2.c"
+    r7 += IMMEDIATE(24);
+    // EBPF_OP_MOV64_IMM pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=53 dst=r10 src=r1 offset=-70 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=25973
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25973);
+    // EBPF_OP_STXH pc=55 dst=r10 src=r1 offset=-72 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=2037544046
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-80 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1869770784
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-88 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=62 dst=r1 src=r0 offset=0 imm=1853189958
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3924359741021974342;
+    // EBPF_OP_STXDW pc=64 dst=r10 src=r1 offset=-96 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r10 offset=0 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=66 dst=r1 src=r0 offset=0 imm=-96
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-96);
+    // EBPF_OP_MOV64_IMM pc=67 dst=r2 src=r0 offset=0 imm=27
+#line 120 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=12
+#line 120 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[2].address
+#line 120 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 120 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+#line 120 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=12 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=52 dst=r7 src=r1 offset=12 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=70 dst=r7 src=r1 offset=12 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=53 dst=r1 src=r8 offset=8 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=71 dst=r1 src=r8 offset=8 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=54 dst=r7 src=r1 offset=8 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=72 dst=r7 src=r1 offset=8 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=55 dst=r1 src=r8 offset=4 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=4 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=56 dst=r7 src=r1 offset=4 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=4 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=57 dst=r1 src=r8 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=58 dst=r7 src=r1 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=59 dst=r1 src=r8 offset=16 imm=0
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=77 dst=r1 src=r8 offset=16 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=60 dst=r6 src=r1 offset=40 imm=0
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=78 dst=r6 src=r1 offset=40 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=61 dst=r7 src=r0 offset=0 imm=1
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=79 dst=r7 src=r0 offset=0 imm=1
+#line 122 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=62 dst=r10 src=r9 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=63 dst=r10 src=r9 offset=-56 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r9 offset=-64 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=66 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
+    r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=70 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[3].address
-#line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
-#line 45 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
-#line 45 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
-#line 46 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=21
-#line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
+#line 45 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 45 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+#line 45 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-96 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+#line 46 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
+    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=75 dst=r1 src=r6 offset=20 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
+    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=77 dst=r10 src=r1 offset=-44 imm=0
+    // EBPF_OP_STXH pc=93 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=78 dst=r2 src=r10 offset=0 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_REG pc=94 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=79 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=95 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=80 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=81 dst=r3 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=97 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
-    r3 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=82 dst=r1 src=r0 offset=0 imm=0
+    r3 += IMMEDIATE(-96);
+    // EBPF_OP_LDDW pc=98 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=84 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=100 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[5].address
+    r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 50 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=86 dst=r0 src=r7 offset=0 imm=0
-#line 132 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r7 offset=0 imm=0
+#line 143 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=87 dst=r0 src=r0 offset=0 imm=0
-#line 132 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=103 dst=r0 src=r0 offset=0 imm=0
+#line 143 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 132 "sample/cgroup_sock_addr2.c"
+#line 143 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -764,8 +863,8 @@ static program_entry_t _programs[] = {
         connect_redirect4_maps,
         2,
         connect_redirect4_helpers,
-        6,
-        78,
+        7,
+        95,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -778,8 +877,8 @@ static program_entry_t _programs[] = {
         connect_redirect6_maps,
         2,
         connect_redirect6_helpers,
-        6,
-        88,
+        7,
+        104,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -172,7 +172,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=67 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=71 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
@@ -181,12 +181,12 @@ label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=65 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=69 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
@@ -207,27 +207,30 @@ label_1:
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
 #line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
+        // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=35 dst=r7 src=r0 offset=57 imm=0
+    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=36 dst=r7 src=r0 offset=60 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
 #line 72 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=36 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=37 dst=r2 src=r0 offset=0 imm=-32
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
 #line 77 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=40 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
 #line 77 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
 #line 77 "sample/cgroup_sock_addr2.c"
@@ -236,69 +239,72 @@ label_1:
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
 #line 77 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=41 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r9 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=27 imm=0
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=27 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 78 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=44 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=45 dst=r10 src=r1 offset=-70 imm=0
+    // EBPF_OP_STXB pc=47 dst=r10 src=r1 offset=-70 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=29989
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=29989
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=540697973
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=540697973
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=2037544046
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=2037544046
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1869770784
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1869770784
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=57 dst=r1 src=r0 offset=0 imm=1853189958
+    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1853189958
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=59 dst=r10 src=r1 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-104 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=60 dst=r4 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=62 dst=r4 src=r8 offset=16 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=61 dst=r3 src=r8 offset=0 imm=0
+    // EBPF_OP_LDXW pc=63 dst=r3 src=r8 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=64 dst=r1 src=r10 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=63 dst=r1 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=65 dst=r1 src=r0 offset=0 imm=-104
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=64 dst=r2 src=r0 offset=0 imm=35
+    // EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=35
 #line 79 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=14
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=14
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
 #line 79 "sample/cgroup_sock_addr2.c"
@@ -307,29 +313,35 @@ label_1:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 79 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=66 dst=r1 src=r8 offset=0 imm=0
+        // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
 #line 80 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=67 dst=r6 src=r1 offset=24 imm=0
+    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
 #line 80 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=68 dst=r1 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=69 dst=r6 src=r1 offset=40 imm=0
+    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=70 dst=r7 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
 #line 81 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -338,16 +350,16 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -356,13 +368,13 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -371,37 +383,37 @@ label_2:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=85 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=86 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=87 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=88 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=89 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=91 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -411,10 +423,10 @@ label_2:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=93 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
 #line 136 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=94 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
 #line 136 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 136 "sample/cgroup_sock_addr2.c"
@@ -484,71 +496,77 @@ connect_redirect6(void* context)
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 95 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=25959
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
 #line 95 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=4 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=14 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=15 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
 #line 98 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=16 dst=r1 src=r0 offset=1 imm=17
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 98 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
 #line 98 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=84 imm=6
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
 #line 98 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 98 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=82 imm=23
+    // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=21 dst=r2 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
 #line 106 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r3 src=r0 offset=0 imm=27
+    // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
 #line 106 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=65537
+    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
 #line 106 "sample/cgroup_sock_addr2.c"
@@ -557,69 +575,72 @@ label_1:
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
 #line 106 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=25 dst=r0 src=r0 offset=0 imm=32
+        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=26 dst=r0 src=r0 offset=0 imm=32
+    // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=27 dst=r7 src=r0 offset=74 imm=0
+    // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
 #line 106 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=28 dst=r1 src=r6 offset=36 imm=0
+        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=29 dst=r1 src=r0 offset=0 imm=32
+    // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=30 dst=r2 src=r6 offset=32 imm=0
+    // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=31 dst=r1 src=r2 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
-    // EBPF_OP_STXDW pc=32 dst=r10 src=r1 offset=-24 imm=0
+    // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=33 dst=r1 src=r6 offset=28 imm=0
+    // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=34 dst=r1 src=r0 offset=0 imm=32
+    // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=35 dst=r2 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=36 dst=r1 src=r2 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
-    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=38 dst=r1 src=r6 offset=40 imm=0
+    // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=40 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-12 imm=0
+    // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-32
+    // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 118 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
 #line 118 "sample/cgroup_sock_addr2.c"
@@ -628,63 +649,66 @@ label_1:
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
 #line 118 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=47 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r9 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=49 dst=r8 src=r0 offset=30 imm=0
+    // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 119 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=50 dst=r7 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=51 dst=r7 src=r0 offset=0 imm=24
+    // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
 #line 119 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=52 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=53 dst=r10 src=r1 offset=-70 imm=0
+    // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=25973
+    // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=55 dst=r10 src=r1 offset=-72 imm=0
+    // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=2037544046
+    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1869770784
+    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=62 dst=r1 src=r0 offset=0 imm=1853189958
+    // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r1 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r1 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=67 dst=r2 src=r0 offset=0 imm=27
+    // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
 #line 120 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=12
+    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
 #line 120 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
 #line 120 "sample/cgroup_sock_addr2.c"
@@ -693,47 +717,53 @@ label_1:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 120 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=12 imm=0
+        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=70 dst=r7 src=r1 offset=12 imm=0
+    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=71 dst=r1 src=r8 offset=8 imm=0
+    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=72 dst=r7 src=r1 offset=8 imm=0
+    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=4 imm=0
+    // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=4 imm=0
+    // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=0 imm=0
+    // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=0 imm=0
+    // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=77 dst=r1 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=78 dst=r6 src=r1 offset=40 imm=0
+    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=79 dst=r7 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
 #line 122 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -742,16 +772,16 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -760,13 +790,13 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -775,37 +805,37 @@ label_2:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=93 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=94 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=95 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=96 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=97 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=98 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=100 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -815,10 +845,10 @@ label_2:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
 #line 143 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=103 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
 #line 143 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 143 "sample/cgroup_sock_addr2.c"
@@ -838,7 +868,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        95,
+        99,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -852,7 +882,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        104,
+        110,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -49,6 +49,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65536, "helper_id_65536"},
@@ -69,45 +70,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
 {
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -121,257 +122,308 @@ connect_redirect4(void* context)
     // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_LDXW pc=6 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=25959
+#line 57 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25959);
+    // EBPF_OP_STXH pc=7 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1299477349
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7022083122929103717;
+    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-48 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1953394499
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)6085621373624807235;
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-56 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=14 dst=r1 src=r0 offset=0 imm=1768187218
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)8386658473162859858;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-64 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+    // EBPF_OP_STXB pc=17 dst=r10 src=r7 offset=-38 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
+    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=24 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-32 imm=0
-#line 58 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=19 dst=r10 src=r1 offset=-32 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=8 dst=r1 src=r6 offset=40 imm=0
-#line 59 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=20 dst=r1 src=r6 offset=40 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=9 dst=r10 src=r1 offset=-16 imm=0
-#line 59 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r6 offset=44 imm=0
-#line 60 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=22 dst=r1 src=r6 offset=44 imm=0
+#line 62 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-12 imm=0
-#line 60 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-12 imm=0
+#line 62 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_JEQ_IMM pc=12 dst=r1 src=r0 offset=1 imm=17
-#line 62 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=24 dst=r1 src=r0 offset=1 imm=17
+#line 64 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 62 "sample/cgroup_sock_addr2.c"
+#line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
-#line 62 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=67 imm=6
+#line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 62 "sample/cgroup_sock_addr2.c"
+#line 64 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=60 imm=2
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=65 imm=2
+#line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
-#line 66 "sample/cgroup_sock_addr2.c"
+#line 68 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+#line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=17 dst=r2 src=r0 offset=0 imm=-32
-#line 71 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=18 dst=r1 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=1
-#line 71 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
+#line 72 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=31 dst=r3 src=r0 offset=0 imm=27
+#line 72 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=65537
+#line 72 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=22 dst=r9 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=23 dst=r7 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=24 dst=r8 src=r0 offset=27 imm=0
+    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=35 dst=r7 src=r0 offset=57 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=26 dst=r10 src=r1 offset=-38 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=29989
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=28 dst=r10 src=r1 offset=-40 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=29 dst=r1 src=r0 offset=0 imm=540697973
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-48 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=32 dst=r1 src=r0 offset=0 imm=2037544046
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=34 dst=r10 src=r1 offset=-56 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=35 dst=r1 src=r0 offset=0 imm=1869770784
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-64 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=1853189958
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-72 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=41 dst=r4 src=r8 offset=16 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=42 dst=r3 src=r8 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=43 dst=r1 src=r10 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=44 dst=r1 src=r0 offset=0 imm=-72
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-72);
-    // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=35
-#line 73 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=14
-#line 73 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 72 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+    // EBPF_OP_MOV64_REG pc=36 dst=r2 src=r10 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=37 dst=r2 src=r0 offset=0 imm=-32
+#line 77 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-32);
+    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=40 dst=r0 src=r0 offset=0 imm=1
+#line 77 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=41 dst=r8 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r8 = r0;
+    // EBPF_OP_MOV64_IMM pc=42 dst=r9 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r9 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=27 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    if (r8 == IMMEDIATE(0))
+#line 78 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+    // EBPF_OP_MOV64_IMM pc=44 dst=r1 src=r0 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=45 dst=r10 src=r1 offset=-70 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=29989
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=540697973
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=2037544046
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1869770784
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=57 dst=r1 src=r0 offset=0 imm=1853189958
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=59 dst=r10 src=r1 offset=-104 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=60 dst=r4 src=r8 offset=16 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=61 dst=r3 src=r8 offset=0 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r10 offset=0 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=63 dst=r1 src=r0 offset=0 imm=-104
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=64 dst=r2 src=r0 offset=0 imm=35
+#line 79 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=14
+#line 79 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 79 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 79 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 79 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_LDXW pc=66 dst=r1 src=r8 offset=0 imm=0
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=48 dst=r6 src=r1 offset=24 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=67 dst=r6 src=r1 offset=24 imm=0
+#line 80 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=49 dst=r1 src=r8 offset=16 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=68 dst=r1 src=r8 offset=16 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=50 dst=r6 src=r1 offset=40 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=69 dst=r6 src=r1 offset=40 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=51 dst=r7 src=r0 offset=0 imm=1
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=70 dst=r7 src=r0 offset=0 imm=1
+#line 81 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r9 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=71 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r9 offset=-64 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r9 offset=-72 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
+    r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[3].address
-#line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
-#line 45 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
-#line 45 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
-#line 46 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=21
-#line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
+#line 45 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 45 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+#line 45 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
+#line 46 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
+    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=65 dst=r1 src=r6 offset=20 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
+    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=66 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=67 dst=r10 src=r1 offset=-52 imm=0
+    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=68 dst=r2 src=r10 offset=0 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_REG pc=85 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=69 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=86 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=70 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=71 dst=r3 src=r0 offset=0 imm=-72
+    // EBPF_OP_ADD64_IMM pc=88 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
-    r3 += IMMEDIATE(-72);
-    // EBPF_OP_LDDW pc=72 dst=r1 src=r0 offset=0 imm=0
+    r3 += IMMEDIATE(-104);
+    // EBPF_OP_LDDW pc=89 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=74 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=91 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=75 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[5].address
+    r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 50 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=76 dst=r0 src=r7 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=93 dst=r0 src=r7 offset=0 imm=0
+#line 136 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=77 dst=r0 src=r0 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=94 dst=r0 src=r0 offset=0 imm=0
+#line 136 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 125 "sample/cgroup_sock_addr2.c"
+#line 136 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
 
 static helper_function_entry_t connect_redirect6_helpers[] = {
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
     {NULL, 65536, "helper_id_65536"},
@@ -392,337 +444,384 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
 {
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
-    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
-    // EBPF_OP_LDXW pc=5 dst=r1 src=r6 offset=44 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=25959
+#line 95 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25959);
+    // EBPF_OP_STXH pc=4 dst=r10 src=r1 offset=-40 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=1299477349
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7022083122929103717;
+    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1953394499
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)6085621373624807235;
+    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-56 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1768187218
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)8386658473162859858;
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-64 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+    // EBPF_OP_STXB pc=14 dst=r10 src=r7 offset=-38 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
+    // EBPF_OP_LDXW pc=15 dst=r1 src=r6 offset=44 imm=0
+#line 98 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=6 dst=r1 src=r0 offset=1 imm=17
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=16 dst=r1 src=r0 offset=1 imm=17
+#line 98 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 91 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=84 imm=6
+#line 98 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 91 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=8 dst=r2 src=r6 offset=0 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=76 imm=23
-#line 95 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
-#line 95 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=82 imm=23
+#line 102 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(23))
+#line 102 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
+    // EBPF_OP_MOV64_REG pc=20 dst=r2 src=r10 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=11 dst=r2 src=r0 offset=0 imm=32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=12 dst=r3 src=r6 offset=32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=13 dst=r2 src=r3 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=14 dst=r10 src=r2 offset=-24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_LDXW pc=15 dst=r2 src=r6 offset=28 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=17 dst=r3 src=r6 offset=24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=18 dst=r2 src=r3 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r2 offset=-32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_LDXH pc=20 dst=r2 src=r6 offset=40 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=21 dst=r10 src=r2 offset=-16 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
-    // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-12 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=23 dst=r2 src=r10 offset=0 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r2 src=r0 offset=0 imm=-32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=1
-#line 107 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=21 dst=r2 src=r0 offset=0 imm=-64
+#line 106 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=23 dst=r3 src=r0 offset=0 imm=27
+#line 106 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=65537
+#line 106 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=29 dst=r9 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=30 dst=r7 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=31 dst=r8 src=r0 offset=30 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=33 dst=r7 src=r0 offset=0 imm=24
-#line 108 "sample/cgroup_sock_addr2.c"
-    r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=34 dst=r1 src=r0 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=35 dst=r10 src=r1 offset=-38 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=25973
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=37 dst=r10 src=r1 offset=-40 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=2037544046
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-48 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=1869770784
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-56 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=1853189958
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-64 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=47 dst=r1 src=r10 offset=0 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=48 dst=r1 src=r0 offset=0 imm=-64
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_IMM pc=49 dst=r2 src=r0 offset=0 imm=27
-#line 109 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=12
-#line 109 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LSH64_IMM pc=25 dst=r0 src=r0 offset=0 imm=32
+#line 106 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=26 dst=r0 src=r0 offset=0 imm=32
+#line 106 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=27 dst=r7 src=r0 offset=74 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 106 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+    // EBPF_OP_LDXW pc=28 dst=r1 src=r6 offset=36 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=29 dst=r1 src=r0 offset=0 imm=32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=30 dst=r2 src=r6 offset=32 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=31 dst=r1 src=r2 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=32 dst=r10 src=r1 offset=-24 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDXW pc=33 dst=r1 src=r6 offset=28 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=34 dst=r1 src=r0 offset=0 imm=32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=35 dst=r2 src=r6 offset=24 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=36 dst=r1 src=r2 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-32 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=38 dst=r1 src=r6 offset=40 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-16 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
+    // EBPF_OP_LDXW pc=40 dst=r1 src=r6 offset=44 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-12 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-32);
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
+#line 118 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=47 dst=r8 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r8 = r0;
+    // EBPF_OP_MOV64_IMM pc=48 dst=r9 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r9 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=49 dst=r8 src=r0 offset=30 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    if (r8 == IMMEDIATE(0))
+#line 119 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+    // EBPF_OP_MOV64_REG pc=50 dst=r7 src=r6 offset=0 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    r7 = r6;
+    // EBPF_OP_ADD64_IMM pc=51 dst=r7 src=r0 offset=0 imm=24
+#line 119 "sample/cgroup_sock_addr2.c"
+    r7 += IMMEDIATE(24);
+    // EBPF_OP_MOV64_IMM pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=53 dst=r10 src=r1 offset=-70 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=25973
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25973);
+    // EBPF_OP_STXH pc=55 dst=r10 src=r1 offset=-72 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=2037544046
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-80 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1869770784
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-88 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=62 dst=r1 src=r0 offset=0 imm=1853189958
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3924359741021974342;
+    // EBPF_OP_STXDW pc=64 dst=r10 src=r1 offset=-96 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r10 offset=0 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=66 dst=r1 src=r0 offset=0 imm=-96
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-96);
+    // EBPF_OP_MOV64_IMM pc=67 dst=r2 src=r0 offset=0 imm=27
+#line 120 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=12
+#line 120 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[2].address
+#line 120 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 120 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+#line 120 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=12 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=52 dst=r7 src=r1 offset=12 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=70 dst=r7 src=r1 offset=12 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=53 dst=r1 src=r8 offset=8 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=71 dst=r1 src=r8 offset=8 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=54 dst=r7 src=r1 offset=8 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=72 dst=r7 src=r1 offset=8 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=55 dst=r1 src=r8 offset=4 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=4 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=56 dst=r7 src=r1 offset=4 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=4 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=57 dst=r1 src=r8 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=58 dst=r7 src=r1 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=59 dst=r1 src=r8 offset=16 imm=0
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=77 dst=r1 src=r8 offset=16 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=60 dst=r6 src=r1 offset=40 imm=0
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=78 dst=r6 src=r1 offset=40 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=61 dst=r7 src=r0 offset=0 imm=1
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=79 dst=r7 src=r0 offset=0 imm=1
+#line 122 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=62 dst=r10 src=r9 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=63 dst=r10 src=r9 offset=-56 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r9 offset=-64 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=66 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
+    r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=70 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[3].address
-#line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
-#line 45 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
-#line 45 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
-#line 46 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=21
-#line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
+#line 45 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 45 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+#line 45 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-96 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+#line 46 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
+    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=75 dst=r1 src=r6 offset=20 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
+    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=77 dst=r10 src=r1 offset=-44 imm=0
+    // EBPF_OP_STXH pc=93 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=78 dst=r2 src=r10 offset=0 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_REG pc=94 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=79 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=95 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=80 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=81 dst=r3 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=97 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
-    r3 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=82 dst=r1 src=r0 offset=0 imm=0
+    r3 += IMMEDIATE(-96);
+    // EBPF_OP_LDDW pc=98 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=84 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=100 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[5].address
+    r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 50 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=86 dst=r0 src=r7 offset=0 imm=0
-#line 132 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r7 offset=0 imm=0
+#line 143 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=87 dst=r0 src=r0 offset=0 imm=0
-#line 132 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=103 dst=r0 src=r0 offset=0 imm=0
+#line 143 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 132 "sample/cgroup_sock_addr2.c"
+#line 143 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -738,8 +837,8 @@ static program_entry_t _programs[] = {
         connect_redirect4_maps,
         2,
         connect_redirect4_helpers,
-        6,
-        78,
+        7,
+        95,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -752,8 +851,8 @@ static program_entry_t _programs[] = {
         connect_redirect6_maps,
         2,
         connect_redirect6_helpers,
-        6,
-        88,
+        7,
+        104,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -333,7 +333,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=67 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=71 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
@@ -342,12 +342,12 @@ label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=65 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=69 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
@@ -368,27 +368,30 @@ label_1:
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
 #line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
+        // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=35 dst=r7 src=r0 offset=57 imm=0
+    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=36 dst=r7 src=r0 offset=60 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
 #line 72 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=36 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=37 dst=r2 src=r0 offset=0 imm=-32
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
 #line 77 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=40 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
 #line 77 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
 #line 77 "sample/cgroup_sock_addr2.c"
@@ -397,69 +400,72 @@ label_1:
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
 #line 77 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=41 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r9 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
 #line 77 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=27 imm=0
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=27 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 78 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=44 dst=r1 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=0
 #line 78 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=45 dst=r10 src=r1 offset=-70 imm=0
+    // EBPF_OP_STXB pc=47 dst=r10 src=r1 offset=-70 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=29989
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=29989
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=540697973
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=540697973
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=2037544046
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=2037544046
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1869770784
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1869770784
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=57 dst=r1 src=r0 offset=0 imm=1853189958
+    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1853189958
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=59 dst=r10 src=r1 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-104 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=60 dst=r4 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=62 dst=r4 src=r8 offset=16 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=61 dst=r3 src=r8 offset=0 imm=0
+    // EBPF_OP_LDXW pc=63 dst=r3 src=r8 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=64 dst=r1 src=r10 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=63 dst=r1 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=65 dst=r1 src=r0 offset=0 imm=-104
 #line 79 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=64 dst=r2 src=r0 offset=0 imm=35
+    // EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=35
 #line 79 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=14
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=14
 #line 79 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
 #line 79 "sample/cgroup_sock_addr2.c"
@@ -468,29 +474,35 @@ label_1:
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 79 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=66 dst=r1 src=r8 offset=0 imm=0
+        // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
 #line 80 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=67 dst=r6 src=r1 offset=24 imm=0
+    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
 #line 80 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=68 dst=r1 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=69 dst=r6 src=r1 offset=40 imm=0
+    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=70 dst=r7 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
 #line 81 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -499,16 +511,16 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -517,13 +529,13 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -532,37 +544,37 @@ label_2:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=85 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=86 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=87 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=88 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=89 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=91 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -572,10 +584,10 @@ label_2:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=93 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
 #line 136 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=94 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
 #line 136 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 136 "sample/cgroup_sock_addr2.c"
@@ -645,71 +657,77 @@ connect_redirect6(void* context)
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
 #line 141 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 95 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=25959
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
 #line 95 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=4 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
 #line 96 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=14 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
 #line 96 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=15 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
 #line 98 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=16 dst=r1 src=r0 offset=1 imm=17
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 98 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
 #line 98 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=84 imm=6
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
 #line 98 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 98 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=82 imm=23
+    // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
 #line 102 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
 #line 102 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=20 dst=r2 src=r10 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=21 dst=r2 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
 #line 106 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r3 src=r0 offset=0 imm=27
+    // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
 #line 106 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=65537
+    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
 #line 106 "sample/cgroup_sock_addr2.c"
@@ -718,69 +736,72 @@ label_1:
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
 #line 106 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=25 dst=r0 src=r0 offset=0 imm=32
+        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=26 dst=r0 src=r0 offset=0 imm=32
+    // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
 #line 106 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=27 dst=r7 src=r0 offset=74 imm=0
+    // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
 #line 106 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
 #line 106 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=28 dst=r1 src=r6 offset=36 imm=0
+        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=29 dst=r1 src=r0 offset=0 imm=32
+    // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=30 dst=r2 src=r6 offset=32 imm=0
+    // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=31 dst=r1 src=r2 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
-    // EBPF_OP_STXDW pc=32 dst=r10 src=r1 offset=-24 imm=0
+    // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=33 dst=r1 src=r6 offset=28 imm=0
+    // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=34 dst=r1 src=r0 offset=0 imm=32
+    // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=35 dst=r2 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=36 dst=r1 src=r2 offset=0 imm=0
+    // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
-    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-32 imm=0
+    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
 #line 113 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=38 dst=r1 src=r6 offset=40 imm=0
+    // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
 #line 114 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=40 dst=r1 src=r6 offset=44 imm=0
+    // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-12 imm=0
+    // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
 #line 115 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-32
+    // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
 #line 113 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
+    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
 #line 118 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
 #line 118 "sample/cgroup_sock_addr2.c"
@@ -789,63 +810,66 @@ label_1:
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
 #line 118 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=47 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r9 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
 #line 118 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=49 dst=r8 src=r0 offset=30 imm=0
+    // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 119 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=50 dst=r7 src=r6 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=51 dst=r7 src=r0 offset=0 imm=24
+    // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
 #line 119 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=52 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
 #line 119 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=53 dst=r10 src=r1 offset=-70 imm=0
+    // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=25973
+    // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=55 dst=r10 src=r1 offset=-72 imm=0
+    // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=2037544046
+    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1869770784
+    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=62 dst=r1 src=r0 offset=0 imm=1853189958
+    // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r1 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r1 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
 #line 120 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=67 dst=r2 src=r0 offset=0 imm=27
+    // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
 #line 120 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=12
+    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
 #line 120 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
 #line 120 "sample/cgroup_sock_addr2.c"
@@ -854,47 +878,53 @@ label_1:
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
 #line 120 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=12 imm=0
+        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=70 dst=r7 src=r1 offset=12 imm=0
+    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=71 dst=r1 src=r8 offset=8 imm=0
+    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=72 dst=r7 src=r1 offset=8 imm=0
+    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=4 imm=0
+    // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=4 imm=0
+    // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=0 imm=0
+    // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=0 imm=0
+    // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
 #line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=77 dst=r1 src=r8 offset=16 imm=0
+    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=78 dst=r6 src=r1 offset=40 imm=0
+    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
 #line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=79 dst=r7 src=r0 offset=0 imm=1
+    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
 #line 122 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
+#line 43 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -903,16 +933,16 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -921,13 +951,13 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -936,37 +966,37 @@ label_2:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=93 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=94 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=95 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=96 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=97 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=98 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=100 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -976,10 +1006,10 @@ label_2:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r7 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
 #line 143 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=103 dst=r0 src=r0 offset=0 imm=0
+    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
 #line 143 "sample/cgroup_sock_addr2.c"
     return r0;
 #line 143 "sample/cgroup_sock_addr2.c"
@@ -999,7 +1029,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        95,
+        99,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -1013,7 +1043,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        104,
+        110,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -210,6 +210,7 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65536, "helper_id_65536"},
@@ -230,45 +231,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
 {
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -282,257 +283,308 @@ connect_redirect4(void* context)
     // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_LDXW pc=6 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=25959
+#line 57 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25959);
+    // EBPF_OP_STXH pc=7 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1299477349
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7022083122929103717;
+    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-48 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1953394499
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)6085621373624807235;
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-56 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=14 dst=r1 src=r0 offset=0 imm=1768187218
+#line 58 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)8386658473162859858;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-64 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+    // EBPF_OP_STXB pc=17 dst=r10 src=r7 offset=-38 imm=0
+#line 58 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
+    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=24 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=7 dst=r10 src=r1 offset=-32 imm=0
-#line 58 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=19 dst=r10 src=r1 offset=-32 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=8 dst=r1 src=r6 offset=40 imm=0
-#line 59 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=20 dst=r1 src=r6 offset=40 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=9 dst=r10 src=r1 offset=-16 imm=0
-#line 59 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-16 imm=0
+#line 61 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=10 dst=r1 src=r6 offset=44 imm=0
-#line 60 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=22 dst=r1 src=r6 offset=44 imm=0
+#line 62 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=11 dst=r10 src=r1 offset=-12 imm=0
-#line 60 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-12 imm=0
+#line 62 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_JEQ_IMM pc=12 dst=r1 src=r0 offset=1 imm=17
-#line 62 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=24 dst=r1 src=r0 offset=1 imm=17
+#line 64 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 62 "sample/cgroup_sock_addr2.c"
+#line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=13 dst=r1 src=r0 offset=62 imm=6
-#line 62 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=67 imm=6
+#line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 62 "sample/cgroup_sock_addr2.c"
+#line 64 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=14 dst=r1 src=r6 offset=0 imm=0
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
+#line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=15 dst=r1 src=r0 offset=60 imm=2
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=65 imm=2
+#line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
-#line 66 "sample/cgroup_sock_addr2.c"
+#line 68 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r10 offset=0 imm=0
-#line 66 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+#line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=17 dst=r2 src=r0 offset=0 imm=-32
-#line 71 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=18 dst=r1 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=20 dst=r0 src=r0 offset=0 imm=1
-#line 71 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
+#line 72 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=31 dst=r3 src=r0 offset=0 imm=27
+#line 72 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=65537
+#line 72 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 71 "sample/cgroup_sock_addr2.c"
+#line 72 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=21 dst=r8 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=22 dst=r9 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=23 dst=r7 src=r0 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=24 dst=r8 src=r0 offset=27 imm=0
+    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
 #line 72 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_IMM pc=25 dst=r1 src=r0 offset=0 imm=0
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=35 dst=r7 src=r0 offset=57 imm=0
 #line 72 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=26 dst=r10 src=r1 offset=-38 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=29989
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=28 dst=r10 src=r1 offset=-40 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=29 dst=r1 src=r0 offset=0 imm=540697973
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=31 dst=r10 src=r1 offset=-48 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=32 dst=r1 src=r0 offset=0 imm=2037544046
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=34 dst=r10 src=r1 offset=-56 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=35 dst=r1 src=r0 offset=0 imm=1869770784
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-64 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=1853189958
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-72 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=41 dst=r4 src=r8 offset=16 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=42 dst=r3 src=r8 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=43 dst=r1 src=r10 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=44 dst=r1 src=r0 offset=0 imm=-72
-#line 73 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-72);
-    // EBPF_OP_MOV64_IMM pc=45 dst=r2 src=r0 offset=0 imm=35
-#line 73 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=14
-#line 73 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 72 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+    // EBPF_OP_MOV64_REG pc=36 dst=r2 src=r10 offset=0 imm=0
+#line 72 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=37 dst=r2 src=r0 offset=0 imm=-32
+#line 77 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-32);
+    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=40 dst=r0 src=r0 offset=0 imm=1
+#line 77 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=47 dst=r1 src=r8 offset=0 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=41 dst=r8 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r8 = r0;
+    // EBPF_OP_MOV64_IMM pc=42 dst=r9 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r9 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=27 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    if (r8 == IMMEDIATE(0))
+#line 78 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+    // EBPF_OP_MOV64_IMM pc=44 dst=r1 src=r0 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=45 dst=r10 src=r1 offset=-70 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=29989
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=540697973
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=2037544046
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1869770784
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=57 dst=r1 src=r0 offset=0 imm=1853189958
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=59 dst=r10 src=r1 offset=-104 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=60 dst=r4 src=r8 offset=16 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=61 dst=r3 src=r8 offset=0 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r10 offset=0 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=63 dst=r1 src=r0 offset=0 imm=-104
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=64 dst=r2 src=r0 offset=0 imm=35
+#line 79 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=14
+#line 79 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 79 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 79 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 79 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_LDXW pc=66 dst=r1 src=r8 offset=0 imm=0
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=48 dst=r6 src=r1 offset=24 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=67 dst=r6 src=r1 offset=24 imm=0
+#line 80 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=49 dst=r1 src=r8 offset=16 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=68 dst=r1 src=r8 offset=16 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=50 dst=r6 src=r1 offset=40 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=69 dst=r6 src=r1 offset=40 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=51 dst=r7 src=r0 offset=0 imm=1
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=70 dst=r7 src=r0 offset=0 imm=1
+#line 81 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r9 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=71 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r9 offset=-64 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r9 offset=-72 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=56 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
+    r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=57 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=74 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r8 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[3].address
-#line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
-#line 45 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_STXDW pc=61 dst=r10 src=r0 offset=-72 imm=0
-#line 45 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
-#line 46 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=63 dst=r0 src=r0 offset=0 imm=21
-#line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
+#line 45 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 45 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+#line 45 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r0 offset=-104 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=79 dst=r1 src=r6 offset=0 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=80 dst=r0 src=r0 offset=0 imm=21
+#line 46 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=64 dst=r10 src=r0 offset=-56 imm=0
+    // EBPF_OP_STXW pc=81 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=65 dst=r1 src=r6 offset=20 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
+    // EBPF_OP_LDXH pc=82 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=66 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=67 dst=r10 src=r1 offset=-52 imm=0
+    // EBPF_OP_STXH pc=84 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-52)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=68 dst=r2 src=r10 offset=0 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_REG pc=85 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=69 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=86 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=70 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=71 dst=r3 src=r0 offset=0 imm=-72
+    // EBPF_OP_ADD64_IMM pc=88 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
-    r3 += IMMEDIATE(-72);
-    // EBPF_OP_LDDW pc=72 dst=r1 src=r0 offset=0 imm=0
+    r3 += IMMEDIATE(-104);
+    // EBPF_OP_LDDW pc=89 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=74 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=91 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=75 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[5].address
+    r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 50 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=76 dst=r0 src=r7 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=93 dst=r0 src=r7 offset=0 imm=0
+#line 136 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=77 dst=r0 src=r0 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=94 dst=r0 src=r0 offset=0 imm=0
+#line 136 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 125 "sample/cgroup_sock_addr2.c"
+#line 136 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
 
 static helper_function_entry_t connect_redirect6_helpers[] = {
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
     {NULL, 65536, "helper_id_65536"},
@@ -553,337 +605,384 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
 {
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
-    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
-    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 89 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
-    // EBPF_OP_LDXW pc=5 dst=r1 src=r6 offset=44 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+#line 95 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=3 dst=r1 src=r0 offset=0 imm=25959
+#line 95 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25959);
+    // EBPF_OP_STXH pc=4 dst=r10 src=r1 offset=-40 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=5 dst=r1 src=r0 offset=0 imm=1299477349
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7022083122929103717;
+    // EBPF_OP_STXDW pc=7 dst=r10 src=r1 offset=-48 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1953394499
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)6085621373624807235;
+    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-56 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1768187218
+#line 96 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)8386658473162859858;
+    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-64 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
+    // EBPF_OP_STXB pc=14 dst=r10 src=r7 offset=-38 imm=0
+#line 96 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
+    // EBPF_OP_LDXW pc=15 dst=r1 src=r6 offset=44 imm=0
+#line 98 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=6 dst=r1 src=r0 offset=1 imm=17
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=16 dst=r1 src=r0 offset=1 imm=17
+#line 98 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 91 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=7 dst=r1 src=r0 offset=78 imm=6
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=17 dst=r1 src=r0 offset=84 imm=6
+#line 98 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 91 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
-    // EBPF_OP_LDXW pc=8 dst=r2 src=r6 offset=0 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=9 dst=r2 src=r0 offset=76 imm=23
-#line 95 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
-#line 95 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=0 imm=0
+#line 102 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=82 imm=23
+#line 102 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(23))
+#line 102 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=10 dst=r2 src=r6 offset=36 imm=0
+    // EBPF_OP_MOV64_REG pc=20 dst=r2 src=r10 offset=0 imm=0
 #line 102 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=11 dst=r2 src=r0 offset=0 imm=32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=12 dst=r3 src=r6 offset=32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=13 dst=r2 src=r3 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=14 dst=r10 src=r2 offset=-24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_LDXW pc=15 dst=r2 src=r6 offset=28 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=16 dst=r2 src=r0 offset=0 imm=32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=17 dst=r3 src=r6 offset=24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=18 dst=r2 src=r3 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r2 offset=-32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_LDXH pc=20 dst=r2 src=r6 offset=40 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=21 dst=r10 src=r2 offset=-16 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
-    // EBPF_OP_STXW pc=22 dst=r10 src=r1 offset=-12 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=23 dst=r2 src=r10 offset=0 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=24 dst=r2 src=r0 offset=0 imm=-32
-#line 102 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=25 dst=r1 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=27 dst=r0 src=r0 offset=0 imm=1
-#line 107 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=21 dst=r2 src=r0 offset=0 imm=-64
+#line 106 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=22 dst=r1 src=r6 offset=0 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=23 dst=r3 src=r0 offset=0 imm=27
+#line 106 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=24 dst=r0 src=r0 offset=0 imm=65537
+#line 106 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 107 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=28 dst=r8 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=29 dst=r9 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=30 dst=r7 src=r0 offset=0 imm=0
-#line 107 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=31 dst=r8 src=r0 offset=30 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r8 == IMMEDIATE(0))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=32 dst=r7 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=33 dst=r7 src=r0 offset=0 imm=24
-#line 108 "sample/cgroup_sock_addr2.c"
-    r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=34 dst=r1 src=r0 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=35 dst=r10 src=r1 offset=-38 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=36 dst=r1 src=r0 offset=0 imm=25973
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=37 dst=r10 src=r1 offset=-40 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=38 dst=r1 src=r0 offset=0 imm=2037544046
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-48 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=1869770784
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-56 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=1853189958
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-64 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=47 dst=r1 src=r10 offset=0 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=48 dst=r1 src=r0 offset=0 imm=-64
-#line 109 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_IMM pc=49 dst=r2 src=r0 offset=0 imm=27
-#line 109 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=50 dst=r0 src=r0 offset=0 imm=12
-#line 109 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LSH64_IMM pc=25 dst=r0 src=r0 offset=0 imm=32
+#line 106 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=26 dst=r0 src=r0 offset=0 imm=32
+#line 106 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=27 dst=r7 src=r0 offset=74 imm=0
+#line 106 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 106 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+    // EBPF_OP_LDXW pc=28 dst=r1 src=r6 offset=36 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=29 dst=r1 src=r0 offset=0 imm=32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=30 dst=r2 src=r6 offset=32 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=31 dst=r1 src=r2 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=32 dst=r10 src=r1 offset=-24 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDXW pc=33 dst=r1 src=r6 offset=28 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=34 dst=r1 src=r0 offset=0 imm=32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=35 dst=r2 src=r6 offset=24 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=36 dst=r1 src=r2 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=37 dst=r10 src=r1 offset=-32 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=38 dst=r1 src=r6 offset=40 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-16 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
+    // EBPF_OP_LDXW pc=40 dst=r1 src=r6 offset=44 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_STXW pc=41 dst=r10 src=r1 offset=-12 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_MOV64_REG pc=42 dst=r2 src=r10 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=43 dst=r2 src=r0 offset=0 imm=-32
+#line 113 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-32);
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=46 dst=r0 src=r0 offset=0 imm=1
+#line 118 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 109 "sample/cgroup_sock_addr2.c"
+#line 118 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=51 dst=r1 src=r8 offset=12 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=47 dst=r8 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r8 = r0;
+    // EBPF_OP_MOV64_IMM pc=48 dst=r9 src=r0 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
+    r9 = IMMEDIATE(0);
+    // EBPF_OP_JEQ_IMM pc=49 dst=r8 src=r0 offset=30 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    if (r8 == IMMEDIATE(0))
+#line 119 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+    // EBPF_OP_MOV64_REG pc=50 dst=r7 src=r6 offset=0 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    r7 = r6;
+    // EBPF_OP_ADD64_IMM pc=51 dst=r7 src=r0 offset=0 imm=24
+#line 119 "sample/cgroup_sock_addr2.c"
+    r7 += IMMEDIATE(24);
+    // EBPF_OP_MOV64_IMM pc=52 dst=r1 src=r0 offset=0 imm=0
+#line 119 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=53 dst=r10 src=r1 offset=-70 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=54 dst=r1 src=r0 offset=0 imm=25973
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(25973);
+    // EBPF_OP_STXH pc=55 dst=r10 src=r1 offset=-72 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=2037544046
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-80 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1869770784
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-88 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=62 dst=r1 src=r0 offset=0 imm=1853189958
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3924359741021974342;
+    // EBPF_OP_STXDW pc=64 dst=r10 src=r1 offset=-96 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r10 offset=0 imm=0
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=66 dst=r1 src=r0 offset=0 imm=-96
+#line 120 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-96);
+    // EBPF_OP_MOV64_IMM pc=67 dst=r2 src=r0 offset=0 imm=27
+#line 120 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=12
+#line 120 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[2].address
+#line 120 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 120 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+#line 120 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=12 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=52 dst=r7 src=r1 offset=12 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=70 dst=r7 src=r1 offset=12 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=53 dst=r1 src=r8 offset=8 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=71 dst=r1 src=r8 offset=8 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=54 dst=r7 src=r1 offset=8 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=72 dst=r7 src=r1 offset=8 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=55 dst=r1 src=r8 offset=4 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=4 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=56 dst=r7 src=r1 offset=4 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=4 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=57 dst=r1 src=r8 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=58 dst=r7 src=r1 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=59 dst=r1 src=r8 offset=16 imm=0
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=77 dst=r1 src=r8 offset=16 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=60 dst=r6 src=r1 offset=40 imm=0
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=78 dst=r6 src=r1 offset=40 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=61 dst=r7 src=r0 offset=0 imm=1
-#line 111 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=79 dst=r7 src=r0 offset=0 imm=1
+#line 122 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
-    // EBPF_OP_STXDW pc=62 dst=r10 src=r9 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=80 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=63 dst=r10 src=r9 offset=-56 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r9 offset=-64 imm=0
-#line 43 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
+    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=66 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
+    r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 44 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=67 dst=r8 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r8 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r6 offset=0 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=70 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[3].address
-#line 45 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 45 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
-#line 45 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_STXDW pc=71 dst=r10 src=r0 offset=-64 imm=0
-#line 45 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=72 dst=r1 src=r6 offset=0 imm=0
-#line 46 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_CALL pc=73 dst=r0 src=r0 offset=0 imm=21
-#line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
+#line 45 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 45 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+#line 45 "sample/cgroup_sock_addr2.c"
+        return 0;
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r0 offset=-96 imm=0
+#line 45 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
+    // EBPF_OP_MOV64_REG pc=88 dst=r1 src=r6 offset=0 imm=0
+#line 46 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_CALL pc=89 dst=r0 src=r0 offset=0 imm=21
+#line 46 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 46 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=74 dst=r10 src=r0 offset=-48 imm=0
+    // EBPF_OP_STXW pc=90 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=75 dst=r1 src=r6 offset=20 imm=0
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
+    // EBPF_OP_LDXH pc=91 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=77 dst=r10 src=r1 offset=-44 imm=0
+    // EBPF_OP_STXH pc=93 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=78 dst=r2 src=r10 offset=0 imm=0
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_REG pc=94 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=79 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=95 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=80 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=81 dst=r3 src=r0 offset=0 imm=-64
+    // EBPF_OP_ADD64_IMM pc=97 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
-    r3 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=82 dst=r1 src=r0 offset=0 imm=0
+    r3 += IMMEDIATE(-96);
+    // EBPF_OP_LDDW pc=98 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=84 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=100 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=101 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[5].address
+    r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
 #line 50 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
+    if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_3:
-    // EBPF_OP_MOV64_REG pc=86 dst=r0 src=r7 offset=0 imm=0
-#line 132 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=102 dst=r0 src=r7 offset=0 imm=0
+#line 143 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=87 dst=r0 src=r0 offset=0 imm=0
-#line 132 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=103 dst=r0 src=r0 offset=0 imm=0
+#line 143 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 132 "sample/cgroup_sock_addr2.c"
+#line 143 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -899,8 +998,8 @@ static program_entry_t _programs[] = {
         connect_redirect4_maps,
         2,
         connect_redirect4_helpers,
-        6,
-        78,
+        7,
+        95,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -913,8 +1012,8 @@ static program_entry_t _programs[] = {
         connect_redirect6_maps,
         2,
         connect_redirect6_helpers,
-        6,
-        88,
+        7,
+        104,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -379,9 +379,9 @@ connect_redirect_test(
 
         sender_socket->get_received_message(bytes_received, received_message);
 
-        std::string expected_response;
         // Remote redirection expects the SERVER_MESSAGE response.
         // Local redirection expects the redirect context response.
+        std::string expected_response;
         if (proxy_address_string == _remote_ip_v4 || proxy_address_string == _remote_ip_v6) {
             expected_response = SERVER_MESSAGE + std::to_string(proxy_port);
         } else {

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -359,6 +359,7 @@ connect_redirect_test(
     uint32_t bytes_received = 0;
     char* received_message = nullptr;
     uint64_t authentication_id;
+    std::string proxy_address_string = get_string_from_address(reinterpret_cast<const SOCKADDR*>(&proxy));
 
     // Update policy in the map to redirect the connection to the proxy.
     _update_policy_map(destination, proxy, destination_port, proxy_port, _globals.protocol, dual_stack, add_policy);
@@ -378,7 +379,14 @@ connect_redirect_test(
 
         sender_socket->get_received_message(bytes_received, received_message);
 
-        std::string expected_response = SERVER_MESSAGE + std::to_string(proxy_port);
+        std::string expected_response;
+        // Remote redirection expects the SERVER_MESSAGE response.
+        // Local redirection expects the redirect context response.
+        if (proxy_address_string == _remote_ip_v4 || proxy_address_string == _remote_ip_v6) {
+            expected_response = SERVER_MESSAGE + std::to_string(proxy_port);
+        } else {
+            expected_response = REDIRECT_CONTEXT_MESSAGE + std::to_string(proxy_port);
+        }
         REQUIRE(strlen(received_message) == strlen(expected_response.c_str()));
         REQUIRE(memcmp(received_message, expected_response.c_str(), strlen(received_message)) == 0);
     }

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -128,7 +128,8 @@ _base_socket::get_received_message(_Out_ uint32_t& message_size, _Outref_result_
 
 _client_socket::_client_socket(int _sock_type, int _protocol, uint16_t _port, socket_family_t _family)
     : _base_socket{_sock_type, _protocol, _port, _family}, overlapped{}, receive_posted(false)
-{}
+{
+}
 
 void
 _client_socket::close()
@@ -256,7 +257,8 @@ _datagram_client_socket::send_message_to_remote_host(
 
 void
 _datagram_client_socket::cancel_send_message()
-{}
+{
+}
 
 void
 _datagram_client_socket::complete_async_send(int timeout_in_ms, expected_result_t expected_result)
@@ -431,6 +433,21 @@ void
 _server_socket::complete_async_receive(bool timeout_expected)
 {
     complete_async_receive(1000, timeout_expected);
+}
+
+int
+_server_socket::query_redirect_context(_Out_ void* buffer, uint32_t buffer_size, _Out_ uint32_t& redirect_context_size)
+{
+    return WSAIoctl(
+        socket,
+        SIO_QUERY_WFP_CONNECTION_REDIRECT_CONTEXT,
+        nullptr,
+        0,
+        buffer,
+        static_cast<unsigned long>(buffer_size),
+        reinterpret_cast<unsigned long*>(&redirect_context_size),
+        nullptr,
+        nullptr);
 }
 
 _datagram_server_socket::_datagram_server_socket(int _sock_type, int _protocol, uint16_t _port)

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -37,7 +37,7 @@ get_address_from_string(
     _Out_opt_ ADDRESS_FAMILY* address_family = nullptr);
 
 std::string
-get_string_from_address(_In_ SOCKADDR* sockaddr);
+get_string_from_address(_In_ const SOCKADDR* sockaddr);
 
 typedef enum _expected_result
 {
@@ -160,6 +160,9 @@ typedef class _server_socket : public _base_socket
     get_sender_address(_Out_ PSOCKADDR& from, _Out_ int& from_length) = 0;
     virtual void
     close() = 0;
+
+    int
+    query_redirect_context(_Out_ void* buffer, uint32_t buffer_size, _Out_ uint32_t& redirect_context_size);
 
   protected:
     WSAOVERLAPPED overlapped;

--- a/tests/sample/cgroup_sock_addr2.c
+++ b/tests/sample/cgroup_sock_addr2.c
@@ -50,17 +50,12 @@ update_audit_map_entry(bpf_sock_addr_t* ctx)
     bpf_map_update_elem(&audit_map, &key, &entry, 0);
 }
 
-// __inline int
-// set_redirect_context(bpf_sock_addr_t* ctx)
-// {
-//     return bpf_sock_addr_set_redirect_context(ctx, REDIRECT_CONTEXT_MESSAGE, sizeof(REDIRECT_CONTEXT_MESSAGE));
-// }
-
 __inline int
 redirect_v4(bpf_sock_addr_t* ctx)
 {
     int verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
     destination_entry_t entry = {0};
+    char redirect_context[] = REDIRECT_CONTEXT_MESSAGE;
 
     entry.destination_ip.ipv4 = ctx->user_ip4;
     entry.destination_port = ctx->user_port;
@@ -74,12 +69,9 @@ redirect_v4(bpf_sock_addr_t* ctx)
         return verdict;
     }
 
-    if (bpf_sock_addr_set_redirect_context(ctx, REDIRECT_CONTEXT_MESSAGE, sizeof(REDIRECT_CONTEXT_MESSAGE)) < 0) {
+    if (bpf_sock_addr_set_redirect_context(ctx, redirect_context, sizeof(redirect_context)) < 0) {
         return verdict;
     }
-    // if (set_redirect_context(ctx) < 0) {
-    //     return verdict;
-    // }
 
     // Find the entry in the policy map.
     destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
@@ -101,6 +93,7 @@ redirect_v6(bpf_sock_addr_t* ctx)
 {
     int verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
     destination_entry_t entry = {0};
+    char redirect_context[] = REDIRECT_CONTEXT_MESSAGE;
 
     if (ctx->protocol != IPPROTO_TCP && ctx->protocol != IPPROTO_UDP) {
         return verdict;
@@ -110,12 +103,9 @@ redirect_v6(bpf_sock_addr_t* ctx)
         return verdict;
     }
 
-    if (bpf_sock_addr_set_redirect_context(ctx, REDIRECT_CONTEXT_MESSAGE, sizeof(REDIRECT_CONTEXT_MESSAGE)) < 0) {
+    if (bpf_sock_addr_set_redirect_context(ctx, redirect_context, sizeof(redirect_context)) < 0) {
         return verdict;
     }
-    // if (set_redirect_context(ctx) < 0) {
-    //     return verdict;
-    // }
 
     // Copy the IPv6 address. Note this has a design flaw for scoped IPv6 addresses
     // where the scope id or interface is not provided, so the policy can match the

--- a/tests/socket/socket_tests_common.h
+++ b/tests/socket/socket_tests_common.h
@@ -7,6 +7,7 @@
 #include <stdint.h>
 
 #define SOCKET_TEST_PORT 8989
+#define REDIRECT_CONTEXT_MESSAGE "RedirectContextTestMessage"
 
 typedef struct _ip_address
 {

--- a/tests/tcp_udp_listener/tcp_udp_listener.cpp
+++ b/tests/tcp_udp_listener/tcp_udp_listener.cpp
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #define CATCH_CONFIG_RUNNER
-#define REDIRECT_CONTEXT_BUFFER_SIZE 100
+#define REDIRECT_CONTEXT_BUFFER_SIZE 128
 
 #include "catch_wrapper.hpp"
 #include "socket_helper.h"
@@ -38,7 +38,7 @@ create_listener(_Inout_ receiver_socket_t* receiver_socket)
     receiver_socket->complete_async_receive(WSA_INFINITE, false);
     printf("Received data from remote\n");
 
-    // Query for the redirect record.
+    // Query for the redirect context.
     // This is expected to only be valid for local redirections.
     // If not present, use the generic SERVER_MESSAGE response.
     if (receiver_socket->query_redirect_context(

--- a/tests/tcp_udp_listener/tcp_udp_listener.cpp
+++ b/tests/tcp_udp_listener/tcp_udp_listener.cpp
@@ -25,6 +25,10 @@ _get_protocol_from_string(std::string protocol)
 void
 create_listener(_Inout_ receiver_socket_t* receiver_socket)
 {
+    std::string response;
+    char redirect_context_buffer[REDIRECT_CONTEXT_BUFFER_SIZE] = "\0";
+    uint32_t redirect_context_size = 0;
+
     _global_counter++;
     // Post a receive. Wait for client to connect.
     printf("=====================================\n");
@@ -37,9 +41,6 @@ create_listener(_Inout_ receiver_socket_t* receiver_socket)
     // Query for the redirect record.
     // This is expected to only be valid for local redirections.
     // If not present, use the generic SERVER_MESSAGE response.
-    std::string response;
-    char redirect_context_buffer[REDIRECT_CONTEXT_BUFFER_SIZE];
-    uint32_t redirect_context_size = 0;
     if (receiver_socket->query_redirect_context(
             &redirect_context_buffer, REDIRECT_CONTEXT_BUFFER_SIZE, redirect_context_size)) {
         response = SERVER_MESSAGE + std::to_string(_local_port);

--- a/tests/tcp_udp_listener/tcp_udp_listener.cpp
+++ b/tests/tcp_udp_listener/tcp_udp_listener.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #define CATCH_CONFIG_RUNNER
+#define REDIRECT_CONTEXT_BUFFER_SIZE 100
 
 #include "catch_wrapper.hpp"
 #include "socket_helper.h"
@@ -33,9 +34,20 @@ create_listener(_Inout_ receiver_socket_t* receiver_socket)
     receiver_socket->complete_async_receive(WSA_INFINITE, false);
     printf("Received data from remote\n");
 
-    // Send a response back.
-    std::string response = SERVER_MESSAGE + std::to_string(_local_port);
+    // Query for the redirect record.
+    // This is expected to only be valid for local redirections.
+    // If not present, use the generic SERVER_MESSAGE response.
+    std::string response;
+    char redirect_context_buffer[REDIRECT_CONTEXT_BUFFER_SIZE];
+    uint32_t redirect_context_size = 0;
+    if (receiver_socket->query_redirect_context(
+            &redirect_context_buffer, REDIRECT_CONTEXT_BUFFER_SIZE, redirect_context_size)) {
+        response = SERVER_MESSAGE + std::to_string(_local_port);
+    } else {
+        response = redirect_context_buffer + std::to_string(_local_port);
+    }
     printf("Sending response: %s\n", response.c_str());
+    // Send a response back.
     receiver_socket->send_async_response(response.c_str());
     receiver_socket->complete_async_send(1000);
     printf("Sent data to remote\n");


### PR DESCRIPTION
## Description

Proxy applications receiving redirected connections currently are unable to identify details about the original underlying connection. This new helper function allows for a program to store data which can be retrieved by the proxy application receiving the redirected connection via WSAIoctl.

## Testing

Updated existing connect_redirect_tests to utilize this helper function.
cgroup_sockaddr2 program was updated to set the redirect_context message.
tcp_udp_listener was updated to fetch the redirect_context using the WSAIoctl.

## Documentation

N/A

## Installation

N/A