### PR TITLE
Remove unnecessary dependency in eBPFAPI.DLL.

### DIFF
--- a/scripts/check_binary_dependencies_ebpfapi_dll_nativeonly_release.txt
+++ b/scripts/check_binary_dependencies_ebpfapi_dll_nativeonly_release.txt
@@ -25,7 +25,6 @@ api-ms-win-core-profile-l1-1-0.dll
 api-ms-win-core-sysinfo-l1-1-0.dll
 api-ms-win-core-interlocked-l1-1-0.dll
 api-ms-win-core-debug-l1-1-0.dll
-api-ms-win-core-libraryloader-l1-2-0.dll
 KERNEL32.dll
 api-ms-win-core-memory-l1-1-0.dll
 api-ms-win-core-string-l1-1-0.dll


### PR DESCRIPTION
## Description

Remove _api-ms-win-core-libraryloader-l1-2-0.dll_ from list of NativeRelease dependencies.
