### PR TITLE
Restore VM after driver job finishes.

### DIFF
--- a/scripts/cleanup_ebpf_cicd_tests.ps1
+++ b/scripts/cleanup_ebpf_cicd_tests.ps1
@@ -24,5 +24,6 @@ Import-ResultsFromVM -VMList $VMList
 
 # Stop the VMs.
 Stop-AllVMs -VMList $VMList
+Restore-AllVMs -VMList $VMList
 
 Pop-Location


### PR DESCRIPTION
## Description

Fixes #2913 

Restore VM checkpoint after `driver `job finishes.
If Duonic devices are accidentally persisted in the checkpoint during runner maintenance,
it causes subsequent test runs to fail.

This is a workaround for us not being able to cleanly uninstall Duonic currently.

In cases where we want to manually grab a dump if it failed to upload, this checkpoint restore comes after the dump was copied to the runner host. So this doesn't reduce the amount of time we'd have to do that before another job is scheduled on a given runner.