### PR TITLE
Raise IRQL to DISPATCH _after_ test_helper is successfully initialized.

### DIFF
--- a/libs/runtime/ebpf_async.c
+++ b/libs/runtime/ebpf_async.c
@@ -20,16 +20,12 @@ ebpf_async_initiate()
 {
     EBPF_LOG_ENTRY();
 
-#if 1
-    EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
-#else
     const ebpf_hash_table_creation_options_t options = {
         .key_size = sizeof(ebpf_handle_t),
         .value_size = sizeof(ebpf_async_tracker_t),
     };
 
     EBPF_RETURN_RESULT(ebpf_hash_table_create(&_ebpf_async_tracker_table, &options));
-#endif
 }
 
 void

--- a/libs/runtime/ebpf_async.c
+++ b/libs/runtime/ebpf_async.c
@@ -20,12 +20,16 @@ ebpf_async_initiate()
 {
     EBPF_LOG_ENTRY();
 
+#if 1
+    EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
+#else
     const ebpf_hash_table_creation_options_t options = {
         .key_size = sizeof(ebpf_handle_t),
         .value_size = sizeof(ebpf_async_tracker_t),
     };
 
     EBPF_RETURN_RESULT(ebpf_hash_table_create(&_ebpf_async_tracker_table, &options));
+#endif
 }
 
 void

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -308,6 +308,7 @@ Error:
         }
         cxplat_free(
             _ebpf_epoch_cpu_table, CXPLAT_POOL_FLAG_NON_PAGED | CXPLAT_POOL_FLAG_CACHE_ALIGNED, EBPF_POOL_TAG_EPOCH);
+        _ebpf_epoch_cpu_table = NULL;
     }
 
     EBPF_RETURN_RESULT(return_value);

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -1206,12 +1206,22 @@ has_dominant_frequency(size_t sequence_length, std::function<uint32_t()> random_
     return (std::abs(max_frequency) - average_frequency) > 10 * std_dev_frequency;
 }
 
+class _raise_irql_to_dpc_helper
+{
+  public:
+    _raise_irql_to_dpc_helper() { old_irql = KeRaiseIrqlToDpcLevel(); }
+    ~_raise_irql_to_dpc_helper() { KeLowerIrql(old_irql); }
+
+  private:
+    KIRQL old_irql{0};
+};
+
 TEST_CASE("verify random", "[platform]")
 {
-    KIRQL old_irql = KeRaiseIrqlToDpcLevel();
-
     _test_helper test_helper;
     test_helper.initialize();
+
+    _raise_irql_to_dpc_helper irql_helper;
 
     bool odd = false;
     std::function<uint32_t()> ebpf_random_uint32_biased = [&odd]() {
@@ -1254,8 +1264,6 @@ TEST_CASE("verify random", "[platform]")
         }
         std::cout << std::endl;
     }
-
-    KeLowerIrql(old_irql);
 }
 
 TEST_CASE("work_queue", "[platform]")


### PR DESCRIPTION
## Description

Fixes in this PR:
1. Raise IRQL _after_ `test_helper` initialization, so that its destructor is called at PASSIVE in we hit an error in `test_helper::initialize()`.
_(The `test_helper::~test_helper()` destructor calls `ebpf_flush_epoch()` that ends up blocking on a lock if called at DISPATCH.)_

2. Ensure that the `_ebpf_epoch_cpu_table` ptr is reset to NULL if `ebpf_epoch_initiate` frees that pointer in its error handling path.
_(Not doing so led to the 'use-after-free' crash seen in [this](https://github.com/microsoft/ebpf-for-windows/issues/2973#issuecomment-1759363487) comment, where the code path initiated by `ebpf_epoch_flush` ends up referencing this (now freed) pointer.)_

## Testing

_Do any existing tests cover this change? Are new tests needed?_
Issued exposed by existing test.  No new test needed.

Fix Verification:
Successful local run of:
`powershell.exe .\Test-FaultInjection.ps1 D:\wrk\ebpf-for-windows\x64\Debug 3600 .\unit_tests.exe 16`

## Documentation

_Is there any documentation impact for this change?_
No doc impact.

## Installation

_Is there any installer impact for this change?_
No installer impact.

Fixes #2973 
