### PR TITLE
Fix typo in actions/upload-artifact

### DIFF
--- a/.github/workflows/upload-perf-results.yml
+++ b/.github/workflows/upload-perf-results.yml
@@ -83,7 +83,7 @@ jobs:
 
     # Grab the output from the results directory and upload it as an artifact to debug failures.
     - name: Upload data as artifacts for debugging
-      uses: actions/upload-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
       with:
         name: Test-Results-${{inputs.result_artifact}}
         path: ${{github.workspace}}/results


### PR DESCRIPTION
## Description

Fix wrong sha1 hash in reference to actions/upload-artifact.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
