### PR TITLE
Add test case calling an IOCTL in ebpfcore_usersim.dll

### DIFF
--- a/libs/runtime/ebpf_object.c
+++ b/libs/runtime/ebpf_object.c
@@ -237,8 +237,8 @@ void
 ebpf_object_tracking_terminate()
 {
     for (int index = 0; index < EBPF_COUNT_OF(_ebpf_id_table); index++) {
-        ebpf_assert(_ebpf_id_table[index].object == NULL || cxplat_fault_injection_is_enabled());
-        ebpf_assert(_ebpf_id_table[index].reference_count == 0 || cxplat_fault_injection_is_enabled());
+        ebpf_assert(_ebpf_id_table[index].object == NULL || ebpf_fault_injection_is_enabled());
+        ebpf_assert(_ebpf_id_table[index].reference_count == 0 || ebpf_fault_injection_is_enabled());
     }
 }
 

--- a/libs/runtime/kernel/framework.h
+++ b/libs/runtime/kernel/framework.h
@@ -28,3 +28,4 @@
 #define ebpf_list_remove_head_entry RemoveHeadList
 #define ebpf_list_append_tail_list AppendTailList
 #define ebpf_probe_for_write ProbeForWrite
+#define ebpf_fault_injection_is_enabled() false

--- a/libs/runtime/kernel/platform_kernel.vcxproj.filters
+++ b/libs/runtime/kernel/platform_kernel.vcxproj.filters
@@ -135,5 +135,17 @@
     <ClInclude Include="..\ebpf_random.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\..\external\usersim\cxplat\inc\cxplat.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external\usersim\cxplat\inc\cxplat_common.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external\usersim\cxplat\inc\cxplat_size.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\..\external\usersim\cxplat\inc\winkernel\cxplat_winkernel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/libs/runtime/user/framework.h
+++ b/libs/runtime/user/framework.h
@@ -3,12 +3,15 @@
 
 #pragma once
 
+#include "cxplat_fault_injection.h"
 #include "ebpf_shared_framework.h"
 #include "usersim\ex.h"
 #include "usersim\ke.h"
 #include "usersim\ps.h"
 #include "usersim\rtl.h"
 #include "usersim\se.h"
+
+#define ebpf_fault_injection_is_enabled() cxplat_fault_injection_is_enabled()
 
 #ifdef __cplusplus
 extern "C"

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -6,6 +6,7 @@
 #pragma warning(disable : 4200)
 #include "bpf/libbpf.h"
 #pragma warning(pop)
+#include "cxplat_fault_injection.h"
 #include "ebpf_epoch.h"
 #include "netsh_test_helper.h"
 #include "platform.h"

--- a/tests/end_to_end/test_helper.cpp
+++ b/tests/end_to_end/test_helper.cpp
@@ -6,6 +6,7 @@
 #include "bpf/bpf.h"
 #include "bpf2c.h"
 #include "catch_wrapper.hpp"
+#include "cxplat_fault_injection.h"
 #include "ebpf_async.h"
 #include "ebpf_core.h"
 #include "ebpf_platform.h"

--- a/tests/netebpfext_unit/netebpfext_unit.cpp
+++ b/tests/netebpfext_unit/netebpfext_unit.cpp
@@ -4,6 +4,7 @@
 #define CATCH_CONFIG_MAIN
 #include "bpf_helpers.h"
 #include "catch_wrapper.hpp"
+#include "cxplat_fault_injection.h"
 #include "cxplat_passed_test_log.h"
 #include "netebpf_ext_helper.h"
 #include "watchdog.h"

--- a/tests/unit/ebpfcore_test.cpp
+++ b/tests/unit/ebpfcore_test.cpp
@@ -1,11 +1,47 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 #include "catch_wrapper.hpp"
+#include "device_helper.hpp"
+#include "ebpf_protocol.h"
+#include "usersim/wdf.h"
 
 TEST_CASE("DriverEntry", "[usersim]")
 {
     HMODULE module = LoadLibraryW(L"ebpfcore_usersim.dll");
     REQUIRE(module != nullptr);
+
+    WDFDRIVER driver = usersim_get_driver_from_module(module);
+    REQUIRE(driver != nullptr);
+
+    WDFDEVICE device = usersim_get_device_by_name(driver, L"\\Device\\EbpfIoDevice");
+    REQUIRE(device != nullptr);
+
+    // Test an unrecognized IO control code.
+    DWORD bytes_returned;
+    BOOL ok = usersim_device_io_control(device, 0, nullptr, 0, nullptr, 0, &bytes_returned, nullptr);
+    REQUIRE(!ok);
+
+    // Unsupported input buffer size.
+    ok = usersim_device_io_control(
+        device, IOCTL_EBPF_CTL_METHOD_BUFFERED, nullptr, 0, nullptr, 0, &bytes_returned, nullptr);
+    REQUIRE(!ok);
+
+    // Make an actual call.
+    ebpf_operation_get_next_id_request_t request;
+    request.header.id = EBPF_OPERATION_GET_NEXT_PROGRAM_ID;
+    request.header.length = sizeof(request);
+    request.start_id = 0;
+    ebpf_operation_get_next_id_reply_t reply;
+    ok = usersim_device_io_control(
+        device,
+        IOCTL_EBPF_CTL_METHOD_BUFFERED,
+        &request,
+        sizeof(request),
+        &reply,
+        sizeof(reply),
+        &bytes_returned,
+        nullptr);
+    REQUIRE(!ok);
 
     FreeLibrary(module);
 }


### PR DESCRIPTION
## Description

* Update usersim to latest
* Add test case calling an IOCTL in ebpfcore_usersim.dll

## Testing

This updates the ebpfcore_usersim unit test.
Future work (not in this PR) will take some of the existing unit tests that don't use ebpfcore_usersim.dll and add support for using ebpfcore_usersim.dll.

## Documentation

No impact.

## Installation

No impact.
