### PR TITLE
Delay free of objects to epoch end

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -278,7 +278,7 @@ ebpf_link_create(
 
     // Note: This must be the last thing done in this function as it inserts the object into the global list.
     // After this point, the object can be accessed by other threads.
-    ebpf_result_t result = EBPF_OBJECT_INITIALIZE(&local_link->object, EBPF_OBJECT_LINK, _ebpf_link_free, NULL);
+    ebpf_result_t result = EBPF_OBJECT_INITIALIZE(&local_link->object, EBPF_OBJECT_LINK, _ebpf_link_free, NULL, NULL);
     if (result != EBPF_SUCCESS) {
         EBPF_LOG_MESSAGE_ERROR(
             EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_LINK, "ebpf_object_initialize failed for link", result);

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -801,9 +801,9 @@ _get_object_from_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_
         ebpf_object_type_t value_type =
             (map->ebpf_map_definition.type == BPF_MAP_TYPE_PROG_ARRAY) ? EBPF_OBJECT_PROGRAM : EBPF_OBJECT_MAP;
         if (id != 0) {
-            if (ebpf_object_pointer_by_id(id, value_type, &object) != EBPF_SUCCESS) {
-                object = NULL;
-            }
+            // Find the object by id.
+            // Ignore the returned status as the object may have been deleted.
+            (void)ebpf_object_pointer_by_id(id, value_type, &object);
         }
     }
 

--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -801,10 +801,9 @@ _get_object_from_array_map_entry(_Inout_ ebpf_core_map_t* map, _In_ const uint8_
         ebpf_object_type_t value_type =
             (map->ebpf_map_definition.type == BPF_MAP_TYPE_PROG_ARRAY) ? EBPF_OBJECT_PROGRAM : EBPF_OBJECT_MAP;
         if (id != 0) {
-
-            // Note that this call might fail and that's fine.  The id might be valid, but the object might have been
-            // since deleted.
-            (void)EBPF_OBJECT_REFERENCE_BY_ID(id, value_type, &object);
+            if (ebpf_object_pointer_by_id(id, value_type, &object) != EBPF_SUCCESS) {
+                object = NULL;
+            }
         }
     }
 
@@ -1274,7 +1273,9 @@ _get_object_from_hash_map_entry(_In_ ebpf_core_map_t* map, _In_ const uint8_t* k
     uint8_t* value = NULL;
     if (_find_hash_map_entry(map, key, false, &value) == EBPF_SUCCESS) {
         ebpf_id_t id = *(ebpf_id_t*)value;
-        (void)EBPF_OBJECT_REFERENCE_BY_ID(id, EBPF_OBJECT_MAP, &object);
+        if (ebpf_object_pointer_by_id(id, EBPF_OBJECT_MAP, &object) != EBPF_SUCCESS) {
+            object = NULL;
+        }
     }
 
     return object;
@@ -2151,7 +2152,7 @@ ebpf_map_create(
 
     const ebpf_map_metadata_table_t* table = &ebpf_map_metadata_tables[local_map->ebpf_map_definition.type];
     ebpf_object_get_program_type_t get_program_type = (table->get_object_from_entry) ? _get_map_program_type : NULL;
-    result = EBPF_OBJECT_INITIALIZE(&local_map->object, EBPF_OBJECT_MAP, _ebpf_map_delete, get_program_type);
+    result = EBPF_OBJECT_INITIALIZE(&local_map->object, EBPF_OBJECT_MAP, _ebpf_map_delete, NULL, get_program_type);
     if (result != EBPF_SUCCESS) {
         goto Exit;
     }
@@ -2218,11 +2219,7 @@ ebpf_map_find_entry(
         }
 
         ebpf_core_object_t* object = ebpf_map_metadata_tables[type].get_object_from_entry(map, key);
-
-        // Release the extra reference obtained.
-        // REVIEW: is this safe?
         if (object) {
-            EBPF_OBJECT_RELEASE_REFERENCE(object);
             return_value = (uint8_t*)object;
         }
     } else {

--- a/libs/runtime/ebpf_object.c
+++ b/libs/runtime/ebpf_object.c
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include "cxplat.h"
+#include "ebpf_epoch.h"
 #include "ebpf_handle.h"
 #include "ebpf_hash_table.h"
 #include "ebpf_object.h"
@@ -160,20 +161,41 @@ ebpf_object_tracking_initiate()
 void
 ebpf_object_tracking_terminate()
 {
-    ebpf_assert(!_ebpf_id_table || ebpf_hash_table_key_count(_ebpf_id_table) == 0 || ebpf_fault_injection_is_enabled());
+    if (!_ebpf_id_table) {
+        return;
+    }
+    if (!ebpf_fault_injection_is_enabled()) {
+        while (ebpf_hash_table_key_count(_ebpf_id_table)) {
+            ebpf_epoch_flush();
+        }
+    }
     ebpf_hash_table_destroy(_ebpf_id_table);
     _ebpf_id_table = NULL;
+}
+
+static void
+_ebpf_object_epoch_free(_Inout_ void* context)
+{
+    ebpf_core_object_t* object = (ebpf_core_object_t*)context;
+    EBPF_LOG_MESSAGE_POINTER_ENUM(
+        EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_BASE, "eBPF object terminated", object, object->type);
+
+    object->base.marker = ~object->base.marker;
+    object->free_function(object);
 }
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_object_initialize(
     _Inout_ ebpf_core_object_t* object,
     ebpf_object_type_t object_type,
-    ebpf_free_object_t free_function,
+    _In_ ebpf_free_object_t free_function,
+    _In_opt_ ebpf_zero_ref_count_t zero_ref_count_function,
     ebpf_object_get_program_type_t get_program_type_function,
     ebpf_file_id_t file_id,
     uint32_t line)
 {
+    ebpf_result_t result;
+
     EBPF_LOG_MESSAGE_POINTER_ENUM(
         EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_BASE, "eBPF object initialized", object, object_type);
     object->base.marker = _ebpf_object_marker;
@@ -182,6 +204,7 @@ ebpf_object_initialize(
     object->base.release_reference = ebpf_object_release_reference;
     object->type = object_type;
     object->free_function = free_function;
+    object->zero_ref_count = zero_ref_count_function;
     object->get_program_type = get_program_type_function;
     object->id = ebpf_interlocked_increment_int32((volatile int32_t*)&_ebpf_next_id);
     // Skip invalid IDs.
@@ -189,9 +212,16 @@ ebpf_object_initialize(
         object->id = ebpf_interlocked_increment_int32((volatile int32_t*)&_ebpf_next_id);
     }
     ebpf_list_initialize(&object->object_list_entry);
+    ebpf_epoch_work_item_t* free_work_item = NULL;
+
+    free_work_item = ebpf_epoch_allocate_work_item(object, _ebpf_object_epoch_free);
+    if (!free_work_item) {
+        result = EBPF_NO_MEMORY;
+        goto Done;
+    }
+
     _update_reference_history(object, EBPF_OBJECT_CREATE, file_id, line);
 
-    ebpf_result_t result;
     ebpf_id_entry_t entry = {.reference_count = 1, .type = object_type, .object = object};
 
     // Use EBPF_HASH_TABLE_OPERATION_INSERT so that it fails if the key already exists.
@@ -216,7 +246,11 @@ ebpf_object_initialize(
     _update_reference_history(new_entry, EBPF_OBJECT_CREATE, file_id, line);
 #endif
 
+    object->free_work_item = free_work_item;
+    free_work_item = NULL;
+
 Done:
+    ebpf_epoch_cancel_work_item(free_work_item);
     return result;
 }
 
@@ -288,15 +322,12 @@ ebpf_object_release_reference(_Inout_opt_ ebpf_core_object_t* object, uint32_t f
     }
 
     if (new_ref_count == 0) {
-        EBPF_LOG_MESSAGE_POINTER_ENUM(
-            EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_BASE, "eBPF object terminated", object, object->type);
-
         _ebpf_object_tracking_list_remove(object, file_id, line);
-
         _update_reference_history(object, EBPF_OBJECT_DESTROY, file_id, line);
-
-        object->base.marker = ~object->base.marker;
-        object->free_function(object);
+        if (object->zero_ref_count) {
+            object->zero_ref_count(object);
+        }
+        ebpf_epoch_schedule_work_item(object->free_work_item);
     }
 }
 
@@ -448,6 +479,38 @@ ebpf_object_reference_by_id(
     *object = found_object;
 Done:
 
+    return result;
+}
+
+_Must_inspect_result_ ebpf_result_t
+ebpf_object_pointer_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_ ebpf_core_object_t** object)
+{
+    ebpf_result_t result;
+    ebpf_id_entry_t* entry = NULL;
+    ebpf_core_object_t* found_object = NULL;
+
+    result = ebpf_hash_table_find(_ebpf_id_table, (const uint8_t*)&id, (uint8_t**)&entry);
+    if (result != EBPF_SUCCESS) {
+        goto Done;
+    }
+
+    found_object = entry->object;
+    // Skip entries that have been deleted.
+    if (found_object == NULL) {
+        result = EBPF_KEY_NOT_FOUND;
+        goto Done;
+    }
+
+    // Skip entries that are not of the requested type.
+    if (entry->type != object_type) {
+        result = EBPF_KEY_NOT_FOUND;
+        goto Done;
+    }
+
+    result = EBPF_SUCCESS;
+    *object = found_object;
+
+Done:
     return result;
 }
 

--- a/libs/runtime/ebpf_object.c
+++ b/libs/runtime/ebpf_object.c
@@ -506,10 +506,10 @@ ebpf_object_pointer_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_
         goto Done;
     }
 
-    // Skip entries that are not of the requested type.
+    // If the type is wrong, then the caller's reference is invalid.
+    // This is a bug in the caller, so we fail fast.
     if (entry->type != object_type) {
-        result = EBPF_KEY_NOT_FOUND;
-        goto Done;
+        __fastfail(FAST_FAIL_INVALID_REFERENCE_COUNT);
     }
 
     result = EBPF_SUCCESS;

--- a/libs/runtime/ebpf_object.h
+++ b/libs/runtime/ebpf_object.h
@@ -94,13 +94,14 @@ extern "C"
  * @brief Macro to initialize an object and record the file and line number of the reference.
  *EBPF_OBJECT_INITIALIZE
  */
-#define EBPF_OBJECT_INITIALIZE(object, object_type, free_function, get_program_type_function) \
-    ebpf_object_initialize(                                                                   \
-        (ebpf_core_object_t*)(object),                                                        \
-        (object_type),                                                                        \
-        (free_function),                                                                      \
-        (get_program_type_function),                                                          \
-        EBPF_FILE_ID,                                                                         \
+#define EBPF_OBJECT_INITIALIZE(object, object_type, free_function, zero_ref_function, get_program_type_function) \
+    ebpf_object_initialize(                                                                                      \
+        (ebpf_core_object_t*)(object),                                                                           \
+        (object_type),                                                                                           \
+        (free_function),                                                                                         \
+        (zero_ref_function),                                                                                     \
+        (get_program_type_function),                                                                             \
+        EBPF_FILE_ID,                                                                                            \
         __LINE__)
 
     typedef enum _ebpf_object_type
@@ -116,6 +117,7 @@ extern "C"
     typedef void (*ebpf_base_acquire_reference_t)(_Inout_ void* base_object, ebpf_file_id_t file_id, uint32_t line);
 
     typedef struct _ebpf_core_object ebpf_core_object_t;
+    typedef void (*ebpf_zero_ref_count_t)(ebpf_core_object_t* object);
     typedef void (*ebpf_free_object_t)(ebpf_core_object_t* object);
     typedef const ebpf_program_type_t (*ebpf_object_get_program_type_t)(_In_ const ebpf_core_object_t* object);
 
@@ -141,7 +143,9 @@ extern "C"
     {
         ebpf_base_object_t base;
         ebpf_object_type_t type;
-        ebpf_free_object_t free_function;
+        ebpf_free_object_t free_function;     ///< Function to free this object.
+        ebpf_zero_ref_count_t zero_ref_count; ///< Function to notify the object that the reference count has reached
+                                              ///< zero.
         ebpf_object_get_program_type_t get_program_type;
         // ID for this object.
         ebpf_id_t id;
@@ -149,6 +153,7 @@ extern "C"
         ebpf_list_entry_t object_list_entry;
         // # of pinned paths, for diagnostic purposes.
         volatile int32_t pinned_path_count;
+        struct _ebpf_epoch_work_item* free_work_item; ///< Work item to free this object when the epoch ends.
     } ebpf_core_object_t;
 
     /**
@@ -185,7 +190,8 @@ extern "C"
     ebpf_object_initialize(
         _Inout_ ebpf_core_object_t* object,
         ebpf_object_type_t object_type,
-        ebpf_free_object_t free_function,
+        _In_ ebpf_free_object_t free_function,
+        _In_opt_ ebpf_zero_ref_count_t zero_ref_count_function,
         ebpf_object_get_program_type_t get_program_type_function,
         ebpf_file_id_t file_id,
         uint32_t line);
@@ -259,6 +265,19 @@ extern "C"
         _Outptr_ ebpf_core_object_t** object,
         ebpf_file_id_t file_id,
         uint32_t line);
+
+    /**
+     * @brief Obtain pointer to object given its ID and type and do not acquire a reference.
+     * Note: The object returned may have a zero reference count and may be freed at the end of the current epoch.
+     *
+     * @param[in] id ID to find in table.
+     * @param[in] object_type Object type to match.
+     * @param[out] object Pointer to memory that contains object success.
+     * @retval EBPF_SUCCESS The operation was successful.
+     * @retval EBPF_KEY_NOT_FOUND The provided ID is not valid.
+     */
+    _Must_inspect_result_ ebpf_result_t
+    ebpf_object_pointer_by_id(ebpf_id_t id, ebpf_object_type_t object_type, _Outptr_ ebpf_core_object_t** object);
 
     /**
      * @brief Find the object of a given type with the next ID greater than a given ID.

--- a/libs/runtime/ebpf_object.h
+++ b/libs/runtime/ebpf_object.h
@@ -131,29 +131,26 @@ extern "C"
      */
     typedef struct _ebpf_base_object
     {
-        uint32_t marker; // Contains the 32bit value 'eobj' when the object is valid and is inverted when the object is
-                         // freed.
-        uint32_t zero_fill; // Zero fill to make the reference count is 8-byte aligned.
-        volatile int64_t reference_count;
-        ebpf_base_acquire_reference_t acquire_reference;
-        ebpf_base_release_reference_t release_reference;
+        uint32_t marker; ///< Contains the 32bit value 'eobj' when the object is valid and is inverted when the object
+                         ///< is freed.
+        uint32_t zero_fill;                              ///< Zero fill to make the reference count is 8-byte aligned.
+        volatile int64_t reference_count;                ///< Reference count for the object.
+        ebpf_base_acquire_reference_t acquire_reference; ///< Function to acquire a reference on this object.
+        ebpf_base_release_reference_t release_reference; ///< Function to release a reference on this object.
     } ebpf_base_object_t;
 
     typedef struct _ebpf_core_object
     {
-        ebpf_base_object_t base;
-        ebpf_object_type_t type;
+        ebpf_base_object_t base;              ///< Base object for all reference counted eBPF objects.
+        ebpf_object_type_t type;              ///< Type of this object.
         ebpf_free_object_t free_function;     ///< Function to free this object.
         ebpf_zero_ref_count_t zero_ref_count; ///< Function to notify the object that the reference count has reached
                                               ///< zero.
-        ebpf_object_get_program_type_t get_program_type;
-        // ID for this object.
-        ebpf_id_t id;
-        // Used to insert object in an object specific list.
-        ebpf_list_entry_t object_list_entry;
-        // # of pinned paths, for diagnostic purposes.
-        volatile int32_t pinned_path_count;
-        struct _ebpf_epoch_work_item* free_work_item; ///< Work item to free this object when the epoch ends.
+        ebpf_object_get_program_type_t get_program_type; ///< Function to get the program type of this object.
+        ebpf_id_t id;                                    ///< ID of this object.
+        ebpf_list_entry_t object_list_entry;             ///< Entry in the object list.
+        volatile int32_t pinned_path_count;              ///< Number of pinned paths for this object.
+        struct _ebpf_epoch_work_item* free_work_item;    ///< Work item to free this object when the epoch ends.
     } ebpf_core_object_t;
 
     /**

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -64,6 +64,29 @@ typedef struct _free_trampoline_table
 
 typedef std::unique_ptr<ebpf_trampoline_table_t, free_trampoline_table_t> ebpf_trampoline_table_ptr;
 
+typedef class _signal
+{
+  public:
+    void
+    wait()
+    {
+        std::unique_lock l(lock);
+        condition_variable.wait(l, [&]() { return signaled; });
+    }
+    void
+    signal()
+    {
+        std::unique_lock l(lock);
+        signaled = true;
+        condition_variable.notify_all();
+    }
+
+  private:
+    std::mutex lock;
+    std::condition_variable condition_variable;
+    bool signaled = false;
+} signal_t;
+
 class _test_helper
 {
   public:
@@ -373,6 +396,7 @@ TEST_CASE("pinning_test", "[platform]")
     {
         ebpf_core_object_t object{};
         std::string name;
+        signal_t signal;
     } some_object_t;
 
     some_object_t an_object;
@@ -383,10 +407,24 @@ TEST_CASE("pinning_test", "[platform]")
 
     REQUIRE(
         EBPF_OBJECT_INITIALIZE(
-            &an_object.object, EBPF_OBJECT_MAP, [](ebpf_core_object_t*) {}, NULL, NULL) == EBPF_SUCCESS);
+            &an_object.object,
+            EBPF_OBJECT_MAP,
+            [](ebpf_core_object_t* object) {
+                auto some_object = reinterpret_cast<some_object_t*>(object);
+                some_object->signal.signal();
+            },
+            NULL,
+            NULL) == EBPF_SUCCESS);
     REQUIRE(
         EBPF_OBJECT_INITIALIZE(
-            &another_object.object, EBPF_OBJECT_MAP, [](ebpf_core_object_t*) {}, NULL, NULL) == EBPF_SUCCESS);
+            &another_object.object,
+            EBPF_OBJECT_MAP,
+            [](ebpf_core_object_t* object) {
+                auto some_object = reinterpret_cast<some_object_t*>(object);
+                some_object->signal.signal();
+            },
+            NULL,
+            NULL) == EBPF_SUCCESS);
 
     ebpf_pinning_table_ptr pinning_table;
     {
@@ -412,6 +450,9 @@ TEST_CASE("pinning_test", "[platform]")
 
     EBPF_OBJECT_RELEASE_REFERENCE(&an_object.object);
     EBPF_OBJECT_RELEASE_REFERENCE(&another_object.object);
+
+    an_object.signal.wait();
+    another_object.signal.wait();
 }
 
 TEST_CASE("epoch_test_single_epoch", "[platform]")
@@ -448,29 +489,6 @@ TEST_CASE("epoch_test_two_threads", "[platform]")
     thread_1.join();
     thread_2.join();
 }
-
-class _signal
-{
-  public:
-    void
-    wait()
-    {
-        std::unique_lock l(lock);
-        condition_variable.wait(l, [&]() { return signaled; });
-    }
-    void
-    signal()
-    {
-        std::unique_lock l(lock);
-        signaled = true;
-        condition_variable.notify_all();
-    }
-
-  private:
-    std::mutex lock;
-    std::condition_variable condition_variable;
-    bool signaled = false;
-};
 
 /**
  * @brief Verify that the stale item worker runs.

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -383,10 +383,10 @@ TEST_CASE("pinning_test", "[platform]")
 
     REQUIRE(
         EBPF_OBJECT_INITIALIZE(
-            &an_object.object, EBPF_OBJECT_MAP, [](ebpf_core_object_t*) {}, NULL) == EBPF_SUCCESS);
+            &an_object.object, EBPF_OBJECT_MAP, [](ebpf_core_object_t*) {}, NULL, NULL) == EBPF_SUCCESS);
     REQUIRE(
         EBPF_OBJECT_INITIALIZE(
-            &another_object.object, EBPF_OBJECT_MAP, [](ebpf_core_object_t*) {}, NULL) == EBPF_SUCCESS);
+            &another_object.object, EBPF_OBJECT_MAP, [](ebpf_core_object_t*) {}, NULL, NULL) == EBPF_SUCCESS);
 
     ebpf_pinning_table_ptr pinning_table;
     {


### PR DESCRIPTION
Split cleanup of eBPF objects into zero-refcount and free operations. Zero-rerfcount is permits the object to release refcounts on other objects while still permitting it to operate. The free operation is the final release of the object and is performed once the current epoch ends.

## Description

Delay freeing all objects util the end of the current epoch.
Expose function to obtain pointer to object in current epoch.

## Testing

CI/CD & Perf

## Documentation

No.

## Installation

No.

Before:
```
C:\test>Release\bpf_performance_runner.exe -i tests.yml -e .sys -t "bpf_tail_call"
Timestamp,Test,Average Duration (ns),CPU 0 Duration (ns),CPU 1 Duration (ns),CPU 2 Duration (ns),CPU 3 Duration (ns),CPU 4 Duration (ns),CPU 5 Duration (ns)
2023-10-20T18:22:01-0800,bpf_tail_call,1448,1467,1459,1469,1452,1444,1401
```

After:
```
C:\test>Release\bpf_performance_runner.exe -i tests.yml -e .sys -t "bpf_tail_call"
Timestamp,Test,Average Duration (ns),CPU 0 Duration (ns),CPU 1 Duration (ns),CPU 2 Duration (ns),CPU 3 Duration (ns),CPU 4 Duration (ns),CPU 5 Duration (ns)
2023-10-20T18:24:35-0800,bpf_tail_call,306,283,335,334,262,318,308
```

