### PR TITLE
Fix netsh show maps alignment issue

### DIFF
--- a/libs/ebpfnetsh/maps.cpp
+++ b/libs/ebpfnetsh/maps.cpp
@@ -35,9 +35,9 @@ handle_ebpf_show_maps(
     UNREFERENCED_PARAMETER(done);
 
     std::cout << "\n";
-    std::cout << "                             Key  Value      Max  Inner\n";
-    std::cout << "    ID            Map Type  Size   Size  Entries     ID  Pins  Name\n";
-    std::cout << "======  ==================  ====  =====  =======  =====  ====  ========\n";
+    std::cout << "                              Key  Value      Max  Inner\n";
+    std::cout << "     ID            Map Type  Size   Size  Entries     ID  Pins  Name\n";
+    std::cout << "=======  ==================  ====  =====  =======  =====  ====  ========\n";
 
     uint32_t map_id = 0;
     for (;;) {
@@ -54,7 +54,7 @@ handle_ebpf_show_maps(
         uint32_t info_size = (uint32_t)sizeof(info);
         if (bpf_obj_get_info_by_fd(map_fd, &info, &info_size) == 0) {
             printf(
-                "%6u  %18s%6u%7u%9u%7d%6u  %s\n",
+                "%7u  %18s%6u%7u%9u%7d%6u  %s\n",
                 info.id,
                 libbpf_bpf_map_type_str(info.type),
                 info.key_size,

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -613,11 +613,11 @@ TEST_CASE("show maps", "[netsh][maps]")
     REQUIRE(result == NO_ERROR);
     REQUIRE(
         output == "\n"
-                  "                             Key  Value      Max  Inner\n"
-                  "    ID            Map Type  Size   Size  Entries     ID  Pins  Name\n"
-                  "======  ==================  ====  =====  =======  =====  ====  ========\n"
-                  " 65538                hash     4      4        1     -1     0  inner_map\n"
-                  "131073       array_of_maps     4      4        1  65538     0  outer_map\n");
+                  "                              Key  Value      Max  Inner\n"
+                  "     ID            Map Type  Size   Size  Entries     ID  Pins  Name\n"
+                  "=======  ==================  ====  =====  =======  =====  ====  ========\n"
+                  "  65538                hash     4      4        1     -1     0  inner_map\n"
+                  " 131073       array_of_maps     4      4        1  65538     0  outer_map\n");
 
     output = _run_netsh_command(handle_ebpf_delete_program, L"196609", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
@@ -630,9 +630,9 @@ TEST_CASE("show maps", "[netsh][maps]")
     REQUIRE(result == NO_ERROR);
     REQUIRE(
         output == "\n"
-                  "                             Key  Value      Max  Inner\n"
-                  "    ID            Map Type  Size   Size  Entries     ID  Pins  Name\n"
-                  "======  ==================  ====  =====  =======  =====  ====  ========\n");
+                  "                              Key  Value      Max  Inner\n"
+                  "     ID            Map Type  Size   Size  Entries     ID  Pins  Name\n"
+                  "=======  ==================  ====  =====  =======  =====  ====  ========\n");
 }
 
 TEST_CASE("show links", "[netsh][links]")


### PR DESCRIPTION
## Description

Fix column alignment issue in netsh "show maps" output

Fixes #2917

## Testing

This PR updates tests.

## Documentation

No impact.

## Installation

No impact.
