### PR TITLE
Mitigate dump upload timing out.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -508,9 +508,9 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: km_mt_stress_tests_restart_extension
-      pre_test: .\setup_ebpf_cicd_stress_tests.ps1
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
-      post_test: .\cleanup_ebpf_cicd_tests.ps1
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       build_artifact: Build-x64
       environment: ebpf_cicd_tests_ws2019
       code_coverage: false

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,7 +51,7 @@ jobs:
       build_msi: true
       build_nuget: true
       build_options: /p:ReleaseJIT='True'
-      configurations: '["Debug", "FuzzerDebug", "Release"]'
+      configurations: '["Debug"]' #', "FuzzerDebug", "Release"]'
 
   # Perform the native-only build.
   regular_native-only:
@@ -504,7 +504,7 @@ jobs:
   # against the kernel mode eBPF sub-system.
   km_mt_stress_tests_restart_extension:
     needs: regular
-    if: github.event_name == 'schedule'
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: km_mt_stress_tests_restart_extension
@@ -516,6 +516,7 @@ jobs:
       code_coverage: false
       # For this test, we only want kernel mode dumps and not user mode dumps.
       gather_dumps: false
+      configurations: '["Debug"]'
 
   performance:
     needs: regular

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -51,466 +51,466 @@ jobs:
       build_msi: true
       build_nuget: true
       build_options: /p:ReleaseJIT='True'
-      configurations: '["Debug"]' #', "FuzzerDebug", "Release"]'
+      configurations: '["Debug"]' #, "FuzzerDebug", "Release"]'
 
-  # Perform the native-only build.
-  regular_native-only:
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-native-only
-      build_msi: true
-      build_nuget: true
-      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
+  # # Perform the native-only build.
+  # regular_native-only:
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     build_artifact: Build-x64-native-only
+  #     build_msi: true
+  #     build_nuget: true
+  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
-  # Run the unit tests in GitHub.
-  unit_tests:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
+  # # Run the unit tests in GitHub.
+  # unit_tests:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
 
-  # Run the netebpfext unit tests in GitHub.
-  netebpf_ext_unit_tests:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpf_ext_unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      test_command: .\netebpfext_unit.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
+  # # Run the netebpfext unit tests in GitHub.
+  # netebpf_ext_unit_tests:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: netebpf_ext_unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     test_command: .\netebpfext_unit.exe -d yes
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
 
-  # Run the bpf2c tests in GitHub.
-  bpf2c:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      test_command: .\bpf2c_tests.exe -d yes
-      name: bpf2c
-      build_artifact: Build-x64
-      environment: windows-2022
-      vs_dev: true
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
+  # # Run the bpf2c tests in GitHub.
+  # bpf2c:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     test_command: .\bpf2c_tests.exe -d yes
+  #     name: bpf2c
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     vs_dev: true
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
 
-  # Run the bpf2c conformance tests in GitHub.
-  bpf2c_conformance:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
-      name: bpf2c_conformance
-      build_artifact: Build-x64
-      environment: windows-2022
-      vs_dev: true
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
+  # # Run the bpf2c conformance tests in GitHub.
+  # bpf2c_conformance:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+  #     test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+  #     name: bpf2c_conformance
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     vs_dev: true
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
 
-  # Run the driver tests on self-hosted runners.
-  driver_ws2019:
-    # Always run this job.
-    # Only run this on repos that have self-host runners.
-    needs: regular
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      name: driver_ws2019
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      # driver test copies dumps to testlog folder.
-      gather_dumps: false
-      # driver tests manually gather code coverage
-      code_coverage: false
+  # # Run the driver tests on self-hosted runners.
+  # driver_ws2019:
+  #   # Always run this job.
+  #   # Only run this on repos that have self-host runners.
+  #   needs: regular
+  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1
+  #     name: driver_ws2019
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_tests_ws2019
+  #     # driver test copies dumps to testlog folder.
+  #     gather_dumps: false
+  #     # driver tests manually gather code coverage
+  #     code_coverage: false
 
-  # Run the driver tests on self-hosted runners.
-  driver_ws2022:
-    # Always run this job.
-    # Only run this on repos that have self-host runners.
-    needs: regular
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      name: driver_ws2022
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2022
-      # driver test copies dumps to testlog folder.
-      gather_dumps: false
-      # driver tests manually gather code coverage
-      code_coverage: false
+  # # Run the driver tests on self-hosted runners.
+  # driver_ws2022:
+  #   # Always run this job.
+  #   # Only run this on repos that have self-host runners.
+  #   needs: regular
+  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1
+  #     name: driver_ws2022
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_tests_ws2022
+  #     # driver test copies dumps to testlog folder.
+  #     gather_dumps: false
+  #     # driver tests manually gather code coverage
+  #     code_coverage: false
 
-  # Run the native-only driver tests on self-hosted runners.
-  driver_native_only_ws2019:
-    # Always run this job.
-    # Only run this on repos that have self-host runners.
-    needs: regular_native-only
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      name: driver_native_only_ws2019
-      build_artifact: Build-x64-native-only
-      environment: ebpf_cicd_tests_ws2019
-      # driver test copies dumps to testlog folder.
-      gather_dumps: false
-      # driver tests manually gather code coverage
-      code_coverage: false
-      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
+  # # Run the native-only driver tests on self-hosted runners.
+  # driver_native_only_ws2019:
+  #   # Always run this job.
+  #   # Only run this on repos that have self-host runners.
+  #   needs: regular_native-only
+  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1
+  #     name: driver_native_only_ws2019
+  #     build_artifact: Build-x64-native-only
+  #     environment: ebpf_cicd_tests_ws2019
+  #     # driver test copies dumps to testlog folder.
+  #     gather_dumps: false
+  #     # driver tests manually gather code coverage
+  #     code_coverage: false
+  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
-  driver_native_only_ws2022:
-    # Always run this job.
-    # Only run this on repos that have self-host runners.
-    needs: regular_native-only
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      name: driver_native_only_ws2022
-      build_artifact: Build-x64-native-only
-      environment: ebpf_cicd_tests_ws2022
-      # driver test copies dumps to testlog folder.
-      gather_dumps: false
-      # driver tests manually gather code coverage
-      code_coverage: false
-      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
+  # driver_native_only_ws2022:
+  #   # Always run this job.
+  #   # Only run this on repos that have self-host runners.
+  #   needs: regular_native-only
+  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group')
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1
+  #     name: driver_native_only_ws2022
+  #     build_artifact: Build-x64-native-only
+  #     environment: ebpf_cicd_tests_ws2022
+  #     # driver test copies dumps to testlog folder.
+  #     gather_dumps: false
+  #     # driver tests manually gather code coverage
+  #     code_coverage: false
+  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
-  ossar:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/ossar-scan.yml
-    with:
-      build_artifact: Build-x64
+  # ossar:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/ossar-scan.yml
+  #   with:
+  #     build_artifact: Build-x64
 
-  # Additional jobs to run on pull and schedule only (skip push).
-  # ---------------------------------------------------------------------------
-  # Build with C++ static analyzer.
-  analyze:
-    # Only run on schedule and pull request.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-Analyze
-      # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
-      build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
+  # # Additional jobs to run on pull and schedule only (skip push).
+  # # ---------------------------------------------------------------------------
+  # # Build with C++ static analyzer.
+  # analyze:
+  #   # Only run on schedule and pull request.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     build_artifact: Build-x64-Analyze
+  #     # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
+  #     build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
 
-  # Build with C++ address sanitizer.
-  sanitize:
-    # Only run on schedule and pull request.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-Sanitize
-      build_options: /p:AddressSanitizer='True'
+  # # Build with C++ address sanitizer.
+  # sanitize:
+  #   # Only run on schedule and pull request.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     build_artifact: Build-x64-Sanitize
+  #     build_options: /p:AddressSanitizer='True'
 
-  bpf2c_fuzzer:
-    needs: regular
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: bpf2c_fuzzer
-      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
+  # bpf2c_fuzzer:
+  #   needs: regular
+  #   if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: bpf2c_fuzzer
+  #     test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
 
-  bpf2c_fuzzer_scheduled:
-    needs: regular
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: bpf2c_fuzzer
-      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
+  # bpf2c_fuzzer_scheduled:
+  #   needs: regular
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: bpf2c_fuzzer
+  #     test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
 
-  execution_context_fuzzer:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: execution_context_fuzzer
-      test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
+  # execution_context_fuzzer:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: execution_context_fuzzer
+  #     test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
 
-  # Run the verifier fuzzer.
-  verifier_fuzzer:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: verifier_fuzzer
-      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
+  # # Run the verifier fuzzer.
+  # verifier_fuzzer:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: verifier_fuzzer
+  #     test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
 
-  verifier_fuzzer_scheduled:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: verifier_fuzzer
-      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
+  # verifier_fuzzer_scheduled:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: verifier_fuzzer
+  #     test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
 
-  core_helper_fuzzer:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: core_helper_fuzzer
-      test_command: .\core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
+  # core_helper_fuzzer:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: core_helper_fuzzer
+  #     test_command: .\core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
 
-  netebpfext_fuzzer:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpfext_fuzzer
-      test_command: .\netebpfext_fuzzer netebpfext_corpus -max_len=12 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
+  # netebpfext_fuzzer:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: netebpfext_fuzzer
+  #     test_command: .\netebpfext_fuzzer netebpfext_corpus -max_len=12 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
 
-  # Run Cilium regression tests in GitHub.
-  cilium_tests:
-    needs: regular
-    # Only run on schedule and pull request.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: cilium_tests
-      test_command: .\cilium_tests.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
+  # # Run Cilium regression tests in GitHub.
+  # cilium_tests:
+  #   needs: regular
+  #   # Only run on schedule and pull request.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: cilium_tests
+  #     test_command: .\cilium_tests.exe -d yes
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
 
-  # Run the quick stress tests in GitHub.
-  stress:
-    needs: regular
-    # Only run on schedule and pull request.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: stress
-      # Until there is a dedicated stress test, re-use the perf test.
-      test_command: .\ebpf_performance.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      # No code coverage on stress.
-      code_coverage: false
-      gather_dumps: true
+  # # Run the quick stress tests in GitHub.
+  # stress:
+  #   needs: regular
+  #   # Only run on schedule and pull request.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: stress
+  #     # Until there is a dedicated stress test, re-use the perf test.
+  #     test_command: .\ebpf_performance.exe -d yes
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     # No code coverage on stress.
+  #     code_coverage: false
+  #     gather_dumps: true
 
-  # Run the unit tests in GitHub with address sanitizer.
-  sanitize_unit_tests:
-    needs: sanitize
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      # Exclude [processes] test that ASAN can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64-Sanitize
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      capture_etw: true
+  # # Run the unit tests in GitHub with address sanitizer.
+  # sanitize_unit_tests:
+  #   needs: sanitize
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     # Exclude [processes] test that ASAN can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64-Sanitize
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     capture_etw: true
 
-  # Run the fault injection simulator in GitHub.
-  fault_injection:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: fault_injection
-      test_command: .\unit_tests.exe
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      fault_injection: true
-      leak_detection: true
+  # # Run the fault injection simulator in GitHub.
+  # fault_injection:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: fault_injection
+  #     test_command: .\unit_tests.exe
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     fault_injection: true
+  #     leak_detection: true
 
-  # Run the low memory simulator for netebpfext_unit tests.
-  fault_injection_netebpfext_unit:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpfext_fault_injection
-      test_command: .\netebpfext_unit.exe
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      fault_injection: true
-      leak_detection: true
+  # # Run the low memory simulator for netebpfext_unit tests.
+  # fault_injection_netebpfext_unit:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: netebpfext_fault_injection
+  #     test_command: .\netebpfext_unit.exe
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     fault_injection: true
+  #     leak_detection: true
 
-  # Run a fast multi-threaded stress test pass against the usersim user-mode 'mock' framework.
-  # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
-  quick_user_mode_multi_threaded_stress_test:
-    needs: regular
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: quick_user_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_um -tt=8 -td=2
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      leak_detection: false
-      gather_dumps: true
-      capture_etw: true
+  # # Run a fast multi-threaded stress test pass against the usersim user-mode 'mock' framework.
+  # # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
+  # quick_user_mode_multi_threaded_stress_test:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: quick_user_mode_multi_threaded_stress
+  #     test_command: .\ebpf_stress_tests_um -tt=8 -td=2
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     leak_detection: false
+  #     gather_dumps: true
+  #     capture_etw: true
 
-  # Additional jobs to run on a schedule only (skip push and pull request).
-  # ---------------------------------------------------------------------------
-  codeql:
-    # Only run during daily scheduled run
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-CodeQl
-      build_codeql: true
+  # # Additional jobs to run on a schedule only (skip push and pull request).
+  # # ---------------------------------------------------------------------------
+  # codeql:
+  #   # Only run during daily scheduled run
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     build_artifact: Build-x64-CodeQl
+  #     build_codeql: true
 
 
-  # Run the complete fault injection simulator in GitHub.
-  # Runs on a schedule as this takes a long time to run.
-  fault_injection_full:
-    needs: regular
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: fault_injection_full
-      test_command: .\unit_tests.exe
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      fault_injection: true
-      leak_detection: true
+  # # Run the complete fault injection simulator in GitHub.
+  # # Runs on a schedule as this takes a long time to run.
+  # fault_injection_full:
+  #   needs: regular
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: fault_injection_full
+  #     test_command: .\unit_tests.exe
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     fault_injection: true
+  #     leak_detection: true
 
-  # Run the complete fault injection simulator for netebpfext in GitHub.
-  # Runs on a schedule as this takes a long time to run.
-  netebpfext_fault_injection_full:
-    needs: regular
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpfext_fault_injection_full
-      test_command: .\netebpfext_unit.exe
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      fault_injection: true
+  # # Run the complete fault injection simulator for netebpfext in GitHub.
+  # # Runs on a schedule as this takes a long time to run.
+  # netebpfext_fault_injection_full:
+  #   needs: regular
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: netebpfext_fault_injection_full
+  #     test_command: .\netebpfext_unit.exe
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     fault_injection: true
 
-  # Run multi-threaded stress tests against the user mode 'mock' framework.
-  user_mode_multi_threaded_stress_test:
-    needs: regular
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: user_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_um -tt=8 -td=10
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      leak_detection: false
-      gather_dumps: true
-      capture_etw: true
+  # # Run multi-threaded stress tests against the user mode 'mock' framework.
+  # user_mode_multi_threaded_stress_test:
+  #   needs: regular
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: user_mode_multi_threaded_stress
+  #     test_command: .\ebpf_stress_tests_um -tt=8 -td=10
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     leak_detection: false
+  #     gather_dumps: true
+  #     capture_etw: true
 
-  # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
-  # against the kernel mode eBPF sub-system.
-  km_mt_stress_tests:
-    needs: regular
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_mt_stress_tests
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      code_coverage: false
-      # For this test, we only want kernel mode dumps and not user mode dumps.
-      gather_dumps: false
+  # # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
+  # # against the kernel mode eBPF sub-system.
+  # km_mt_stress_tests:
+  #   needs: regular
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: km_mt_stress_tests
+  #     pre_test: .\setup_ebpf_cicd_stress_tests.ps1
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_tests_ws2019
+  #     code_coverage: false
+  #     # For this test, we only want kernel mode dumps and not user mode dumps.
+  #     gather_dumps: false
 
   # Run multi-threaded stress tests with 'restart extension' enabled
   # against the kernel mode eBPF sub-system.
   km_mt_stress_tests_restart_extension:
     needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push'
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: km_mt_stress_tests_restart_extension
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+      pre_test: .\setup_ebpf_cicd_stress_tests.ps1
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      post_test: .\cleanup_ebpf_cicd_tests.ps1
       build_artifact: Build-x64
       environment: ebpf_cicd_tests_ws2019
       code_coverage: false
@@ -518,40 +518,40 @@ jobs:
       gather_dumps: false
       configurations: '["Debug"]'
 
-  performance:
-    needs: regular
-    if: github.event_name == 'schedule'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_performance
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_perf_ws2022
-      configurations: '["Release"]'
+  # performance:
+  #   needs: regular
+  #   if: github.event_name == 'schedule'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: km_performance
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_perf_ws2022
+  #     configurations: '["Release"]'
 
-  performance_with_profile:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_performance
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance" -Options @("CaptureProfile")
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      configurations: '["Release"]'
-      environment: ebpf_cicd_perf_ws2022
+  # performance_with_profile:
+  #   needs: regular
+  #   if: github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: km_performance
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance" -Options @("CaptureProfile")
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1
+  #     build_artifact: Build-x64
+  #     configurations: '["Release"]'
+  #     environment: ebpf_cicd_perf_ws2022
 
-  upload_perf_results:
-    needs: performance
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
-    uses: ./.github/workflows/upload-perf-results.yml
-    with:
-      name: upload_perf_results
-      result_artifact: km_performance-x64-Release
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  # upload_perf_results:
+  #   needs: performance
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+  #   uses: ./.github/workflows/upload-perf-results.yml
+  #   with:
+  #     name: upload_perf_results
+  #     result_artifact: km_performance-x64-Release
+  #   secrets:
+  #     AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  #     AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  #     AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/ossar-scan.yml
+++ b/.github/workflows/ossar-scan.yml
@@ -50,7 +50,7 @@ jobs:
 
     - name: Download build artifact
       if: (steps.skip_check.outputs.should_skip != 'true') && success()
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      uses: actions/download-artifact@88dadfbcfcdd10293192ac8ee1e3ffe61f7055ee
       id: download_artifact
       with:
         name: ${{inputs.build_artifact}}-${{matrix.configurations}}

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -233,7 +233,7 @@ jobs:
 
     - name: Upload Build Output
       if: always() && (steps.skip_check.outputs.should_skip != 'true')
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@aa5cae10db2b39d79f5244f6bc5084278993a3ae
       with:
         name: ${{inputs.build_artifact}}-${{matrix.configurations}}
         path: ${{github.workspace}}/build-${{ matrix.configurations }}.zip
@@ -241,7 +241,7 @@ jobs:
 
     - name: Upload the MSI package
       if: inputs.build_msi == true
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@aa5cae10db2b39d79f5244f6bc5084278993a3ae
       with:
         name: ebpf-for-windows - MSI installer (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/ebpf-for-windows.msi
@@ -253,7 +253,7 @@ jobs:
 
     - name: Upload the NuGet package
       if: inputs.build_nuget == true && matrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@aa5cae10db2b39d79f5244f6bc5084278993a3ae
       with:
         name: ebpf-for-windows - NuGet package (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/eBPF-for-Windows.*.nupkg
@@ -265,7 +265,7 @@ jobs:
 
     - name: Upload the NuGet Redist package
       if: inputs.build_nuget == true && matrix.configurations == 'Release' && steps.skip_check.outputs.should_skip != 'true'
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@aa5cae10db2b39d79f5244f6bc5084278993a3ae
       with:
         name: ebpf-for-windows - NuGet Redist package (${{inputs.build_artifact}}_${{env.BUILD_CONFIGURATION}})
         path: ${{github.workspace}}/${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}/eBPF-for-Windows-Redist.*.nupkg
@@ -281,7 +281,7 @@ jobs:
     - name: Upload any crash dumps
       # Upload crash dumps even if the workflow failed.
       if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_dumps.outputs.files_exists == 'true')
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@aa5cae10db2b39d79f5244f6bc5084278993a3ae
       id: upload_crash_dumps
       with:
         name: Crash-Dumps-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -136,7 +136,7 @@ jobs:
 
     - name: Download build artifact
       if: (steps.skip_check.outputs.should_skip != 'true') && success()
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      uses: actions/download-artifact@88dadfbcfcdd10293192ac8ee1e3ffe61f7055ee
       id: download_artifact
       with:
         name: ${{inputs.build_artifact}}-${{matrix.configurations}}
@@ -347,7 +347,7 @@ jobs:
     - name: Upload any crash dumps
       # Upload crash dumps even if the workflow failed.
       if: always() && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_dumps.outputs.files_exists == 'true') && (inputs.gather_dumps == true)
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@aa5cae10db2b39d79f5244f6bc5084278993a3ae
       id: upload_crash_dumps
       with:
         name: Crash-Dumps-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
@@ -366,7 +366,7 @@ jobs:
       # Upload test logs even if the workflow failed.
       if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_logs.outputs.files_exists == 'true')
       id: upload_logs
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@aa5cae10db2b39d79f5244f6bc5084278993a3ae
       continue-on-error: true
       with:
         name: Test-Logs-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
@@ -386,7 +386,7 @@ jobs:
       if: (success() || failure()) && (steps.skip_check.outputs.should_skip != 'true') && (steps.check_artifacts.outputs.files_exists == 'true')
       id: upload_artifacts
       continue-on-error: true
-      uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32
+      uses: actions/upload-artifact@aa5cae10db2b39d79f5244f6bc5084278993a3ae
       with:
         name: Artifacts-${{env.NAME}}-${{env.BUILD_PLATFORM}}-${{env.BUILD_CONFIGURATION}}
         path: ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\Artifacts

--- a/.github/workflows/upload-perf-results.yml
+++ b/.github/workflows/upload-perf-results.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Download performance result artifacts
-      uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+      uses: actions/download-artifact@88dadfbcfcdd10293192ac8ee1e3ffe61f7055ee
       with:
         name: Test-Logs-${{inputs.result_artifact}}
         path: ${{github.workspace}}/results_artifact

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -240,9 +240,10 @@ function Import-ResultsFromVM
             if (!(Test-Path "$Env:SystemDrive\KernelDumps")) {
                 New-Item -ItemType Directory -Path "$Env:SystemDrive\KernelDumps"
             }
-            tar czf $Env:SystemDrive\KernelDumps\km_dumps.zip -C $Env:WinDir *.dmp
-            #Move-Item $Env:WinDir\*.dmp $Env:SystemDrive\KernelDumps -ErrorAction Ignore
-
+            if (Test-Path $Env:WinDir\*.dmp -PathType Leaf) {
+                tar czf $Env:SystemDrive\KernelDumps\km_dumps.tgz -C $Env:WinDir *.dmp
+                Remove-Item -Path $Env:WinDir\*.dmp
+            }
         }
         Copy-Item -FromSession $VMSession "$VMSystemDrive\KernelDumps" -Destination ".\TestLogs\$VMName" -Recurse -Force -ErrorAction Ignore 2>&1 | Write-Log
 

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -240,7 +240,9 @@ function Import-ResultsFromVM
             if (!(Test-Path "$Env:SystemDrive\KernelDumps")) {
                 New-Item -ItemType Directory -Path "$Env:SystemDrive\KernelDumps"
             }
-            Move-Item $Env:WinDir\*.dmp $Env:SystemDrive\KernelDumps -ErrorAction Ignore
+            tar czf $Env:SystemDrive\KernelDumps\km_dumps.zip -C $Env:WinDir *.dmp
+            #Move-Item $Env:WinDir\*.dmp $Env:SystemDrive\KernelDumps -ErrorAction Ignore
+
         }
         Copy-Item -FromSession $VMSession "$VMSystemDrive\KernelDumps" -Destination ".\TestLogs\$VMName" -Recurse -Force -ErrorAction Ignore 2>&1 | Write-Log
 

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -264,6 +264,7 @@ function Invoke-CICDStressTests
         .\ebpf_stress_tests_km -tt=8 -td=5
     } else {
         write-host "Test command-line: .\ebpf_stress_tests_km -tt=8 -td=5 -erd=1000 -er=1"
+        .\ebpf_stress_tests_km bindmonitor_tail_call_invoke_program_test -tt=8 -td=10 -erd=1000 -er=1
         .\ebpf_stress_tests_km -tt=8 -td=5 -erd=1000 -er=1
     }
 


### PR DESCRIPTION
## Description

Fixes #2948 

Use V4 Beta of `actions/upload-artifact` and `@actions/download-artifact` to mitigate the consistent timeouts during KM dump upload from some of our self-hosted runners.

Host `TK5-3WP07R0703` has abnormally slow upload speed, which causes crash dumps to fail to upload. 
A combination of 2 changes is needed to address that: 
- upgrading to a more robust, pre-release version of the upload action (download version needs to match it) 
- compressing the dump before upload (600MB -> 70MB).

Separately, I'm investigating why this very powerful machine is struggling with upload, while download works fine.
For reference, the old, small hosts take ~90s to upload the 600MB KM dump, while this one times out after 35mins.

## Testing

Modified the km_stress job to run on PR as a one-off, and observed the dump was successfully uploaded:
https://github.com/microsoft/ebpf-for-windows/actions/runs/6616799258/job/17972459737?pr=2978

![image](https://github.com/microsoft/ebpf-for-windows/assets/12816515/7c1ebd30-663a-4407-8779-0e0eac6afaf4)

