### PR TITLE
Add connected UDP tests to cgroup/sock_addr_connect

### DIFF
--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -296,17 +296,9 @@ _ebpf_sock_addr_set_redirect_context(_In_ const bpf_sock_addr_t* ctx, _In_ void*
         goto Exit;
     }
     memcpy(redirect_context, data, data_size);
-    TraceLoggingWrite(
-        net_ebpf_ext_tracelog_provider,
-        "[maige] Allocate redirect context",
-        TraceLoggingPointer(redirect_context, "redirect_context"));
 
     // If a redirect context already exists, free the existing buffer.
     if (sock_addr_ctx->redirect_context != NULL) {
-        TraceLoggingWrite(
-            net_ebpf_ext_tracelog_provider,
-            "[maige] Freeing redirect context 1",
-            TraceLoggingPointer(sock_addr_ctx->redirect_context, "redirect_context"));
         ExFreePool(sock_addr_ctx->redirect_context);
     }
 
@@ -839,19 +831,6 @@ _net_ebpf_ext_get_and_remove_connection_context(
 
     ExReleaseSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock, old_irql);
 
-    // if (connection_context) {
-    //     TraceLoggingWrite(
-    //         net_ebpf_ext_tracelog_provider,
-    //         "_net_ebpf_ext_get_and_remove_connection_context[maige]",
-    //         TraceLoggingPointer(connection_context, "connection_context_pointer"),
-    //         TraceLoggingUInt64((connection_context->transport_endpoint_handle), "transport_endpoint_handle"),
-    //         TraceLoggingIPv4Address((connection_context->address_info.destination_ip.ipv4), "destination_ip"),
-    //         TraceLoggingUInt16((connection_context->address_info.destination_port), "destination_port"),
-    //         TraceLoggingUInt16((connection_context->address_info.source_port), "source_port"));
-    // } else {
-    //     TraceLoggingWrite(
-    //         net_ebpf_ext_tracelog_provider, "_net_ebpf_ext_get_and_remove_connection_context[maige]::NULL");
-    // }
     NET_EBPF_EXT_RETURN_POINTER(net_ebpf_extension_connection_context_t*, connection_context);
 }
 
@@ -910,20 +889,6 @@ _net_ebpf_ext_insert_connection_context_to_list(_Inout_ net_ebpf_extension_conne
     _net_ebpf_ext_purge_lru_contexts_under_lock(FALSE);
 
     ExReleaseSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock, old_irql);
-
-    // if (connection_context) {
-    //     TraceLoggingWrite(
-    //         net_ebpf_ext_tracelog_provider,
-    //         "_net_ebpf_ext_insert_connection_context_to_list[maige]",
-    //         TraceLoggingPointer(connection_context, "connection_context_pointer"),
-    //         TraceLoggingUInt64((connection_context->transport_endpoint_handle), "transport_endpoint_handle"),
-    //         TraceLoggingIPv4Address((connection_context->address_info.destination_ip.ipv4), "destination_ip"),
-    //         TraceLoggingUInt16((connection_context->address_info.destination_port), "destination_port"),
-    //         TraceLoggingUInt16((connection_context->address_info.source_port), "source_port"));
-    // } else {
-    //     TraceLoggingWrite(
-    //         net_ebpf_ext_tracelog_provider, "_net_ebpf_ext_insert_connection_context_to_list[maige]::NULL");
-    // }
 }
 
 NTSTATUS
@@ -1447,10 +1412,6 @@ _net_ebpf_ext_process_redirect_verdict(
         connect_request->localRedirectTargetPID = TARGET_PROCESS_ID;
         connect_request->localRedirectHandle = redirect_handle;
 
-        TraceLoggingWrite(
-            net_ebpf_ext_tracelog_provider,
-            "[maige] Transferring redirect context to WFP",
-            TraceLoggingPointer(sock_addr_ctx->redirect_context, "redirect_context"));
         connect_request->localRedirectContext = sock_addr_ctx->redirect_context;
         connect_request->localRedirectContextSize = sock_addr_ctx->redirect_context_size;
         // Ownership transferred to WFP.
@@ -1761,13 +1722,7 @@ Exit:
         net_ebpf_extension_hook_client_leave_rundown(attached_client);
     }
 
-    // TODO - this looks like it should always free the context properly. But we need to double check
-
     if (net_ebpf_sock_addr_ctx.redirect_context != NULL) {
-        TraceLoggingWrite(
-            net_ebpf_ext_tracelog_provider,
-            "[maige] Freeing redirect context 2",
-            TraceLoggingPointer(net_ebpf_sock_addr_ctx.redirect_context, "redirect_context"));
         ExFreePool(net_ebpf_sock_addr_ctx.redirect_context);
     }
 

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -831,19 +831,19 @@ _net_ebpf_ext_get_and_remove_connection_context(
 
     ExReleaseSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock, old_irql);
 
-    if (connection_context) {
-        TraceLoggingWrite(
-            net_ebpf_ext_tracelog_provider,
-            "_net_ebpf_ext_get_and_remove_connection_context[maige]",
-            TraceLoggingPointer(connection_context, "connection_context_pointer"),
-            TraceLoggingUInt64((connection_context->transport_endpoint_handle), "transport_endpoint_handle"),
-            TraceLoggingIPv4Address((connection_context->address_info.destination_ip.ipv4), "destination_ip"),
-            TraceLoggingUInt16((connection_context->address_info.destination_port), "destination_port"),
-            TraceLoggingUInt16((connection_context->address_info.source_port), "source_port"));
-    } else {
-        TraceLoggingWrite(
-            net_ebpf_ext_tracelog_provider, "_net_ebpf_ext_get_and_remove_connection_context[maige]::NULL");
-    }
+    // if (connection_context) {
+    //     TraceLoggingWrite(
+    //         net_ebpf_ext_tracelog_provider,
+    //         "_net_ebpf_ext_get_and_remove_connection_context[maige]",
+    //         TraceLoggingPointer(connection_context, "connection_context_pointer"),
+    //         TraceLoggingUInt64((connection_context->transport_endpoint_handle), "transport_endpoint_handle"),
+    //         TraceLoggingIPv4Address((connection_context->address_info.destination_ip.ipv4), "destination_ip"),
+    //         TraceLoggingUInt16((connection_context->address_info.destination_port), "destination_port"),
+    //         TraceLoggingUInt16((connection_context->address_info.source_port), "source_port"));
+    // } else {
+    //     TraceLoggingWrite(
+    //         net_ebpf_ext_tracelog_provider, "_net_ebpf_ext_get_and_remove_connection_context[maige]::NULL");
+    // }
     NET_EBPF_EXT_RETURN_POINTER(net_ebpf_extension_connection_context_t*, connection_context);
 }
 
@@ -903,19 +903,19 @@ _net_ebpf_ext_insert_connection_context_to_list(_Inout_ net_ebpf_extension_conne
 
     ExReleaseSpinLockExclusive(&_net_ebpf_ext_sock_addr_lock, old_irql);
 
-    if (connection_context) {
-        TraceLoggingWrite(
-            net_ebpf_ext_tracelog_provider,
-            "_net_ebpf_ext_insert_connection_context_to_list[maige]",
-            TraceLoggingPointer(connection_context, "connection_context_pointer"),
-            TraceLoggingUInt64((connection_context->transport_endpoint_handle), "transport_endpoint_handle"),
-            TraceLoggingIPv4Address((connection_context->address_info.destination_ip.ipv4), "destination_ip"),
-            TraceLoggingUInt16((connection_context->address_info.destination_port), "destination_port"),
-            TraceLoggingUInt16((connection_context->address_info.source_port), "source_port"));
-    } else {
-        TraceLoggingWrite(
-            net_ebpf_ext_tracelog_provider, "_net_ebpf_ext_insert_connection_context_to_list[maige]::NULL");
-    }
+    // if (connection_context) {
+    //     TraceLoggingWrite(
+    //         net_ebpf_ext_tracelog_provider,
+    //         "_net_ebpf_ext_insert_connection_context_to_list[maige]",
+    //         TraceLoggingPointer(connection_context, "connection_context_pointer"),
+    //         TraceLoggingUInt64((connection_context->transport_endpoint_handle), "transport_endpoint_handle"),
+    //         TraceLoggingIPv4Address((connection_context->address_info.destination_ip.ipv4), "destination_ip"),
+    //         TraceLoggingUInt16((connection_context->address_info.destination_port), "destination_port"),
+    //         TraceLoggingUInt16((connection_context->address_info.source_port), "source_port"));
+    // } else {
+    //     TraceLoggingWrite(
+    //         net_ebpf_ext_tracelog_provider, "_net_ebpf_ext_insert_connection_context_to_list[maige]::NULL");
+    // }
 }
 
 NTSTATUS
@@ -1731,7 +1731,9 @@ Exit:
         net_ebpf_extension_connection_context_t* stale_connection_context =
             _net_ebpf_ext_get_and_remove_connection_context(
                 incoming_metadata_values->transportEndpointHandle, sock_addr_ctx);
-        ExFreePool(stale_connection_context);
+        if (stale_connection_context) {
+            ExFreePool(stale_connection_context);
+        }
     }
     // Callout at CONNECT_REDIRECT layer always returns WFP action PERMIT.
     // If the eBPF program was invoked and it returned a REJECT verdict, it would be enforced by the callout at

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -1701,6 +1701,10 @@ Exit:
         InterlockedIncrement(&_net_ebpf_ext_statistics.block_connection_count);
     } else {
         // Remove any 'stale' connection context if found.
+        // A stale context is expected in the case of connected UDP, where the connect()
+        // call results in WFP invoking the callout at the connect_redirect layer, and the
+        // send() call results in WFP invoking the callout at the connect_redirect layer (again),
+        // followed by the connect layer.
         net_ebpf_extension_connection_context_t* stale_connection_context =
             _net_ebpf_ext_get_and_remove_connection_context(
                 incoming_metadata_values->transportEndpointHandle, sock_addr_ctx);

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -48,7 +48,7 @@ static map_entry_t _maps[] = {
          100,               // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         18,                // Identifier for a map template.
+         21,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "policy_map"},
@@ -60,7 +60,7 @@ static map_entry_t _maps[] = {
          100,               // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         27,                // Identifier for a map template.
+         30,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "audit_map"},
@@ -96,293 +96,281 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
 {
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=3 dst=r10 src=r7 offset=-20 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=4 dst=r10 src=r7 offset=-24 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
-#line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=6 dst=r10 src=r7 offset=-12 imm=0
-#line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=25959
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
 #line 57 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=8 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=14 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=15 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=18 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=20 dst=r10 src=r1 offset=-32 imm=0
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 60 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=21 dst=r1 src=r6 offset=40 imm=0
-#line 61 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=22 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=1
-#line 61 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=24 dst=r2 src=r6 offset=44 imm=0
-#line 63 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=25 dst=r2 src=r0 offset=2 imm=6
-#line 63 "sample/cgroup_sock_addr2.c"
-    if (r2 == IMMEDIATE(6))
-#line 63 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(17))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=26 dst=r2 src=r0 offset=74 imm=17
-#line 63 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(17))
-#line 63 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=77 imm=6
+#line 60 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
-#line 63 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_STXW pc=28 dst=r10 src=r1 offset=-12 imm=0
-#line 63 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=29 dst=r1 src=r6 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=30 dst=r1 src=r0 offset=70 imm=2
-#line 71 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(2))
-#line 71 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=75 imm=2
+#line 60 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(2))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
+#line 64 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_STXW pc=23 dst=r10 src=r2 offset=-32 imm=0
+#line 64 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXH pc=24 dst=r2 src=r6 offset=40 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXW pc=25 dst=r10 src=r1 offset=-12 imm=0
+#line 66 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_STXH pc=26 dst=r10 src=r2 offset=-16 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r10 offset=0 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=32 dst=r2 src=r0 offset=0 imm=-32
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=28 dst=r2 src=r0 offset=0 imm=-32
+#line 64 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=33 dst=r1 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=1
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=1
+#line 69 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=36 dst=r8 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=37 dst=r9 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=33 dst=r9 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=38 dst=r7 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=39 dst=r8 src=r0 offset=37 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=35 dst=r8 src=r0 offset=37 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 77 "sample/cgroup_sock_addr2.c"
+#line 70 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=40 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=41 dst=r10 src=r7 offset=-70 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=37 dst=r10 src=r7 offset=-70 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r1 src=r0 offset=0 imm=29989
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=38 dst=r1 src=r0 offset=0 imm=29989
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=43 dst=r10 src=r1 offset=-72 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-72 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=540697973
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=40 dst=r1 src=r0 offset=0 imm=540697973
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-80 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=42 dst=r10 src=r1 offset=-80 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=2037544046
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=43 dst=r1 src=r0 offset=0 imm=2037544046
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-88 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=45 dst=r10 src=r1 offset=-88 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1869770784
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=1869770784
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-96 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=48 dst=r10 src=r1 offset=-96 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1853189958
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=49 dst=r1 src=r0 offset=0 imm=1853189958
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-104 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=51 dst=r10 src=r1 offset=-104 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=56 dst=r4 src=r8 offset=16 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=52 dst=r4 src=r8 offset=16 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=57 dst=r3 src=r8 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=53 dst=r3 src=r8 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r10 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=54 dst=r1 src=r10 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=59 dst=r1 src=r0 offset=0 imm=-104
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=55 dst=r1 src=r0 offset=0 imm=-104
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=35
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=56 dst=r2 src=r0 offset=0 imm=35
+#line 71 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=14
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=14
+#line 71 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 71 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=59 dst=r1 src=r0 offset=8 imm=3
+#line 77 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 77 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=61 dst=r2 src=r0 offset=0 imm=-64
+#line 78 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=63 dst=r3 src=r0 offset=0 imm=27
+#line 78 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=65537
+#line 78 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 78 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 78 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 78 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=20 imm=0
-#line 84 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=63 dst=r1 src=r0 offset=8 imm=3
-#line 84 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
-#line 84 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=64 dst=r2 src=r10 offset=0 imm=0
-#line 84 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=65 dst=r2 src=r0 offset=0 imm=-64
-#line 85 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r6 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=27
-#line 85 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=65537
-#line 85 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 85 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 85 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
-#line 85 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
-#line 85 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=71 dst=r7 src=r0 offset=29 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=67 dst=r7 src=r0 offset=29 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 85 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_LDXW pc=72 dst=r1 src=r8 offset=0 imm=0
-#line 90 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
+#line 83 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=73 dst=r6 src=r1 offset=24 imm=0
-#line 90 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
+#line 83 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=74 dst=r1 src=r8 offset=16 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=75 dst=r6 src=r1 offset=40 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=76 dst=r7 src=r0 offset=0 imm=1
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
+#line 84 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=78 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -391,16 +379,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -409,13 +397,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -424,37 +412,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=93 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=94 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=95 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=96 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=97 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=99 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -464,13 +452,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=101 dst=r0 src=r7 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
+#line 141 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=102 dst=r0 src=r0 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
+#line 141 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -497,323 +485,317 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
 {
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=18 dst=r1 src=r0 offset=91 imm=23
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(23))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_4;
-        // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=36 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=20 dst=r1 src=r0 offset=0 imm=32
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=32 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=22 dst=r1 src=r2 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-24 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=24 dst=r1 src=r6 offset=28 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=25 dst=r1 src=r0 offset=0 imm=32
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=26 dst=r2 src=r6 offset=24 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=27 dst=r1 src=r2 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-32 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=29 dst=r1 src=r6 offset=40 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=30 dst=r10 src=r1 offset=-16 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r1 src=r0 offset=0 imm=1
-#line 116 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=32 dst=r2 src=r6 offset=44 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=33 dst=r2 src=r0 offset=2 imm=6
-#line 117 "sample/cgroup_sock_addr2.c"
-    if (r2 == IMMEDIATE(6))
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
+#line 101 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(17))
+#line 101 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=34 dst=r2 src=r0 offset=75 imm=17
-#line 117 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(17))
-#line 117 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6))
+#line 101 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=35 dst=r1 src=r0 offset=0 imm=2
-#line 117 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_STXW pc=36 dst=r10 src=r1 offset=-12 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 101 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(23))
+#line 101 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
+#line 108 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
+#line 113 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=40 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=47 dst=r10 src=r7 offset=-70 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=25973
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=2037544046
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1869770784
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1853189958
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r10 offset=0 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=-96
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=27
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
+#line 115 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=12
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
+#line 115 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=63 dst=r1 src=r8 offset=20 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=64 dst=r1 src=r0 offset=8 imm=3
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
+#line 121 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-64
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
+#line 122 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=67 dst=r1 src=r6 offset=0 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=68 dst=r3 src=r0 offset=0 imm=27
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
+#line 122 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=65537
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
-#line 135 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=71 dst=r0 src=r0 offset=0 imm=32
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=72 dst=r7 src=r0 offset=37 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=24
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(24);
-    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=12 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=12 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=8 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=8 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=4 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=4 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=81 dst=r2 src=r8 offset=0 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=82 dst=r1 src=r2 offset=0 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
-    // EBPF_OP_LDXH pc=83 dst=r1 src=r8 offset=16 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=84 dst=r6 src=r1 offset=40 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=85 dst=r7 src=r0 offset=0 imm=1
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=89 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -822,16 +804,16 @@ label_3:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=91 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -840,13 +822,13 @@ label_3:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=96 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -855,37 +837,37 @@ label_3:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=98 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=99 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=100 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=102 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=103 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=104 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=105 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=108 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=109 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -895,13 +877,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r7 offset=0 imm=0
-#line 161 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
+#line 148 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
-#line 161 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
+#line 148 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 161 "sample/cgroup_sock_addr2.c"
+#line 148 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -918,7 +900,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        103,
+        99,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -932,7 +914,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        112,
+        110,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -96,45 +96,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
 {
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -148,232 +148,241 @@ connect_redirect4(void* context)
     // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=25959
+    // EBPF_OP_STXW pc=6 dst=r10 src=r7 offset=-12 imm=0
+#line 57 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=25959
 #line 57 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=7 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=8 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=1299477349
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r1 offset=-48 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1953394499
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=14 dst=r10 src=r1 offset=-56 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=14 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=15 dst=r1 src=r0 offset=0 imm=1768187218
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r1 offset=-64 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=17 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=18 dst=r10 src=r7 offset=-38 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=24 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=19 dst=r10 src=r1 offset=-32 imm=0
+    // EBPF_OP_STXW pc=20 dst=r10 src=r1 offset=-32 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=20 dst=r1 src=r6 offset=40 imm=0
+    // EBPF_OP_LDXH pc=21 dst=r1 src=r6 offset=40 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXH pc=22 dst=r10 src=r1 offset=-16 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=22 dst=r1 src=r6 offset=44 imm=0
-#line 62 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-12 imm=0
-#line 62 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_JEQ_IMM pc=24 dst=r1 src=r0 offset=1 imm=17
-#line 64 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
-#line 64 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=1
+#line 61 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=24 dst=r2 src=r6 offset=44 imm=0
+#line 63 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=25 dst=r2 src=r0 offset=2 imm=6
+#line 63 "sample/cgroup_sock_addr2.c"
+    if (r2 == IMMEDIATE(6))
+#line 63 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=72 imm=6
-#line 64 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
-#line 64 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=26 dst=r2 src=r0 offset=74 imm=17
+#line 63 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(17))
+#line 63 "sample/cgroup_sock_addr2.c"
         goto label_4;
+        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
+#line 63 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
-#line 68 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=28 dst=r10 src=r1 offset=-12 imm=0
+#line 63 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_LDXW pc=29 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=70 imm=2
-#line 68 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=30 dst=r1 src=r0 offset=70 imm=2
+#line 71 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
-#line 68 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 68 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-32
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=32 dst=r2 src=r0 offset=0 imm=-32
+#line 76 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=30 dst=r1 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=33 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=1
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=1
+#line 76 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=33 dst=r8 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=36 dst=r8 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r9 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=37 dst=r9 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=38 dst=r7 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=37 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=39 dst=r8 src=r0 offset=37 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 74 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=37 dst=r7 src=r0 offset=0 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=40 dst=r7 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=38 dst=r10 src=r7 offset=-70 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=41 dst=r10 src=r7 offset=-70 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=39 dst=r1 src=r0 offset=0 imm=29989
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r1 src=r0 offset=0 imm=29989
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=40 dst=r10 src=r1 offset=-72 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=43 dst=r10 src=r1 offset=-72 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=540697973
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=540697973
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-80 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-80 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=2037544046
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=2037544046
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-88 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-88 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=1869770784
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1869770784
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-96 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-96 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1853189958
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1853189958
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-104 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-104 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=53 dst=r4 src=r8 offset=16 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=56 dst=r4 src=r8 offset=16 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=54 dst=r3 src=r8 offset=0 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=57 dst=r3 src=r8 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r10 offset=0 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r10 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=56 dst=r1 src=r0 offset=0 imm=-104
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=59 dst=r1 src=r0 offset=0 imm=-104
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=57 dst=r2 src=r0 offset=0 imm=35
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=35
+#line 78 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=14
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=14
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=59 dst=r1 src=r8 offset=20 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=20 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=8 imm=3
-#line 81 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=63 dst=r1 src=r0 offset=8 imm=3
+#line 84 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 84 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=61 dst=r2 src=r10 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=64 dst=r2 src=r10 offset=0 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=62 dst=r2 src=r0 offset=0 imm=-64
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=65 dst=r2 src=r0 offset=0 imm=-64
+#line 85 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=63 dst=r1 src=r6 offset=0 imm=0
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r6 offset=0 imm=0
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r3 src=r0 offset=0 imm=27
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=27
+#line 85 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=65537
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=65537
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
-#line 82 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=32
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=68 dst=r7 src=r0 offset=29 imm=0
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=71 dst=r7 src=r0 offset=29 imm=0
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=0 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=72 dst=r1 src=r8 offset=0 imm=0
+#line 90 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=70 dst=r6 src=r1 offset=24 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=73 dst=r6 src=r1 offset=24 imm=0
+#line 90 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=71 dst=r1 src=r8 offset=16 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=74 dst=r1 src=r8 offset=16 imm=0
+#line 91 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=72 dst=r6 src=r1 offset=40 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=75 dst=r6 src=r1 offset=40 imm=0
+#line 91 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=73 dst=r7 src=r0 offset=0 imm=1
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=76 dst=r7 src=r0 offset=0 imm=1
+#line 91 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -382,16 +391,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=79 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=80 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -400,13 +409,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=83 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -415,37 +424,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=86 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=87 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=89 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=90 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=91 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=94 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=92 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=95 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=93 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=96 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=94 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=97 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=96 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=99 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -455,13 +464,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=98 dst=r0 src=r7 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=101 dst=r0 src=r7 offset=0 imm=0
+#line 154 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=99 dst=r0 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=102 dst=r0 src=r0 offset=0 imm=0
+#line 154 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -488,317 +497,323 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
 {
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 105 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
-#line 105 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=18 dst=r1 src=r0 offset=91 imm=23
+#line 108 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(23))
+#line 108 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=36 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=20 dst=r1 src=r0 offset=0 imm=32
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=32 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=22 dst=r1 src=r2 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-24 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDXW pc=24 dst=r1 src=r6 offset=28 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=25 dst=r1 src=r0 offset=0 imm=32
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=26 dst=r2 src=r6 offset=24 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=27 dst=r1 src=r2 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-32 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=29 dst=r1 src=r6 offset=40 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=30 dst=r10 src=r1 offset=-16 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=31 dst=r1 src=r0 offset=0 imm=1
+#line 116 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=32 dst=r2 src=r6 offset=44 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=33 dst=r2 src=r0 offset=2 imm=6
+#line 117 "sample/cgroup_sock_addr2.c"
+    if (r2 == IMMEDIATE(6))
+#line 117 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 105 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
-#line 105 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=34 dst=r2 src=r0 offset=75 imm=17
+#line 117 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(17))
+#line 117 "sample/cgroup_sock_addr2.c"
         goto label_4;
+        // EBPF_OP_MOV64_IMM pc=35 dst=r1 src=r0 offset=0 imm=2
+#line 117 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
-#line 109 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
-#line 109 "sample/cgroup_sock_addr2.c"
-        goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+    // EBPF_OP_STXW pc=36 dst=r10 src=r1 offset=-12 imm=0
 #line 117 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
-    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
-#line 116 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
+#line 117 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=40 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=47 dst=r10 src=r7 offset=-70 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=25973
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=2037544046
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1869770784
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1853189958
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r10 offset=0 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=-96
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=27
+#line 128 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=12
+#line 128 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=63 dst=r1 src=r8 offset=20 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
-#line 129 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=64 dst=r1 src=r0 offset=8 imm=3
+#line 134 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-64
+#line 135 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=67 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=68 dst=r3 src=r0 offset=0 imm=27
+#line 135 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=65537
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
-#line 130 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=71 dst=r0 src=r0 offset=0 imm=32
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=72 dst=r7 src=r0 offset=37 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=24
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(24);
-    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=12 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=12 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=8 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=8 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=4 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=4 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=81 dst=r2 src=r8 offset=0 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=82 dst=r1 src=r2 offset=0 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
-    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=83 dst=r1 src=r8 offset=16 imm=0
+#line 140 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=84 dst=r6 src=r1 offset=40 imm=0
+#line 140 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=85 dst=r7 src=r0 offset=0 imm=1
+#line 140 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=88 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -807,16 +822,16 @@ label_3:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -825,13 +840,13 @@ label_3:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -840,37 +855,37 @@ label_3:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=98 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=99 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=100 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=103 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=104 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=105 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=108 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=109 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -880,13 +895,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 156 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r7 offset=0 imm=0
+#line 161 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 156 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
+#line 161 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 156 "sample/cgroup_sock_addr2.c"
+#line 161 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -903,7 +918,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        100,
+        103,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -917,7 +932,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        110,
+        112,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -96,45 +96,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
 {
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -256,112 +256,112 @@ label_1:
 #line 79 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
     // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
     // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
     // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
     // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
     // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+#line 86 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+#line 86 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
     // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
@@ -459,12 +459,12 @@ label_3:
         return 0;
 label_4:
     // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -491,299 +491,299 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
 {
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
         goto label_1;
         // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
         goto label_3;
         // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
         goto label_3;
         // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
     // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
     // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 120 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 120 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
     // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
     // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
         goto label_2;
         // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
     // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
     // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
     // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
     // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
     // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
@@ -881,12 +881,12 @@ label_2:
         return 0;
 label_3:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -75,8 +75,8 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
@@ -96,45 +96,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
 {
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -198,176 +198,185 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=71 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=73 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
-        goto label_3;
+        goto label_4;
 label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=69 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=71 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+        goto label_4;
+        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
-#line 72 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r3 src=r0 offset=0 imm=27
-#line 72 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=65537
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[0].address
-#line 72 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 72 "sample/cgroup_sock_addr2.c"
-        return 0;
-    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=36 dst=r7 src=r0 offset=60 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
-#line 72 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-32
+#line 73 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=30 dst=r1 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
-#line 77 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=1
+#line 73 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[0].address
+#line 73 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 77 "sample/cgroup_sock_addr2.c"
+#line 73 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
+#line 73 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=33 dst=r8 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=34 dst=r9 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=27 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=38 imm=0
+#line 74 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 74 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+        // EBPF_OP_LDXW pc=37 dst=r1 src=r8 offset=20 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=38 dst=r1 src=r0 offset=9 imm=3
+#line 79 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 79 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=47 dst=r10 src=r1 offset=-70 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r10 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=29989
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=540697973
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=2037544046
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1869770784
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1853189958
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-104 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=62 dst=r4 src=r8 offset=16 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=63 dst=r3 src=r8 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=64 dst=r1 src=r10 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=65 dst=r1 src=r0 offset=0 imm=-104
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=35
-#line 79 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=14
-#line 79 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 79 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
+#line 81 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
+#line 81 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
+#line 81 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[1].address
+#line 81 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 79 "sample/cgroup_sock_addr2.c"
+#line 81 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 81 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
+        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
 #line 81 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
 #line 81 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(1);
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 81 "sample/cgroup_sock_addr2.c"
+        goto label_4;
 label_2:
-    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
+#line 86 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
+#line 86 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 86 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 86 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 86 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
+    // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
+#line 88 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(1);
+label_3:
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=78 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=79 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -376,16 +385,16 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=80 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=81 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=82 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -394,13 +403,13 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=84 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -409,37 +418,37 @@ label_2:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=87 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=88 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=89 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=90 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=92 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=94 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=97 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=98 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -448,14 +457,14 @@ label_2:
     if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
-label_3:
-    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
-#line 136 "sample/cgroup_sock_addr2.c"
+label_4:
+    // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
+#line 144 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
-#line 136 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
+#line 144 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 136 "sample/cgroup_sock_addr2.c"
+#line 144 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -482,299 +491,299 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 {
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 98 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
+#line 106 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 106 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
     // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
     // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
     // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
     // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
     // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
     // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
     // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
     // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
     // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
@@ -798,7 +807,7 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
@@ -816,7 +825,7 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
@@ -831,7 +840,7 @@ label_2:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
@@ -872,12 +881,12 @@ label_2:
         return 0;
 label_3:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -894,7 +903,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        99,
+        101,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_dll.c
@@ -76,8 +76,8 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 14, "helper_id_14"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
@@ -96,45 +96,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
 {
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -198,7 +198,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=73 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=72 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
@@ -207,7 +207,7 @@ label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=71 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=70 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
@@ -239,144 +239,141 @@ label_1:
     // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 73 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=38 imm=0
+    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=37 imm=0
 #line 74 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 74 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=37 dst=r1 src=r8 offset=20 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=38 dst=r1 src=r0 offset=9 imm=3
-#line 79 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
-#line 79 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r10 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
-#line 80 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
-#line 80 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
-#line 80 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 80 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=37 dst=r7 src=r0 offset=0 imm=0
+#line 74 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=38 dst=r10 src=r7 offset=-70 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
+    // EBPF_OP_MOV64_IMM pc=39 dst=r1 src=r0 offset=0 imm=29989
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=40 dst=r10 src=r1 offset=-72 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=540697973
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-80 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=2037544046
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-88 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=1869770784
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-96 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1853189958
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-104 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=53 dst=r4 src=r8 offset=16 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=54 dst=r3 src=r8 offset=0 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r10 offset=0 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=56 dst=r1 src=r0 offset=0 imm=-104
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=57 dst=r2 src=r0 offset=0 imm=35
+#line 75 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=14
+#line 75 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[1].address
+#line 75 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 75 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 75 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=59 dst=r1 src=r8 offset=20 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=8 imm=3
+#line 81 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 81 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=61 dst=r2 src=r10 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=62 dst=r2 src=r0 offset=0 imm=-64
+#line 82 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=63 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=64 dst=r3 src=r0 offset=0 imm=27
+#line 82 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=65537
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 82 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 82 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 82 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=32
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=68 dst=r7 src=r0 offset=29 imm=0
+#line 82 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 80 "sample/cgroup_sock_addr2.c"
+#line 82 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
-#line 85 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
-#line 85 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 85 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 85 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=0 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=70 dst=r6 src=r1 offset=24 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=71 dst=r1 src=r8 offset=16 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=72 dst=r6 src=r1 offset=40 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=73 dst=r7 src=r0 offset=0 imm=1
+#line 88 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=78 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=79 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -385,16 +382,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=80 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=79 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=81 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=80 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=82 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -403,13 +400,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=84 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=83 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -418,37 +415,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=87 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=86 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=88 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=87 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=89 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=90 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=89 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=91 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=90 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=91 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=93 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=92 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=94 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=93 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=94 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=97 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=96 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=98 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -458,21 +455,21 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=98 dst=r0 src=r7 offset=0 imm=0
+#line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=99 dst=r0 src=r0 offset=0 imm=0
+#line 149 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
 
 static helper_function_entry_t connect_redirect6_helpers[] = {
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
@@ -491,301 +488,304 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
 {
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
         goto label_1;
         // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 104 "sample/cgroup_sock_addr2.c"
-        goto label_3;
+#line 105 "sample/cgroup_sock_addr2.c"
+        goto label_4;
 label_1:
-    // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(23))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 112 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 112 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[0].address
-#line 112 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 112 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
-#line 112 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
+#line 109 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(23))
+#line 109 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 119 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
+#line 116 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 124 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[1].address
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
+#line 121 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[0].address
+#line 121 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 124 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 124 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
+#line 121 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 125 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
-    r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 125 "sample/cgroup_sock_addr2.c"
-    r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
+#line 123 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 126 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
+#line 123 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[1].address
+#line 123 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
+#line 123 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
+        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
+#line 129 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 129 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
+#line 130 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
+#line 130 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[2].address
+#line 130 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 130 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+#line 130 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 130 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+label_2:
+    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(24);
+    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
+    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
-label_2:
+label_3:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
@@ -879,14 +879,14 @@ label_2:
     if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
-label_3:
+label_4:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -903,7 +903,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        101,
+        100,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -50,8 +50,8 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 14, "helper_id_14"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
@@ -70,45 +70,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
 {
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -172,7 +172,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=73 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=72 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
@@ -181,7 +181,7 @@ label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=71 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=70 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
@@ -213,144 +213,141 @@ label_1:
     // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 73 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=38 imm=0
+    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=37 imm=0
 #line 74 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 74 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=37 dst=r1 src=r8 offset=20 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=38 dst=r1 src=r0 offset=9 imm=3
-#line 79 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
-#line 79 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r10 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
-#line 80 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
-#line 80 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
-#line 80 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 80 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=37 dst=r7 src=r0 offset=0 imm=0
+#line 74 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=38 dst=r10 src=r7 offset=-70 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
+    // EBPF_OP_MOV64_IMM pc=39 dst=r1 src=r0 offset=0 imm=29989
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=40 dst=r10 src=r1 offset=-72 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=540697973
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-80 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=2037544046
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-88 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=1869770784
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-96 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1853189958
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-104 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=53 dst=r4 src=r8 offset=16 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=54 dst=r3 src=r8 offset=0 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r10 offset=0 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=56 dst=r1 src=r0 offset=0 imm=-104
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=57 dst=r2 src=r0 offset=0 imm=35
+#line 75 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=14
+#line 75 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[1].address
+#line 75 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 75 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 75 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=59 dst=r1 src=r8 offset=20 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=8 imm=3
+#line 81 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 81 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=61 dst=r2 src=r10 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=62 dst=r2 src=r0 offset=0 imm=-64
+#line 82 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=63 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=64 dst=r3 src=r0 offset=0 imm=27
+#line 82 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=65537
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 82 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 82 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 82 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=32
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=68 dst=r7 src=r0 offset=29 imm=0
+#line 82 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 80 "sample/cgroup_sock_addr2.c"
+#line 82 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
-#line 85 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
-#line 85 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 85 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 85 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=0 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=70 dst=r6 src=r1 offset=24 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=71 dst=r1 src=r8 offset=16 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=72 dst=r6 src=r1 offset=40 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=73 dst=r7 src=r0 offset=0 imm=1
+#line 88 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=78 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=79 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -359,16 +356,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=80 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=79 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=81 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=80 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=82 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -377,13 +374,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=84 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=83 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -392,37 +389,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=87 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=86 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=88 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=87 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=89 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=90 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=89 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=91 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=90 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=91 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=93 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=92 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=94 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=93 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=94 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=97 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=96 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=98 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -432,21 +429,21 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=98 dst=r0 src=r7 offset=0 imm=0
+#line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=99 dst=r0 src=r0 offset=0 imm=0
+#line 149 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
 
 static helper_function_entry_t connect_redirect6_helpers[] = {
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
@@ -465,301 +462,304 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
 {
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
         goto label_1;
         // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 104 "sample/cgroup_sock_addr2.c"
-        goto label_3;
+#line 105 "sample/cgroup_sock_addr2.c"
+        goto label_4;
 label_1:
-    // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(23))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 112 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 112 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[0].address
-#line 112 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 112 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
-#line 112 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
+#line 109 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(23))
+#line 109 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 119 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
+#line 116 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 124 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[1].address
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
+#line 121 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[0].address
+#line 121 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 124 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 124 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
+#line 121 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 125 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
-    r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 125 "sample/cgroup_sock_addr2.c"
-    r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
+#line 123 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 126 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
+#line 123 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[1].address
+#line 123 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
+#line 123 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
+        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
+#line 129 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 129 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
+#line 130 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
+#line 130 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[2].address
+#line 130 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 130 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+#line 130 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 130 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+label_2:
+    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(24);
+    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
+    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
-label_2:
+label_3:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
@@ -853,14 +853,14 @@ label_2:
     if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
-label_3:
+label_4:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -877,7 +877,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        101,
+        100,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -70,45 +70,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
 {
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -122,232 +122,241 @@ connect_redirect4(void* context)
     // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=25959
+    // EBPF_OP_STXW pc=6 dst=r10 src=r7 offset=-12 imm=0
+#line 57 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=25959
 #line 57 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=7 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=8 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=1299477349
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r1 offset=-48 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1953394499
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=14 dst=r10 src=r1 offset=-56 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=14 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=15 dst=r1 src=r0 offset=0 imm=1768187218
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r1 offset=-64 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=17 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=18 dst=r10 src=r7 offset=-38 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=24 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=19 dst=r10 src=r1 offset=-32 imm=0
+    // EBPF_OP_STXW pc=20 dst=r10 src=r1 offset=-32 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=20 dst=r1 src=r6 offset=40 imm=0
+    // EBPF_OP_LDXH pc=21 dst=r1 src=r6 offset=40 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXH pc=22 dst=r10 src=r1 offset=-16 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=22 dst=r1 src=r6 offset=44 imm=0
-#line 62 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-12 imm=0
-#line 62 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_JEQ_IMM pc=24 dst=r1 src=r0 offset=1 imm=17
-#line 64 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
-#line 64 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=1
+#line 61 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=24 dst=r2 src=r6 offset=44 imm=0
+#line 63 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=25 dst=r2 src=r0 offset=2 imm=6
+#line 63 "sample/cgroup_sock_addr2.c"
+    if (r2 == IMMEDIATE(6))
+#line 63 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=72 imm=6
-#line 64 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
-#line 64 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=26 dst=r2 src=r0 offset=74 imm=17
+#line 63 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(17))
+#line 63 "sample/cgroup_sock_addr2.c"
         goto label_4;
+        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
+#line 63 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
-#line 68 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=28 dst=r10 src=r1 offset=-12 imm=0
+#line 63 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_LDXW pc=29 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=70 imm=2
-#line 68 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=30 dst=r1 src=r0 offset=70 imm=2
+#line 71 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
-#line 68 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 68 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-32
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=32 dst=r2 src=r0 offset=0 imm=-32
+#line 76 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=30 dst=r1 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=33 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=1
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=1
+#line 76 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=33 dst=r8 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=36 dst=r8 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r9 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=37 dst=r9 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=38 dst=r7 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=37 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=39 dst=r8 src=r0 offset=37 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 74 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=37 dst=r7 src=r0 offset=0 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=40 dst=r7 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=38 dst=r10 src=r7 offset=-70 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=41 dst=r10 src=r7 offset=-70 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=39 dst=r1 src=r0 offset=0 imm=29989
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r1 src=r0 offset=0 imm=29989
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=40 dst=r10 src=r1 offset=-72 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=43 dst=r10 src=r1 offset=-72 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=540697973
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=540697973
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-80 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-80 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=2037544046
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=2037544046
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-88 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-88 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=1869770784
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1869770784
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-96 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-96 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1853189958
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1853189958
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-104 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-104 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=53 dst=r4 src=r8 offset=16 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=56 dst=r4 src=r8 offset=16 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=54 dst=r3 src=r8 offset=0 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=57 dst=r3 src=r8 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r10 offset=0 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r10 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=56 dst=r1 src=r0 offset=0 imm=-104
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=59 dst=r1 src=r0 offset=0 imm=-104
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=57 dst=r2 src=r0 offset=0 imm=35
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=35
+#line 78 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=14
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=14
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=59 dst=r1 src=r8 offset=20 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=20 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=8 imm=3
-#line 81 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=63 dst=r1 src=r0 offset=8 imm=3
+#line 84 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 84 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=61 dst=r2 src=r10 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=64 dst=r2 src=r10 offset=0 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=62 dst=r2 src=r0 offset=0 imm=-64
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=65 dst=r2 src=r0 offset=0 imm=-64
+#line 85 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=63 dst=r1 src=r6 offset=0 imm=0
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r6 offset=0 imm=0
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r3 src=r0 offset=0 imm=27
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=27
+#line 85 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=65537
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=65537
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
-#line 82 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=32
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=68 dst=r7 src=r0 offset=29 imm=0
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=71 dst=r7 src=r0 offset=29 imm=0
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=0 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=72 dst=r1 src=r8 offset=0 imm=0
+#line 90 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=70 dst=r6 src=r1 offset=24 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=73 dst=r6 src=r1 offset=24 imm=0
+#line 90 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=71 dst=r1 src=r8 offset=16 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=74 dst=r1 src=r8 offset=16 imm=0
+#line 91 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=72 dst=r6 src=r1 offset=40 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=75 dst=r6 src=r1 offset=40 imm=0
+#line 91 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=73 dst=r7 src=r0 offset=0 imm=1
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=76 dst=r7 src=r0 offset=0 imm=1
+#line 91 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -356,16 +365,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=79 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=80 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -374,13 +383,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=83 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -389,37 +398,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=86 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=87 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=89 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=90 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=91 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=94 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=92 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=95 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=93 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=96 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=94 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=97 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=96 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=99 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -429,13 +438,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=98 dst=r0 src=r7 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=101 dst=r0 src=r7 offset=0 imm=0
+#line 154 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=99 dst=r0 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=102 dst=r0 src=r0 offset=0 imm=0
+#line 154 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -462,317 +471,323 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
 {
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 105 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
-#line 105 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=18 dst=r1 src=r0 offset=91 imm=23
+#line 108 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(23))
+#line 108 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=36 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=20 dst=r1 src=r0 offset=0 imm=32
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=32 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=22 dst=r1 src=r2 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-24 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDXW pc=24 dst=r1 src=r6 offset=28 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=25 dst=r1 src=r0 offset=0 imm=32
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=26 dst=r2 src=r6 offset=24 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=27 dst=r1 src=r2 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-32 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=29 dst=r1 src=r6 offset=40 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=30 dst=r10 src=r1 offset=-16 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=31 dst=r1 src=r0 offset=0 imm=1
+#line 116 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=32 dst=r2 src=r6 offset=44 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=33 dst=r2 src=r0 offset=2 imm=6
+#line 117 "sample/cgroup_sock_addr2.c"
+    if (r2 == IMMEDIATE(6))
+#line 117 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 105 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
-#line 105 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=34 dst=r2 src=r0 offset=75 imm=17
+#line 117 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(17))
+#line 117 "sample/cgroup_sock_addr2.c"
         goto label_4;
+        // EBPF_OP_MOV64_IMM pc=35 dst=r1 src=r0 offset=0 imm=2
+#line 117 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
-#line 109 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
-#line 109 "sample/cgroup_sock_addr2.c"
-        goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+    // EBPF_OP_STXW pc=36 dst=r10 src=r1 offset=-12 imm=0
 #line 117 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
-    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
-#line 116 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
+#line 117 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=40 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=47 dst=r10 src=r7 offset=-70 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=25973
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=2037544046
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1869770784
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1853189958
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r10 offset=0 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=-96
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=27
+#line 128 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=12
+#line 128 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=63 dst=r1 src=r8 offset=20 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
-#line 129 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=64 dst=r1 src=r0 offset=8 imm=3
+#line 134 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-64
+#line 135 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=67 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=68 dst=r3 src=r0 offset=0 imm=27
+#line 135 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=65537
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
-#line 130 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=71 dst=r0 src=r0 offset=0 imm=32
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=72 dst=r7 src=r0 offset=37 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=24
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(24);
-    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=12 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=12 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=8 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=8 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=4 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=4 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=81 dst=r2 src=r8 offset=0 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=82 dst=r1 src=r2 offset=0 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
-    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=83 dst=r1 src=r8 offset=16 imm=0
+#line 140 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=84 dst=r6 src=r1 offset=40 imm=0
+#line 140 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=85 dst=r7 src=r0 offset=0 imm=1
+#line 140 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=88 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -781,16 +796,16 @@ label_3:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -799,13 +814,13 @@ label_3:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -814,37 +829,37 @@ label_3:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=98 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=99 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=100 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=103 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=104 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=105 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=108 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=109 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -854,13 +869,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 156 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r7 offset=0 imm=0
+#line 161 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 156 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
+#line 161 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 156 "sample/cgroup_sock_addr2.c"
+#line 161 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -877,7 +892,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        100,
+        103,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -891,7 +906,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        110,
+        112,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -70,45 +70,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
 {
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -230,112 +230,112 @@ label_1:
 #line 79 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
     // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
     // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
     // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
     // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
     // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+#line 86 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+#line 86 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
     // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
@@ -433,12 +433,12 @@ label_3:
         return 0;
 label_4:
     // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -465,299 +465,299 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
 {
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
         goto label_1;
         // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
         goto label_3;
         // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
         goto label_3;
         // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
     // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
     // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 120 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 120 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
     // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
     // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
         goto label_2;
         // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
     // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
     // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
     // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
     // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
     // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
@@ -855,12 +855,12 @@ label_2:
         return 0;
 label_3:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -49,8 +49,8 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
@@ -70,45 +70,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
 {
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -172,176 +172,185 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=71 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=73 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
-        goto label_3;
+        goto label_4;
 label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=69 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=71 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+        goto label_4;
+        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
-#line 72 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r3 src=r0 offset=0 imm=27
-#line 72 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=65537
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[0].address
-#line 72 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 72 "sample/cgroup_sock_addr2.c"
-        return 0;
-    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=36 dst=r7 src=r0 offset=60 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
-#line 72 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-32
+#line 73 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=30 dst=r1 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
-#line 77 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=1
+#line 73 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[0].address
+#line 73 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 77 "sample/cgroup_sock_addr2.c"
+#line 73 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
+#line 73 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=33 dst=r8 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=34 dst=r9 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=27 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=38 imm=0
+#line 74 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 74 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+        // EBPF_OP_LDXW pc=37 dst=r1 src=r8 offset=20 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=38 dst=r1 src=r0 offset=9 imm=3
+#line 79 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 79 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=47 dst=r10 src=r1 offset=-70 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r10 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=29989
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=540697973
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=2037544046
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1869770784
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1853189958
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-104 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=62 dst=r4 src=r8 offset=16 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=63 dst=r3 src=r8 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=64 dst=r1 src=r10 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=65 dst=r1 src=r0 offset=0 imm=-104
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=35
-#line 79 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=14
-#line 79 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 79 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
+#line 81 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
+#line 81 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
+#line 81 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[1].address
+#line 81 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 79 "sample/cgroup_sock_addr2.c"
+#line 81 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 81 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
+        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
 #line 81 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
 #line 81 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(1);
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 81 "sample/cgroup_sock_addr2.c"
+        goto label_4;
 label_2:
-    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
+#line 86 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
+#line 86 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 86 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 86 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 86 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
+    // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
+#line 88 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(1);
+label_3:
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=78 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=79 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -350,16 +359,16 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=80 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=81 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=82 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -368,13 +377,13 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=84 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -383,37 +392,37 @@ label_2:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=87 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=88 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=89 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=90 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=92 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=94 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=97 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=98 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -422,14 +431,14 @@ label_2:
     if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
-label_3:
-    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
-#line 136 "sample/cgroup_sock_addr2.c"
+label_4:
+    // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
+#line 144 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
-#line 136 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
+#line 144 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 136 "sample/cgroup_sock_addr2.c"
+#line 144 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -456,299 +465,299 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 {
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 98 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
+#line 106 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 106 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
     // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
     // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
     // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
     // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
     // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
     // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
     // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
     // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
     // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
@@ -772,7 +781,7 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
@@ -790,7 +799,7 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
@@ -805,7 +814,7 @@ label_2:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
@@ -846,12 +855,12 @@ label_2:
         return 0;
 label_3:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -868,7 +877,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        99,
+        101,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_raw.c
@@ -22,7 +22,7 @@ static map_entry_t _maps[] = {
          100,               // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         18,                // Identifier for a map template.
+         21,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "policy_map"},
@@ -34,7 +34,7 @@ static map_entry_t _maps[] = {
          100,               // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         27,                // Identifier for a map template.
+         30,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "audit_map"},
@@ -70,293 +70,281 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
 {
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=3 dst=r10 src=r7 offset=-20 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=4 dst=r10 src=r7 offset=-24 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
-#line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=6 dst=r10 src=r7 offset=-12 imm=0
-#line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=25959
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
 #line 57 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=8 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=14 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=15 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=18 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=20 dst=r10 src=r1 offset=-32 imm=0
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 60 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=21 dst=r1 src=r6 offset=40 imm=0
-#line 61 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=22 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=1
-#line 61 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=24 dst=r2 src=r6 offset=44 imm=0
-#line 63 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=25 dst=r2 src=r0 offset=2 imm=6
-#line 63 "sample/cgroup_sock_addr2.c"
-    if (r2 == IMMEDIATE(6))
-#line 63 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(17))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=26 dst=r2 src=r0 offset=74 imm=17
-#line 63 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(17))
-#line 63 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=77 imm=6
+#line 60 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
-#line 63 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_STXW pc=28 dst=r10 src=r1 offset=-12 imm=0
-#line 63 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=29 dst=r1 src=r6 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=30 dst=r1 src=r0 offset=70 imm=2
-#line 71 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(2))
-#line 71 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=75 imm=2
+#line 60 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(2))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
+#line 64 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_STXW pc=23 dst=r10 src=r2 offset=-32 imm=0
+#line 64 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXH pc=24 dst=r2 src=r6 offset=40 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXW pc=25 dst=r10 src=r1 offset=-12 imm=0
+#line 66 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_STXH pc=26 dst=r10 src=r2 offset=-16 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r10 offset=0 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=32 dst=r2 src=r0 offset=0 imm=-32
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=28 dst=r2 src=r0 offset=0 imm=-32
+#line 64 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=33 dst=r1 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=1
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=1
+#line 69 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=36 dst=r8 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=37 dst=r9 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=33 dst=r9 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=38 dst=r7 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=39 dst=r8 src=r0 offset=37 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=35 dst=r8 src=r0 offset=37 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 77 "sample/cgroup_sock_addr2.c"
+#line 70 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=40 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=41 dst=r10 src=r7 offset=-70 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=37 dst=r10 src=r7 offset=-70 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r1 src=r0 offset=0 imm=29989
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=38 dst=r1 src=r0 offset=0 imm=29989
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=43 dst=r10 src=r1 offset=-72 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-72 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=540697973
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=40 dst=r1 src=r0 offset=0 imm=540697973
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-80 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=42 dst=r10 src=r1 offset=-80 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=2037544046
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=43 dst=r1 src=r0 offset=0 imm=2037544046
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-88 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=45 dst=r10 src=r1 offset=-88 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1869770784
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=1869770784
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-96 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=48 dst=r10 src=r1 offset=-96 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1853189958
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=49 dst=r1 src=r0 offset=0 imm=1853189958
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-104 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=51 dst=r10 src=r1 offset=-104 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=56 dst=r4 src=r8 offset=16 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=52 dst=r4 src=r8 offset=16 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=57 dst=r3 src=r8 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=53 dst=r3 src=r8 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r10 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=54 dst=r1 src=r10 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=59 dst=r1 src=r0 offset=0 imm=-104
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=55 dst=r1 src=r0 offset=0 imm=-104
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=35
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=56 dst=r2 src=r0 offset=0 imm=35
+#line 71 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=14
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=14
+#line 71 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 71 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=59 dst=r1 src=r0 offset=8 imm=3
+#line 77 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 77 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=61 dst=r2 src=r0 offset=0 imm=-64
+#line 78 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=63 dst=r3 src=r0 offset=0 imm=27
+#line 78 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=65537
+#line 78 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 78 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 78 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 78 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=20 imm=0
-#line 84 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=63 dst=r1 src=r0 offset=8 imm=3
-#line 84 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
-#line 84 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=64 dst=r2 src=r10 offset=0 imm=0
-#line 84 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=65 dst=r2 src=r0 offset=0 imm=-64
-#line 85 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r6 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=27
-#line 85 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=65537
-#line 85 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 85 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 85 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
-#line 85 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
-#line 85 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=71 dst=r7 src=r0 offset=29 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=67 dst=r7 src=r0 offset=29 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 85 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_LDXW pc=72 dst=r1 src=r8 offset=0 imm=0
-#line 90 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
+#line 83 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=73 dst=r6 src=r1 offset=24 imm=0
-#line 90 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
+#line 83 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=74 dst=r1 src=r8 offset=16 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=75 dst=r6 src=r1 offset=40 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=76 dst=r7 src=r0 offset=0 imm=1
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
+#line 84 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=78 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -365,16 +353,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -383,13 +371,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -398,37 +386,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=93 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=94 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=95 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=96 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=97 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=99 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -438,13 +426,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=101 dst=r0 src=r7 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
+#line 141 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=102 dst=r0 src=r0 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
+#line 141 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -471,323 +459,317 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
 {
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=18 dst=r1 src=r0 offset=91 imm=23
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(23))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_4;
-        // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=36 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=20 dst=r1 src=r0 offset=0 imm=32
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=32 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=22 dst=r1 src=r2 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-24 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=24 dst=r1 src=r6 offset=28 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=25 dst=r1 src=r0 offset=0 imm=32
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=26 dst=r2 src=r6 offset=24 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=27 dst=r1 src=r2 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-32 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=29 dst=r1 src=r6 offset=40 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=30 dst=r10 src=r1 offset=-16 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r1 src=r0 offset=0 imm=1
-#line 116 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=32 dst=r2 src=r6 offset=44 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=33 dst=r2 src=r0 offset=2 imm=6
-#line 117 "sample/cgroup_sock_addr2.c"
-    if (r2 == IMMEDIATE(6))
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
+#line 101 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(17))
+#line 101 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=34 dst=r2 src=r0 offset=75 imm=17
-#line 117 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(17))
-#line 117 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6))
+#line 101 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=35 dst=r1 src=r0 offset=0 imm=2
-#line 117 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_STXW pc=36 dst=r10 src=r1 offset=-12 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 101 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(23))
+#line 101 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
+#line 108 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
+#line 113 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=40 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=47 dst=r10 src=r7 offset=-70 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=25973
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=2037544046
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1869770784
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1853189958
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r10 offset=0 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=-96
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=27
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
+#line 115 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=12
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
+#line 115 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=63 dst=r1 src=r8 offset=20 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=64 dst=r1 src=r0 offset=8 imm=3
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
+#line 121 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-64
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
+#line 122 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=67 dst=r1 src=r6 offset=0 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=68 dst=r3 src=r0 offset=0 imm=27
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
+#line 122 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=65537
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
-#line 135 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=71 dst=r0 src=r0 offset=0 imm=32
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=72 dst=r7 src=r0 offset=37 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=24
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(24);
-    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=12 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=12 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=8 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=8 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=4 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=4 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=81 dst=r2 src=r8 offset=0 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=82 dst=r1 src=r2 offset=0 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
-    // EBPF_OP_LDXH pc=83 dst=r1 src=r8 offset=16 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=84 dst=r6 src=r1 offset=40 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=85 dst=r7 src=r0 offset=0 imm=1
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=89 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -796,16 +778,16 @@ label_3:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=91 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -814,13 +796,13 @@ label_3:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=96 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -829,37 +811,37 @@ label_3:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=98 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=99 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=100 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=102 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=103 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=104 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=105 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=108 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=109 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -869,13 +851,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r7 offset=0 imm=0
-#line 161 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
+#line 148 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
-#line 161 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
+#line 148 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 161 "sample/cgroup_sock_addr2.c"
+#line 148 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -892,7 +874,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        103,
+        99,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -906,7 +888,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        112,
+        110,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -231,45 +231,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
 {
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 152 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -283,232 +283,241 @@ connect_redirect4(void* context)
     // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=6 dst=r1 src=r0 offset=0 imm=25959
+    // EBPF_OP_STXW pc=6 dst=r10 src=r7 offset=-12 imm=0
+#line 57 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
+    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=25959
 #line 57 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=7 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=8 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=8 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=1299477349
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=10 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=11 dst=r10 src=r1 offset=-48 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=11 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1953394499
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=13 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=14 dst=r10 src=r1 offset=-56 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=14 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=15 dst=r1 src=r0 offset=0 imm=1768187218
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r1 offset=-64 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=17 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=18 dst=r10 src=r7 offset=-38 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=18 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=24 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=19 dst=r10 src=r1 offset=-32 imm=0
+    // EBPF_OP_STXW pc=20 dst=r10 src=r1 offset=-32 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=20 dst=r1 src=r6 offset=40 imm=0
+    // EBPF_OP_LDXH pc=21 dst=r1 src=r6 offset=40 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=21 dst=r10 src=r1 offset=-16 imm=0
+    // EBPF_OP_STXH pc=22 dst=r10 src=r1 offset=-16 imm=0
 #line 61 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=22 dst=r1 src=r6 offset=44 imm=0
-#line 62 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=23 dst=r10 src=r1 offset=-12 imm=0
-#line 62 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_JEQ_IMM pc=24 dst=r1 src=r0 offset=1 imm=17
-#line 64 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
-#line 64 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=1
+#line 61 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=24 dst=r2 src=r6 offset=44 imm=0
+#line 63 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=25 dst=r2 src=r0 offset=2 imm=6
+#line 63 "sample/cgroup_sock_addr2.c"
+    if (r2 == IMMEDIATE(6))
+#line 63 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=72 imm=6
-#line 64 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
-#line 64 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=26 dst=r2 src=r0 offset=74 imm=17
+#line 63 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(17))
+#line 63 "sample/cgroup_sock_addr2.c"
         goto label_4;
+        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
+#line 63 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
-#line 68 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=28 dst=r10 src=r1 offset=-12 imm=0
+#line 63 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_LDXW pc=29 dst=r1 src=r6 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=70 imm=2
-#line 68 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JNE_IMM pc=30 dst=r1 src=r0 offset=70 imm=2
+#line 71 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
-#line 68 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
-#line 68 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-32
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=32 dst=r2 src=r0 offset=0 imm=-32
+#line 76 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=30 dst=r1 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=33 dst=r1 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=1
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=1
+#line 76 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 73 "sample/cgroup_sock_addr2.c"
+#line 76 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=33 dst=r8 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=36 dst=r8 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r9 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=37 dst=r9 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
-#line 73 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=38 dst=r7 src=r0 offset=0 imm=0
+#line 76 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=37 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=39 dst=r8 src=r0 offset=37 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 74 "sample/cgroup_sock_addr2.c"
+#line 77 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=37 dst=r7 src=r0 offset=0 imm=0
-#line 74 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=40 dst=r7 src=r0 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=38 dst=r10 src=r7 offset=-70 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=41 dst=r10 src=r7 offset=-70 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=39 dst=r1 src=r0 offset=0 imm=29989
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r1 src=r0 offset=0 imm=29989
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=40 dst=r10 src=r1 offset=-72 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=43 dst=r10 src=r1 offset=-72 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=540697973
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=540697973
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-80 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-80 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=2037544046
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=2037544046
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-88 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-88 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=1869770784
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1869770784
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-96 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-96 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1853189958
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1853189958
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-104 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-104 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=53 dst=r4 src=r8 offset=16 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=56 dst=r4 src=r8 offset=16 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=54 dst=r3 src=r8 offset=0 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=57 dst=r3 src=r8 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r10 offset=0 imm=0
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r10 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=56 dst=r1 src=r0 offset=0 imm=-104
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=59 dst=r1 src=r0 offset=0 imm=-104
+#line 78 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=57 dst=r2 src=r0 offset=0 imm=35
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=35
+#line 78 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=14
-#line 75 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=14
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 75 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=59 dst=r1 src=r8 offset=20 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=20 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=8 imm=3
-#line 81 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=63 dst=r1 src=r0 offset=8 imm=3
+#line 84 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 84 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=61 dst=r2 src=r10 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=64 dst=r2 src=r10 offset=0 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=62 dst=r2 src=r0 offset=0 imm=-64
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=65 dst=r2 src=r0 offset=0 imm=-64
+#line 85 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=63 dst=r1 src=r6 offset=0 imm=0
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r6 offset=0 imm=0
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=64 dst=r3 src=r0 offset=0 imm=27
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=27
+#line 85 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=65537
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=65537
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
-#line 82 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=32
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=68 dst=r7 src=r0 offset=29 imm=0
-#line 82 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=71 dst=r7 src=r0 offset=29 imm=0
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 82 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=0 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=72 dst=r1 src=r8 offset=0 imm=0
+#line 90 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=70 dst=r6 src=r1 offset=24 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=73 dst=r6 src=r1 offset=24 imm=0
+#line 90 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=71 dst=r1 src=r8 offset=16 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=74 dst=r1 src=r8 offset=16 imm=0
+#line 91 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=72 dst=r6 src=r1 offset=40 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=75 dst=r6 src=r1 offset=40 imm=0
+#line 91 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=73 dst=r7 src=r0 offset=0 imm=1
-#line 88 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=76 dst=r7 src=r0 offset=0 imm=1
+#line 91 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=78 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -517,16 +526,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=79 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=80 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -535,13 +544,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=83 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -550,37 +559,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=86 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=87 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=89 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=90 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=91 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=94 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=92 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=95 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=93 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=96 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=94 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=97 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=96 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=99 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -590,13 +599,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=98 dst=r0 src=r7 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=101 dst=r0 src=r7 offset=0 imm=0
+#line 154 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=99 dst=r0 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=102 dst=r0 src=r0 offset=0 imm=0
+#line 154 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -623,317 +632,323 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
 {
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 159 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 105 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(17))
-#line 105 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=18 dst=r1 src=r0 offset=91 imm=23
+#line 108 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(23))
+#line 108 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=36 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=20 dst=r1 src=r0 offset=0 imm=32
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=32 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=22 dst=r1 src=r2 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-24 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
+    // EBPF_OP_LDXW pc=24 dst=r1 src=r6 offset=28 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=25 dst=r1 src=r0 offset=0 imm=32
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=26 dst=r2 src=r6 offset=24 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=27 dst=r1 src=r2 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    r1 |= r2;
+    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-32 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=29 dst=r1 src=r6 offset=40 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=30 dst=r10 src=r1 offset=-16 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=31 dst=r1 src=r0 offset=0 imm=1
+#line 116 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=32 dst=r2 src=r6 offset=44 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=33 dst=r2 src=r0 offset=2 imm=6
+#line 117 "sample/cgroup_sock_addr2.c"
+    if (r2 == IMMEDIATE(6))
+#line 117 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 105 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(6))
-#line 105 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=34 dst=r2 src=r0 offset=75 imm=17
+#line 117 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(17))
+#line 117 "sample/cgroup_sock_addr2.c"
         goto label_4;
+        // EBPF_OP_MOV64_IMM pc=35 dst=r1 src=r0 offset=0 imm=2
+#line 117 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
-#line 109 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
-#line 109 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(23))
-#line 109 "sample/cgroup_sock_addr2.c"
-        goto label_4;
-        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r2 |= r3;
-    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+    // EBPF_OP_STXW pc=36 dst=r10 src=r1 offset=-12 imm=0
 #line 117 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
-    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
-#line 116 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
+#line 117 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=40 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=47 dst=r10 src=r7 offset=-70 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=25973
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=2037544046
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1869770784
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1853189958
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r10 offset=0 imm=0
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=-96
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=27
+#line 128 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
-#line 123 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=12
+#line 128 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=63 dst=r1 src=r8 offset=20 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
-#line 129 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=64 dst=r1 src=r0 offset=8 imm=3
+#line 134 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 134 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-64
+#line 135 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=67 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=68 dst=r3 src=r0 offset=0 imm=27
+#line 135 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=65537
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
-#line 130 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=71 dst=r0 src=r0 offset=0 imm=32
+#line 135 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=72 dst=r7 src=r0 offset=37 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
-#line 130 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=24
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(24);
-    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=12 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=12 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=8 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=8 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=4 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=4 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=81 dst=r2 src=r8 offset=0 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=82 dst=r1 src=r2 offset=0 imm=0
+#line 139 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
-    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=83 dst=r1 src=r8 offset=16 imm=0
+#line 140 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=84 dst=r6 src=r1 offset=40 imm=0
+#line 140 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=85 dst=r7 src=r0 offset=0 imm=1
+#line 140 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=88 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -942,16 +957,16 @@ label_3:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=91 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -960,13 +975,13 @@ label_3:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=96 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -975,37 +990,37 @@ label_3:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=98 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=99 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=100 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=103 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=104 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=105 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=108 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=109 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -1015,13 +1030,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 156 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r7 offset=0 imm=0
+#line 161 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 156 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
+#line 161 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 156 "sample/cgroup_sock_addr2.c"
+#line 161 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1038,7 +1053,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        100,
+        103,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -1052,7 +1067,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        110,
+        112,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -183,7 +183,7 @@ static map_entry_t _maps[] = {
          100,               // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         18,                // Identifier for a map template.
+         21,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "policy_map"},
@@ -195,7 +195,7 @@ static map_entry_t _maps[] = {
          100,               // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         27,                // Identifier for a map template.
+         30,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "audit_map"},
@@ -231,293 +231,281 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
 {
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 152 "sample/cgroup_sock_addr2.c"
+#line 139 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
+    // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=3 dst=r10 src=r7 offset=-20 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-20)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=4 dst=r10 src=r7 offset=-24 imm=0
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
+    // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=5 dst=r10 src=r7 offset=-28 imm=0
-#line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint32_t)r7;
-    // EBPF_OP_STXW pc=6 dst=r10 src=r7 offset=-12 imm=0
-#line 57 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r7;
-    // EBPF_OP_MOV64_IMM pc=7 dst=r1 src=r0 offset=0 imm=25959
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
+    // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
 #line 57 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
-    // EBPF_OP_STXH pc=8 dst=r10 src=r1 offset=-40 imm=0
+    // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=9 dst=r1 src=r0 offset=0 imm=1299477349
+    // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
-    // EBPF_OP_STXDW pc=11 dst=r10 src=r1 offset=-48 imm=0
+    // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=12 dst=r1 src=r0 offset=0 imm=1953394499
+    // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
-    // EBPF_OP_STXDW pc=14 dst=r10 src=r1 offset=-56 imm=0
+    // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=15 dst=r1 src=r0 offset=0 imm=1768187218
+    // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
 #line 58 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r1 offset=-64 imm=0
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
-    // EBPF_OP_STXB pc=18 dst=r10 src=r7 offset=-38 imm=0
+    // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
 #line 58 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=24 imm=0
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
 #line 60 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_STXW pc=20 dst=r10 src=r1 offset=-32 imm=0
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
 #line 60 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=21 dst=r1 src=r6 offset=40 imm=0
-#line 61 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=22 dst=r10 src=r1 offset=-16 imm=0
-#line 61 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r1 src=r0 offset=0 imm=1
-#line 61 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=24 dst=r2 src=r6 offset=44 imm=0
-#line 63 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=25 dst=r2 src=r0 offset=2 imm=6
-#line 63 "sample/cgroup_sock_addr2.c"
-    if (r2 == IMMEDIATE(6))
-#line 63 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(17))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=26 dst=r2 src=r0 offset=74 imm=17
-#line 63 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(17))
-#line 63 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=77 imm=6
+#line 60 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=27 dst=r1 src=r0 offset=0 imm=2
-#line 63 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_STXW pc=28 dst=r10 src=r1 offset=-12 imm=0
-#line 63 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=29 dst=r1 src=r6 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=30 dst=r1 src=r0 offset=70 imm=2
-#line 71 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(2))
-#line 71 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 60 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=75 imm=2
+#line 60 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(2))
+#line 60 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_REG pc=31 dst=r2 src=r10 offset=0 imm=0
-#line 71 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=24 imm=0
+#line 64 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_STXW pc=23 dst=r10 src=r2 offset=-32 imm=0
+#line 64 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
+    // EBPF_OP_LDXH pc=24 dst=r2 src=r6 offset=40 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXW pc=25 dst=r10 src=r1 offset=-12 imm=0
+#line 66 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
+    // EBPF_OP_STXH pc=26 dst=r10 src=r2 offset=-16 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_MOV64_REG pc=27 dst=r2 src=r10 offset=0 imm=0
+#line 65 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=32 dst=r2 src=r0 offset=0 imm=-32
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=28 dst=r2 src=r0 offset=0 imm=-32
+#line 64 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=33 dst=r1 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=29 dst=r1 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=35 dst=r0 src=r0 offset=0 imm=1
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=31 dst=r0 src=r0 offset=0 imm=1
+#line 69 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[0].address
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 76 "sample/cgroup_sock_addr2.c"
+#line 69 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=36 dst=r8 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=32 dst=r8 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=37 dst=r9 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=33 dst=r9 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=38 dst=r7 src=r0 offset=0 imm=0
-#line 76 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=34 dst=r7 src=r0 offset=0 imm=0
+#line 69 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=39 dst=r8 src=r0 offset=37 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=35 dst=r8 src=r0 offset=37 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 77 "sample/cgroup_sock_addr2.c"
+#line 70 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=40 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=36 dst=r7 src=r0 offset=0 imm=0
+#line 70 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=41 dst=r10 src=r7 offset=-70 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=37 dst=r10 src=r7 offset=-70 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r1 src=r0 offset=0 imm=29989
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=38 dst=r1 src=r0 offset=0 imm=29989
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=43 dst=r10 src=r1 offset=-72 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=39 dst=r10 src=r1 offset=-72 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=540697973
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=40 dst=r1 src=r0 offset=0 imm=540697973
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-80 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=42 dst=r10 src=r1 offset=-80 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=2037544046
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=43 dst=r1 src=r0 offset=0 imm=2037544046
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-88 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=45 dst=r10 src=r1 offset=-88 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1869770784
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=46 dst=r1 src=r0 offset=0 imm=1869770784
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-96 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=48 dst=r10 src=r1 offset=-96 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1853189958
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=49 dst=r1 src=r0 offset=0 imm=1853189958
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-104 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=51 dst=r10 src=r1 offset=-104 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=56 dst=r4 src=r8 offset=16 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=52 dst=r4 src=r8 offset=16 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=57 dst=r3 src=r8 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=53 dst=r3 src=r8 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=58 dst=r1 src=r10 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=54 dst=r1 src=r10 offset=0 imm=0
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=59 dst=r1 src=r0 offset=0 imm=-104
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=55 dst=r1 src=r0 offset=0 imm=-104
+#line 71 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=60 dst=r2 src=r0 offset=0 imm=35
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=56 dst=r2 src=r0 offset=0 imm=35
+#line 71 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=14
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=57 dst=r0 src=r0 offset=0 imm=14
+#line 71 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 71 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 71 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=58 dst=r1 src=r8 offset=20 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=59 dst=r1 src=r0 offset=8 imm=3
+#line 77 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 77 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=60 dst=r2 src=r10 offset=0 imm=0
+#line 77 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=61 dst=r2 src=r0 offset=0 imm=-64
+#line 78 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=62 dst=r1 src=r6 offset=0 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=63 dst=r3 src=r0 offset=0 imm=27
+#line 78 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=64 dst=r0 src=r0 offset=0 imm=65537
+#line 78 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 78 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 78 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
 #line 78 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=62 dst=r1 src=r8 offset=20 imm=0
-#line 84 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=63 dst=r1 src=r0 offset=8 imm=3
-#line 84 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
-#line 84 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=64 dst=r2 src=r10 offset=0 imm=0
-#line 84 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=65 dst=r2 src=r0 offset=0 imm=-64
-#line 85 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r6 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=67 dst=r3 src=r0 offset=0 imm=27
-#line 85 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=68 dst=r0 src=r0 offset=0 imm=65537
-#line 85 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 85 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 85 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
-#line 85 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=65 dst=r0 src=r0 offset=0 imm=32
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
-#line 85 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
+#line 78 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=71 dst=r7 src=r0 offset=29 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=67 dst=r7 src=r0 offset=29 imm=0
+#line 78 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 85 "sample/cgroup_sock_addr2.c"
+#line 78 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_LDXW pc=72 dst=r1 src=r8 offset=0 imm=0
-#line 90 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
+#line 83 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=73 dst=r6 src=r1 offset=24 imm=0
-#line 90 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
+#line 83 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=74 dst=r1 src=r8 offset=16 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=75 dst=r6 src=r1 offset=40 imm=0
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
+#line 84 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=76 dst=r7 src=r0 offset=0 imm=1
-#line 91 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
+#line 84 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=78 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -526,16 +514,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=82 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -544,13 +532,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=86 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -559,37 +547,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=89 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=90 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=91 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=92 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=93 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=94 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=95 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=96 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=97 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=99 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=100 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -599,13 +587,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=101 dst=r0 src=r7 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
+#line 141 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=102 dst=r0 src=r0 offset=0 imm=0
-#line 154 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
+#line 141 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 154 "sample/cgroup_sock_addr2.c"
+#line 141 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -632,323 +620,317 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
 {
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 159 "sample/cgroup_sock_addr2.c"
+#line 146 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 105 "sample/cgroup_sock_addr2.c"
+#line 98 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 99 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
-    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=18 dst=r1 src=r0 offset=91 imm=23
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(23))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_4;
-        // EBPF_OP_LDXW pc=19 dst=r1 src=r6 offset=36 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=20 dst=r1 src=r0 offset=0 imm=32
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=21 dst=r2 src=r6 offset=32 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=22 dst=r1 src=r2 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-24 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=24 dst=r1 src=r6 offset=28 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=25 dst=r1 src=r0 offset=0 imm=32
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=26 dst=r2 src=r6 offset=24 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=27 dst=r1 src=r2 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=28 dst=r10 src=r1 offset=-32 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=29 dst=r1 src=r6 offset=40 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=30 dst=r10 src=r1 offset=-16 imm=0
-#line 116 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r1 src=r0 offset=0 imm=1
-#line 116 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=32 dst=r2 src=r6 offset=44 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_JEQ_IMM pc=33 dst=r2 src=r0 offset=2 imm=6
-#line 117 "sample/cgroup_sock_addr2.c"
-    if (r2 == IMMEDIATE(6))
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
+#line 101 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
+    // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(17))
+#line 101 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=34 dst=r2 src=r0 offset=75 imm=17
-#line 117 "sample/cgroup_sock_addr2.c"
-    if (r2 != IMMEDIATE(17))
-#line 117 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r1 != IMMEDIATE(6))
+#line 101 "sample/cgroup_sock_addr2.c"
         goto label_4;
-        // EBPF_OP_MOV64_IMM pc=35 dst=r1 src=r0 offset=0 imm=2
-#line 117 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(2);
 label_1:
-    // EBPF_OP_STXW pc=36 dst=r10 src=r1 offset=-12 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 101 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
+#line 101 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(23))
+#line 101 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
+#line 108 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
-#line 117 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
+#line 108 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
+#line 113 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 113 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
+#line 113 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=40 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 114 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=47 dst=r10 src=r7 offset=-70 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=25973
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=2037544046
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=1869770784
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1853189958
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=59 dst=r1 src=r10 offset=0 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=60 dst=r1 src=r0 offset=0 imm=-96
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
+#line 115 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=61 dst=r2 src=r0 offset=0 imm=27
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
+#line 115 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=62 dst=r0 src=r0 offset=0 imm=12
-#line 128 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
+#line 115 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 115 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=63 dst=r1 src=r8 offset=20 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=64 dst=r1 src=r0 offset=8 imm=3
-#line 134 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
+#line 121 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(3))
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
         goto label_2;
-        // EBPF_OP_MOV64_REG pc=65 dst=r2 src=r10 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=66 dst=r2 src=r0 offset=0 imm=-64
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
+#line 122 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=67 dst=r1 src=r6 offset=0 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=68 dst=r3 src=r0 offset=0 imm=27
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
+#line 122 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=65537
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=32
-#line 135 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=71 dst=r0 src=r0 offset=0 imm=32
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 122 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_JSGT_REG pc=72 dst=r7 src=r0 offset=37 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 135 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_REG pc=73 dst=r1 src=r6 offset=0 imm=0
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_ADD64_IMM pc=74 dst=r1 src=r0 offset=0 imm=24
-#line 135 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(24);
-    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=12 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=12 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=8 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=8 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=4 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=4 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
-    // EBPF_OP_LDXW pc=81 dst=r2 src=r8 offset=0 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=82 dst=r1 src=r2 offset=0 imm=0
-#line 139 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
-    // EBPF_OP_LDXH pc=83 dst=r1 src=r8 offset=16 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=84 dst=r6 src=r1 offset=40 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=85 dst=r7 src=r0 offset=0 imm=1
-#line 140 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-80 imm=0
+    // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=88 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=86 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=89 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=87 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=90 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=88 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -957,16 +939,16 @@ label_3:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=91 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=92 dst=r10 src=r8 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=93 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=94 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=92 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -975,13 +957,13 @@ label_3:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=95 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=96 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=95 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -990,37 +972,37 @@ label_3:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=98 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=99 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=100 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=98 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=101 dst=r10 src=r1 offset=-76 imm=0
+    // EBPF_OP_STXH pc=99 dst=r10 src=r1 offset=-76 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-76)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=102 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=100 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=103 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=101 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=104 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=102 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=105 dst=r3 src=r0 offset=0 imm=-96
+    // EBPF_OP_ADD64_IMM pc=103 dst=r3 src=r0 offset=0 imm=-96
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-96);
-    // EBPF_OP_LDDW pc=106 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=104 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=108 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=106 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=109 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=107 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -1030,13 +1012,13 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=110 dst=r0 src=r7 offset=0 imm=0
-#line 161 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
+#line 148 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=111 dst=r0 src=r0 offset=0 imm=0
-#line 161 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
+#line 148 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 161 "sample/cgroup_sock_addr2.c"
+#line 148 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1053,7 +1035,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        103,
+        99,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },
@@ -1067,7 +1049,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect6_helpers,
         7,
-        112,
+        110,
         &connect_redirect6_program_type_guid,
         &connect_redirect6_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -211,8 +211,8 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
     {NULL, 1, "helper_id_1"},
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 14, "helper_id_14"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
@@ -231,45 +231,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
 {
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 140 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -333,7 +333,7 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=73 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=72 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
@@ -342,7 +342,7 @@ label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=71 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=70 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
@@ -374,144 +374,141 @@ label_1:
     // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
 #line 73 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=38 imm=0
+    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=37 imm=0
 #line 74 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
 #line 74 "sample/cgroup_sock_addr2.c"
         goto label_3;
-        // EBPF_OP_LDXW pc=37 dst=r1 src=r8 offset=20 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
-    // EBPF_OP_JEQ_IMM pc=38 dst=r1 src=r0 offset=9 imm=3
-#line 79 "sample/cgroup_sock_addr2.c"
-    if (r1 == IMMEDIATE(3))
-#line 79 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r10 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
-#line 80 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
-#line 80 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
-#line 80 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 80 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 80 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
-#line 80 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_IMM pc=37 dst=r7 src=r0 offset=0 imm=0
+#line 74 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXB pc=38 dst=r10 src=r7 offset=-70 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
+    // EBPF_OP_MOV64_IMM pc=39 dst=r1 src=r0 offset=0 imm=29989
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=40 dst=r10 src=r1 offset=-72 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=41 dst=r1 src=r0 offset=0 imm=540697973
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=43 dst=r10 src=r1 offset=-80 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=44 dst=r1 src=r0 offset=0 imm=2037544046
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=46 dst=r10 src=r1 offset=-88 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=1869770784
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r1 offset=-96 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=1853189958
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-104 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=53 dst=r4 src=r8 offset=16 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=54 dst=r3 src=r8 offset=0 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=55 dst=r1 src=r10 offset=0 imm=0
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=56 dst=r1 src=r0 offset=0 imm=-104
+#line 75 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=57 dst=r2 src=r0 offset=0 imm=35
+#line 75 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=58 dst=r0 src=r0 offset=0 imm=14
+#line 75 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[1].address
+#line 75 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 75 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 75 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=59 dst=r1 src=r8 offset=20 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=60 dst=r1 src=r0 offset=8 imm=3
+#line 81 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 81 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=61 dst=r2 src=r10 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=62 dst=r2 src=r0 offset=0 imm=-64
+#line 82 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=63 dst=r1 src=r6 offset=0 imm=0
+#line 82 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=64 dst=r3 src=r0 offset=0 imm=27
+#line 82 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=65 dst=r0 src=r0 offset=0 imm=65537
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 82 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 82 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 82 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LSH64_IMM pc=66 dst=r0 src=r0 offset=0 imm=32
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=32
+#line 82 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=68 dst=r7 src=r0 offset=29 imm=0
+#line 82 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 80 "sample/cgroup_sock_addr2.c"
+#line 82 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
-#line 85 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
-#line 85 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
-#line 85 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 85 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 85 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 85 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=69 dst=r1 src=r8 offset=0 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXW pc=70 dst=r6 src=r1 offset=24 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXH pc=71 dst=r1 src=r8 offset=16 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=72 dst=r6 src=r1 offset=40 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
-#line 87 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=73 dst=r7 src=r0 offset=0 imm=1
+#line 88 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=78 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=77 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=79 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=78 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -520,16 +517,16 @@ label_3:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=80 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=79 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=81 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=80 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=82 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=81 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=82 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -538,13 +535,13 @@ label_3:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXDW pc=84 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=83 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=84 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=85 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -553,37 +550,37 @@ label_3:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_STXW pc=87 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=86 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=88 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=87 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=89 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=88 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=90 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=89 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=91 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=90 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=91 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=93 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=92 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=94 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=93 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=94 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=97 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=96 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=98 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=97 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -593,21 +590,21 @@ label_3:
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
 label_4:
-    // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=98 dst=r0 src=r7 offset=0 imm=0
+#line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=99 dst=r0 src=r0 offset=0 imm=0
+#line 149 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
 
 static helper_function_entry_t connect_redirect6_helpers[] = {
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
     {NULL, 12, "helper_id_12"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
     {NULL, 21, "helper_id_21"},
@@ -626,301 +623,304 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
 {
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 147 "sample/cgroup_sock_addr2.c"
+#line 154 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 101 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
         goto label_1;
         // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 105 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 104 "sample/cgroup_sock_addr2.c"
-        goto label_3;
+#line 105 "sample/cgroup_sock_addr2.c"
+        goto label_4;
 label_1:
-    // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 108 "sample/cgroup_sock_addr2.c"
-    if (r1 != IMMEDIATE(23))
-#line 108 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 108 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 112 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 112 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[0].address
-#line 112 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 112 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 112 "sample/cgroup_sock_addr2.c"
-        return 0;
-        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 112 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 112 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
-#line 112 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
-    // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
-    // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
-    // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
-    // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
-    // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    r1 |= r2;
-    // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
-    // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
-    // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
-    // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDXW pc=20 dst=r2 src=r6 offset=0 imm=0
+#line 109 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
+    // EBPF_OP_JNE_IMM pc=21 dst=r2 src=r0 offset=86 imm=23
+#line 109 "sample/cgroup_sock_addr2.c"
+    if (r2 != IMMEDIATE(23))
+#line 109 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+        // EBPF_OP_LDXW pc=22 dst=r2 src=r6 offset=36 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
+    // EBPF_OP_LSH64_IMM pc=23 dst=r2 src=r0 offset=0 imm=32
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=24 dst=r3 src=r6 offset=32 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=25 dst=r2 src=r3 offset=0 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=26 dst=r10 src=r2 offset=-24 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
+    // EBPF_OP_LDXW pc=27 dst=r2 src=r6 offset=28 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
+    // EBPF_OP_LSH64_IMM pc=28 dst=r2 src=r0 offset=0 imm=32
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_LDXW pc=29 dst=r3 src=r6 offset=24 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
+    // EBPF_OP_OR64_REG pc=30 dst=r2 src=r3 offset=0 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    r2 |= r3;
+    // EBPF_OP_STXDW pc=31 dst=r10 src=r2 offset=-32 imm=0
+#line 116 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
+    // EBPF_OP_LDXH pc=32 dst=r2 src=r6 offset=40 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
+    // EBPF_OP_STXH pc=33 dst=r10 src=r2 offset=-16 imm=0
+#line 117 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r2;
+    // EBPF_OP_STXW pc=34 dst=r10 src=r1 offset=-12 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
-    // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=35 dst=r2 src=r10 offset=0 imm=0
+#line 118 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 119 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=36 dst=r2 src=r0 offset=0 imm=-32
+#line 116 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=37 dst=r1 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 124 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[1].address
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=39 dst=r0 src=r0 offset=0 imm=1
+#line 121 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[0].address
+#line 121 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 124 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 124 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
+#line 121 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=40 dst=r8 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=41 dst=r9 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 124 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=42 dst=r7 src=r0 offset=0 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=43 dst=r8 src=r0 offset=40 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 125 "sample/cgroup_sock_addr2.c"
-        goto label_2;
-        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
-    r7 = r6;
-    // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 125 "sample/cgroup_sock_addr2.c"
-    r7 += IMMEDIATE(24);
-    // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 125 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+        // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
+#line 122 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=45 dst=r10 src=r7 offset=-70 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r7;
+    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=25973
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
-    // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXH pc=47 dst=r10 src=r1 offset=-72 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=48 dst=r1 src=r0 offset=0 imm=2037544046
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r1 offset=-80 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=51 dst=r1 src=r0 offset=0 imm=1869770784
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r1 offset=-88 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=54 dst=r1 src=r0 offset=0 imm=1853189958
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-96 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_REG pc=57 dst=r1 src=r10 offset=0 imm=0
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=58 dst=r1 src=r0 offset=0 imm=-96
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
-    // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=59 dst=r2 src=r0 offset=0 imm=27
+#line 123 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 126 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect6_helpers[2].address
-#line 126 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=60 dst=r0 src=r0 offset=0 imm=12
+#line 123 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[1].address
+#line 123 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
+#line 123 "sample/cgroup_sock_addr2.c"
         return 0;
-        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
-    // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
-    // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
-    // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
-    // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
+        // EBPF_OP_LDXW pc=61 dst=r1 src=r8 offset=20 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=62 dst=r1 src=r0 offset=8 imm=3
+#line 129 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 129 "sample/cgroup_sock_addr2.c"
+        goto label_2;
+        // EBPF_OP_MOV64_REG pc=63 dst=r2 src=r10 offset=0 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=64 dst=r2 src=r0 offset=0 imm=-64
+#line 130 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=65 dst=r1 src=r6 offset=0 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=66 dst=r3 src=r0 offset=0 imm=27
+#line 130 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=65537
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect6_helpers[2].address
+#line 130 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 130 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
+#line 130 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LSH64_IMM pc=68 dst=r0 src=r0 offset=0 imm=32
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=69 dst=r0 src=r0 offset=0 imm=32
+#line 130 "sample/cgroup_sock_addr2.c"
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_JSGT_REG pc=70 dst=r7 src=r0 offset=37 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 130 "sample/cgroup_sock_addr2.c"
+        goto label_4;
+label_2:
+    // EBPF_OP_MOV64_REG pc=71 dst=r1 src=r6 offset=0 imm=0
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_ADD64_IMM pc=72 dst=r1 src=r0 offset=0 imm=24
+#line 130 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(24);
+    // EBPF_OP_LDXW pc=73 dst=r2 src=r8 offset=12 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
+    // EBPF_OP_STXW pc=74 dst=r1 src=r2 offset=12 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(12)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=75 dst=r2 src=r8 offset=8 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
+    // EBPF_OP_STXW pc=76 dst=r1 src=r2 offset=8 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(8)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=77 dst=r2 src=r8 offset=4 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
+    // EBPF_OP_STXW pc=78 dst=r1 src=r2 offset=4 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(4)) = (uint32_t)r2;
+    // EBPF_OP_LDXW pc=79 dst=r2 src=r8 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    r2 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_STXW pc=80 dst=r1 src=r2 offset=0 imm=0
+#line 134 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r1 + OFFSET(0)) = (uint32_t)r2;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 135 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
-label_2:
+label_3:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r9;
@@ -1014,14 +1014,14 @@ label_2:
     if ((connect_redirect6_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
-label_3:
+label_4:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 156 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1038,7 +1038,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        101,
+        100,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -231,45 +231,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
 {
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 142 "sample/cgroup_sock_addr2.c"
+#line 140 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -391,112 +391,112 @@ label_1:
 #line 79 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[1].address
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
         goto label_4;
 label_2:
     // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
-#line 81 "sample/cgroup_sock_addr2.c"
+#line 80 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(29989);
     // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)2318356710503900533;
     // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3780244552946118470;
     // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-104);
     // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(35);
     // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[2].address
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 86 "sample/cgroup_sock_addr2.c"
+#line 85 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+#line 86 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
-#line 87 "sample/cgroup_sock_addr2.c"
+#line 86 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
-#line 88 "sample/cgroup_sock_addr2.c"
+#line 87 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_3:
     // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
@@ -594,12 +594,12 @@ label_3:
         return 0;
 label_4:
     // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 144 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -626,299 +626,299 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
 {
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 149 "sample/cgroup_sock_addr2.c"
+#line 147 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 103 "sample/cgroup_sock_addr2.c"
+#line 101 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 104 "sample/cgroup_sock_addr2.c"
+#line 102 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
         goto label_1;
         // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
         goto label_3;
         // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 110 "sample/cgroup_sock_addr2.c"
+#line 108 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 112 "sample/cgroup_sock_addr2.c"
         goto label_3;
         // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
     // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
     // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 120 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 120 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
     // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 123 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 119 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
     // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 126 "sample/cgroup_sock_addr2.c"
+#line 124 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
         goto label_2;
         // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
     // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 127 "sample/cgroup_sock_addr2.c"
+#line 125 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
     // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
     // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 128 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
         // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
     // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
     // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 129 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 130 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
@@ -1016,12 +1016,12 @@ label_2:
         return 0;
 label_3:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 151 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__

--- a/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
+++ b/tests/bpf2c_tests/expected/cgroup_sock_addr2_sys.c
@@ -210,8 +210,8 @@ _get_maps(_Outptr_result_buffer_maybenull_(*count) map_entry_t** maps, _Out_ siz
 }
 
 static helper_function_entry_t connect_redirect4_helpers[] = {
-    {NULL, 65537, "helper_id_65537"},
     {NULL, 1, "helper_id_1"},
+    {NULL, 65537, "helper_id_65537"},
     {NULL, 14, "helper_id_14"},
     {NULL, 65536, "helper_id_65536"},
     {NULL, 20, "helper_id_20"},
@@ -231,45 +231,45 @@ static uint16_t connect_redirect4_maps[] = {
 #pragma code_seg(push, "cgroup~1")
 static uint64_t
 connect_redirect4(void* context)
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
 {
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 134 "sample/cgroup_sock_addr2.c"
+#line 142 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXW pc=2 dst=r10 src=r7 offset=-16 imm=0
 #line 57 "sample/cgroup_sock_addr2.c"
@@ -333,176 +333,185 @@ connect_redirect4(void* context)
     if (r1 == IMMEDIATE(17))
 #line 64 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=71 imm=6
+        // EBPF_OP_JNE_IMM pc=25 dst=r1 src=r0 offset=73 imm=6
 #line 64 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
 #line 64 "sample/cgroup_sock_addr2.c"
-        goto label_3;
+        goto label_4;
 label_1:
     // EBPF_OP_LDXW pc=26 dst=r1 src=r6 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
-    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=69 imm=2
+    // EBPF_OP_JNE_IMM pc=27 dst=r1 src=r0 offset=71 imm=2
 #line 68 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(2))
 #line 68 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-    // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
+        goto label_4;
+        // EBPF_OP_MOV64_REG pc=28 dst=r2 src=r10 offset=0 imm=0
 #line 68 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-64
-#line 72 "sample/cgroup_sock_addr2.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_MOV64_REG pc=30 dst=r1 src=r6 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r1 = r6;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r3 src=r0 offset=0 imm=27
-#line 72 "sample/cgroup_sock_addr2.c"
-    r3 = IMMEDIATE(27);
-    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=65537
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[0].address
-#line 72 "sample/cgroup_sock_addr2.c"
-         (r1, r2, r3, r4, r5);
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
-#line 72 "sample/cgroup_sock_addr2.c"
-        return 0;
-    // EBPF_OP_LSH64_IMM pc=33 dst=r0 src=r0 offset=0 imm=32
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_ARSH64_IMM pc=34 dst=r0 src=r0 offset=0 imm=32
-#line 72 "sample/cgroup_sock_addr2.c"
-    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
-    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(0);
-    // EBPF_OP_JSGT_REG pc=36 dst=r7 src=r0 offset=60 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    if ((int64_t)r7 > (int64_t)r0)
-#line 72 "sample/cgroup_sock_addr2.c"
-        goto label_3;
-    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
-#line 72 "sample/cgroup_sock_addr2.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-32
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_ADD64_IMM pc=29 dst=r2 src=r0 offset=0 imm=-32
+#line 73 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
-    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_LDDW pc=30 dst=r1 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
-#line 77 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[1].address
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_CALL pc=32 dst=r0 src=r0 offset=0 imm=1
+#line 73 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[0].address
+#line 73 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 77 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
-#line 77 "sample/cgroup_sock_addr2.c"
+#line 73 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[0].tail_call) && (r0 == 0))
+#line 73 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=42 dst=r8 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=33 dst=r8 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_MOV64_IMM pc=43 dst=r9 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=34 dst=r9 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=44 dst=r7 src=r0 offset=0 imm=0
-#line 77 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_MOV64_IMM pc=35 dst=r7 src=r0 offset=0 imm=0
+#line 73 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=45 dst=r8 src=r0 offset=27 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_JEQ_IMM pc=36 dst=r8 src=r0 offset=38 imm=0
+#line 74 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 78 "sample/cgroup_sock_addr2.c"
+#line 74 "sample/cgroup_sock_addr2.c"
+        goto label_3;
+        // EBPF_OP_LDXW pc=37 dst=r1 src=r8 offset=20 imm=0
+#line 79 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(20));
+    // EBPF_OP_JEQ_IMM pc=38 dst=r1 src=r0 offset=9 imm=3
+#line 79 "sample/cgroup_sock_addr2.c"
+    if (r1 == IMMEDIATE(3))
+#line 79 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_IMM pc=46 dst=r1 src=r0 offset=0 imm=0
-#line 78 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(0);
-    // EBPF_OP_STXB pc=47 dst=r10 src=r1 offset=-70 imm=0
+        // EBPF_OP_MOV64_REG pc=39 dst=r2 src=r10 offset=0 imm=0
 #line 79 "sample/cgroup_sock_addr2.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
-    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=29989
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = IMMEDIATE(29989);
-    // EBPF_OP_STXH pc=49 dst=r10 src=r1 offset=-72 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
-    // EBPF_OP_LDDW pc=50 dst=r1 src=r0 offset=0 imm=540697973
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)2318356710503900533;
-    // EBPF_OP_STXDW pc=52 dst=r10 src=r1 offset=-80 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=53 dst=r1 src=r0 offset=0 imm=2037544046
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7809653110685725806;
-    // EBPF_OP_STXDW pc=55 dst=r10 src=r1 offset=-88 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=56 dst=r1 src=r0 offset=0 imm=1869770784
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)7286957755258269728;
-    // EBPF_OP_STXDW pc=58 dst=r10 src=r1 offset=-96 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=1853189958
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = (uint64_t)3780244552946118470;
-    // EBPF_OP_STXDW pc=61 dst=r10 src=r1 offset=-104 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
-    // EBPF_OP_LDXH pc=62 dst=r4 src=r8 offset=16 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_LDXW pc=63 dst=r3 src=r8 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_MOV64_REG pc=64 dst=r1 src=r10 offset=0 imm=0
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 = r10;
-    // EBPF_OP_ADD64_IMM pc=65 dst=r1 src=r0 offset=0 imm=-104
-#line 79 "sample/cgroup_sock_addr2.c"
-    r1 += IMMEDIATE(-104);
-    // EBPF_OP_MOV64_IMM pc=66 dst=r2 src=r0 offset=0 imm=35
-#line 79 "sample/cgroup_sock_addr2.c"
-    r2 = IMMEDIATE(35);
-    // EBPF_OP_CALL pc=67 dst=r0 src=r0 offset=0 imm=14
-#line 79 "sample/cgroup_sock_addr2.c"
-    r0 = connect_redirect4_helpers[2].address
-#line 79 "sample/cgroup_sock_addr2.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=40 dst=r2 src=r0 offset=0 imm=-64
+#line 81 "sample/cgroup_sock_addr2.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_MOV64_REG pc=41 dst=r1 src=r6 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = r6;
+    // EBPF_OP_MOV64_IMM pc=42 dst=r3 src=r0 offset=0 imm=27
+#line 81 "sample/cgroup_sock_addr2.c"
+    r3 = IMMEDIATE(27);
+    // EBPF_OP_CALL pc=43 dst=r0 src=r0 offset=0 imm=65537
+#line 81 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[1].address
+#line 81 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 79 "sample/cgroup_sock_addr2.c"
-    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
-#line 79 "sample/cgroup_sock_addr2.c"
+#line 81 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[1].tail_call) && (r0 == 0))
+#line 81 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=68 dst=r1 src=r8 offset=0 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
-    // EBPF_OP_STXW pc=69 dst=r6 src=r1 offset=24 imm=0
-#line 80 "sample/cgroup_sock_addr2.c"
-    *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
-    // EBPF_OP_LDXH pc=70 dst=r1 src=r8 offset=16 imm=0
+        // EBPF_OP_LSH64_IMM pc=44 dst=r0 src=r0 offset=0 imm=32
 #line 81 "sample/cgroup_sock_addr2.c"
-    r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
-    // EBPF_OP_STXH pc=71 dst=r6 src=r1 offset=40 imm=0
+    r0 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_ARSH64_IMM pc=45 dst=r0 src=r0 offset=0 imm=32
 #line 81 "sample/cgroup_sock_addr2.c"
-    *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_IMM pc=72 dst=r7 src=r0 offset=0 imm=1
+    r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
+    // EBPF_OP_MOV64_IMM pc=46 dst=r7 src=r0 offset=0 imm=0
 #line 81 "sample/cgroup_sock_addr2.c"
-    r7 = IMMEDIATE(1);
+    r7 = IMMEDIATE(0);
+    // EBPF_OP_JSGT_REG pc=47 dst=r7 src=r0 offset=51 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    if ((int64_t)r7 > (int64_t)r0)
+#line 81 "sample/cgroup_sock_addr2.c"
+        goto label_4;
 label_2:
-    // EBPF_OP_STXDW pc=73 dst=r10 src=r9 offset=-88 imm=0
+    // EBPF_OP_MOV64_IMM pc=48 dst=r1 src=r0 offset=0 imm=0
+#line 81 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(0);
+    // EBPF_OP_STXB pc=49 dst=r10 src=r1 offset=-70 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
+    // EBPF_OP_MOV64_IMM pc=50 dst=r1 src=r0 offset=0 imm=29989
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = IMMEDIATE(29989);
+    // EBPF_OP_STXH pc=51 dst=r10 src=r1 offset=-72 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
+    // EBPF_OP_LDDW pc=52 dst=r1 src=r0 offset=0 imm=540697973
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)2318356710503900533;
+    // EBPF_OP_STXDW pc=54 dst=r10 src=r1 offset=-80 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=55 dst=r1 src=r0 offset=0 imm=2037544046
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7809653110685725806;
+    // EBPF_OP_STXDW pc=57 dst=r10 src=r1 offset=-88 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=58 dst=r1 src=r0 offset=0 imm=1869770784
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)7286957755258269728;
+    // EBPF_OP_STXDW pc=60 dst=r10 src=r1 offset=-96 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
+    // EBPF_OP_LDDW pc=61 dst=r1 src=r0 offset=0 imm=1853189958
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = (uint64_t)3780244552946118470;
+    // EBPF_OP_STXDW pc=63 dst=r10 src=r1 offset=-104 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r1;
+    // EBPF_OP_LDXH pc=64 dst=r4 src=r8 offset=16 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r4 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_LDXW pc=65 dst=r3 src=r8 offset=0 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r3 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_MOV64_REG pc=66 dst=r1 src=r10 offset=0 imm=0
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 = r10;
+    // EBPF_OP_ADD64_IMM pc=67 dst=r1 src=r0 offset=0 imm=-104
+#line 86 "sample/cgroup_sock_addr2.c"
+    r1 += IMMEDIATE(-104);
+    // EBPF_OP_MOV64_IMM pc=68 dst=r2 src=r0 offset=0 imm=35
+#line 86 "sample/cgroup_sock_addr2.c"
+    r2 = IMMEDIATE(35);
+    // EBPF_OP_CALL pc=69 dst=r0 src=r0 offset=0 imm=14
+#line 86 "sample/cgroup_sock_addr2.c"
+    r0 = connect_redirect4_helpers[2].address
+#line 86 "sample/cgroup_sock_addr2.c"
+         (r1, r2, r3, r4, r5);
+#line 86 "sample/cgroup_sock_addr2.c"
+    if ((connect_redirect4_helpers[2].tail_call) && (r0 == 0))
+#line 86 "sample/cgroup_sock_addr2.c"
+        return 0;
+        // EBPF_OP_LDXW pc=70 dst=r1 src=r8 offset=0 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
+    // EBPF_OP_STXW pc=71 dst=r6 src=r1 offset=24 imm=0
+#line 87 "sample/cgroup_sock_addr2.c"
+    *(uint32_t*)(uintptr_t)(r6 + OFFSET(24)) = (uint32_t)r1;
+    // EBPF_OP_LDXH pc=72 dst=r1 src=r8 offset=16 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
+    r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
+    // EBPF_OP_STXH pc=73 dst=r6 src=r1 offset=40 imm=0
+#line 88 "sample/cgroup_sock_addr2.c"
+    *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
+    // EBPF_OP_MOV64_IMM pc=74 dst=r7 src=r0 offset=0 imm=1
+#line 88 "sample/cgroup_sock_addr2.c"
+    r7 = IMMEDIATE(1);
+label_3:
+    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-88 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r9 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=76 dst=r10 src=r9 offset=-96 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r9;
-    // EBPF_OP_STXDW pc=75 dst=r10 src=r9 offset=-104 imm=0
+    // EBPF_OP_STXDW pc=77 dst=r10 src=r9 offset=-104 imm=0
 #line 43 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r9;
-    // EBPF_OP_MOV64_REG pc=76 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=78 dst=r1 src=r6 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=77 dst=r0 src=r0 offset=0 imm=65536
+    // EBPF_OP_CALL pc=79 dst=r0 src=r0 offset=0 imm=65536
 #line 44 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[3].address
 #line 44 "sample/cgroup_sock_addr2.c"
@@ -511,16 +520,16 @@ label_2:
     if ((connect_redirect4_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=78 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=80 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
-    // EBPF_OP_STXDW pc=79 dst=r10 src=r8 offset=-96 imm=0
+    // EBPF_OP_STXDW pc=81 dst=r10 src=r8 offset=-96 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r8;
-    // EBPF_OP_MOV64_REG pc=80 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=82 dst=r1 src=r6 offset=0 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=81 dst=r0 src=r0 offset=0 imm=20
+    // EBPF_OP_CALL pc=83 dst=r0 src=r0 offset=0 imm=20
 #line 45 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[4].address
 #line 45 "sample/cgroup_sock_addr2.c"
@@ -529,13 +538,13 @@ label_2:
     if ((connect_redirect4_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=82 dst=r10 src=r0 offset=-104 imm=0
+        // EBPF_OP_STXDW pc=84 dst=r10 src=r0 offset=-104 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r0;
-    // EBPF_OP_MOV64_REG pc=83 dst=r1 src=r6 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=85 dst=r1 src=r6 offset=0 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     r1 = r6;
-    // EBPF_OP_CALL pc=84 dst=r0 src=r0 offset=0 imm=21
+    // EBPF_OP_CALL pc=86 dst=r0 src=r0 offset=0 imm=21
 #line 46 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[5].address
 #line 46 "sample/cgroup_sock_addr2.c"
@@ -544,37 +553,37 @@ label_2:
     if ((connect_redirect4_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=85 dst=r10 src=r0 offset=-88 imm=0
+        // EBPF_OP_STXW pc=87 dst=r10 src=r0 offset=-88 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint32_t)r0;
-    // EBPF_OP_LDXH pc=86 dst=r1 src=r6 offset=20 imm=0
+    // EBPF_OP_LDXH pc=88 dst=r1 src=r6 offset=20 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(20));
-    // EBPF_OP_STXDW pc=87 dst=r10 src=r8 offset=-8 imm=0
+    // EBPF_OP_STXDW pc=89 dst=r10 src=r8 offset=-8 imm=0
 #line 49 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r8;
-    // EBPF_OP_STXH pc=88 dst=r10 src=r1 offset=-84 imm=0
+    // EBPF_OP_STXH pc=90 dst=r10 src=r1 offset=-84 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-84)) = (uint16_t)r1;
-    // EBPF_OP_MOV64_REG pc=89 dst=r2 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=91 dst=r2 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=90 dst=r2 src=r0 offset=0 imm=-8
+    // EBPF_OP_ADD64_IMM pc=92 dst=r2 src=r0 offset=0 imm=-8
 #line 47 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-8);
-    // EBPF_OP_MOV64_REG pc=91 dst=r3 src=r10 offset=0 imm=0
+    // EBPF_OP_MOV64_REG pc=93 dst=r3 src=r10 offset=0 imm=0
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 = r10;
-    // EBPF_OP_ADD64_IMM pc=92 dst=r3 src=r0 offset=0 imm=-104
+    // EBPF_OP_ADD64_IMM pc=94 dst=r3 src=r0 offset=0 imm=-104
 #line 47 "sample/cgroup_sock_addr2.c"
     r3 += IMMEDIATE(-104);
-    // EBPF_OP_LDDW pc=93 dst=r1 src=r0 offset=0 imm=0
+    // EBPF_OP_LDDW pc=95 dst=r1 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=95 dst=r4 src=r0 offset=0 imm=0
+    // EBPF_OP_MOV64_IMM pc=97 dst=r4 src=r0 offset=0 imm=0
 #line 50 "sample/cgroup_sock_addr2.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=96 dst=r0 src=r0 offset=0 imm=2
+    // EBPF_OP_CALL pc=98 dst=r0 src=r0 offset=0 imm=2
 #line 50 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect4_helpers[6].address
 #line 50 "sample/cgroup_sock_addr2.c"
@@ -583,14 +592,14 @@ label_2:
     if ((connect_redirect4_helpers[6].tail_call) && (r0 == 0))
 #line 50 "sample/cgroup_sock_addr2.c"
         return 0;
-label_3:
-    // EBPF_OP_MOV64_REG pc=97 dst=r0 src=r7 offset=0 imm=0
-#line 136 "sample/cgroup_sock_addr2.c"
+label_4:
+    // EBPF_OP_MOV64_REG pc=99 dst=r0 src=r7 offset=0 imm=0
+#line 144 "sample/cgroup_sock_addr2.c"
     r0 = r7;
-    // EBPF_OP_EXIT pc=98 dst=r0 src=r0 offset=0 imm=0
-#line 136 "sample/cgroup_sock_addr2.c"
+    // EBPF_OP_EXIT pc=100 dst=r0 src=r0 offset=0 imm=0
+#line 144 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 136 "sample/cgroup_sock_addr2.c"
+#line 144 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -617,299 +626,299 @@ static uint16_t connect_redirect6_maps[] = {
 #pragma code_seg(push, "cgroup~2")
 static uint64_t
 connect_redirect6(void* context)
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
 {
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     // Prologue
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r0 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r1 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r2 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r3 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r4 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r5 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r6 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r7 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r8 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r9 = 0;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     register uint64_t r10 = 0;
 
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r1 = (uintptr_t)context;
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
     // EBPF_OP_MOV64_REG pc=0 dst=r6 src=r1 offset=0 imm=0
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r6 = r1;
     // EBPF_OP_MOV64_IMM pc=1 dst=r7 src=r0 offset=0 imm=0
-#line 141 "sample/cgroup_sock_addr2.c"
+#line 149 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_STXDW pc=2 dst=r10 src=r7 offset=-16 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=3 dst=r10 src=r7 offset=-24 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r7;
     // EBPF_OP_STXDW pc=4 dst=r10 src=r7 offset=-32 imm=0
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r7;
     // EBPF_OP_MOV64_IMM pc=5 dst=r1 src=r0 offset=0 imm=25959
-#line 95 "sample/cgroup_sock_addr2.c"
+#line 103 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25959);
     // EBPF_OP_STXH pc=6 dst=r10 src=r1 offset=-40 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=7 dst=r1 src=r0 offset=0 imm=1299477349
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7022083122929103717;
     // EBPF_OP_STXDW pc=9 dst=r10 src=r1 offset=-48 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=10 dst=r1 src=r0 offset=0 imm=1953394499
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)6085621373624807235;
     // EBPF_OP_STXDW pc=12 dst=r10 src=r1 offset=-56 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=13 dst=r1 src=r0 offset=0 imm=1768187218
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)8386658473162859858;
     // EBPF_OP_STXDW pc=15 dst=r10 src=r1 offset=-64 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r1;
     // EBPF_OP_STXB pc=16 dst=r10 src=r7 offset=-38 imm=0
-#line 96 "sample/cgroup_sock_addr2.c"
+#line 104 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-38)) = (uint8_t)r7;
     // EBPF_OP_LDXW pc=17 dst=r1 src=r6 offset=44 imm=0
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_JEQ_IMM pc=18 dst=r1 src=r0 offset=1 imm=17
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
     if (r1 == IMMEDIATE(17))
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         goto label_1;
-    // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
-#line 98 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_JNE_IMM pc=19 dst=r1 src=r0 offset=88 imm=6
+#line 106 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(6))
-#line 98 "sample/cgroup_sock_addr2.c"
+#line 106 "sample/cgroup_sock_addr2.c"
         goto label_3;
 label_1:
     // EBPF_OP_LDXW pc=20 dst=r1 src=r6 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(0));
     // EBPF_OP_JNE_IMM pc=21 dst=r1 src=r0 offset=86 imm=23
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
     if (r1 != IMMEDIATE(23))
-#line 102 "sample/cgroup_sock_addr2.c"
+#line 110 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
-#line 102 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=22 dst=r2 src=r10 offset=0 imm=0
+#line 110 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=23 dst=r2 src=r0 offset=0 imm=-64
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-64);
     // EBPF_OP_MOV64_REG pc=24 dst=r1 src=r6 offset=0 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r1 = r6;
     // EBPF_OP_MOV64_IMM pc=25 dst=r3 src=r0 offset=0 imm=27
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r3 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=26 dst=r0 src=r0 offset=0 imm=65537
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[0].address
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[0].tail_call) && (r0 == 0))
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
-#line 106 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LSH64_IMM pc=27 dst=r0 src=r0 offset=0 imm=32
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_ARSH64_IMM pc=28 dst=r0 src=r0 offset=0 imm=32
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r0 = (int64_t)r0 >> (uint32_t)(IMMEDIATE(32) & 63);
     // EBPF_OP_MOV64_IMM pc=29 dst=r7 src=r0 offset=0 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JSGT_REG pc=30 dst=r7 src=r0 offset=77 imm=0
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
     if ((int64_t)r7 > (int64_t)r0)
-#line 106 "sample/cgroup_sock_addr2.c"
+#line 114 "sample/cgroup_sock_addr2.c"
         goto label_3;
-    // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=31 dst=r1 src=r6 offset=36 imm=0
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(36));
     // EBPF_OP_LSH64_IMM pc=32 dst=r1 src=r0 offset=0 imm=32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=33 dst=r2 src=r6 offset=32 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(32));
     // EBPF_OP_OR64_REG pc=34 dst=r1 src=r2 offset=0 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=35 dst=r10 src=r1 offset=-24 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r1;
     // EBPF_OP_LDXW pc=36 dst=r1 src=r6 offset=28 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(28));
     // EBPF_OP_LSH64_IMM pc=37 dst=r1 src=r0 offset=0 imm=32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 <<= (IMMEDIATE(32) & 63);
     // EBPF_OP_LDXW pc=38 dst=r2 src=r6 offset=24 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(24));
     // EBPF_OP_OR64_REG pc=39 dst=r1 src=r2 offset=0 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r1 |= r2;
     // EBPF_OP_STXDW pc=40 dst=r10 src=r1 offset=-32 imm=0
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_LDXH pc=41 dst=r1 src=r6 offset=40 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r6 + OFFSET(40));
     // EBPF_OP_STXH pc=42 dst=r10 src=r1 offset=-16 imm=0
-#line 114 "sample/cgroup_sock_addr2.c"
+#line 122 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint16_t)r1;
     // EBPF_OP_LDXW pc=43 dst=r1 src=r6 offset=44 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r6 + OFFSET(44));
     // EBPF_OP_STXW pc=44 dst=r10 src=r1 offset=-12 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-12)) = (uint32_t)r1;
     // EBPF_OP_MOV64_REG pc=45 dst=r2 src=r10 offset=0 imm=0
-#line 115 "sample/cgroup_sock_addr2.c"
+#line 123 "sample/cgroup_sock_addr2.c"
     r2 = r10;
     // EBPF_OP_ADD64_IMM pc=46 dst=r2 src=r0 offset=0 imm=-32
-#line 113 "sample/cgroup_sock_addr2.c"
+#line 121 "sample/cgroup_sock_addr2.c"
     r2 += IMMEDIATE(-32);
     // EBPF_OP_LDDW pc=47 dst=r1 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r1 = POINTER(_maps[0].address);
     // EBPF_OP_CALL pc=49 dst=r0 src=r0 offset=0 imm=1
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[1].address
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[1].tail_call) && (r0 == 0))
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=50 dst=r8 src=r0 offset=0 imm=0
+#line 126 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_MOV64_IMM pc=51 dst=r9 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r9 = IMMEDIATE(0);
     // EBPF_OP_MOV64_IMM pc=52 dst=r7 src=r0 offset=0 imm=0
-#line 118 "sample/cgroup_sock_addr2.c"
+#line 126 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(0);
     // EBPF_OP_JEQ_IMM pc=53 dst=r8 src=r0 offset=30 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     if (r8 == IMMEDIATE(0))
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
         goto label_2;
-    // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_MOV64_REG pc=54 dst=r7 src=r6 offset=0 imm=0
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 = r6;
     // EBPF_OP_ADD64_IMM pc=55 dst=r7 src=r0 offset=0 imm=24
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r7 += IMMEDIATE(24);
     // EBPF_OP_MOV64_IMM pc=56 dst=r1 src=r0 offset=0 imm=0
-#line 119 "sample/cgroup_sock_addr2.c"
+#line 127 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(0);
     // EBPF_OP_STXB pc=57 dst=r10 src=r1 offset=-70 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint8_t*)(uintptr_t)(r10 + OFFSET(-70)) = (uint8_t)r1;
     // EBPF_OP_MOV64_IMM pc=58 dst=r1 src=r0 offset=0 imm=25973
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = IMMEDIATE(25973);
     // EBPF_OP_STXH pc=59 dst=r10 src=r1 offset=-72 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint16_t)r1;
     // EBPF_OP_LDDW pc=60 dst=r1 src=r0 offset=0 imm=2037544046
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7809653110685725806;
     // EBPF_OP_STXDW pc=62 dst=r10 src=r1 offset=-80 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=63 dst=r1 src=r0 offset=0 imm=1869770784
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)7286957755258269728;
     // EBPF_OP_STXDW pc=65 dst=r10 src=r1 offset=-88 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
     // EBPF_OP_LDDW pc=66 dst=r1 src=r0 offset=0 imm=1853189958
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = (uint64_t)3924359741021974342;
     // EBPF_OP_STXDW pc=68 dst=r10 src=r1 offset=-96 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
     // EBPF_OP_MOV64_REG pc=69 dst=r1 src=r10 offset=0 imm=0
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 = r10;
     // EBPF_OP_ADD64_IMM pc=70 dst=r1 src=r0 offset=0 imm=-96
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r1 += IMMEDIATE(-96);
     // EBPF_OP_MOV64_IMM pc=71 dst=r2 src=r0 offset=0 imm=27
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r2 = IMMEDIATE(27);
     // EBPF_OP_CALL pc=72 dst=r0 src=r0 offset=0 imm=12
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     r0 = connect_redirect6_helpers[2].address
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
          (r1, r2, r3, r4, r5);
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
     if ((connect_redirect6_helpers[2].tail_call) && (r0 == 0))
-#line 120 "sample/cgroup_sock_addr2.c"
+#line 128 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+        // EBPF_OP_LDXW pc=73 dst=r1 src=r8 offset=12 imm=0
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(12));
     // EBPF_OP_STXW pc=74 dst=r7 src=r1 offset=12 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(12)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=75 dst=r1 src=r8 offset=8 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(8));
     // EBPF_OP_STXW pc=76 dst=r7 src=r1 offset=8 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(8)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=77 dst=r1 src=r8 offset=4 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(4));
     // EBPF_OP_STXW pc=78 dst=r7 src=r1 offset=4 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(4)) = (uint32_t)r1;
     // EBPF_OP_LDXW pc=79 dst=r1 src=r8 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     r1 = *(uint32_t*)(uintptr_t)(r8 + OFFSET(0));
     // EBPF_OP_STXW pc=80 dst=r7 src=r1 offset=0 imm=0
-#line 121 "sample/cgroup_sock_addr2.c"
+#line 129 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r7 + OFFSET(0)) = (uint32_t)r1;
     // EBPF_OP_LDXH pc=81 dst=r1 src=r8 offset=16 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     r1 = *(uint16_t*)(uintptr_t)(r8 + OFFSET(16));
     // EBPF_OP_STXH pc=82 dst=r6 src=r1 offset=40 imm=0
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     *(uint16_t*)(uintptr_t)(r6 + OFFSET(40)) = (uint16_t)r1;
     // EBPF_OP_MOV64_IMM pc=83 dst=r7 src=r0 offset=0 imm=1
-#line 122 "sample/cgroup_sock_addr2.c"
+#line 130 "sample/cgroup_sock_addr2.c"
     r7 = IMMEDIATE(1);
 label_2:
     // EBPF_OP_STXDW pc=84 dst=r10 src=r9 offset=-80 imm=0
@@ -933,7 +942,7 @@ label_2:
     if ((connect_redirect6_helpers[3].tail_call) && (r0 == 0))
 #line 44 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=89 dst=r8 src=r0 offset=0 imm=0
 #line 44 "sample/cgroup_sock_addr2.c"
     r8 = r0;
     // EBPF_OP_STXDW pc=90 dst=r10 src=r8 offset=-88 imm=0
@@ -951,7 +960,7 @@ label_2:
     if ((connect_redirect6_helpers[4].tail_call) && (r0 == 0))
 #line 45 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
+        // EBPF_OP_STXDW pc=93 dst=r10 src=r0 offset=-96 imm=0
 #line 45 "sample/cgroup_sock_addr2.c"
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r0;
     // EBPF_OP_MOV64_REG pc=94 dst=r1 src=r6 offset=0 imm=0
@@ -966,7 +975,7 @@ label_2:
     if ((connect_redirect6_helpers[5].tail_call) && (r0 == 0))
 #line 46 "sample/cgroup_sock_addr2.c"
         return 0;
-    // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
+        // EBPF_OP_STXW pc=96 dst=r10 src=r0 offset=-80 imm=0
 #line 46 "sample/cgroup_sock_addr2.c"
     *(uint32_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint32_t)r0;
     // EBPF_OP_LDXH pc=97 dst=r1 src=r6 offset=20 imm=0
@@ -1007,12 +1016,12 @@ label_2:
         return 0;
 label_3:
     // EBPF_OP_MOV64_REG pc=108 dst=r0 src=r7 offset=0 imm=0
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
     r0 = r7;
     // EBPF_OP_EXIT pc=109 dst=r0 src=r0 offset=0 imm=0
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
     return r0;
-#line 143 "sample/cgroup_sock_addr2.c"
+#line 151 "sample/cgroup_sock_addr2.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1029,7 +1038,7 @@ static program_entry_t _programs[] = {
         2,
         connect_redirect4_helpers,
         7,
-        99,
+        101,
         &connect_redirect4_program_type_guid,
         &connect_redirect4_attach_type_guid,
     },

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -701,7 +701,7 @@ DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(loopback_address, local_address, lo
 // Connection redirection test cases.
 
 // IPv4, TCP
-DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::TCP)
+// DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::TCP)
 
 // IPv4, UDP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::UDP)
@@ -710,7 +710,7 @@ DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, fals
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv4, TCP
-DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
+// DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
 
 // Dual stack socket, IPv4, UDP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::UDP)
@@ -719,7 +719,7 @@ DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual,
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::CONNECTED_UDP)
 
 // IPv6, TCP
-DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
+// DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
 
 // IPv6, UDP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
@@ -728,7 +728,7 @@ DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, fals
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv6, TCP
-DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
+// DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
 
 // Dual stack socket, IPv6, UDP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::UDP)

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -572,9 +572,8 @@ DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dua
 // Dual stack socket, IPv4, UDP
 DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::UDP)
 
-// // Dual stack socket, IPv4, CONNECTED_UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true,
-// protocol_type_t::CONNECTED_UDP)
+// Dual stack socket, IPv4, CONNECTED_UDP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::CONNECTED_UDP)
 
 // IPv6, TCP,
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
@@ -582,8 +581,8 @@ DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, fa
 // IPv6, UDP
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
 
-// IPv6, CONNECTED_UDP
-DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
+// // IPv6, CONNECTED_UDP
+// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv6, TCP,
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
@@ -709,9 +708,8 @@ DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual,
 // Dual stack socket, IPv4, UDP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::UDP)
 
-// // Dual stack socket, IPv4, CONNECTED_UDP
-// DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true,
-// protocol_type_t::CONNECTED_UDP)
+// Dual stack socket, IPv4, CONNECTED_UDP
+DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::CONNECTED_UDP)
 
 // IPv6, TCP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
@@ -719,8 +717,8 @@ DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, fals
 // IPv6, UDP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
 
-// IPv6, CONNECTED_UDP
-DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
+// // IPv6, CONNECTED_UDP
+// DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv6, TCP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -156,30 +156,14 @@ _log_on_user(std::string& user_name, std::string& password)
 inline static IPPROTO
 _get_ip_proto_from_protocol_type(protocol_type_t protocol)
 {
-    switch (protocol) {
-    case protocol_type_t::UDP:
-    case protocol_type_t::CONNECTED_UDP:
-        return IPPROTO_UDP;
-    case protocol_type_t::TCP:
+    if (protocol == protocol_type_t::TCP) {
         return IPPROTO_TCP;
-    default:
-        REQUIRE(false);
-        return IPPROTO_IPV4;
-    }
-}
-
-inline static protocol_type_t
-_get_protocol_from_string(std::string protocol)
-{
-    if (protocol.compare("udp") == 0 || protocol.compare("UDP") == 0) {
-        return protocol_type_t::UDP;
-    } else if (protocol.compare("connected_udp") || protocol.compare("CONNECTED_UDP") == 0) {
-        return protocol_type_t::CONNECTED_UDP;
-    } else if (protocol.compare("tcp") == 0 || protocol.compare("TCP") == 0) {
-        return protocol_type_t::TCP;
+    } else if ((protocol == protocol_type_t::UDP) || (protocol == protocol_type_t::CONNECTED_UDP)) {
+        return IPPROTO_UDP;
     }
 
     REQUIRE(false);
+    return IPPROTO_MAX;
 }
 
 static user_type_t
@@ -372,7 +356,7 @@ _update_policy_map(
 }
 
 void
-connect_redirect_test(
+update_policy_map_and_test_connection(
     _In_ client_socket_t* sender_socket,
     _Inout_ sockaddr_storage& destination,
     _In_ const sockaddr_storage& proxy,
@@ -456,7 +440,7 @@ authorize_test(_In_ client_socket_t* sender_socket, _Inout_ sockaddr_storage& de
     _validate_audit_map_entry(authentication_id);
 
     // Now update the policy map to allow the connection and test again.
-    connect_redirect_test(
+    update_policy_map_and_test_connection(
         sender_socket, destination, destination, _globals.destination_port, _globals.destination_port, dual_stack);
 }
 
@@ -503,7 +487,7 @@ connect_redirect_test_wrapper(
     client_socket_t* sender_socket = nullptr;
 
     get_client_socket(dual_stack, &sender_socket, source_address);
-    connect_redirect_test(
+    update_policy_map_and_test_connection(
         sender_socket, destination, proxy, _globals.destination_port, _globals.proxy_port, dual_stack);
     delete sender_socket;
 }

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -563,8 +563,8 @@ DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, fa
 // IPv4, UDP
 DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::UDP)
 
-// // IPv4, CONNECTED_UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
+// IPv4, CONNECTED_UDP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv4, TCP,
 DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
@@ -582,8 +582,8 @@ DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, fa
 // IPv6, UDP
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
 
-// // IPv6, CONNECTED_UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
+// IPv6, CONNECTED_UDP
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv6, TCP,
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
@@ -700,8 +700,8 @@ DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, fals
 // IPv4, UDP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::UDP)
 
-// // IPv4, CONNECTED_UDP
-// DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
+// IPv4, CONNECTED_UDP
+DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv4, TCP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
@@ -719,8 +719,8 @@ DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, fals
 // IPv6, UDP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
 
-// // IPv6, CONNECTED_UDP
-// DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
+// IPv6, CONNECTED_UDP
+DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv6, TCP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -21,6 +21,7 @@
 #include "socket_tests_common.h"
 #include "watchdog.h"
 
+#include <iostream>
 #include <mstcpip.h>
 #include <ntsecapi.h>
 
@@ -388,6 +389,7 @@ update_policy_map_and_test_connection(
         REQUIRE(authentication_id != 0);
 
         // Try to send and receive message to "destination". It should succeed.
+        std::cout << "Expecting succeeded connection" << std::endl;
         sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, _globals.destination_port);
         sender_socket->complete_async_send(1000, expected_result_t::SUCCESS);
 
@@ -429,6 +431,7 @@ authorize_test(_In_ client_socket_t* sender_socket, _Inout_ sockaddr_storage& de
         authentication_id = _get_current_thread_authentication_id();
         REQUIRE(authentication_id != 0);
 
+        std::cout << "Initial connection - expected fail" << std::endl;
         sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, _globals.destination_port);
         sender_socket->complete_async_send(1000, expected_result_t::FAILURE);
 

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -395,7 +395,7 @@ update_policy_map_and_test_connection(
         // If the connection is not redirected or is redirected to a remote address,
         // check for the SERVER_MESSAGE generic response.
         std::string expected_response;
-        if (redirected && local_redirect && (_globals.protocol == IPPROTO_TCP)) {
+        if (redirected && local_redirect && (_globals.protocol == protocol_type_t::TCP)) {
             expected_response = REDIRECT_CONTEXT_MESSAGE + std::to_string(proxy_port);
         } else {
             expected_response = SERVER_MESSAGE + std::to_string(proxy_port);

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -146,7 +146,7 @@ _log_on_user(std::string& user_name, std::string& password)
 }
 
 inline static IPPROTO
-_get_ip_proto_from_connection_type(connetion_type_t connection_type)
+_get_ip_proto_from_connection_type(connection_type_t connection_type)
 {
     if (connection_type == connection_type_t::TCP) {
         return IPPROTO_TCP;
@@ -337,11 +337,11 @@ _update_policy_map(
     }
 
     // For the key, use only UDP or TCP type as the program will not be able to differentiate between
-    // connected and connectionless UDP.
+    // connected and connectionless UDP for the key of the map.
     if (connection_type == connection_type_t::CONNECTED_UDP) {
         key.connection_type = connection_type_t::UDP;
     } else {
-        key.connection_type = connection_type
+        key.connection_type = connection_type;
     }
     // For the value, use the actual connection type.
     value.connection_type = connection_type;

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -563,8 +563,8 @@ DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, fa
 // IPv4, UDP
 DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::UDP)
 
-// IPv4, CONNECTED_UDP
-DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
+// // IPv4, CONNECTED_UDP
+// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv4, TCP,
 DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
@@ -572,8 +572,9 @@ DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dua
 // Dual stack socket, IPv4, UDP
 DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::UDP)
 
-// Dual stack socket, IPv4, CONNECTED_UDP
-DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::CONNECTED_UDP)
+// // Dual stack socket, IPv4, CONNECTED_UDP
+// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true,
+// protocol_type_t::CONNECTED_UDP)
 
 // IPv6, TCP,
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
@@ -581,8 +582,8 @@ DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, fa
 // IPv6, UDP
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
 
-// IPv6, CONNECTED_UDP
-DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
+// // IPv6, CONNECTED_UDP
+// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv6, TCP,
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
@@ -590,8 +591,9 @@ DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv
 // Dual stack socket, IPv6, UDP
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::UDP)
 
-// Dual stack socket, IPv6, CONNECTED_UDP
-DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::CONNECTED_UDP)
+// // Dual stack socket, IPv6, CONNECTED_UDP
+// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true,
+// protocol_type_t::CONNECTED_UDP)
 
 #define DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(source, original_destination, new_destination)                  \
     void connection_redirection_tests_##original_destination##_##new_destination##(                                  \
@@ -698,8 +700,8 @@ DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, fals
 // IPv4, UDP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::UDP)
 
-// IPv4, CONNECTED_UDP
-DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
+// // IPv4, CONNECTED_UDP
+// DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv4, TCP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
@@ -707,8 +709,9 @@ DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual,
 // Dual stack socket, IPv4, UDP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::UDP)
 
-// Dual stack socket, IPv4, CONNECTED_UDP
-DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::CONNECTED_UDP)
+// // Dual stack socket, IPv4, CONNECTED_UDP
+// DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true,
+// protocol_type_t::CONNECTED_UDP)
 
 // IPv6, TCP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
@@ -716,8 +719,8 @@ DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, fals
 // IPv6, UDP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
 
-// IPv6, CONNECTED_UDP
-DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
+// // IPv6, CONNECTED_UDP
+// DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv6, TCP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
@@ -725,8 +728,9 @@ DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6,
 // Dual stack socket, IPv6, UDP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::UDP)
 
-// Dual stack socket, IPv6, CONNECTED_UDP
-DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::CONNECTED_UDP)
+// // Dual stack socket, IPv6, CONNECTED_UDP
+// DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true,
+// protocol_type_t::CONNECTED_UDP)
 
 int
 main(int argc, char* argv[])

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -397,28 +397,28 @@ update_policy_map_and_test_connection(
         expected_response = SERVER_MESSAGE + std::to_string(proxy_port);
     }
 
-    for (int i = 0; i < 3; ++i) {
-        impersonation_helper_t helper(_globals.user_type);
+    // for (int i = 0; i < 3; ++i) {
+    impersonation_helper_t helper(_globals.user_type);
 
-        uint64_t authentication_id = _get_current_thread_authentication_id();
-        REQUIRE(authentication_id != 0);
+    uint64_t authentication_id = _get_current_thread_authentication_id();
+    REQUIRE(authentication_id != 0);
 
-        // Try to send and receive message to "destination". It should succeed.
-        std::cout << "Expecting succeeded connection. To: " << get_string_from_address((SOCKADDR*)&destination)
-                  << std::endl;
-        sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, _globals.destination_port);
-        sender_socket->complete_async_send(1000, expected_result_t::SUCCESS);
+    // Try to send and receive message to "destination". It should succeed.
+    std::cout << "Expecting succeeded connection. To: " << get_string_from_address((SOCKADDR*)&destination)
+              << std::endl;
+    sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, _globals.destination_port);
+    sender_socket->complete_async_send(1000, expected_result_t::SUCCESS);
 
-        sender_socket->post_async_receive();
-        sender_socket->complete_async_receive(2000, false);
+    sender_socket->post_async_receive();
+    sender_socket->complete_async_receive(2000, false);
 
-        sender_socket->get_received_message(bytes_received, received_message);
+    sender_socket->get_received_message(bytes_received, received_message);
 
-        REQUIRE(strlen(received_message) == strlen(expected_response.c_str()));
-        REQUIRE(memcmp(received_message, expected_response.c_str(), strlen(received_message)) == 0);
+    REQUIRE(strlen(received_message) == strlen(expected_response.c_str()));
+    REQUIRE(memcmp(received_message, expected_response.c_str(), strlen(received_message)) == 0);
 
-        _validate_audit_map_entry(authentication_id);
-    }
+    _validate_audit_map_entry(authentication_id);
+    // }
 
     // Remove entry from policy map.
     add_policy = false;
@@ -431,22 +431,22 @@ authorize_test(_In_ client_socket_t* sender_socket, _Inout_ sockaddr_storage& de
     // Default behavior of the eBPF program is to block the connection.
     // Send should fail as the connection is blocked. Repeat this multiple times to ensure that multiple packets are
     // blocked for a single connection.
-    for (int i = 0; i < 3; ++i) {
-        impersonation_helper_t helper(_globals.user_type);
-        uint64_t authentication_id = _get_current_thread_authentication_id();
-        REQUIRE(authentication_id != 0);
+    // for (int i = 0; i < 3; ++i) {
+    impersonation_helper_t helper(_globals.user_type);
+    uint64_t authentication_id = _get_current_thread_authentication_id();
+    REQUIRE(authentication_id != 0);
 
-        std::cout << "Initial connection - expected fail. To: " << get_string_from_address((SOCKADDR*)&destination)
-                  << std::endl;
-        sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, _globals.destination_port);
-        sender_socket->complete_async_send(1000, expected_result_t::FAILURE);
+    std::cout << "Initial connection - expected fail. To: " << get_string_from_address((SOCKADDR*)&destination)
+              << std::endl;
+    sender_socket->send_message_to_remote_host(CLIENT_MESSAGE, destination, _globals.destination_port);
+    sender_socket->complete_async_send(1000, expected_result_t::FAILURE);
 
-        // Receive should time out as connection is blocked.
-        sender_socket->post_async_receive(true);
-        sender_socket->complete_async_receive(1000, true);
+    // Receive should time out as connection is blocked.
+    sender_socket->post_async_receive(true);
+    sender_socket->complete_async_receive(1000, true);
 
-        _validate_audit_map_entry(authentication_id);
-    }
+    _validate_audit_map_entry(authentication_id);
+    // }
 
     // Now update the policy map to allow the connection and test again.
     update_policy_map_and_test_connection(
@@ -561,45 +561,43 @@ DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(remote_address)
     DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                                   \
         socket_family_name, socket_family_type, dual_stack, protocol, remote_address)
 
-// // Connection Authorization test cases
+// Connection Authorization test cases
 
-// // IPv4, TCP
-// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::TCP)
+// IPv4, TCP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::TCP)
 
-// // IPv4, UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::UDP)
+// IPv4, UDP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::UDP)
 
-// // IPv4, CONNECTED_UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
+// IPv4, CONNECTED_UDP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
 
-// // Dual stack socket, IPv4, TCP,
-// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
+// Dual stack socket, IPv4, TCP,
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
 
-// // Dual stack socket, IPv4, UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::UDP)
+// Dual stack socket, IPv4, UDP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::UDP)
 
-// // Dual stack socket, IPv4, CONNECTED_UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true,
-// protocol_type_t::CONNECTED_UDP)
+// Dual stack socket, IPv4, CONNECTED_UDP
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::CONNECTED_UDP)
 
-// // IPv6, TCP,
-// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
+// IPv6, TCP,
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
 
-// // IPv6, UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
+// IPv6, UDP
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
 
-// // IPv6, CONNECTED_UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
+// IPv6, CONNECTED_UDP
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
-// // Dual stack socket, IPv6, TCP,
-// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
+// Dual stack socket, IPv6, TCP,
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
 
-// // Dual stack socket, IPv6, UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::UDP)
+// Dual stack socket, IPv6, UDP
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::UDP)
 
-// // Dual stack socket, IPv6, CONNECTED_UDP
-// DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true,
-// protocol_type_t::CONNECTED_UDP)
+// Dual stack socket, IPv6, CONNECTED_UDP
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::CONNECTED_UDP)
 
 #define DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(source, original_destination, new_destination)                  \
     void connection_redirection_tests_##original_destination##_##new_destination##(                                  \
@@ -701,7 +699,7 @@ DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(loopback_address, local_address, lo
 // Connection redirection test cases.
 
 // IPv4, TCP
-// DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::TCP)
+DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::TCP)
 
 // IPv4, UDP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::UDP)
@@ -710,7 +708,7 @@ DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, fals
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("ipv4", socket_family_t::IPv4, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv4, TCP
-// DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
+DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::TCP)
 
 // Dual stack socket, IPv4, UDP
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::UDP)
@@ -719,7 +717,7 @@ DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual,
 DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, protocol_type_t::CONNECTED_UDP)
 
 // IPv6, TCP
-// DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
+DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::TCP)
 
 // IPv6, UDP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::UDP)
@@ -728,7 +726,7 @@ DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, fals
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, protocol_type_t::CONNECTED_UDP)
 
 // Dual stack socket, IPv6, TCP
-// DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
+DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::TCP)
 
 // Dual stack socket, IPv6, UDP
 DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, protocol_type_t::UDP)

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -164,9 +164,8 @@ _get_ip_proto_from_protocol_type(protocol_type_t protocol)
         return IPPROTO_TCP;
     default:
         REQUIRE(false);
+        return IPPROTO_IPV4;
     }
-
-    return IPPROTO_IPV4;
 }
 
 inline static protocol_type_t

--- a/tests/connect_redirect/connect_redirect_tests.cpp
+++ b/tests/connect_redirect/connect_redirect_tests.cpp
@@ -379,7 +379,8 @@ update_policy_map_and_test_connection(
         !INETADDR_ISEQUAL((SOCKADDR*)&proxy, (SOCKADDR*)&_globals.addresses[remote_address_family].remote_address);
 
     // Update policy in the map to redirect the connection to the proxy.
-    _update_policy_map(destination, proxy, destination_port, proxy_port, _globals.connection_type, dual_stack, add_policy);
+    _update_policy_map(
+        destination, proxy, destination_port, proxy_port, _globals.connection_type, dual_stack, add_policy);
 
     {
         impersonation_helper_t helper(_globals.user_type);
@@ -413,7 +414,8 @@ update_policy_map_and_test_connection(
 
     // Remove entry from policy map.
     add_policy = false;
-    _update_policy_map(destination, proxy, destination_port, proxy_port, _globals.connection_type, dual_stack, add_policy);
+    _update_policy_map(
+        destination, proxy, destination_port, proxy_port, _globals.connection_type, dual_stack, add_policy);
 }
 
 void
@@ -492,21 +494,22 @@ connect_redirect_test_wrapper(
     delete sender_socket;
 }
 
-#define DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(destination)                                                     \
-    void connection_authorization_tests_##destination##(                                                                \
-        ADDRESS_FAMILY family, connection_type_t connection_type, bool dual_stack, _In_ test_addresses_t& addresses)    \
-    {                                                                                                                   \
-        _initialize_test_globals();                                                                                     \
-        _globals.family = family;                                                                                       \
-        _globals.connection_type = connection_type;                                                                     \
-        const char* connection_type_string = (_globals.connection_type == connection_type_t::TCP)                       \
-                                          ? "TCP"                                                                       \
-                                          : ((_globals.connection_type == connection_type_t::UDP) ? "UDP"               \
-                                          : "CONNECTED_UDP");                                                           \
-        const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";                                     \
-        const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";                                    \
-        printf("CONNECT: " #destination " | %s | %s | %s\n", connection_type_string, family_string, dual_stack_string); \
-        authorize_test_wrapper(dual_stack, addresses.##destination##);                                                  \
+#define DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(destination)                                                  \
+    void connection_authorization_tests_##destination##(                                                             \
+        ADDRESS_FAMILY family, connection_type_t connection_type, bool dual_stack, _In_ test_addresses_t& addresses) \
+    {                                                                                                                \
+        _initialize_test_globals();                                                                                  \
+        _globals.family = family;                                                                                    \
+        _globals.connection_type = connection_type;                                                                  \
+        const char* connection_type_string =                                                                         \
+            (_globals.connection_type == connection_type_t::TCP)                                                     \
+                ? "TCP"                                                                                              \
+                : ((_globals.connection_type == connection_type_t::UDP) ? "UDP" : "CONNECTED_UDP");                  \
+        const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";                                  \
+        const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";                                 \
+        printf(                                                                                                      \
+            "CONNECT: " #destination " | %s | %s | %s\n", connection_type_string, family_string, dual_stack_string); \
+        authorize_test_wrapper(dual_stack, addresses.##destination##);                                               \
     }
 
 // Declare connection_authorization_* test functions.
@@ -529,12 +532,13 @@ DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(remote_address)
             AF_INET, connection_type, (dual_stack), _globals.addresses[##socket_family_type##]);                 \
     }
 
-#define DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, connection_type) \
-    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address)                              \
-    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, local_address)                                 \
-    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                                                          \
+#define DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP(                                        \
+    socket_family_name, socket_family_type, dual_stack, connection_type)                       \
+    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                             \
+        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address) \
+    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                             \
+        socket_family_name, socket_family_type, dual_stack, connection_type, local_address)    \
+    DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_CASE(                                             \
         socket_family_name, socket_family_type, dual_stack, connection_type, remote_address)
 
 #define DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                           \
@@ -545,12 +549,13 @@ DECLARE_CONNECTION_AUTHORIZATION_TEST_FUNCTION(remote_address)
             AF_INET6, connection_type, (dual_stack), _globals.addresses[##socket_family_type##]);                \
     }
 
-#define DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, connection_type) \
-    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address)                              \
-    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, local_address)                                 \
-    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                                                          \
+#define DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP(                                        \
+    socket_family_name, socket_family_type, dual_stack, connection_type)                       \
+    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                             \
+        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address) \
+    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                             \
+        socket_family_name, socket_family_type, dual_stack, connection_type, local_address)    \
+    DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_CASE(                                             \
         socket_family_name, socket_family_type, dual_stack, connection_type, remote_address)
 
 // Connection Authorization test cases
@@ -571,7 +576,8 @@ DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dua
 DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, connection_type_t::UDP)
 
 // Dual stack socket, IPv4, CONNECTED_UDP
-DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP("v4_mapped", socket_family_t::Dual, true, connection_type_t::CONNECTED_UDP)
+DECLARE_CONNECTION_AUTHORIZATION_V4_TEST_GROUP(
+    "v4_mapped", socket_family_t::Dual, true, connection_type_t::CONNECTED_UDP)
 
 // IPv6, TCP,
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("ipv6", socket_family_t::IPv6, false, connection_type_t::TCP)
@@ -589,27 +595,29 @@ DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv
 DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, connection_type_t::UDP)
 
 // Dual stack socket, IPv6, CONNECTED_UDP
-DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP("dual_ipv6", socket_family_t::IPv6, true, connection_type_t::CONNECTED_UDP)
+DECLARE_CONNECTION_AUTHORIZATION_V6_TEST_GROUP(
+    "dual_ipv6", socket_family_t::IPv6, true, connection_type_t::CONNECTED_UDP)
 
-#define DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(source, original_destination, new_destination)                           \
-    void connection_redirection_tests_##original_destination##_##new_destination##(                                           \
-        ADDRESS_FAMILY family, connection_type_t connection_type, bool dual_stack, _In_ test_addresses_t& addresses)          \
-    {                                                                                                                         \
-        _initialize_test_globals();                                                                                           \
-        _globals.family = family;                                                                                             \
-        _globals.connection_type = connection_type;                                                                           \
-        const char* connection_type_string = (_globals.connection_type == connection_type_t::TCP)                             \
-                                          ? "TCP"                                                                             \
-                                          : ((_globals.connection_type == connection_type_t::UDP) ? "UDP" : "CONNECTED_UDP"); \
-        const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";                                           \
-        const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";                                          \
-        printf(                                                                                                               \
-            "REDIRECT: " #original_destination " -> " #new_destination " | %s | %s | %s\n",                                   \
-            connection_type_string,                                                                                           \
-            family_string,                                                                                                    \
-            dual_stack_string);                                                                                               \
-        connect_redirect_test_wrapper(                                                                                        \
-            addresses.##source##, addresses.##original_destination##, addresses.##new_destination##, dual_stack);             \
+#define DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(source, original_destination, new_destination)                  \
+    void connection_redirection_tests_##original_destination##_##new_destination##(                                  \
+        ADDRESS_FAMILY family, connection_type_t connection_type, bool dual_stack, _In_ test_addresses_t& addresses) \
+    {                                                                                                                \
+        _initialize_test_globals();                                                                                  \
+        _globals.family = family;                                                                                    \
+        _globals.connection_type = connection_type;                                                                  \
+        const char* connection_type_string =                                                                         \
+            (_globals.connection_type == connection_type_t::TCP)                                                     \
+                ? "TCP"                                                                                              \
+                : ((_globals.connection_type == connection_type_t::UDP) ? "UDP" : "CONNECTED_UDP");                  \
+        const char* family_string = (_globals.family == AF_INET) ? "IPv4" : "IPv6";                                  \
+        const char* dual_stack_string = dual_stack ? "Dual Stack" : "No Dual Stack";                                 \
+        printf(                                                                                                      \
+            "REDIRECT: " #original_destination " -> " #new_destination " | %s | %s | %s\n",                          \
+            connection_type_string,                                                                                  \
+            family_string,                                                                                           \
+            dual_stack_string);                                                                                      \
+        connect_redirect_test_wrapper(                                                                               \
+            addresses.##source##, addresses.##original_destination##, addresses.##new_destination##, dual_stack);    \
     }
 
 // Declare connection_redirection_* test functions.
@@ -646,20 +654,21 @@ DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(loopback_address, local_address, lo
             AF_INET, connection_type, (dual_stack), _globals.addresses[##socket_family_type##]);                \
     }
 
-#define DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, connection_type) \
-    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, remote_address)                 \
-    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, loopback_address)               \
-    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, local_address)                  \
-    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address, remote_address)            \
-    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address, local_address)             \
-    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, local_address, loopback_address)             \
-    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                                          \
+#define DECLARE_CONNECTION_REDIRECTION_V4_TEST_GROUP(                                                          \
+    socket_family_name, socket_family_type, dual_stack, connection_type)                                       \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, remote_address)      \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, loopback_address)    \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, local_address)       \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address, remote_address) \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address, local_address)  \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, local_address, loopback_address)  \
+    DECLARE_CONNECTION_REDIRECTION_V4_TEST_CASE(                                                               \
         socket_family_name, socket_family_type, dual_stack, connection_type, local_address, remote_address)
 
 #define DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                            \
@@ -672,20 +681,21 @@ DECLARE_CONNECTION_REDIRECTION_TEST_FUNCTION(loopback_address, local_address, lo
             AF_INET6, connection_type, (dual_stack), _globals.addresses[##socket_family_type##]);               \
     }
 
-#define DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP(socket_family_name, socket_family_type, dual_stack, connection_type) \
-    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, remote_address)                 \
-    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, loopback_address)               \
-    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, local_address)                  \
-    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address, remote_address)            \
-    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address, local_address)             \
-    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                          \
-        socket_family_name, socket_family_type, dual_stack, connection_type, local_address, loopback_address)             \
-    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                                          \
+#define DECLARE_CONNECTION_REDIRECTION_V6_TEST_GROUP(                                                          \
+    socket_family_name, socket_family_type, dual_stack, connection_type)                                       \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, remote_address)      \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, loopback_address)    \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, vip_address, local_address)       \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address, remote_address) \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, loopback_address, local_address)  \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                               \
+        socket_family_name, socket_family_type, dual_stack, connection_type, local_address, loopback_address)  \
+    DECLARE_CONNECTION_REDIRECTION_V6_TEST_CASE(                                                               \
         socket_family_name, socket_family_type, dual_stack, connection_type, local_address, remote_address)
 
 // Connection redirection test cases.

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -238,13 +238,14 @@ _datagram_client_socket::send_message_to_remote_host(
     ((PSOCKADDR_IN6)&remote_address)->sin6_port = htons(remote_port);
 
     // If this is a connected socket, issue a connect call prior to sending traffic.
-    if (connected_udp) {
+    if (connected_udp && !connected) {
         error = WSAConnect(
             socket, (const SOCKADDR*)&remote_address, sizeof(remote_address), nullptr, nullptr, nullptr, nullptr);
         if (error != 0) {
             FAIL("WSAConnect failed with " << WSAGetLastError());
             return;
         }
+        connected = true;
     }
 
     // Send a message to the remote host using the sender socket.

--- a/tests/libs/util/socket_helper.cpp
+++ b/tests/libs/util/socket_helper.cpp
@@ -219,8 +219,9 @@ _client_socket::complete_async_receive(int timeout_in_ms, bool timeout_or_error_
     }
 }
 
-_datagram_client_socket::_datagram_client_socket(int _sock_type, int _protocol, uint16_t _port, socket_family_t _family)
-    : _client_socket{_sock_type, _protocol, _port, _family}
+_datagram_client_socket::_datagram_client_socket(
+    int _sock_type, int _protocol, uint16_t _port, socket_family_t _family, bool _connected_udp)
+    : _client_socket{_sock_type, _protocol, _port, _family}, connected_udp{_connected_udp}
 {
     if (!(sock_type == SOCK_DGRAM || sock_type == SOCK_RAW) &&
         !(protocol == IPPROTO_UDP || protocol == IPPROTO_IPV4 || protocol == IPPROTO_IPV6))
@@ -234,8 +235,19 @@ _datagram_client_socket::send_message_to_remote_host(
 {
     int error = 0;
 
-    // Send a message to the remote host using the sender socket.
     ((PSOCKADDR_IN6)&remote_address)->sin6_port = htons(remote_port);
+
+    // If this is a connected socket, issue a connect call prior to sending traffic.
+    if (connected_udp) {
+        error = WSAConnect(
+            socket, (const SOCKADDR*)&remote_address, sizeof(remote_address), nullptr, nullptr, nullptr, nullptr);
+        if (error != 0) {
+            FAIL("WSAConnect failed with " << WSAGetLastError());
+            return;
+        }
+    }
+
+    // Send a message to the remote host using the sender socket.
     std::vector<char> send_buffer(message, message + strlen(message));
     WSABUF wsa_send_buffer{static_cast<unsigned long>(send_buffer.size()), reinterpret_cast<char*>(send_buffer.data())};
     uint32_t bytes_sent = 0;

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -118,7 +118,8 @@ typedef class _client_socket : public _base_socket
 typedef class _datagram_client_socket : public _client_socket
 {
   public:
-    _datagram_client_socket(int _sock_type, int _protocol, uint16_t port, socket_family_t family = Dual);
+    _datagram_client_socket(
+        int _sock_type, int _protocol, uint16_t port, socket_family_t family = Dual, bool connected_udp = false);
     void
     send_message_to_remote_host(
         _In_z_ const char* message, _Inout_ sockaddr_storage& remote_address, uint16_t remote_port);
@@ -126,6 +127,9 @@ typedef class _datagram_client_socket : public _client_socket
     cancel_send_message();
     void
     complete_async_send(int timeout_in_ms, expected_result_t expected_result = expected_result_t::SUCCESS);
+
+  private:
+    bool connected_udp = false;
 } datagram_client_socket_t;
 
 /**

--- a/tests/libs/util/socket_helper.h
+++ b/tests/libs/util/socket_helper.h
@@ -129,7 +129,11 @@ typedef class _datagram_client_socket : public _client_socket
     complete_async_send(int timeout_in_ms, expected_result_t expected_result = expected_result_t::SUCCESS);
 
   private:
+    // Indicates if connected UDP should be used.
     bool connected_udp = false;
+
+    // Indicates if we have already called connect on this socket.
+    bool connected = false;
 } datagram_client_socket_t;
 
 /**

--- a/tests/sample/cgroup_sock_addr2.c
+++ b/tests/sample/cgroup_sock_addr2.c
@@ -23,8 +23,8 @@
 struct
 {
     __uint(type, BPF_MAP_TYPE_HASH);
-    __type(key, destination_entry_t);
-    __type(value, destination_entry_t);
+    __type(key, destination_entry_key_t);
+    __type(value, destination_entry_value_t);
     __uint(max_entries, 100);
 } policy_map SEC(".maps");
 
@@ -54,26 +54,19 @@ __inline int
 redirect_v4(bpf_sock_addr_t* ctx)
 {
     int verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
-    destination_entry_t entry = {0};
+    destination_entry_key_t entry = {0};
     char redirect_context[] = REDIRECT_CONTEXT_MESSAGE;
+
+    if (((ctx->protocol != IPPROTO_TCP) && (ctx->protocol != IPPROTO_UDP)) || (ctx->family != AF_INET)) {
+        return verdict;
+    }
 
     entry.destination_ip.ipv4 = ctx->user_ip4;
     entry.destination_port = ctx->user_port;
-
-    if (ctx->protocol == IPPROTO_TCP) {
-        entry.connection_type = TCP;
-    } else if (ctx->protocol == IPPROTO_UDP) {
-        entry.connection_type = UDP;
-    } else {
-        return verdict;
-    }
-
-    if (ctx->family != AF_INET) {
-        return verdict;
-    }
+    entry.protocol = ctx->protocol;
 
     // Find the entry in the policy map.
-    destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
+    destination_entry_value_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
     if (policy != NULL) {
         bpf_printk("Found v4 proxy entry value: %u, %u", policy->destination_ip.ipv4, policy->destination_port);
 
@@ -102,10 +95,10 @@ __inline int
 redirect_v6(bpf_sock_addr_t* ctx)
 {
     int verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
-    destination_entry_t entry = {0};
+    destination_entry_key_t entry = {0};
     char redirect_context[] = REDIRECT_CONTEXT_MESSAGE;
 
-    if (ctx->family != AF_INET6) {
+    if (((ctx->protocol != IPPROTO_TCP) && (ctx->protocol != IPPROTO_UDP)) || (ctx->family != AF_INET6)) {
         return verdict;
     }
 
@@ -114,16 +107,10 @@ redirect_v6(bpf_sock_addr_t* ctx)
     // wrong address.
     __builtin_memcpy(entry.destination_ip.ipv6, ctx->user_ip6, sizeof(ctx->user_ip6));
     entry.destination_port = ctx->user_port;
-    if (ctx->protocol == IPPROTO_TCP) {
-        entry.connection_type = TCP;
-    } else if (ctx->protocol == IPPROTO_UDP) {
-        entry.connection_type = UDP;
-    } else {
-        return verdict;
-    }
+    entry.protocol = ctx->protocol;
 
     // Find the entry in the policy map.
-    destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
+    destination_entry_value_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
     if (policy != NULL) {
         bpf_printk("Found v6 proxy entry value");
 

--- a/tests/sample/cgroup_sock_addr2.c
+++ b/tests/sample/cgroup_sock_addr2.c
@@ -69,13 +69,19 @@ redirect_v4(bpf_sock_addr_t* ctx)
         return verdict;
     }
 
-    if (bpf_sock_addr_set_redirect_context(ctx, redirect_context, sizeof(redirect_context)) < 0) {
-        return verdict;
-    }
-
     // Find the entry in the policy map.
     destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
     if (policy != NULL) {
+        // Currently, we are unable to validate the redirect context path for connected UDP.
+        // Tracking issue: <>
+        // When the above issue is resolved, we should validate setting the redirect_context unconditionally,
+        // including when the verdict is BPF_SOCK_ADDR_VERDICT_REJECT.
+        if (policy->protocol != (uint32_t)CONNECTED_UDP) {
+            if (bpf_sock_addr_set_redirect_context(ctx, redirect_context, sizeof(redirect_context)) < 0) {
+                return verdict;
+            }
+        }
+
         bpf_printk("Found v4 proxy entry value: %u, %u", policy->destination_ip.ipv4, policy->destination_port);
         ctx->user_ip4 = policy->destination_ip.ipv4;
         ctx->user_port = policy->destination_port;

--- a/tests/sample/cgroup_sock_addr2.c
+++ b/tests/sample/cgroup_sock_addr2.c
@@ -64,99 +64,86 @@ redirect_v4(bpf_sock_addr_t* ctx)
         entry.connection_type = connection_type_t::TCP;
     } else if (ctx->protocol == IPPROTO_UDP) {
         entry.connection_type = connection_type_t::UDP;
-    else {
-        return verdict
-    }
+        else { return verdict }
 
-    if (ctx->family != AF_INET) {
+        if (ctx->family != AF_INET) {
+            return verdict;
+        }
+
+        // Find the entry in the policy map.
+        destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
+        if (policy != NULL) {
+            bpf_printk("Found v4 proxy entry value: %u, %u", policy->destination_ip.ipv4, policy->destination_port);
+
+            // Currently, we are unable to validate the redirect context path for connected UDP.
+            // Tracking issue #3052
+            // When the above issue is resolved, we should validate setting the redirect_context unconditionally,
+            // including when the verdict is BPF_SOCK_ADDR_VERDICT_REJECT.
+            if (policy->connection_type != connection_type_t::CONNECTED_UDP) {
+                if (bpf_sock_addr_set_redirect_context(ctx, redirect_context, sizeof(redirect_context)) < 0) {
+                    return verdict;
+                }
+            }
+
+            ctx->user_ip4 = policy->destination_ip.ipv4;
+            ctx->user_port = policy->destination_port;
+
+            verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
+        }
+
+        update_audit_map_entry(ctx);
+
         return verdict;
     }
 
-    // Find the entry in the policy map.
-    destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
-    if (policy != NULL) {
-        bpf_printk("Found v4 proxy entry value: %u, %u", policy->destination_ip.ipv4, policy->destination_port);
+    __inline int redirect_v6(bpf_sock_addr_t * ctx)
+    {
+        int verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
+        destination_entry_t entry = {0};
+        char redirect_context[] = REDIRECT_CONTEXT_MESSAGE;
 
-        // Currently, we are unable to validate the redirect context path for connected UDP.
-        // Tracking issue #3052
-        // When the above issue is resolved, we should validate setting the redirect_context unconditionally,
-        // including when the verdict is BPF_SOCK_ADDR_VERDICT_REJECT.
-        if (policy->connection_type != connection_type_t::CONNECTED_UDP) {
-            if (bpf_sock_addr_set_redirect_context(ctx, redirect_context, sizeof(redirect_context)) < 0) {
-                return verdict;
-            }
+        if (ctx->family != AF_INET6) {
+            return verdict;
         }
 
-        ctx->user_ip4 = policy->destination_ip.ipv4;
-        ctx->user_port = policy->destination_port;
+        // Copy the IPv6 address. Note this has a design flaw for scoped IPv6 addresses
+        // where the scope id or interface is not provided, so the policy can match the
+        // wrong address.
+        __builtin_memcpy(entry.destination_ip.ipv6, ctx->user_ip6, sizeof(ctx->user_ip6));
+        entry.destination_port = ctx->user_port;
+        if (ctx->protocol == IPPROTO_TCP) {
+            entry.connection_type = connection_type_t::TCP;
+        } else if (ctx->protocol == IPPROTO_UDP) {
+            entry.connection_type = connection_type_t::UDP;
+            else {return verdict}
 
-        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
-    }
+            // Find the entry in the policy map.
+            destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
+            if (policy != NULL) {
+                bpf_printk("Found v6 proxy entry value");
 
-    update_audit_map_entry(ctx);
+                // Currently, we are unable to validate the redirect context path for connected UDP.
+                // Tracking issue #3052
+                // When the above issue is resolved, we should validate setting the redirect_context unconditionally,
+                // including when the verdict is BPF_SOCK_ADDR_VERDICT_REJECT.
+                if (policy->connection_type != CONNECTED_UDP) {
+                    if (bpf_sock_addr_set_redirect_context(ctx, redirect_context, sizeof(redirect_context)) < 0) {
+                        return verdict;
+                    }
+                }
+                __builtin_memcpy(ctx->user_ip6, policy->destination_ip.ipv6, sizeof(ctx->user_ip6));
+                ctx->user_port = policy->destination_port;
 
-    return verdict;
-}
-
-__inline int
-redirect_v6(bpf_sock_addr_t* ctx)
-{
-    int verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
-    destination_entry_t entry = {0};
-    char redirect_context[] = REDIRECT_CONTEXT_MESSAGE;
-
-    if (ctx->family != AF_INET6) {
-        return verdict;
-    }
-
-    // Copy the IPv6 address. Note this has a design flaw for scoped IPv6 addresses
-    // where the scope id or interface is not provided, so the policy can match the
-    // wrong address.
-    __builtin_memcpy(entry.destination_ip.ipv6, ctx->user_ip6, sizeof(ctx->user_ip6));
-    entry.destination_port = ctx->user_port;
-    if (ctx->protocol == IPPROTO_TCP) {
-        entry.connection_type = connection_type_t::TCP;
-    } else if (ctx->protocol == IPPROTO_UDP) {
-        entry.connection_type = connection_type_t::UDP;
-    else {
-        return verdict
-    }
-
-    // Find the entry in the policy map.
-    destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
-    if (policy != NULL) {
-        bpf_printk("Found v6 proxy entry value");
-
-        // Currently, we are unable to validate the redirect context path for connected UDP.
-        // Tracking issue #3052
-        // When the above issue is resolved, we should validate setting the redirect_context unconditionally,
-        // including when the verdict is BPF_SOCK_ADDR_VERDICT_REJECT.
-        if (policy->connection_type != CONNECTED_UDP) {
-            if (bpf_sock_addr_set_redirect_context(ctx, redirect_context, sizeof(redirect_context)) < 0) {
-                return verdict;
+                verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
             }
+
+            update_audit_map_entry(ctx);
+
+            return verdict;
         }
-        __builtin_memcpy(ctx->user_ip6, policy->destination_ip.ipv6, sizeof(ctx->user_ip6));
-        ctx->user_port = policy->destination_port;
 
-        verdict = BPF_SOCK_ADDR_VERDICT_PROCEED;
-    }
+        SEC("cgroup/connect4")
+        int connect_redirect4(bpf_sock_addr_t * ctx) { return redirect_v4(ctx); }
 
-    update_audit_map_entry(ctx);
-
-    return verdict;
-}
-
-SEC("cgroup/connect4")
-int
-connect_redirect4(bpf_sock_addr_t* ctx)
-{
-    return redirect_v4(ctx);
-}
-
-SEC("cgroup/connect6")
-int
-connect_redirect6(bpf_sock_addr_t* ctx)
-{
-    return redirect_v6(ctx);
-}
+        SEC("cgroup/connect6")
+        int connect_redirect6(bpf_sock_addr_t * ctx) { return redirect_v6(ctx); }

--- a/tests/sample/cgroup_sock_addr2.c
+++ b/tests/sample/cgroup_sock_addr2.c
@@ -73,7 +73,7 @@ redirect_v4(bpf_sock_addr_t* ctx)
     destination_entry_t* policy = bpf_map_lookup_elem(&policy_map, &entry);
     if (policy != NULL) {
         // Currently, we are unable to validate the redirect context path for connected UDP.
-        // Tracking issue: <>
+        // Tracking issue #3052
         // When the above issue is resolved, we should validate setting the redirect_context unconditionally,
         // including when the verdict is BPF_SOCK_ADDR_VERDICT_REJECT.
         if (policy->protocol != (uint32_t)CONNECTED_UDP) {

--- a/tests/socket/socket_tests_common.h
+++ b/tests/socket/socket_tests_common.h
@@ -18,13 +18,13 @@ typedef struct _ip_address
     };
 } ip_address_t;
 
-typedef enum _protocol_type
+typedef enum _connection_type
 {
     INVALID,
     TCP,
     UDP,
     CONNECTED_UDP
-} protocol_type_t;
+} connection_type_t;
 
 typedef struct _connection_tuple
 {
@@ -47,7 +47,7 @@ typedef struct _destination_entry
 {
     ip_address_t destination_ip;
     uint16_t destination_port;
-    uint32_t protocol;
+    uint32_t connection_type;
 } destination_entry_t;
 
 typedef struct _sock_addr_audit_entry

--- a/tests/socket/socket_tests_common.h
+++ b/tests/socket/socket_tests_common.h
@@ -18,6 +18,14 @@ typedef struct _ip_address
     };
 } ip_address_t;
 
+typedef enum _protocol_type
+{
+    INVALID,
+    TCP,
+    UDP,
+    CONNECTED_UDP
+} protocol_type_t;
+
 typedef struct _connection_tuple
 {
     ip_address_t src_ip;

--- a/tests/socket/socket_tests_common.h
+++ b/tests/socket/socket_tests_common.h
@@ -22,7 +22,7 @@ typedef enum _connection_type
 {
     INVALID,
     TCP,
-    UDP,
+    UNCONNECTED_UDP,
     CONNECTED_UDP
 } connection_type_t;
 
@@ -43,12 +43,19 @@ typedef struct _audit_entry
     bool connected : 1;
 } audit_entry_t;
 
-typedef struct _destination_entry
+typedef struct _destination_entry_key
+{
+    ip_address_t destination_ip;
+    uint16_t destination_port;
+    uint32_t protocol;
+} destination_entry_key_t;
+
+typedef struct _destination_entry_value
 {
     ip_address_t destination_ip;
     uint16_t destination_port;
     uint32_t connection_type;
-} destination_entry_t;
+} destination_entry_value_t;
 
 typedef struct _sock_addr_audit_entry
 {


### PR DESCRIPTION
## Description
- Adds connected UDP tests for cgroup/sock_addr_connect. Closes #1917.
- Adding these tests exposed issue #3053. This PR also resolves the issue by removing a stale connection context for the same connection if it exists. Closes #3053.

Future work: These tests also found issue #3052 which is NOT resolved in this PR.

## Testing
- Modified the connect_redirect_tests to also utilize connected UDP sockets.
- Modified cgroup_sock_addr2.c to skip setting the redirect context (filed issue #3052 for tracking).

## Documentation
N/A

## Installation
N/A