### PR TITLE
Fix some Catch2 tests not returning exit code.

### DIFF
--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -737,9 +737,11 @@ main(int argc, char* argv[])
 
     // Run the tests.
     printf("Running tests...\n");
-    session.run();
+    returnCode = session.run();
 
     // Clean up Windows Sockets.
     printf("Cleaning up Winsock.\n");
     WSACleanup();
+
+    return returnCode;
 }

--- a/tests/xdp/xdp_tests.cpp
+++ b/tests/xdp/xdp_tests.cpp
@@ -118,6 +118,8 @@ main(int argc, char* argv[])
         return 1;
     }
 
-    session.run();
+    returnCode = session.run();
     WSACleanup();
+
+    return returnCode;
 }


### PR DESCRIPTION
## Description

#2707 was recently fixed by amending the error parsing expression.

This is a follow-up fix that will make use of us checking for `$LASTEXITCODE `too.
`xdp_test` and `connect_redirect_test` were swallowing the return code and implicitly returning 0 (per the C standard, p.13 https://www.open-std.org/jtc1/sc22/WG14/www/docs/n1256.pdf)
so the exit code portion of our error detecting was being ignored.

Here's an example from Catch2 docs: 
https://github.com/catchorg/Catch2/blob/devel/docs/own-main.md#amending-the-catch2-config

And we're doing it right in `socket_tests.cpp`:
https://github.com/microsoft/ebpf-for-windows/blob/main/tests/socket/socket_tests.cpp#L471

## Testing

Locally running the tests without eBPF installed fails as expected and sets the $LASTEXITCODE to the number of failed tests.
![image](https://github.com/microsoft/ebpf-for-windows/assets/12816515/a8f7a17a-05f4-4a9d-9de8-8e408b9b1156)

