### PR TITLE
chore: fix the hash for setup scripts

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -58,7 +58,7 @@ Alternative install steps (for *basic* Visual Studio Community edition):
 
    ```ps
    Invoke-WebRequest 'https://raw.githubusercontent.com/microsoft/ebpf-for-windows/main/scripts/Setup-DevEnv.ps1' -OutFile $env:TEMP\Setup-DeveEnv.ps1
-   if ((get-filehash -Algorithm SHA256 $env:TEMP\Setup-DeveEnv.ps1).Hash -eq '9B9C4358B05DBD16EF58C0548B1ADBA4B5591FE14DFD3239FC580BB95B39988C') { &"$env:TEMP\Setup-DeveEnv.ps1" }
+   if ((get-filehash -Algorithm SHA256 $env:TEMP\Setup-DeveEnv.ps1).Hash -eq '0E8733AC82CFDEC93A3606AEA586A6BD08980D2301754EC165230FBA353E7B4C') { &"$env:TEMP\Setup-DeveEnv.ps1" }
    ```
    >**Note**: the WDK for Windows 11 is [not currently available on Chocolatey](https://community.chocolatey.org/packages?q=windowsdriverkit),
     please install manually with the link in the [Prerequisites](#prerequisites) section above.

--- a/scripts/Setup-DevEnv.ps1
+++ b/scripts/Setup-DevEnv.ps1
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 Invoke-WebRequest 'https://community.chocolatey.org/install.ps1' -OutFile $env:TEMP\install_choco.ps1
-if ((get-filehash -Algorithm SHA256 $env:TEMP\install_choco.ps1).Hash -ne '45014AC94BAAA135449D73DA9F4760ACDAE4C8943FA9998A47B74D0BBA8A5295') { throw "Wrong file hash for Chocolatey installer"}
+if ((get-filehash -Algorithm SHA256 $env:TEMP\install_choco.ps1).Hash -ne 'B2980C92C1E3EFB45E3EFA428E2EF26EAC846F8B2606DA0D2B1342AC26D36B97') { throw "Wrong file hash for Chocolatey installer"}
 &"$env:TEMP\install_choco.ps1"
 choco install git --version 2.38.1 -y
 choco install visualstudio2022community --version 117.4.2.0 -y


### PR DESCRIPTION
## Description

chore: fix the hash for setup scripts, orelse scripts/Setup-DevEnv.ps1 would always fail.


## Testing

_Do any existing tests cover this change? Are new tests needed?_

## Documentation

_Is there any documentation impact for this change?_

## Installation

_Is there any installer impact for this change?_
