### PR TITLE
Timed work queue

### DIFF
--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -317,7 +317,7 @@ ebpf_epoch_terminate()
     // Cancel the timer.
     KeCancelTimer(&_ebpf_epoch_compute_release_epoch_timer);
 
-    // Wait for the DPC to complete.
+    // Wait for the active DPC to complete.
     KeFlushQueuedDpcs();
 
     for (cpu_id = 0; cpu_id < _ebpf_epoch_cpu_count; cpu_id++) {

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -911,8 +911,6 @@ _IRQL_requires_(DISPATCH_LEVEL) static void _ebpf_epoch_messenger_worker(
         return;
     }
 
-    _Analysis_assume_(arg1 != NULL);
-
     if (message->message_type > EBPF_COUNT_OF(_ebpf_epoch_messenger_workers) || message->message_type < 0) {
         ebpf_assert(!"Invalid message type");
         return;

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -342,9 +342,9 @@ ebpf_epoch_terminate()
 }
 
 #pragma warning(push)
-#pragma warning(disable : 28166) // warning C28166: The function 'ebpf_epoch_enter' does not restore the IRQL to the
-                                 // value that was current at function entry and is required to do so. IRQL was last set
-                                 // to 2 at line 334.
+#pragma warning(disable : 28166) // warning C28166: Code analysis incorrectly reports that the function
+                                 // 'ebpf_epoch_enter' does not restore the IRQL to the value that was current at
+                                 // function entry.
 _IRQL_requires_same_ void
 ebpf_epoch_enter(_Out_ ebpf_epoch_state_t* epoch_state)
 {
@@ -360,10 +360,9 @@ ebpf_epoch_enter(_Out_ ebpf_epoch_state_t* epoch_state)
 #pragma warning(pop)
 
 #pragma warning(push)
-#pragma warning(disable : 28166) // warning C28166: The function 'ebpf_epoch_exit' does not restore the IRQL to the
-                                 // value that was current at function entry and is required to do so. IRQL was last set
-                                 // to 2 at line 353.
-// the IRQL.
+#pragma warning( \
+    disable : 28166) // warning C28166: Code analysis incorrectly reports that the function 'ebpf_epoch_exit'
+                     // does not restore the IRQL to the value that was current at function entry.
 _IRQL_requires_same_ void
 ebpf_epoch_exit(_In_ ebpf_epoch_state_t* epoch_state)
 {

--- a/libs/runtime/ebpf_work_queue.c
+++ b/libs/runtime/ebpf_work_queue.c
@@ -15,9 +15,9 @@ typedef struct _ebpf_timed_work_queue
     void* context;
 } ebpf_timed_work_queue_t;
 
-KDEFERRED_ROUTINE ebpf_timed_work_queue_timer_callback;
+KDEFERRED_ROUTINE _ebpf_timed_work_queue_timer_callback;
 
-static void
+void
 _ebpf_timed_work_queue_timer_callback(
     _In_ KDPC* dpc, _In_opt_ void* deferred_context, _In_opt_ void* system_argument1, _In_opt_ void* system_argument2);
 
@@ -127,7 +127,7 @@ ebpf_timed_work_queued_poll(_In_ ebpf_timed_work_queue_t* work_queue)
     ebpf_lock_unlock(&work_queue->lock, lock_state);
 }
 
-static void
+void
 _ebpf_timed_work_queue_timer_callback(
     _In_ KDPC* dpc, _In_opt_ void* context, _In_opt_ void* system_argument1, _In_opt_ void* system_argument2)
 {

--- a/libs/runtime/ebpf_work_queue.c
+++ b/libs/runtime/ebpf_work_queue.c
@@ -1,0 +1,141 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#include "ebpf_work_queue.h"
+
+typedef struct _ebpf_timed_work_queue
+{
+    KTIMER timer;
+    KDPC dpc;
+    ebpf_list_entry_t work_items;
+    ebpf_lock_t lock;
+    bool timer_armed;
+    LARGE_INTEGER interval;
+    void (*callback)(void* context, ebpf_list_entry_t*);
+    void* context;
+} ebpf_timed_work_queue_t;
+
+KDEFERRED_ROUTINE ebpf_timed_work_queue_timer_callback;
+
+static void
+_ebpf_timed_work_queue_timer_callback(
+    _In_ KDPC* dpc, _In_opt_ void* deferred_context, _In_opt_ void* system_argument1, _In_opt_ void* system_argument2);
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_timed_work_queue_create(
+    _Out_ ebpf_timed_work_queue_t** work_queue,
+    uint32_t cpu_id,
+    LARGE_INTEGER* interval,
+    void (*callback)(void* context, ebpf_list_entry_t*),
+    void* context)
+{
+    ebpf_timed_work_queue_t* local_work_queue = NULL;
+    ebpf_result_t return_value;
+
+    local_work_queue = ebpf_allocate(sizeof(ebpf_timed_work_queue_t));
+    if (!local_work_queue) {
+        return_value = EBPF_NO_MEMORY;
+        goto Done;
+    }
+
+    local_work_queue->callback = callback;
+    local_work_queue->context = context;
+    local_work_queue->interval = *interval;
+
+    ebpf_lock_create(&local_work_queue->lock);
+
+    ebpf_list_initialize(&local_work_queue->work_items);
+
+    KeInitializeTimer(&local_work_queue->timer);
+    KeInitializeDpc(&local_work_queue->dpc, _ebpf_timed_work_queue_timer_callback, local_work_queue);
+    KeSetTargetProcessorDpc(&local_work_queue->dpc, (CCHAR)cpu_id);
+
+    *work_queue = local_work_queue;
+    local_work_queue = NULL;
+    return_value = EBPF_SUCCESS;
+
+Done:
+    if (local_work_queue) {
+        ebpf_timed_work_queue_destroy(local_work_queue);
+    }
+    return return_value;
+}
+
+void
+ebpf_timed_work_queue_destroy(_In_ ebpf_timed_work_queue_t* work_queue)
+{
+    // Cancel the timer.
+    KeCancelTimer(&work_queue->timer);
+
+    // Wait for the DPC to complete.
+    KeFlushQueuedDpcs();
+
+    // Destroy the lock.
+    ebpf_lock_destroy(&work_queue->lock);
+
+    // Free the work queue.
+    ebpf_free(work_queue);
+}
+
+void
+ebpf_timed_work_queue_insert(_In_ ebpf_timed_work_queue_t* work_queue, _In_ ebpf_list_entry_t* work_item, bool flush)
+{
+    ebpf_lock_state_t lock_state;
+    bool timer_armed;
+
+    lock_state = ebpf_lock_lock(&work_queue->lock);
+
+    timer_armed = work_queue->timer_armed;
+    ebpf_list_insert_tail(&work_queue->work_items, work_item);
+
+    if (flush) {
+        KeCancelTimer(&work_queue->timer);
+        work_queue->timer_armed = false;
+        KeInsertQueueDpc(&work_queue->dpc, NULL, NULL);
+    } else if (!timer_armed) {
+        LARGE_INTEGER due_time;
+        due_time.QuadPart = -work_queue->interval.QuadPart;
+        KeSetTimer(&work_queue->timer, due_time, &work_queue->dpc);
+        work_queue->timer_armed = true;
+    }
+
+    ebpf_lock_unlock(&work_queue->lock, lock_state);
+}
+
+bool
+ebpf_timed_work_queue_is_empty(_In_ ebpf_timed_work_queue_t* work_queue)
+{
+    return ebpf_list_is_empty(&work_queue->work_items);
+}
+
+void
+ebpf_timed_work_queued_poll(_In_ ebpf_timed_work_queue_t* work_queue)
+{
+    ebpf_lock_state_t lock_state;
+    ebpf_list_entry_t* work_item;
+
+    lock_state = ebpf_lock_lock(&work_queue->lock);
+
+    while (!ebpf_list_is_empty(&work_queue->work_items)) {
+        work_item = work_queue->work_items.Flink;
+        ebpf_list_remove_entry(work_item);
+        ebpf_lock_unlock(&work_queue->lock, lock_state);
+        work_queue->callback(work_queue->context, work_item);
+        lock_state = ebpf_lock_lock(&work_queue->lock);
+    }
+
+    ebpf_lock_unlock(&work_queue->lock, lock_state);
+}
+
+static void
+_ebpf_timed_work_queue_timer_callback(
+    _In_ KDPC* dpc, _In_opt_ void* context, _In_opt_ void* system_argument1, _In_opt_ void* system_argument2)
+{
+    UNREFERENCED_PARAMETER(dpc);
+    UNREFERENCED_PARAMETER(system_argument1);
+    UNREFERENCED_PARAMETER(system_argument2);
+    ebpf_timed_work_queue_t* work_queue = (ebpf_timed_work_queue_t*)context;
+    if (work_queue) {
+        ebpf_timed_work_queued_poll(work_queue);
+    }
+}

--- a/libs/runtime/ebpf_work_queue.c
+++ b/libs/runtime/ebpf_work_queue.c
@@ -66,6 +66,10 @@ Done:
 void
 ebpf_timed_work_queue_destroy(_In_ ebpf_timed_work_queue_t* work_queue)
 {
+    if (!work_queue) {
+        return;
+    }
+
     // Cancel the timer.
     KeCancelTimer(&work_queue->timer);
 

--- a/libs/runtime/ebpf_work_queue.c
+++ b/libs/runtime/ebpf_work_queue.c
@@ -57,14 +57,13 @@ ebpf_timed_work_queue_create(
     return_value = EBPF_SUCCESS;
 
 Done:
-    if (local_work_queue) {
-        ebpf_timed_work_queue_destroy(local_work_queue);
-    }
+    ebpf_timed_work_queue_destroy(local_work_queue);
+
     return return_value;
 }
 
 void
-ebpf_timed_work_queue_destroy(_In_ ebpf_timed_work_queue_t* work_queue)
+ebpf_timed_work_queue_destroy(_In_opt_ ebpf_timed_work_queue_t* work_queue)
 {
     if (!work_queue) {
         return;

--- a/libs/runtime/ebpf_work_queue.c
+++ b/libs/runtime/ebpf_work_queue.c
@@ -26,9 +26,9 @@ _Must_inspect_result_ ebpf_result_t
 ebpf_timed_work_queue_create(
     _Out_ ebpf_timed_work_queue_t** work_queue,
     uint32_t cpu_id,
-    LARGE_INTEGER* interval,
-    ebpf_timed_work_queue_callback_t callback,
-    void* context)
+    _In_ LARGE_INTEGER* interval,
+    _In_ ebpf_timed_work_queue_callback_t callback,
+    _In_ void* context)
 {
     ebpf_timed_work_queue_t* local_work_queue = NULL;
     ebpf_result_t return_value;

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -52,7 +52,6 @@ extern "C"
 
     /**
      * @brief Insert a work item into the timed work queue. If immediate is true, the timer will fire immediately.
-     * immediately.
      *
      * @param[in] work_queue The work queue to insert the work item into.
      * @param[in] work_item The work item to insert.

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -21,6 +21,12 @@ extern "C"
     typedef _IRQL_requires_(DISPATCH_LEVEL) void (*ebpf_timed_work_queue_callback_t)(
         _Inout_ void* context, uint32_t cpu_id, _Inout_ ebpf_list_entry_t*);
 
+    typedef enum _ebpf_work_queue_wakeup_behavior
+    {
+        EBPF_WORK_QUEUE_WAKEUP_ON_INSERT = 0, ///< Wake up the work queue.
+        EBPF_WORK_QUEUE_WAKEUP_ON_TIMER = 1,  ///< Don't wake up the work queue.
+    } ebpf_work_queue_wakeup_behavior_t;
+
     /**
      * @brief Create a timed work queue.
      *
@@ -55,11 +61,13 @@ extern "C"
      *
      * @param[in] work_queue The work queue to insert the work item into.
      * @param[in] work_item The work item to insert.
-     * @param[in] flush Fire the timer immediately.
+     * @param[in] wake_behavior Wake up the work queue if true.
      */
     void
     ebpf_timed_work_queue_insert(
-        _In_ ebpf_timed_work_queue_t* work_queue, _In_ ebpf_list_entry_t* work_item, bool flush);
+        _In_ ebpf_timed_work_queue_t* work_queue,
+        _In_ ebpf_list_entry_t* work_item,
+        ebpf_work_queue_wakeup_behavior_t wake_behavior);
 
     /**
      * @brief Check if the timed work queue is empty without acquiring the lock.
@@ -77,7 +85,7 @@ extern "C"
      * @param[in] work_queue The work queue to execute the callback for.
      */
     void
-    ebpf_timed_work_queued_poll(_In_ ebpf_timed_work_queue_t* work_queue);
+    ebpf_timed_work_queued_flush(_In_ ebpf_timed_work_queue_t* work_queue);
 
 #ifdef __cplusplus
 }

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -38,9 +38,9 @@ extern "C"
     ebpf_timed_work_queue_create(
         _Out_ ebpf_timed_work_queue_t** work_queue,
         uint32_t cpu_id,
-        LARGE_INTEGER* interval,
-        ebpf_timed_work_queue_callback_t callback,
-        void* context);
+        _In_ LARGE_INTEGER* interval,
+        _In_ ebpf_timed_work_queue_callback_t callback,
+        _In_ void* context);
 
     /**
      * @brief Destroy a timed work queue.

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -18,7 +18,7 @@ extern "C"
      */
     typedef struct _ebpf_timed_work_queue ebpf_timed_work_queue_t;
 
-    typedef void (*ebpf_timed_work_queue_callback_t)(
+    typedef _IRQL_requires_(DISPATCH_LEVEL) void (*ebpf_timed_work_queue_callback_t)(
         _Inout_ void* context, uint32_t cpu_id, _Inout_ ebpf_list_entry_t*);
 
     /**

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -18,6 +18,9 @@ extern "C"
      */
     typedef struct _ebpf_timed_work_queue ebpf_timed_work_queue_t;
 
+    typedef void (*ebpf_timed_work_queue_callback_t)(
+        _Inout_ void* context, _In_ uint32_t cpu_id, _Inout_ ebpf_list_entry_t*);
+
     /**
      * @brief Create a timed work queue.
      *
@@ -36,7 +39,7 @@ extern "C"
         _Out_ ebpf_timed_work_queue_t** work_queue,
         uint32_t cpu_id,
         LARGE_INTEGER* interval,
-        void (*callback)(_Inout_ void* context, _Inout_ ebpf_list_entry_t*),
+        ebpf_timed_work_queue_callback_t callback,
         void* context);
 
     /**

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+#pragma once
+
+#include "ebpf_platform.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+    /**
+     * @brief A timed work queue. Entries in the work queue are executed
+     * either after a fixed interval or when the queue is polled. The purpose of this
+     * work queue is to allow for deferred execution of work items that are not
+     * time critical and can be batched together with other work via the poll API.
+     */
+    typedef struct _ebpf_timed_work_queue ebpf_timed_work_queue_t;
+
+    /**
+     * @brief Create a timed work queue.
+     *
+     * @param[out] work_queue Pointer to memory that contains the work queue on success.
+     * @param[in] cpu_id The CPU to run the work queue on.
+     * @param[in] interval The interval at which to run the work queue.
+     * @param[in] callback The callback to execute for each work item.
+     * @param[in] context The context to pass to the callback.
+     *
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_NO_MEMORY Unable to allocate resources for this
+     *  operation.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_timed_work_queue_create(
+        _Out_ ebpf_timed_work_queue_t** work_queue,
+        uint32_t cpu_id,
+        LARGE_INTEGER* interval,
+        void (*callback)(_Inout_ void* context, _Inout_ ebpf_list_entry_t*),
+        void* context);
+
+    /**
+     * @brief Destroy a timed work queue.
+     *
+     * @param work_queue
+     */
+    void
+    ebpf_timed_work_queue_destroy(_In_ ebpf_timed_work_queue_t* work_queue);
+
+    /**
+     * @brief Insert a work item into the timed work queue. If immediate is true, time timer will fire immediately.
+     * immediately.
+     *
+     * @param[in] work_queue The work queue to insert the work item into.
+     * @param[in] work_item The work item to insert.
+     * @param[in] flush Fire the timer immediately.
+     */
+    void
+    ebpf_timed_work_queue_insert(
+        _In_ ebpf_timed_work_queue_t* work_queue, _In_ ebpf_list_entry_t* work_item, bool flush);
+
+    /**
+     * @brief Check if the timed work queue is empty with out acquiring the lock.
+     *
+     * @param[in] work_queue The work queue to check.
+     * @return true The work queue is empty.
+     * @return false The work queue is not empty.
+     */
+    bool
+    ebpf_timed_work_queue_is_empty(_In_ ebpf_timed_work_queue_t* work_queue);
+
+    /**
+     * @brief Execute the callback for all work items in the timed work queue.
+     *
+     * @param[in] work_queue The work queue to execute the callback for.
+     */
+    void
+    ebpf_timed_work_queued_poll(_In_ ebpf_timed_work_queue_t* work_queue);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -48,7 +48,7 @@ extern "C"
      * @param[in] work_queue The timed work queue to destroy.
      */
     void
-    ebpf_timed_work_queue_destroy(_In_ ebpf_timed_work_queue_t* work_queue);
+    ebpf_timed_work_queue_destroy(_In_opt_ ebpf_timed_work_queue_t* work_queue);
 
     /**
      * @brief Insert a work item into the timed work queue. If immediate is true, the timer will fire immediately.

--- a/libs/runtime/ebpf_work_queue.h
+++ b/libs/runtime/ebpf_work_queue.h
@@ -19,7 +19,7 @@ extern "C"
     typedef struct _ebpf_timed_work_queue ebpf_timed_work_queue_t;
 
     typedef void (*ebpf_timed_work_queue_callback_t)(
-        _Inout_ void* context, _In_ uint32_t cpu_id, _Inout_ ebpf_list_entry_t*);
+        _Inout_ void* context, uint32_t cpu_id, _Inout_ ebpf_list_entry_t*);
 
     /**
      * @brief Create a timed work queue.
@@ -45,13 +45,13 @@ extern "C"
     /**
      * @brief Destroy a timed work queue.
      *
-     * @param work_queue
+     * @param[in] work_queue The timed work queue to destroy.
      */
     void
     ebpf_timed_work_queue_destroy(_In_ ebpf_timed_work_queue_t* work_queue);
 
     /**
-     * @brief Insert a work item into the timed work queue. If immediate is true, time timer will fire immediately.
+     * @brief Insert a work item into the timed work queue. If immediate is true, the timer will fire immediately.
      * immediately.
      *
      * @param[in] work_queue The work queue to insert the work item into.
@@ -63,7 +63,7 @@ extern "C"
         _In_ ebpf_timed_work_queue_t* work_queue, _In_ ebpf_list_entry_t* work_item, bool flush);
 
     /**
-     * @brief Check if the timed work queue is empty with out acquiring the lock.
+     * @brief Check if the timed work queue is empty without acquiring the lock.
      *
      * @param[in] work_queue The work queue to check.
      * @return true The work queue is empty.

--- a/libs/runtime/kernel/platform_kernel.vcxproj
+++ b/libs/runtime/kernel/platform_kernel.vcxproj
@@ -45,6 +45,7 @@
     <ClCompile Include="..\ebpf_ring_buffer.c" />
     <ClCompile Include="..\ebpf_state.c" />
     <ClCompile Include="..\ebpf_trampoline.c" />
+    <ClCompile Include="..\ebpf_work_queue.c" />
     <ClCompile Include="ebpf_fault_injection_kernel.c" />
     <ClCompile Include="ebpf_handle_kernel.c" />
     <ClCompile Include="ebpf_native_kernel.c" />
@@ -72,6 +73,7 @@
     <ClInclude Include="..\ebpf_ring_buffer.h" />
     <ClInclude Include="..\ebpf_serialize.h" />
     <ClInclude Include="..\ebpf_state.h" />
+    <ClInclude Include="..\ebpf_work_queue.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="stdbool.h" />
     <ClInclude Include="stdint.h" />

--- a/libs/runtime/kernel/platform_kernel.vcxproj.filters
+++ b/libs/runtime/kernel/platform_kernel.vcxproj.filters
@@ -73,6 +73,9 @@
     <ClCompile Include="..\ebpf_random.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ebpf_work_queue.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ebpf_epoch.h">
@@ -145,6 +148,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\external\usersim\cxplat\inc\winkernel\cxplat_winkernel.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ebpf_work_queue.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -1285,6 +1285,7 @@ TEST_CASE("work_queue", "[platform]")
 
     // Queue a work item with flush.
     ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, true);
+
     // Wait for active DPCs to complete.
     KeFlushQueuedDpcs();
 

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -1251,8 +1251,9 @@ TEST_CASE("work_queue", "[platform]")
             &work_queue,
             0,
             &interval,
-            [](_Inout_ void* context, _Inout_ ebpf_list_entry_t* entry) {
+            [](_Inout_ void* context, uint32_t cpu_id, _Inout_ ebpf_list_entry_t* entry) {
                 UNREFERENCED_PARAMETER(context);
+                UNREFERENCED_PARAMETER(cpu_id);
                 auto work_item_context = reinterpret_cast<_work_item_context*>(entry);
                 KeSetEvent(&work_item_context->completion_event, 0, FALSE);
             },

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -1263,7 +1263,7 @@ TEST_CASE("work_queue", "[platform]")
     std::unique_ptr<ebpf_timed_work_queue_t, decltype(&ebpf_timed_work_queue_destroy)> work_queue_ptr(
         work_queue, &ebpf_timed_work_queue_destroy);
 
-    // Queue a work item with out flush.
+    // Queue a work item without flush.
     ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, false);
 
     LARGE_INTEGER timeout = {0};

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -17,6 +17,7 @@
 #include "ebpf_ring_buffer.h"
 #include "ebpf_serialize.h"
 #include "ebpf_state.h"
+#include "ebpf_work_queue.h"
 #include "helpers.h"
 
 #include <winsock2.h>
@@ -1224,4 +1225,80 @@ TEST_CASE("verify random", "[platform]")
 
     // Verify that the random number generators do not have a dominant frequency.
     REQUIRE(!has_dominant_frequency(SEQUENCE_LENGTH, ebpf_random_uint32));
+}
+
+TEST_CASE("work_queue", "[platform]")
+{
+    _test_helper test_helper;
+    test_helper.initialize();
+    struct _work_item_context
+    {
+        LIST_ENTRY list_entry;
+        KEVENT completion_event;
+    } work_item_context;
+
+    ebpf_list_initialize(&work_item_context.list_entry);
+
+    KeInitializeEvent(&work_item_context.completion_event, NotificationEvent, FALSE);
+
+    ebpf_timed_work_queue_t* work_queue;
+    LARGE_INTEGER interval;
+
+    interval.QuadPart = 10 * 1000 * 100; // 100ms
+
+    REQUIRE(
+        ebpf_timed_work_queue_create(
+            &work_queue,
+            0,
+            &interval,
+            [](_Inout_ void* context, _Inout_ ebpf_list_entry_t* entry) {
+                UNREFERENCED_PARAMETER(context);
+                auto work_item_context = reinterpret_cast<_work_item_context*>(entry);
+                KeSetEvent(&work_item_context->completion_event, 0, FALSE);
+            },
+            nullptr) == EBPF_SUCCESS);
+
+    // Unique ptr that will call ebpf_timed_work_queue_destroy when it goes out of scope.
+    std::unique_ptr<ebpf_timed_work_queue_t, decltype(&ebpf_timed_work_queue_destroy)> work_queue_ptr(
+        work_queue, &ebpf_timed_work_queue_destroy);
+
+    // Queue a work item with out flush.
+    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, false);
+
+    LARGE_INTEGER timeout = {0};
+
+    // Verify that the work item is not signaled immediately.
+    REQUIRE(
+        KeWaitForSingleObject(&work_item_context.completion_event, Executive, KernelMode, FALSE, &timeout) ==
+        STATUS_TIMEOUT);
+
+    // Verify the queue is not empty.
+    REQUIRE(ebpf_timed_work_queue_is_empty(work_queue) == false);
+
+    timeout.QuadPart = -10 * 1000 * 1000; // 1s
+
+    // Verify that the work item is signaled after 100ms.
+    REQUIRE(
+        KeWaitForSingleObject(&work_item_context.completion_event, Executive, KernelMode, FALSE, &timeout) ==
+        STATUS_SUCCESS);
+
+    // Queue a work item with flush.
+    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, true);
+    // Wait for active DPCs to complete.
+    KeFlushQueuedDpcs();
+
+    // Verify the queue is now empty.
+    REQUIRE(ebpf_timed_work_queue_is_empty(work_queue) == true);
+
+    // Queue a work item without flush.
+    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, false);
+
+    // Verify the queue is not empty.
+    REQUIRE(ebpf_timed_work_queue_is_empty(work_queue) == false);
+
+    // Process the work queue.
+    ebpf_timed_work_queued_poll(work_queue);
+
+    // Verify the queue is now empty.
+    REQUIRE(ebpf_timed_work_queue_is_empty(work_queue) == true);
 }

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -1245,7 +1245,7 @@ TEST_CASE("work_queue", "[platform]")
     LARGE_INTEGER interval;
 
     interval.QuadPart = 10 * 1000 * 100; // 100ms
-
+    int context = 1;
     REQUIRE(
         ebpf_timed_work_queue_create(
             &work_queue,
@@ -1257,7 +1257,7 @@ TEST_CASE("work_queue", "[platform]")
                 auto work_item_context = reinterpret_cast<_work_item_context*>(entry);
                 KeSetEvent(&work_item_context->completion_event, 0, FALSE);
             },
-            nullptr) == EBPF_SUCCESS);
+            &context) == EBPF_SUCCESS);
 
     // Unique ptr that will call ebpf_timed_work_queue_destroy when it goes out of scope.
     std::unique_ptr<ebpf_timed_work_queue_t, decltype(&ebpf_timed_work_queue_destroy)> work_queue_ptr(

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -1264,7 +1264,7 @@ TEST_CASE("work_queue", "[platform]")
         work_queue, &ebpf_timed_work_queue_destroy);
 
     // Queue a work item without flush.
-    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, false);
+    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, EBPF_WORK_QUEUE_WAKEUP_ON_TIMER);
 
     LARGE_INTEGER timeout = {0};
 
@@ -1284,7 +1284,7 @@ TEST_CASE("work_queue", "[platform]")
         STATUS_SUCCESS);
 
     // Queue a work item with flush.
-    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, true);
+    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, EBPF_WORK_QUEUE_WAKEUP_ON_INSERT);
 
     // Wait for active DPCs to complete.
     KeFlushQueuedDpcs();
@@ -1293,13 +1293,13 @@ TEST_CASE("work_queue", "[platform]")
     REQUIRE(ebpf_timed_work_queue_is_empty(work_queue) == true);
 
     // Queue a work item without flush.
-    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, false);
+    ebpf_timed_work_queue_insert(work_queue, &work_item_context.list_entry, EBPF_WORK_QUEUE_WAKEUP_ON_TIMER);
 
     // Verify the queue is not empty.
     REQUIRE(ebpf_timed_work_queue_is_empty(work_queue) == false);
 
     // Process the work queue.
-    ebpf_timed_work_queued_poll(work_queue);
+    ebpf_timed_work_queued_flush(work_queue);
 
     // Verify the queue is now empty.
     REQUIRE(ebpf_timed_work_queue_is_empty(work_queue) == true);

--- a/libs/runtime/user/platform_user.vcxproj
+++ b/libs/runtime/user/platform_user.vcxproj
@@ -34,6 +34,7 @@
     <ClCompile Include="..\ebpf_ring_buffer.c" />
     <ClCompile Include="..\ebpf_state.c" />
     <ClCompile Include="..\ebpf_trampoline.c" />
+    <ClCompile Include="..\ebpf_work_queue.c" />
     <ClCompile Include="ebpf_handle_user.c" />
     <ClCompile Include="ebpf_native_user.c" />
     <ClCompile Include="ebpf_platform_user.cpp" />
@@ -48,6 +49,7 @@
     <ClInclude Include="..\ebpf_random.h" />
     <ClInclude Include="..\ebpf_ring_buffer.h" />
     <ClInclude Include="..\ebpf_state.h" />
+    <ClInclude Include="..\ebpf_work_queue.h" />
     <ClInclude Include="framework.h" />
   </ItemGroup>
   <PropertyGroup Label="Globals">

--- a/libs/runtime/user/platform_user.vcxproj.filters
+++ b/libs/runtime/user/platform_user.vcxproj.filters
@@ -76,6 +76,9 @@
     <ClCompile Include="..\..\shared\tracelog.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\ebpf_work_queue.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\ebpf_epoch.h">
@@ -112,6 +115,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\external\usersim\cxplat\inc\cxplat.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\ebpf_work_queue.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
## Description

1) Add a timed work queue that maintains a per-CPU list of work items to execute. Items inserted into the queue are executed either when the timer expires or when the queue is polled.
2) Switch to using timed work queues to manage inter-processor messages. Messages sent between CPU are inserted into the timed work queue and then either processed via polling the timed work queue or via a timer.

This reduces the number of DPCs that need to be queued to process epoch's distributed consensus algorithm.

## Testing

CI/CD

## Documentation

Doxygen.

## Installation

No.
