### PR TITLE
Fix bpf_map_get_next_key for hash-of-maps

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -2006,7 +2006,7 @@ const ebpf_map_metadata_table_t ebpf_map_metadata_tables[] = {
         .get_object_from_entry = _get_object_from_hash_map_entry,
         .update_entry_with_handle = _update_map_hash_map_entry_with_handle,
         .delete_entry = _delete_map_hash_map_entry,
-        .next_key = _next_array_map_key,
+        .next_key = _next_hash_map_key,
     },
     {
         .map_type = BPF_MAP_TYPE_ARRAY_OF_MAPS,


### PR DESCRIPTION
## Description
Problem:
The next_key was incorrectly set to _next_array_map_key.
Fix:
Set .next_key = _next_hash_map_key,

## Testing

_Do any existing tests cover this change? No.
Are new tests needed? Yes

## Documentation

_Is there any documentation impact for this change? No

## Installation

_Is there any installer impact for this change? No
