### PR TITLE
Allow static initialization for BPF_MAP_TYPE_HASH_OF_MAPS map with integer as key_size

### DIFF
--- a/installer/Product.wxs
+++ b/installer/Product.wxs
@@ -838,6 +838,18 @@ SPDX-License-Identifier: MIT
 				<File Id="INVALID_HELPERS_UM.PDB" Name="invalid_helpers_um.pdb" Source="$(var.SolutionDir)$(var.Platform)\$(var.Configuration)\invalid_helpers_um.pdb" />
 			</Component>
 			<?endif?>
+			<Component Id="HASH_OF_MAP_IN_ARRAY_MAP.O" DiskId="1" Guid="{11E1BE5E-67BF-47A6-BA41-0DE85C4A00A3}">
+				<File Id="HASH_OF_MAP_IN_ARRAY_MAP.O" Name="hash_of_map_in_array_map.o" Source="$(var.SolutionDir)$(var.Platform)\$(var.Configuration)\hash_of_map_in_array_map.o" />
+			</Component>
+			<Component Id="HASH_OF_MAP_IN_ARRAY_MAP.SYS" DiskId="1" Guid="{6DFC3E32-1673-4CCE-9311-5CCE169C6745}">
+				<File Id="HASH_OF_MAP_IN_ARRAY_MAP.SYS" Name="hash_of_map_in_array_map.sys" Source="$(var.SolutionDir)$(var.Platform)\$(var.Configuration)\hash_of_map_in_array_map.sys" />
+			</Component>
+			<Component Id="HASH_OF_MAP_IN_ARRAY_MAP_UM.DLL" DiskId="1" Guid="{166856FA-5BEF-4CBD-85F4-06442F6B6997}">
+				<File Id="HASH_OF_MAP_IN_ARRAY_MAP_UM.DLL" Name="hash_of_map_in_array_map_um.dll" Source="$(var.SolutionDir)$(var.Platform)\$(var.Configuration)\hash_of_map_in_array_map_um.dll" />
+			</Component>
+			<Component Id="HASH_OF_MAP_IN_ARRAY_MAP_UM.PDB" DiskId="1" Guid="{BCAFD0E6-6D92-486B-985E-58CA19C2E9E7}">
+				<File Id="HASH_OF_MAP_IN_ARRAY_MAP.PDB" Name="hash_of_map_in_array_map_um.pdb" Source="$(var.SolutionDir)$(var.Platform)\$(var.Configuration)\hash_of_map_in_array_map_um.pdb" />
+			</Component>
 			<Component Id="MAP.O" DiskId="1" Guid="{C0461A4A-1195-4965-9710-8EED78A271F6}">
 				<File Id="MAP.O" Name="map.o" Source="$(var.SolutionDir)$(var.Platform)\$(var.Configuration)\map.o" />
 			</Component>

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -921,8 +921,10 @@ _ebpf_native_set_initial_map_values(_Inout_ ebpf_native_module_t* module)
             }
 
             ebpf_handle_t handle_to_insert = ebpf_handle_invalid;
+            ebpf_map_definition_in_file_t map_def = native_map_to_update->entry->definition;
 
-            if (native_map_to_update->entry->definition.type == BPF_MAP_TYPE_ARRAY_OF_MAPS) {
+            if (map_def.type == BPF_MAP_TYPE_ARRAY_OF_MAPS ||
+                ((map_def.type == BPF_MAP_TYPE_HASH_OF_MAPS) && (map_def.key_size == sizeof(uint32_t)))) {
                 ebpf_native_map_t* native_map_to_insert =
                     _ebpf_native_find_map_by_name(module, map_initial_values[i].values[j]);
                 if (native_map_to_update == NULL) {
@@ -930,7 +932,7 @@ _ebpf_native_set_initial_map_values(_Inout_ ebpf_native_module_t* module)
                     break;
                 }
                 handle_to_insert = native_map_to_insert->handle;
-            } else if (native_map_to_update->entry->definition.type == BPF_MAP_TYPE_PROG_ARRAY) {
+            } else if (map_def.type == BPF_MAP_TYPE_PROG_ARRAY) {
                 ebpf_native_program_t* program_to_insert =
                     _ebpf_native_find_program_by_name(module, map_initial_values[i].values[j]);
                 if (program_to_insert == NULL) {

--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -922,9 +922,13 @@ _ebpf_native_set_initial_map_values(_Inout_ ebpf_native_module_t* module)
 
             ebpf_handle_t handle_to_insert = ebpf_handle_invalid;
             ebpf_map_definition_in_file_t map_def = native_map_to_update->entry->definition;
+            uint32_t key_size = map_def.key_size;
+            bool is_hash_of_maps_with_int_key = (map_def.type == BPF_MAP_TYPE_HASH_OF_MAPS) &&
+                                                (key_size == sizeof(uint8_t) ||
+                                                 key_size == sizeof(uint16_t) ||
+                                                 key_size == sizeof(uint32_t));
 
-            if (map_def.type == BPF_MAP_TYPE_ARRAY_OF_MAPS ||
-                ((map_def.type == BPF_MAP_TYPE_HASH_OF_MAPS) && (map_def.key_size == sizeof(uint32_t)))) {
+            if (map_def.type == BPF_MAP_TYPE_ARRAY_OF_MAPS || is_hash_of_maps_with_int_key) {
                 ebpf_native_map_t* native_map_to_insert =
                     _ebpf_native_find_map_by_name(module, map_initial_values[i].values[j]);
                 if (native_map_to_update == NULL) {

--- a/scripts/deploy-ebpf.ps1.in
+++ b/scripts/deploy-ebpf.ps1.in
@@ -119,6 +119,10 @@ $source_directory="."
     "encap_reflect_packet_um.dll",
     "encap_reflect_packet_um.pdb",
     "encap_reflect_packet.sys",
+    "hash_of_map_in_array_map.o"
+    "hash_of_map_in_array_map_um.dll",
+    "hash_of_map_in_array_map_um.pdb",
+    "hash_of_map_in_array_map.sys",
     "invalid_maps1_um.dll",
     "invalid_maps1.sys",
     "invalid_maps2_um.dll",

--- a/tests/bpf2c_tests/elf_bpf.cpp
+++ b/tests/bpf2c_tests/elf_bpf.cpp
@@ -219,6 +219,7 @@ DECLARE_TEST("droppacket", _test_mode::Verify)
 DECLARE_TEST("droppacket_unsafe", _test_mode::NoVerify)
 DECLARE_TEST("empty", _test_mode::NoVerify)
 DECLARE_TEST("encap_reflect_packet", _test_mode::Verify)
+DECLARE_TEST("hash_of_map_in_array_map", _test_mode::Verify)
 DECLARE_TEST("invalid_helpers", _test_mode::NoVerify);
 DECLARE_TEST("invalid_maps1", _test_mode::NoVerify);
 DECLARE_TEST("invalid_maps2", _test_mode::NoVerify);

--- a/tests/bpf2c_tests/expected/hash_of_map_in_array_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_in_array_map_dll.c
@@ -1,0 +1,251 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from hash_of_map_in_array_map.o
+
+#include "bpf2c.h"
+
+#include <stdio.h>
+#define WIN32_LEAN_AND_MEAN // Exclude rarely-used stuff from Windows headers
+#include <windows.h>
+
+#define metadata_table hash_of_map_in_array_map##_metadata_table
+extern metadata_table_t metadata_table;
+
+bool APIENTRY
+DllMain(_In_ HMODULE hModule, unsigned int ul_reason_for_call, _In_ void* lpReserved)
+{
+    UNREFERENCED_PARAMETER(hModule);
+    UNREFERENCED_PARAMETER(lpReserved);
+    switch (ul_reason_for_call) {
+    case DLL_PROCESS_ATTACH:
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+__declspec(dllexport) metadata_table_t* get_metadata_table() { return &metadata_table; }
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         9,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "inner_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         2,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         65536,                     // Maximum number of entries allowed in the map.
+         0,                         // Inner map index.
+         LIBBPF_PIN_NONE,           // Pinning type for the map.
+         23,                        // Identifier for a map template.
+         9,                         // The id of the inner map template.
+     },
+     "outer_map"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 2;
+}
+
+static helper_function_entry_t lookup_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+};
+
+static GUID lookup_program_type_guid = {0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID lookup_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+static uint16_t lookup_maps[] = {
+    1,
+};
+
+#pragma code_seg(push, "xdp_prog")
+static uint64_t
+lookup(void* context)
+#line 38 "sample/hash_of_map_in_array_map.c"
+{
+#line 38 "sample/hash_of_map_in_array_map.c"
+    // Prologue
+#line 38 "sample/hash_of_map_in_array_map.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r0 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r1 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r2 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r3 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r4 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r5 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r6 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r10 = 0;
+
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r1 = (uintptr_t)context;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r6 src=r0 offset=0 imm=0
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXH pc=1 dst=r10 src=r6 offset=-2 imm=0
+#line 40 "sample/hash_of_map_in_array_map.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-2)) = (uint16_t)r6;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 40 "sample/hash_of_map_in_array_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-2
+#line 40 "sample/hash_of_map_in_array_map.c"
+    r2 += IMMEDIATE(-2);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 41 "sample/hash_of_map_in_array_map.c"
+    r1 = POINTER(_maps[1].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 41 "sample/hash_of_map_in_array_map.c"
+    r0 = lookup_helpers[0].address
+#line 41 "sample/hash_of_map_in_array_map.c"
+         (r1, r2, r3, r4, r5);
+#line 41 "sample/hash_of_map_in_array_map.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 41 "sample/hash_of_map_in_array_map.c"
+        return 0;
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 42 "sample/hash_of_map_in_array_map.c"
+    if (r0 == IMMEDIATE(0))
+#line 42 "sample/hash_of_map_in_array_map.c"
+        goto label_2;
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 42 "sample/hash_of_map_in_array_map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
+#line 43 "sample/hash_of_map_in_array_map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r6;
+    // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/hash_of_map_in_array_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-8
+#line 43 "sample/hash_of_map_in_array_map.c"
+    r2 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_REG pc=12 dst=r1 src=r0 offset=0 imm=0
+#line 44 "sample/hash_of_map_in_array_map.c"
+    r1 = r0;
+    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
+#line 44 "sample/hash_of_map_in_array_map.c"
+    r0 = lookup_helpers[0].address
+#line 44 "sample/hash_of_map_in_array_map.c"
+         (r1, r2, r3, r4, r5);
+#line 44 "sample/hash_of_map_in_array_map.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 44 "sample/hash_of_map_in_array_map.c"
+        return 0;
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 45 "sample/hash_of_map_in_array_map.c"
+    if (r0 != IMMEDIATE(0))
+#line 45 "sample/hash_of_map_in_array_map.c"
+        goto label_1;
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 45 "sample/hash_of_map_in_array_map.c"
+    goto label_2;
+label_1:
+    // EBPF_OP_LDXW pc=16 dst=r6 src=r0 offset=0 imm=0
+#line 46 "sample/hash_of_map_in_array_map.c"
+    r6 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+label_2:
+    // EBPF_OP_MOV64_REG pc=17 dst=r0 src=r6 offset=0 imm=0
+#line 50 "sample/hash_of_map_in_array_map.c"
+    r0 = r6;
+    // EBPF_OP_EXIT pc=18 dst=r0 src=r0 offset=0 imm=0
+#line 50 "sample/hash_of_map_in_array_map.c"
+    return r0;
+#line 50 "sample/hash_of_map_in_array_map.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        lookup,
+        "xdp_prog",
+        "xdp_prog",
+        "lookup",
+        lookup_maps,
+        1,
+        lookup_helpers,
+        1,
+        19,
+        &lookup_program_type_guid,
+        &lookup_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 11;
+    version->revision = 0;
+}
+
+#pragma data_seg(push, "map_initial_values")
+static const char* _outer_map_initial_string_table[] = {
+    "inner_map",
+};
+
+static map_initial_values_t _map_initial_values_array[] = {
+    {
+        .name = "outer_map",
+        .count = 1,
+        .values = _outer_map_initial_string_table,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = _map_initial_values_array;
+    *count = 1;
+}
+
+metadata_table_t hash_of_map_in_array_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/bpf2c_tests/expected/hash_of_map_in_array_map_dll.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_in_array_map_dll.c
@@ -222,7 +222,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 11;
+    version->minor = 12;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_in_array_map_raw.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_in_array_map_raw.c
@@ -196,7 +196,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 11;
+    version->minor = 12;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_in_array_map_raw.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_in_array_map_raw.c
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from hash_of_map_in_array_map.o
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         9,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "inner_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         2,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         65536,                     // Maximum number of entries allowed in the map.
+         0,                         // Inner map index.
+         LIBBPF_PIN_NONE,           // Pinning type for the map.
+         23,                        // Identifier for a map template.
+         9,                         // The id of the inner map template.
+     },
+     "outer_map"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 2;
+}
+
+static helper_function_entry_t lookup_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+};
+
+static GUID lookup_program_type_guid = {0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID lookup_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+static uint16_t lookup_maps[] = {
+    1,
+};
+
+#pragma code_seg(push, "xdp_prog")
+static uint64_t
+lookup(void* context)
+#line 38 "sample/hash_of_map_in_array_map.c"
+{
+#line 38 "sample/hash_of_map_in_array_map.c"
+    // Prologue
+#line 38 "sample/hash_of_map_in_array_map.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r0 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r1 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r2 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r3 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r4 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r5 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r6 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r10 = 0;
+
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r1 = (uintptr_t)context;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r6 src=r0 offset=0 imm=0
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXH pc=1 dst=r10 src=r6 offset=-2 imm=0
+#line 40 "sample/hash_of_map_in_array_map.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-2)) = (uint16_t)r6;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 40 "sample/hash_of_map_in_array_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-2
+#line 40 "sample/hash_of_map_in_array_map.c"
+    r2 += IMMEDIATE(-2);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 41 "sample/hash_of_map_in_array_map.c"
+    r1 = POINTER(_maps[1].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 41 "sample/hash_of_map_in_array_map.c"
+    r0 = lookup_helpers[0].address
+#line 41 "sample/hash_of_map_in_array_map.c"
+         (r1, r2, r3, r4, r5);
+#line 41 "sample/hash_of_map_in_array_map.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 41 "sample/hash_of_map_in_array_map.c"
+        return 0;
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 42 "sample/hash_of_map_in_array_map.c"
+    if (r0 == IMMEDIATE(0))
+#line 42 "sample/hash_of_map_in_array_map.c"
+        goto label_2;
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 42 "sample/hash_of_map_in_array_map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
+#line 43 "sample/hash_of_map_in_array_map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r6;
+    // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/hash_of_map_in_array_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-8
+#line 43 "sample/hash_of_map_in_array_map.c"
+    r2 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_REG pc=12 dst=r1 src=r0 offset=0 imm=0
+#line 44 "sample/hash_of_map_in_array_map.c"
+    r1 = r0;
+    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
+#line 44 "sample/hash_of_map_in_array_map.c"
+    r0 = lookup_helpers[0].address
+#line 44 "sample/hash_of_map_in_array_map.c"
+         (r1, r2, r3, r4, r5);
+#line 44 "sample/hash_of_map_in_array_map.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 44 "sample/hash_of_map_in_array_map.c"
+        return 0;
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 45 "sample/hash_of_map_in_array_map.c"
+    if (r0 != IMMEDIATE(0))
+#line 45 "sample/hash_of_map_in_array_map.c"
+        goto label_1;
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 45 "sample/hash_of_map_in_array_map.c"
+    goto label_2;
+label_1:
+    // EBPF_OP_LDXW pc=16 dst=r6 src=r0 offset=0 imm=0
+#line 46 "sample/hash_of_map_in_array_map.c"
+    r6 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+label_2:
+    // EBPF_OP_MOV64_REG pc=17 dst=r0 src=r6 offset=0 imm=0
+#line 50 "sample/hash_of_map_in_array_map.c"
+    r0 = r6;
+    // EBPF_OP_EXIT pc=18 dst=r0 src=r0 offset=0 imm=0
+#line 50 "sample/hash_of_map_in_array_map.c"
+    return r0;
+#line 50 "sample/hash_of_map_in_array_map.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        lookup,
+        "xdp_prog",
+        "xdp_prog",
+        "lookup",
+        lookup_maps,
+        1,
+        lookup_helpers,
+        1,
+        19,
+        &lookup_program_type_guid,
+        &lookup_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 11;
+    version->revision = 0;
+}
+
+#pragma data_seg(push, "map_initial_values")
+static const char* _outer_map_initial_string_table[] = {
+    "inner_map",
+};
+
+static map_initial_values_t _map_initial_values_array[] = {
+    {
+        .name = "outer_map",
+        .count = 1,
+        .values = _outer_map_initial_string_table,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = _map_initial_values_array;
+    *count = 1;
+}
+
+metadata_table_t hash_of_map_in_array_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/bpf2c_tests/expected/hash_of_map_in_array_map_sys.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_in_array_map_sys.c
@@ -357,7 +357,7 @@ static void
 _get_version(_Out_ bpf2c_version_t* version)
 {
     version->major = 0;
-    version->minor = 11;
+    version->minor = 12;
     version->revision = 0;
 }
 

--- a/tests/bpf2c_tests/expected/hash_of_map_in_array_map_sys.c
+++ b/tests/bpf2c_tests/expected/hash_of_map_in_array_map_sys.c
@@ -1,0 +1,386 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Do not alter this generated file.
+// This file was generated from hash_of_map_in_array_map.o
+
+#define NO_CRT
+#include "bpf2c.h"
+
+#include <guiddef.h>
+#include <wdm.h>
+#include <wsk.h>
+
+DRIVER_INITIALIZE DriverEntry;
+DRIVER_UNLOAD DriverUnload;
+RTL_QUERY_REGISTRY_ROUTINE static _bpf2c_query_registry_routine;
+
+#define metadata_table hash_of_map_in_array_map##_metadata_table
+
+static GUID _bpf2c_npi_id = {/* c847aac8-a6f2-4b53-aea3-f4a94b9a80cb */
+                             0xc847aac8,
+                             0xa6f2,
+                             0x4b53,
+                             {0xae, 0xa3, 0xf4, 0xa9, 0x4b, 0x9a, 0x80, 0xcb}};
+static NPI_MODULEID _bpf2c_module_id = {sizeof(_bpf2c_module_id), MIT_GUID, {0}};
+static HANDLE _bpf2c_nmr_client_handle;
+static HANDLE _bpf2c_nmr_provider_handle;
+extern metadata_table_t metadata_table;
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance);
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context);
+
+static const NPI_CLIENT_CHARACTERISTICS _bpf2c_npi_client_characteristics = {
+    0,                                  // Version
+    sizeof(NPI_CLIENT_CHARACTERISTICS), // Length
+    _bpf2c_npi_client_attach_provider,
+    _bpf2c_npi_client_detach_provider,
+    NULL,
+    {0,                                 // Version
+     sizeof(NPI_REGISTRATION_INSTANCE), // Length
+     &_bpf2c_npi_id,
+     &_bpf2c_module_id,
+     0,
+     &metadata_table}};
+
+static NTSTATUS
+_bpf2c_query_npi_module_id(
+    _In_ const wchar_t* value_name,
+    unsigned long value_type,
+    _In_ const void* value_data,
+    unsigned long value_length,
+    _Inout_ void* context,
+    _Inout_ void* entry_context)
+{
+    UNREFERENCED_PARAMETER(value_name);
+    UNREFERENCED_PARAMETER(context);
+    UNREFERENCED_PARAMETER(entry_context);
+
+    if (value_type != REG_BINARY) {
+        return STATUS_INVALID_PARAMETER;
+    }
+    if (value_length != sizeof(_bpf2c_module_id.Guid)) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+    memcpy(&_bpf2c_module_id.Guid, value_data, value_length);
+    return STATUS_SUCCESS;
+}
+
+NTSTATUS
+DriverEntry(_In_ DRIVER_OBJECT* driver_object, _In_ UNICODE_STRING* registry_path)
+{
+    NTSTATUS status;
+    RTL_QUERY_REGISTRY_TABLE query_table[] = {
+        {
+            NULL,                      // Query routine
+            RTL_QUERY_REGISTRY_SUBKEY, // Flags
+            L"Parameters",             // Name
+            NULL,                      // Entry context
+            REG_NONE,                  // Default type
+            NULL,                      // Default data
+            0,                         // Default length
+        },
+        {
+            _bpf2c_query_npi_module_id,  // Query routine
+            RTL_QUERY_REGISTRY_REQUIRED, // Flags
+            L"NpiModuleId",              // Name
+            NULL,                        // Entry context
+            REG_NONE,                    // Default type
+            NULL,                        // Default data
+            0,                           // Default length
+        },
+        {0}};
+
+    status = RtlQueryRegistryValues(RTL_REGISTRY_ABSOLUTE, registry_path->Buffer, query_table, NULL, NULL);
+    if (!NT_SUCCESS(status)) {
+        goto Exit;
+    }
+
+    status = NmrRegisterClient(&_bpf2c_npi_client_characteristics, NULL, &_bpf2c_nmr_client_handle);
+
+Exit:
+    if (NT_SUCCESS(status)) {
+        driver_object->DriverUnload = DriverUnload;
+    }
+
+    return status;
+}
+
+void
+DriverUnload(_In_ DRIVER_OBJECT* driver_object)
+{
+    NTSTATUS status = NmrDeregisterClient(_bpf2c_nmr_client_handle);
+    if (status == STATUS_PENDING) {
+        NmrWaitForClientDeregisterComplete(_bpf2c_nmr_client_handle);
+    }
+    UNREFERENCED_PARAMETER(driver_object);
+}
+
+static NTSTATUS
+_bpf2c_npi_client_attach_provider(
+    _In_ HANDLE nmr_binding_handle,
+    _In_ void* client_context,
+    _In_ const NPI_REGISTRATION_INSTANCE* provider_registration_instance)
+{
+    NTSTATUS status = STATUS_SUCCESS;
+    void* provider_binding_context = NULL;
+    void* provider_dispatch_table = NULL;
+
+    UNREFERENCED_PARAMETER(client_context);
+    UNREFERENCED_PARAMETER(provider_registration_instance);
+
+    if (_bpf2c_nmr_provider_handle != NULL) {
+        return STATUS_INVALID_PARAMETER;
+    }
+
+#pragma warning(push)
+#pragma warning( \
+    disable : 6387) // Param 3 does not adhere to the specification for the function 'NmrClientAttachProvider'
+    // As per MSDN, client dispatch can be NULL, but SAL does not allow it.
+    // https://docs.microsoft.com/en-us/windows-hardware/drivers/ddi/netioddk/nf-netioddk-nmrclientattachprovider
+    status = NmrClientAttachProvider(
+        nmr_binding_handle, client_context, NULL, &provider_binding_context, &provider_dispatch_table);
+    if (status != STATUS_SUCCESS) {
+        goto Done;
+    }
+#pragma warning(pop)
+    _bpf2c_nmr_provider_handle = nmr_binding_handle;
+
+Done:
+    return status;
+}
+
+static NTSTATUS
+_bpf2c_npi_client_detach_provider(_In_ void* client_binding_context)
+{
+    _bpf2c_nmr_provider_handle = NULL;
+    UNREFERENCED_PARAMETER(client_binding_context);
+    return STATUS_SUCCESS;
+}
+
+#include "bpf2c.h"
+
+static void
+_get_hash(_Outptr_result_buffer_maybenull_(*size) const uint8_t** hash, _Out_ size_t* size)
+{
+    *hash = NULL;
+    *size = 0;
+}
+#pragma data_seg(push, "maps")
+static map_entry_t _maps[] = {
+    {NULL,
+     {
+         BPF_MAP_TYPE_ARRAY, // Type of map.
+         4,                  // Size in bytes of a map key.
+         4,                  // Size in bytes of a map value.
+         1,                  // Maximum number of entries allowed in the map.
+         0,                  // Inner map index.
+         LIBBPF_PIN_NONE,    // Pinning type for the map.
+         9,                  // Identifier for a map template.
+         0,                  // The id of the inner map template.
+     },
+     "inner_map"},
+    {NULL,
+     {
+         BPF_MAP_TYPE_HASH_OF_MAPS, // Type of map.
+         2,                         // Size in bytes of a map key.
+         4,                         // Size in bytes of a map value.
+         65536,                     // Maximum number of entries allowed in the map.
+         0,                         // Inner map index.
+         LIBBPF_PIN_NONE,           // Pinning type for the map.
+         23,                        // Identifier for a map template.
+         9,                         // The id of the inner map template.
+     },
+     "outer_map"},
+};
+#pragma data_seg(pop)
+
+static void
+_get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ size_t* count)
+{
+    *maps = _maps;
+    *count = 2;
+}
+
+static helper_function_entry_t lookup_helpers[] = {
+    {NULL, 1, "helper_id_1"},
+};
+
+static GUID lookup_program_type_guid = {0xf1832a85, 0x85d5, 0x45b0, {0x98, 0xa0, 0x70, 0x69, 0xd6, 0x30, 0x13, 0xb0}};
+static GUID lookup_attach_type_guid = {0x85e0d8ef, 0x579e, 0x4931, {0xb0, 0x72, 0x8e, 0xe2, 0x26, 0xbb, 0x2e, 0x9d}};
+static uint16_t lookup_maps[] = {
+    1,
+};
+
+#pragma code_seg(push, "xdp_prog")
+static uint64_t
+lookup(void* context)
+#line 38 "sample/hash_of_map_in_array_map.c"
+{
+#line 38 "sample/hash_of_map_in_array_map.c"
+    // Prologue
+#line 38 "sample/hash_of_map_in_array_map.c"
+    uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r0 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r1 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r2 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r3 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r4 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r5 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r6 = 0;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    register uint64_t r10 = 0;
+
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r1 = (uintptr_t)context;
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
+
+    // EBPF_OP_MOV64_IMM pc=0 dst=r6 src=r0 offset=0 imm=0
+#line 38 "sample/hash_of_map_in_array_map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXH pc=1 dst=r10 src=r6 offset=-2 imm=0
+#line 40 "sample/hash_of_map_in_array_map.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-2)) = (uint16_t)r6;
+    // EBPF_OP_MOV64_REG pc=2 dst=r2 src=r10 offset=0 imm=0
+#line 40 "sample/hash_of_map_in_array_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=3 dst=r2 src=r0 offset=0 imm=-2
+#line 40 "sample/hash_of_map_in_array_map.c"
+    r2 += IMMEDIATE(-2);
+    // EBPF_OP_LDDW pc=4 dst=r1 src=r0 offset=0 imm=0
+#line 41 "sample/hash_of_map_in_array_map.c"
+    r1 = POINTER(_maps[1].address);
+    // EBPF_OP_CALL pc=6 dst=r0 src=r0 offset=0 imm=1
+#line 41 "sample/hash_of_map_in_array_map.c"
+    r0 = lookup_helpers[0].address
+#line 41 "sample/hash_of_map_in_array_map.c"
+         (r1, r2, r3, r4, r5);
+#line 41 "sample/hash_of_map_in_array_map.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 41 "sample/hash_of_map_in_array_map.c"
+        return 0;
+    // EBPF_OP_JEQ_IMM pc=7 dst=r0 src=r0 offset=9 imm=0
+#line 42 "sample/hash_of_map_in_array_map.c"
+    if (r0 == IMMEDIATE(0))
+#line 42 "sample/hash_of_map_in_array_map.c"
+        goto label_2;
+    // EBPF_OP_MOV64_IMM pc=8 dst=r6 src=r0 offset=0 imm=0
+#line 42 "sample/hash_of_map_in_array_map.c"
+    r6 = IMMEDIATE(0);
+    // EBPF_OP_STXW pc=9 dst=r10 src=r6 offset=-8 imm=0
+#line 43 "sample/hash_of_map_in_array_map.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint32_t)r6;
+    // EBPF_OP_MOV64_REG pc=10 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/hash_of_map_in_array_map.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=11 dst=r2 src=r0 offset=0 imm=-8
+#line 43 "sample/hash_of_map_in_array_map.c"
+    r2 += IMMEDIATE(-8);
+    // EBPF_OP_MOV64_REG pc=12 dst=r1 src=r0 offset=0 imm=0
+#line 44 "sample/hash_of_map_in_array_map.c"
+    r1 = r0;
+    // EBPF_OP_CALL pc=13 dst=r0 src=r0 offset=0 imm=1
+#line 44 "sample/hash_of_map_in_array_map.c"
+    r0 = lookup_helpers[0].address
+#line 44 "sample/hash_of_map_in_array_map.c"
+         (r1, r2, r3, r4, r5);
+#line 44 "sample/hash_of_map_in_array_map.c"
+    if ((lookup_helpers[0].tail_call) && (r0 == 0))
+#line 44 "sample/hash_of_map_in_array_map.c"
+        return 0;
+    // EBPF_OP_JNE_IMM pc=14 dst=r0 src=r0 offset=1 imm=0
+#line 45 "sample/hash_of_map_in_array_map.c"
+    if (r0 != IMMEDIATE(0))
+#line 45 "sample/hash_of_map_in_array_map.c"
+        goto label_1;
+    // EBPF_OP_JA pc=15 dst=r0 src=r0 offset=1 imm=0
+#line 45 "sample/hash_of_map_in_array_map.c"
+    goto label_2;
+label_1:
+    // EBPF_OP_LDXW pc=16 dst=r6 src=r0 offset=0 imm=0
+#line 46 "sample/hash_of_map_in_array_map.c"
+    r6 = *(uint32_t*)(uintptr_t)(r0 + OFFSET(0));
+label_2:
+    // EBPF_OP_MOV64_REG pc=17 dst=r0 src=r6 offset=0 imm=0
+#line 50 "sample/hash_of_map_in_array_map.c"
+    r0 = r6;
+    // EBPF_OP_EXIT pc=18 dst=r0 src=r0 offset=0 imm=0
+#line 50 "sample/hash_of_map_in_array_map.c"
+    return r0;
+#line 50 "sample/hash_of_map_in_array_map.c"
+}
+#pragma code_seg(pop)
+#line __LINE__ __FILE__
+
+#pragma data_seg(push, "programs")
+static program_entry_t _programs[] = {
+    {
+        0,
+        lookup,
+        "xdp_prog",
+        "xdp_prog",
+        "lookup",
+        lookup_maps,
+        1,
+        lookup_helpers,
+        1,
+        19,
+        &lookup_program_type_guid,
+        &lookup_attach_type_guid,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_programs(_Outptr_result_buffer_(*count) program_entry_t** programs, _Out_ size_t* count)
+{
+    *programs = _programs;
+    *count = 1;
+}
+
+static void
+_get_version(_Out_ bpf2c_version_t* version)
+{
+    version->major = 0;
+    version->minor = 11;
+    version->revision = 0;
+}
+
+#pragma data_seg(push, "map_initial_values")
+static const char* _outer_map_initial_string_table[] = {
+    "inner_map",
+};
+
+static map_initial_values_t _map_initial_values_array[] = {
+    {
+        .name = "outer_map",
+        .count = 1,
+        .values = _outer_map_initial_string_table,
+    },
+};
+#pragma data_seg(pop)
+
+static void
+_get_map_initial_values(_Outptr_result_buffer_(*count) map_initial_values_t** map_initial_values, _Out_ size_t* count)
+{
+    *map_initial_values = _map_initial_values_array;
+    *count = 1;
+}
+
+metadata_table_t hash_of_map_in_array_map_metadata_table = {
+    sizeof(metadata_table_t), _get_programs, _get_maps, _get_hash, _get_version, _get_map_initial_values};

--- a/tests/sample/hash_of_map_in_array_map.c
+++ b/tests/sample/hash_of_map_in_array_map.c
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// Whenever this sample program changes, bpf2c_tests will fail unless the
+// expected files in tests\bpf2c_tests\expected are updated. The following
+// script can be used to regenerate the expected files:
+//     generate_expected_bpf2c_output.ps1
+//
+// Usage:
+// .\scripts\generate_expected_bpf2c_output.ps1 <build_output_path>
+// Example:
+// .\scripts\generate_expected_bpf2c_output.ps1 .\x64\Debug\
+
+#include "bpf_helpers.h"
+
+#define LB_MAGLEV_MAP_MAX_ENTRIES 65536
+
+struct
+{
+    __uint(type, BPF_MAP_TYPE_ARRAY);
+    __uint(key_size, sizeof(uint32_t));
+    __uint(value_size, sizeof(uint32_t));
+    __uint(max_entries, 1);
+} inner_map SEC(".maps");
+
+struct
+{
+    __uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
+    __type(key, uint16_t);
+    __type(value, uint32_t);
+    __uint(max_entries, LB_MAGLEV_MAP_MAX_ENTRIES);
+    /* Maglev inner map definition */
+    __array(values, inner_map);
+} outer_map SEC(".maps") = {
+    .values = {&inner_map},
+};
+
+SEC("xdp_prog") int lookup(struct xdp_md* ctx)
+{
+    uint16_t outer_key = 0;
+    void* maglev_inner_map = bpf_map_lookup_elem(&outer_map, &outer_key);
+    if (maglev_inner_map) {
+        uint32_t magler_inner_key = 0;
+        uint32_t* value = (uint32_t*)bpf_map_lookup_elem(maglev_inner_map, &magler_inner_key);
+        if (value) {
+            return *(uint32_t*)value;
+        }
+    }
+    return 0;
+}

--- a/tests/sample/hash_of_map_in_array_map.c
+++ b/tests/sample/hash_of_map_in_array_map.c
@@ -13,7 +13,7 @@
 
 #include "bpf_helpers.h"
 
-#define LB_MAGLEV_MAP_MAX_ENTRIES 65536
+#define LB_MAP_MAX_ENTRIES 65536
 
 struct
 {
@@ -28,8 +28,8 @@ struct
     __uint(type, BPF_MAP_TYPE_HASH_OF_MAPS);
     __type(key, uint16_t);
     __type(value, uint32_t);
-    __uint(max_entries, LB_MAGLEV_MAP_MAX_ENTRIES);
-    /* Maglev inner map definition */
+    __uint(max_entries, LB_MAP_MAX_ENTRIES);
+    /* Inner map definition */
     __array(values, inner_map);
 } outer_map SEC(".maps") = {
     .values = {&inner_map},
@@ -38,10 +38,10 @@ struct
 SEC("xdp_prog") int lookup(struct xdp_md* ctx)
 {
     uint16_t outer_key = 0;
-    void* maglev_inner_map = bpf_map_lookup_elem(&outer_map, &outer_key);
-    if (maglev_inner_map) {
-        uint32_t magler_inner_key = 0;
-        uint32_t* value = (uint32_t*)bpf_map_lookup_elem(maglev_inner_map, &magler_inner_key);
+    void* inner_map = bpf_map_lookup_elem(&outer_map, &outer_key);
+    if (inner_map) {
+        uint32_t inner_key = 0;
+        uint32_t* value = (uint32_t*)bpf_map_lookup_elem(inner_map, &inner_key);
         if (value) {
             return *(uint32_t*)value;
         }

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -1662,7 +1662,8 @@ TEST_CASE("simple hash of maps", "[libbpf]") { _ebpf_test_map_in_map(BPF_MAP_TYP
 
 // Verify an app can communicate with an eBPF program via an array of maps.
 static void
-_array_of_maps_test(ebpf_execution_type_t execution_type, _In_ PCSTR dll_name, _In_ PCSTR obj_name)
+_array_of_maps_test(
+    ebpf_execution_type_t execution_type, ebpf_map_type_t inner_map_type, _In_ PCSTR dll_name, _In_ PCSTR obj_name)
 {
     _test_helper_end_to_end test_helper;
     test_helper.initialize();
@@ -1688,7 +1689,7 @@ _array_of_maps_test(ebpf_execution_type_t execution_type, _In_ PCSTR dll_name, _
     REQUIRE(outer_map_fd > 0);
 
     // Create an inner map.
-    int inner_map_fd = bpf_map_create(BPF_MAP_TYPE_HASH, nullptr, sizeof(__u32), sizeof(__u32), 1, nullptr);
+    int inner_map_fd = bpf_map_create(inner_map_type, nullptr, sizeof(__u32), sizeof(__u32), 1, nullptr);
     REQUIRE(inner_map_fd > 0);
 
     // Add a value to the inner map.
@@ -1724,16 +1725,26 @@ _array_of_maps_test(ebpf_execution_type_t execution_type, _In_ PCSTR dll_name, _
 static void
 _array_of_btf_maps_test(ebpf_execution_type_t execution_type)
 {
-    _array_of_maps_test(execution_type, "map_in_map_btf_um.dll", "map_in_map_btf.o");
+    _array_of_maps_test(execution_type, BPF_MAP_TYPE_HASH, "map_in_map_btf_um.dll", "map_in_map_btf.o");
 }
 
 DECLARE_JIT_TEST_CASES("array of btf maps", "[libbpf]", _array_of_btf_maps_test);
+
+// Create a map-in-map with outer map of hash_of_maps and inner map of array.
+static void
+_array_of_hash_maps_test(ebpf_execution_type_t execution_type)
+{
+    _array_of_maps_test(
+        execution_type, BPF_MAP_TYPE_ARRAY, "hash_of_map_in_array_map_um.dll", "hash_of_map_in_array_map.o");
+}
+
+DECLARE_JIT_TEST_CASES("array of hash maps", "[libbpf]", _array_of_hash_maps_test);
 
 // Create a map-in-map using id and inner_id.
 static void
 _array_of_id_maps_test(ebpf_execution_type_t execution_type)
 {
-    _array_of_maps_test(execution_type, "map_in_map_legacy_id_um.dll", "map_in_map_legacy_id.o");
+    _array_of_maps_test(execution_type, BPF_MAP_TYPE_HASH, "map_in_map_legacy_id_um.dll", "map_in_map_legacy_id.o");
 }
 
 DECLARE_JIT_TEST_CASES("array of id maps", "[libbpf]", _array_of_id_maps_test);
@@ -1742,7 +1753,7 @@ DECLARE_JIT_TEST_CASES("array of id maps", "[libbpf]", _array_of_id_maps_test);
 static void
 _array_of_idx_maps_test(ebpf_execution_type_t execution_type)
 {
-    _array_of_maps_test(execution_type, "map_in_map_legacy_idx_um.dll", "map_in_map_legacy_idx.o");
+    _array_of_maps_test(execution_type, BPF_MAP_TYPE_HASH, "map_in_map_legacy_idx_um.dll", "map_in_map_legacy_idx.o");
 }
 
 DECLARE_JIT_TEST_CASES("array of idx maps", "[libbpf]", _array_of_idx_maps_test);


### PR DESCRIPTION
## Description

1. In ebpf_native.c : Check map-in-map is Hash of Maps with integer as key_size. If true, allow initialization.
2. Added test cases in libbpf_tests.cpp.

## Testing

_Do any existing tests cover this change? No
Are new tests needed? Yes

Manual test:
```
PS C:\Temp> netsh ebpf add program .\hash_of_map_in_array_map.sys
Loaded with ID 196609

PS C:\Temp> dir .\hash_of_map_in_array_map.sys


    Directory: C:\Temp


Mode                LastWriteTime         Length Name
----                -------------         ------ ----
-a----        10/5/2023   9:09 AM          11664 hash_of_map_in_array_map.sys


PS C:\Temp> netsh ebpf show programs

    ID  Pins  Links  Mode       Type           Name
======  ====  =====  =========  =============  ====================
196609     1      1  NATIVE     xdp            lookup

PS C:\Temp> netsh ebpf show maps

                              Key  Value      Max  Inner
     ID            Map Type  Size   Size  Entries     ID  Pins  Name
=======  ==================  ====  =====  =======  =====  ====  ========
 131073        hash_of_maps     2      4    65536  65537     0  outer_map

PS C:\Temp>
```
## Documentation

_Is there any documentation impact for this change? No

## Installation

_Is there any installer impact for this change? No
