### PR TITLE
Move required definitions to include/bpf_helpers.h

### DIFF
--- a/include/bpf_helpers.h
+++ b/include/bpf_helpers.h
@@ -16,7 +16,44 @@
 // libbpf's bpf_helpers.h for the rest of the platform-agnostic
 // defines.
 #ifndef _MSC_VER
-#include "libbpf/src/bpf_helpers.h"
+
+// Definitions lifted from libbpf's bpf_helpers.h.
+// Moved here to avoid including libbpf's bpf_helpers.h as that file
+// is not cross-platform.
+
+#define __uint(name, val) int(*name)[val]
+#define __type(name, val) typeof(val)* name
+#define __array(name, val) typeof(val)* name[]
+
+/*
+ * Helper macro to place programs, maps, license in
+ * different sections in elf_bpf file. Section names
+ * are interpreted by libbpf depending on the context (BPF programs, BPF maps,
+ * extern variables, etc).
+ * To allow use of SEC() with externs (e.g., for extern .maps declarations),
+ * make sure __attribute__((unused)) doesn't trigger compilation warning.
+ */
+#if __GNUC__ && !__clang__
+
+/*
+ * Pragma macros are broken on GCC
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=55578
+ * https://gcc.gnu.org/bugzilla/show_bug.cgi?id=90400
+ */
+#define SEC(name) __attribute__((section(name), used))
+
+#else
+
+#define SEC(name)                                                                             \
+    _Pragma("GCC diagnostic push") _Pragma("GCC diagnostic ignored \"-Wignored-attributes\"") \
+        __attribute__((section(name), used)) _Pragma("GCC diagnostic pop")
+
+#endif
+
+#ifndef NULL
+#define NULL ((void*)0)
+#endif
+
 #define bpf_map_def _ebpf_map_definition_in_file
 #include "ebpf_nethooks.h"
 #endif


### PR DESCRIPTION
Resolves: #2730

## Description

The libbpf's version of bpf_helpers.h includes both common cross-platform macro definitions as well as Linux platform specific helper function identifiers. This PR recreates the BTF macros from kernel documentation and eliminated the dependency on the libbfp headers.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
