### PR TITLE
Switch from epoch_flush to epoch_synchronize

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -281,7 +281,7 @@ ebpf_core_terminate()
 
     // Shut down the epoch tracker and free any remaining memory or work items.
     // Note: Some objects may only be released on epoch termination.
-    ebpf_epoch_flush();
+    ebpf_epoch_synchronize();
     ebpf_epoch_terminate();
 
     // Terminate native module. This is a blocking call and will return only when

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2198,6 +2198,8 @@ _ebpf_program_test_run_work_item(_In_ cxplat_preemptible_work_item_t* work_item,
     }
     thread_affinity_set = true;
 
+    ebpf_epoch_synchronize();
+
     old_irql = ebpf_raise_irql(context->required_irql);
     irql_raised = true;
 

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -523,8 +523,7 @@ ebpf_epoch_cancel_work_item(_In_opt_ _Frees_ptr_opt_ ebpf_epoch_work_item_t* wor
     cxplat_release_rundown_protection(&_ebpf_epoch_work_item_rundown_ref);
 }
 
-void
-ebpf_epoch_synchronize()
+_IRQL_requires_max_(PASSIVE_LEVEL) void ebpf_epoch_synchronize()
 {
     if (!_ebpf_epoch_cpu_table) {
         return;

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -655,6 +655,12 @@ _ebpf_epoch_insert_in_free_list(_In_ ebpf_epoch_allocation_header_t* header)
             cxplat_queue_preemptible_work_item(work_item->preemptible_work_item);
             break;
         }
+        case EBPF_EPOCH_ALLOCATION_SYNCHRONIZATION: {
+            ebpf_epoch_synchronization_t* synchronization =
+                CONTAINING_RECORD(header, ebpf_epoch_synchronization_t, header);
+            KeSetEvent(&synchronization->event, 0, false);
+            break;
+        }
         default:
             ebpf_assert(!"Invalid entry type");
         }

--- a/libs/runtime/ebpf_epoch.c
+++ b/libs/runtime/ebpf_epoch.c
@@ -537,6 +537,12 @@ ebpf_epoch_synchronize()
     KeInitializeEvent(&synchronization.event, NotificationEvent, false);
     _ebpf_epoch_insert_in_free_list(&synchronization.header);
 
+    // Trigger epoch computation.
+    ebpf_epoch_cpu_message_t message = {0};
+    message.message_type = EBPF_EPOCH_CPU_MESSAGE_TYPE_PROPOSE_RELEASE_EPOCH;
+    message.wake_behavior = EBPF_WORK_QUEUE_WAKEUP_ON_INSERT;
+    _ebpf_epoch_send_message_and_wait(&message, 0);
+
     KeWaitForSingleObject(&synchronization.event, Executive, KernelMode, false, NULL);
 }
 

--- a/libs/runtime/ebpf_epoch.h
+++ b/libs/runtime/ebpf_epoch.h
@@ -74,10 +74,10 @@ extern "C"
     ebpf_epoch_free(_Frees_ptr_opt_ void* memory);
 
     /**
-     * @Brief Release any memory that is associated with expired epochs.
+     * @brief Wait for the current epoch to end.
      */
     void
-    ebpf_epoch_flush();
+    ebpf_epoch_synchronize();
 
     /**
      * @brief Allocate an epoch work item; a work item that can be scheduled to

--- a/libs/runtime/ebpf_epoch.h
+++ b/libs/runtime/ebpf_epoch.h
@@ -76,8 +76,7 @@ extern "C"
     /**
      * @brief Wait for the current epoch to end.
      */
-    void
-    ebpf_epoch_synchronize();
+    _IRQL_requires_max_(PASSIVE_LEVEL) void ebpf_epoch_synchronize();
 
     /**
      * @brief Allocate an epoch work item; a work item that can be scheduled to

--- a/libs/runtime/unit/platform_unit_test.cpp
+++ b/libs/runtime/unit/platform_unit_test.cpp
@@ -118,7 +118,7 @@ class _test_helper
             ebpf_object_tracking_terminate();
         }
         if (epoch_initiated) {
-            ebpf_epoch_flush();
+            ebpf_epoch_synchronize();
             ebpf_epoch_terminate();
         }
         ebpf_random_terminate();
@@ -476,7 +476,7 @@ TEST_CASE("epoch_test_single_epoch", "[platform]")
     void* memory = ebpf_epoch_allocate(10);
     ebpf_epoch_free(memory);
     ebpf_epoch_exit(&epoch_state);
-    ebpf_epoch_flush();
+    ebpf_epoch_synchronize();
 }
 
 TEST_CASE("epoch_test_two_threads", "[platform]")
@@ -492,7 +492,7 @@ TEST_CASE("epoch_test_two_threads", "[platform]")
 
         ebpf_epoch_free(memory);
         ebpf_epoch_exit(&epoch_state);
-        ebpf_epoch_flush();
+        ebpf_epoch_synchronize();
     };
 
     std::thread thread_1(epoch);

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -624,7 +624,7 @@ TEST_CASE("show maps", "[netsh][maps]")
     REQUIRE(output == "Unpinned 5 from lookup\n");
     verify_no_programs_exist();
 
-    ebpf_epoch_flush();
+    ebpf_epoch_synchronize();
 
     output = _run_netsh_command(handle_ebpf_show_maps, nullptr, nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
@@ -833,7 +833,7 @@ TEST_CASE("xdp interface parameter", "[netsh][programs]")
     output = _run_netsh_command(handle_ebpf_delete_program, L"29", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
 
-    ebpf_epoch_flush();
+    ebpf_epoch_synchronize();
 }
 
 TEST_CASE("cgroup_sock_addr compartment parameter", "[netsh][programs]")
@@ -870,7 +870,7 @@ TEST_CASE("cgroup_sock_addr compartment parameter", "[netsh][programs]")
     REQUIRE(result == ERROR_SUPPRESS_OUTPUT);
     verify_no_programs_exist();
 
-    ebpf_epoch_flush();
+    ebpf_epoch_synchronize();
 }
 
 TEST_CASE("show processes", "[netsh][processes]")


### PR DESCRIPTION
## Description

New API, ebpf_epoch_synchronize, that blocks until the current epoch ends.
Add synchronize to start of perf run to minimize noise.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
