### PR TITLE
Remove debug fprintf calls

### DIFF
--- a/tests/libs/util/wer_report.hpp
+++ b/tests/libs/util/wer_report.hpp
@@ -136,7 +136,6 @@ class _wer_report
         HRESULT hr;
         hr = WerReportCreate(wer_event_type, WerReportApplicationCrash, nullptr, &report_handle);
         if (FAILED(hr)) {
-            fprintf(stderr, "WerReportCreate failed with error %X\n", hr);
             return EXCEPTION_CONTINUE_SEARCH;
         }
         hr = WerReportAddDump(
@@ -148,16 +147,13 @@ class _wer_report
             nullptr,
             0);
         if (FAILED(hr)) {
-            fprintf(stderr, "WerReportAddDump failed with error %X\n", hr);
             return EXCEPTION_CONTINUE_SEARCH;
         }
         hr = WerReportSubmit(report_handle, WerConsentApproved, 0, nullptr);
         if (FAILED(hr)) {
-            fprintf(stderr, "WerReportSubmit failed with error %X\n", hr);
             return EXCEPTION_CONTINUE_SEARCH;
         }
 
-        fprintf(stderr, "Generation of crash dump succeeded\n");
         return EXCEPTION_CONTINUE_SEARCH;
     }
     void* vectored_exception_handler_handle;


### PR DESCRIPTION
Resolves: #2660

## Description

Remove debug fprintf statements.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
