### PR TITLE
Add connected UDP tests for cgroup/sock_addr_connect attach type

### DIFF
--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -164,9 +164,8 @@ _get_ip_proto_from_protocol_type(protocol_type_t protocol)
         return IPPROTO_TCP;
     default:
         REQUIRE(false);
+        return IPPROTO_IPV4;
     }
-
-    return IPPROTO_IPV4;
 }
 
 inline static protocol_type_t

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -238,13 +238,14 @@ _datagram_client_socket::send_message_to_remote_host(
     ((PSOCKADDR_IN6)&remote_address)->sin6_port = htons(remote_port);
 
     // If this is a connected socket, issue a connect call prior to sending traffic.
-    if (connected_udp) {
+    if (connected_udp && !connected) {
         error = WSAConnect(
             socket, (const SOCKADDR*)&remote_address, sizeof(remote_address), nullptr, nullptr, nullptr, nullptr);
         if (error != 0) {
             FAIL("WSAConnect failed with " << WSAGetLastError());
             return;
         }
+        connected = true;
     }
 
     // Send a message to the remote host using the sender socket.

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -219,8 +219,9 @@ _client_socket::complete_async_receive(int timeout_in_ms, bool timeout_or_error_
     }
 }
 
-_datagram_client_socket::_datagram_client_socket(int _sock_type, int _protocol, uint16_t _port, socket_family_t _family)
-    : _client_socket{_sock_type, _protocol, _port, _family}
+_datagram_client_socket::_datagram_client_socket(
+    int _sock_type, int _protocol, uint16_t _port, socket_family_t _family, bool _connected_udp)
+    : _client_socket{_sock_type, _protocol, _port, _family}, connected_udp{_connected_udp}
 {
     if (!(sock_type == SOCK_DGRAM || sock_type == SOCK_RAW) &&
         !(protocol == IPPROTO_UDP || protocol == IPPROTO_IPV4 || protocol == IPPROTO_IPV6))
@@ -234,8 +235,19 @@ _datagram_client_socket::send_message_to_remote_host(
 {
     int error = 0;
 
-    // Send a message to the remote host using the sender socket.
     ((PSOCKADDR_IN6)&remote_address)->sin6_port = htons(remote_port);
+
+    // If this is a connected socket, issue a connect call prior to sending traffic.
+    if (connected_udp) {
+        error = WSAConnect(
+            socket, (const SOCKADDR*)&remote_address, sizeof(remote_address), nullptr, nullptr, nullptr, nullptr);
+        if (error != 0) {
+            FAIL("WSAConnect failed with " << WSAGetLastError());
+            return;
+        }
+    }
+
+    // Send a message to the remote host using the sender socket.
     std::vector<char> send_buffer(message, message + strlen(message));
     WSABUF wsa_send_buffer{static_cast<unsigned long>(send_buffer.size()), reinterpret_cast<char*>(send_buffer.data())};
     uint32_t bytes_sent = 0;

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -118,7 +118,8 @@ typedef class _client_socket : public _base_socket
 typedef class _datagram_client_socket : public _client_socket
 {
   public:
-    _datagram_client_socket(int _sock_type, int _protocol, uint16_t port, socket_family_t family = Dual);
+    _datagram_client_socket(
+        int _sock_type, int _protocol, uint16_t port, socket_family_t family = Dual, bool connected_udp = false);
     void
     send_message_to_remote_host(
         _In_z_ const char* message, _Inout_ sockaddr_storage& remote_address, uint16_t remote_port);
@@ -126,6 +127,9 @@ typedef class _datagram_client_socket : public _client_socket
     cancel_send_message();
     void
     complete_async_send(int timeout_in_ms, expected_result_t expected_result = expected_result_t::SUCCESS);
+
+  private:
+    bool connected_udp = false;
 } datagram_client_socket_t;
 
 /**

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -129,7 +129,11 @@ typedef class _datagram_client_socket : public _client_socket
     complete_async_send(int timeout_in_ms, expected_result_t expected_result = expected_result_t::SUCCESS);
 
   private:
+    // Indicates if connected UDP should be used.
     bool connected_udp = false;
+
+    // Indicates if we have already called connect on this socket.
+    bool connected = false;
 } datagram_client_socket_t;
 
 /**


### PR DESCRIPTION
## Description
Existing UDP tests were only validating the unconnected UDP usage of the cgroup/sock_addr_connect attach type.

Closes #1917

## Testing
Adds connected UDP tests for cgroup/sock_addr_connect attach type.

## Documentation
N/A

## Installation
N/A