### PR TITLE
Fix up km_stress job labels.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -495,7 +495,7 @@ jobs:
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       build_artifact: Build-x64
-      environment: ebpf_cicd_tests
+      environment: ebpf_cicd_tests_ws2019
       code_coverage: false
       # For this test, we only want kernel mode dumps and not user mode dumps.
       gather_dumps: false
@@ -512,7 +512,7 @@ jobs:
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
       post_test: .\cleanup_ebpf_cicd_tests.ps1
       build_artifact: Build-x64
-      environment: ebpf_cicd_tests
+      environment: ebpf_cicd_tests_ws2019
       code_coverage: false
       # For this test, we only want kernel mode dumps and not user mode dumps.
       gather_dumps: false


### PR DESCRIPTION
## Description

When adding the new WS2022 runners, I also renamed all the runner labels for consistency, but forgot to update the stress job to reflect that so it failed in the daily scheduled run.

## Testing

Wait for nightly CI to spin.

## Documentation

No change - docs already contain the new labels.

## Installation

_Is there any installer impact for this change?_
No.