### PR TITLE
Adding a call to ebpf_trace_terminate in case of subsequent APIs faliure

### DIFF
--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -401,6 +401,8 @@ DriverEntry(_In_ DRIVER_OBJECT* driver_object, _In_ UNICODE_STRING* registry_pat
             EBPF_TRACELOG_KEYWORD_ERROR,
             (char*)"_ebpf_driver_initialize_objects failed",
             status);
+        // Terminating ebpf trace.
+        ebpf_trace_terminate();
         goto Exit;
     }
 

--- a/ebpfcore/ebpf_drv.c
+++ b/ebpfcore/ebpf_drv.c
@@ -401,8 +401,6 @@ DriverEntry(_In_ DRIVER_OBJECT* driver_object, _In_ UNICODE_STRING* registry_pat
             EBPF_TRACELOG_KEYWORD_ERROR,
             (char*)"_ebpf_driver_initialize_objects failed",
             status);
-        // Terminating ebpf trace.
-        ebpf_trace_terminate();
         goto Exit;
     }
 
@@ -410,6 +408,9 @@ DriverEntry(_In_ DRIVER_OBJECT* driver_object, _In_ UNICODE_STRING* registry_pat
 
 Exit:
     EBPF_LOG_EXIT();
+    if (!NT_SUCCESS(status)) {
+        ebpf_trace_terminate();
+    }
     return status;
 }
 


### PR DESCRIPTION
## Description

Adding a call to ebpf_trace_termination in case of a subsequent APIs failure.
Following this [issue](https://github.com/microsoft/ebpf-for-windows/issues/2838)

## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_

## Installation

_Is there any installer impact for this change?_
