### PR TITLE
Skip running the 'quick' user-mode multi-threaded stress test in scheduled CI/CD runs

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -414,7 +414,7 @@ jobs:
   # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
   quick_user_mode_multi_threaded_stress_test:
     needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: quick_user_mode_multi_threaded_stress


### PR DESCRIPTION
## Description

The 'quick' version is really meant for the PR validation CI/CD workflow and was inadvertently enabled for the Scheduled CI/CD workflow. The scheduled workflow already runs the extended user-mode multithreaded stress test, so running the quick version as well is redundant.

## Testing
CI/CD

_Do any existing tests cover this change? Are new tests needed?_
CI/CD workflow modification.  No new tests needed.

## Documentation
No documentation impact.

## Installation
No installer impact.

Fixes #2998