### PR TITLE
Fix ASAN linker error

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -68,7 +68,7 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
     </ClCompile>
     <Link>
-      <AdditionalOptions>/spgo %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/spgo %(AdditionalOptions)</AdditionalOptions>
       <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -65,11 +65,11 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release' Or '$(Configuration)'=='NativeOnlyRelease'">
     <ClCompile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <WholeProgramOptimization Condition="'$(EnableAsan)' != 'true'">true</WholeProgramOptimization>
     </ClCompile>
     <Link>
       <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/spgo %(AdditionalOptions)</AdditionalOptions>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <LinkTimeCodeGeneration Condition="'$(EnableAsan)' != 'true'">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='FuzzerDebug' Or '$(Configuration)'=='NativeOnlyDebug'">

--- a/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
+++ b/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
@@ -96,7 +96,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <EnableASAN Condition="'$(EnableASAN)' == ''">false</EnableASAN>
+    <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyRelease|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>

--- a/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
+++ b/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
@@ -96,7 +96,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <EnableASAN>true</EnableASAN>
+    <EnableASAN Condition="'$(EnableASAN)' == ''">false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyRelease|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>

--- a/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
+++ b/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
@@ -66,7 +66,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <EnableASAN>false</EnableASAN>
+    <!-- <EnableASAN>false</EnableASAN> -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FuzzerDebug|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -76,7 +76,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <EnableASAN>false</EnableASAN>
+    <!-- <EnableASAN>false</EnableASAN> -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyDebug|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -86,7 +86,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <EnableASAN>false</EnableASAN>
+    <!-- <EnableASAN>false</EnableASAN> -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -96,7 +96,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <EnableASAN>false</EnableASAN>
+    <!-- <EnableASAN>false</EnableASAN> -->
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyRelease|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -106,7 +106,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <EnableASAN>false</EnableASAN>
+    <!-- <EnableASAN>false</EnableASAN> -->
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
+++ b/ebpfcore/usersim/EbpfCore_Usersim.vcxproj
@@ -66,7 +66,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <!-- <EnableASAN>false</EnableASAN> -->
+    <EnableASAN Condition="'$(EnableASAN)' == ''">false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FuzzerDebug|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -76,7 +76,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <!-- <EnableASAN>false</EnableASAN> -->
+    <EnableASAN Condition="'$(EnableASAN)' == ''">false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyDebug|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -86,7 +86,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <!-- <EnableASAN>false</EnableASAN> -->
+    <EnableASAN Condition="'$(EnableASAN)' == ''">false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -96,7 +96,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <!-- <EnableASAN>false</EnableASAN> -->
+    <EnableASAN Condition="'$(EnableASAN)' == ''">false</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyRelease|x64'" Label="Configuration">
     <TargetVersion>Windows10</TargetVersion>
@@ -106,7 +106,7 @@
     <DriverType>KMDF</DriverType>
     <DriverTargetPlatform>Universal</DriverTargetPlatform>
     <Driver_SpectreMitigation>Spectre</Driver_SpectreMitigation>
-    <!-- <EnableASAN>false</EnableASAN> -->
+    <EnableASAN Condition="'$(EnableASAN)' == ''">false</EnableASAN>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">

--- a/external/Directory.Build.props
+++ b/external/Directory.Build.props
@@ -25,12 +25,12 @@
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
     <ClCompile>
       <RuntimeLibrary>MultiThreadedDLL</RuntimeLibrary>
-      <WholeProgramOptimization>true</WholeProgramOptimization>
+      <WholeProgramOptimization Condition="'$(EnableASAN)' != 'true'">true</WholeProgramOptimization>
       <TreatWarningAsError>false</TreatWarningAsError>
     </ClCompile>
     <Link>
-      <AdditionalOptions>/spgo %(AdditionalOptions)</AdditionalOptions>
-      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+      <AdditionalOptions Condition="'$(EnableASAN)' != 'true'">/spgo %(AdditionalOptions)</AdditionalOptions>
+      <LinkTimeCodeGeneration Condition="'$(EnableASAN)' != 'true'">UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)'=='Debug' OR '$(Configuration)'=='FuzzerDebug'">

--- a/scripts/check_binary_dependencies_ebpfapi_dll_nativeonly_release.txt
+++ b/scripts/check_binary_dependencies_ebpfapi_dll_nativeonly_release.txt
@@ -25,7 +25,6 @@ api-ms-win-core-profile-l1-1-0.dll
 api-ms-win-core-sysinfo-l1-1-0.dll
 api-ms-win-core-interlocked-l1-1-0.dll
 api-ms-win-core-debug-l1-1-0.dll
-api-ms-win-core-libraryloader-l1-2-0.dll
 KERNEL32.dll
 api-ms-win-core-memory-l1-1-0.dll
 api-ms-win-core-string-l1-1-0.dll


### PR DESCRIPTION
## Description
**Problem domain:**
The problem below was exposed due to the latest ASAN update
•	EbpfCore_Usersim depending on usersim_dll_skeleton statically.
•	usersim_dll_skeleton getting EnableASAN set to true (due to Directory.Build.Props)
•	EbpfCore_Usersim getting EnableASAN set to false.

**Solution:**
1. Enable EnableASAN in EbpfCore_Usersim to inherit the root setting from Directory.Build.Props, by adding a conditional flag to the EnableASAN. With this, EbpfCore_Usersim's EnableASAN is set to true.
2. LinkTimeCodeGeneration (LTCG) is set based on EnableASAN value. If EnableASAN is false, then LTCG is enabled.
3. WholeProgramOptimization (WPO) is set based on EnableASAN value.  If EnableASAN is false, then WPO is enabled.
4. SPGO  (SharePoint extension) is set based on EnableASAN value. If EnableASAN is false, then spgo is enabled. As per the VC C++ support engineer, spgo is not supported with ASAN.

The PR addresses the above logic in the entire build system.

5. In addition, it has the fix from https://github.com/microsoft/ebpf-for-windows/pull/3018

## Testing

_Do any existing tests cover this change? No
Are new tests needed? No

Pipeline Test: 

## Documentation

_Is there any documentation impact for this change? No

## Installation

_Is there any installer impact for this change? No

--
