### PR TITLE
Fix #line 0 issue for bpf2c

### DIFF
--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -1473,28 +1473,15 @@ bpf_code_generator::emit_c_code(std::ostream& output_stream)
         auto& line_info = section_line_info[name];
         auto first_line_info = line_info.find(section.output.front().instruction_offset);
         std::string prolog_line_info;
-        uint32_t line_number = 0;
-        if (first_line_info != line_info.end() && !first_line_info->second.file_name.empty()) {
-            line_number = first_line_info->second.line_number;
-            if (line_number == 0) {
-                // Iterate over all the instructions to find a non-zero line number.
-                for (const auto& output : section.output) {
-                    if (output.lines.empty()) {
-                        continue;
-                    }
-                    auto current_line = line_info.find(output.instruction_offset);
-                    if (current_line != line_info.end() && !current_line->second.file_name.empty() &&
-                        current_line->second.line_number != 0) {
-                        line_number = current_line->second.line_number;
-                        break;
-                    }
-                }
+
+        auto result = std::find_if(line_info.begin(), line_info.end(), [&prolog_line_info](const auto& pair) {
+            if (pair.second.file_name.empty() || pair.second.line_number == 0) {
+                return false;
             }
-            if (line_number != 0) {
-                prolog_line_info = std::format(
-                    "#line {} {}\n", std::to_string(line_number), first_line_info->second.file_name.quoted_filename());
-            }
-        }
+            prolog_line_info = std::format(
+                "#line {} {}\n", std::to_string(pair.second.line_number), pair.second.file_name.quoted_filename());
+            return true;
+        });
 
         // Emit entry point
         output_stream << "#pragma code_seg(push, " << section.pe_section_name.quoted() << ")" << std::endl;


### PR DESCRIPTION
## Description

In some cases, the BTF data generated by clang contains line number as 0. bpf2c file generating native code, uses line numbers from BTF data to emit `#line <line_number>`. If line number is 0, it causes an issue with compiler as `#line ` pragma can only start from 1.

bpf2c already has a check in one place to ensure it does not generate `#line 0` pragma, but another place was missing this. This PR adds a check for the missing case.

## Testing

As this is hard to repro on demand and was discovered while converting a `.o` file for a different project, manually tested the changes.

## Documentation

No

## Installation

No.
