### PR TITLE
Fix setup-ebpf.ps1

### DIFF
--- a/scripts/setup-ebpf.ps1
+++ b/scripts/setup-ebpf.ps1
@@ -13,7 +13,7 @@
 param ([switch]$Uninstall,
        [parameter(Mandatory=$false)][string] $LogFileName = "TestLog.log")
 
-$WorkingDirectory = "$PSScriptRoot\.."
+$WorkingDirectory = "$PSScriptRoot"
 Write-Host "PSScriptRoot is $PSScriptRoot"
 Write-Host "WorkingDirectory is $WorkingDirectory"
 Write-Host "LogFileName is $LogFileName"


### PR DESCRIPTION
## Description

This PR fixes `setup-ebpf.ps1` script. Currently the script tries to copy the binaries from a parent directory which causes copy hence installation fail.

## Testing

Manually tested the script + CI/CD

## Documentation

No. 

## Installation

No
