### PR TITLE
Explictly pass secrets to reusable workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -511,3 +511,7 @@ jobs:
     with:
       name: upload_perf_results
       result_artifact: km_performance-x64-Release
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/upload-perf-results.yml
+++ b/.github/workflows/upload-perf-results.yml
@@ -14,6 +14,13 @@ on:
       result_artifact:
         required: true
         type: string
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
 
 jobs:
   upload_results:
@@ -64,14 +71,4 @@ jobs:
         export PGUSER=$(cat ${{github.workspace}}/PGUSER)
         export PGPORT=$(cat ${{github.workspace}}/PGPORT)
         export PGDATABASE=$(cat ${{github.workspace}}/PGDATABASE)
-        psql -f ${{github.workspace}}/results/upload.sql
-
-    - name: Upload results to POSTGRES
-      env:
-        PGHOST: ${{secrets.PGHOST}}
-        PGUSER: ${{secrets.PGUSER}}
-        PGPORT: ${{secrets.PGPORT}}
-        PGDATABASE: ${{secrets.PGDATABASE}}
-        PGPASSWORD: ${{secrets.PGPASSWORD}}
-      run: |
         psql -f ${{github.workspace}}/results/upload.sql


### PR DESCRIPTION
## Description

GitHub requires that secrets are explicitly passed to reusable workflows. 
https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

## Testing

CI/CD

## Documentation

No.

## Installation

No.
