### PR TITLE
Only run unit_tests in Debug flavor with AppVerifier memory checks in the nightly CI run.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -67,7 +67,7 @@ jobs:
   #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
   # Run the unit tests in GitHub.
-  unit_tests_appverif:
+  u1nit_tests_appverif:
     # Always run this job.
     needs: regular
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
@@ -82,142 +82,10 @@ jobs:
       code_coverage: true
       gather_dumps: true
       capture_etw: true
-      leak_detection: true
+      leak_detection: false
 
-  # Run the unit tests in GitHub.
-  no_heaps_unit_tests_appverif:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
-
-  
-  # Run the unit tests in GitHub.
-  no_memory_unit_tests_appverif:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
-
-  # Run the unit tests in GitHub.
-  no_dirtystacks_unit_tests_appverif:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
-
-
-
-  # Run the unit tests in GitHub.
-  no_heaps_memory_unit_tests_appverif:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Leak Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
-
-  # Run the unit tests in GitHub.
-  no_heaps_dirtystacks_unit_tests_appverif:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
-
-  # Run the unit tests in GitHub.
-  no_memory_dirtystacks_unit_tests_appverif:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
-
-
-
-  # Run the unit tests in GitHub.
-  unit_tests:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
-
-
-
-  # Run the unit tests in GitHub.
-  leak1_unit_tests_appverif:
+   #Run the unit tests in GitHub.
+  u2nit_tests_appverif:
     # Always run this job.
     needs: regular
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
@@ -234,15 +102,15 @@ jobs:
       capture_etw: true
       leak_detection: true
 
-  # Run the unit tests in GitHub.
-  leak2_unit_tests_appverif:
+    #Run the unit tests in GitHub.
+  u3nit_tests_appverif:
     # Always run this job.
     needs: regular
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
       test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-x64
@@ -250,43 +118,211 @@ jobs:
       code_coverage: true
       gather_dumps: true
       capture_etw: true
-      leak_detection: true
+      leak_detection: false    
 
-  # Run the unit tests in GitHub.
-  leak3_unit_tests_appverif:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
+  # # Run the unit tests in GitHub.
+  # no_heaps_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
 
-  # Run the unit tests in GitHub.
-  leak4_unit_tests_appverif:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true            
+  
+  # # Run the unit tests in GitHub.
+  # no_memory_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+  # # Run the unit tests in GitHub.
+  # no_dirtystacks_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+
+
+  # # Run the unit tests in GitHub.
+  # no_heaps_memory_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Leak Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+  # # Run the unit tests in GitHub.
+  # no_heaps_dirtystacks_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+  # # Run the unit tests in GitHub.
+  # no_memory_dirtystacks_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+
+
+  # # Run the unit tests in GitHub.
+  # unit_tests:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+
+
+  # # Run the unit tests in GitHub.
+  # leak1_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+  # # Run the unit tests in GitHub.
+  # leak2_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+  # # Run the unit tests in GitHub.
+  # leak3_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
+
+  # # Run the unit tests in GitHub.
+  # leak4_unit_tests_appverif:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
+  #     # Exclude [processes] test that CodeCoverage can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true            
 
 
   # # Run the netebpfext unit tests in GitHub.

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -85,6 +85,119 @@ jobs:
       leak_detection: true
 
   # Run the unit tests in GitHub.
+  no_heaps_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+  
+  # Run the unit tests in GitHub.
+  no_memory_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+  # Run the unit tests in GitHub.
+  no_dirtystacks_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+
+
+  # Run the unit tests in GitHub.
+  no_heaps_memory_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Leak Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+  # Run the unit tests in GitHub.
+  no_heaps_dirtystacks_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+  # Run the unit tests in GitHub.
+  no_memory_dirtystacks_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+
+
+  # Run the unit tests in GitHub.
   unit_tests:
     # Always run this job.
     needs: regular
@@ -100,6 +213,81 @@ jobs:
       gather_dumps: true
       capture_etw: true
       leak_detection: true
+
+
+
+  # Run the unit tests in GitHub.
+  leak1_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Heaps Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+  # Run the unit tests in GitHub.
+  leak2_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+  # Run the unit tests in GitHub.
+  leak3_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Heaps Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true
+
+  # Run the unit tests in GitHub.
+  leak4_unit_tests_appverif:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      pre_test: appverif -enable Exceptions Handles Heaps Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
+      # Exclude [processes] test that CodeCoverage can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
+      leak_detection: true            
+
 
   # # Run the netebpfext unit tests in GitHub.
   # netebpf_ext_unit_tests:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,24 +53,24 @@ jobs:
       build_msi: true
       build_nuget: true
       build_options: /p:ReleaseJIT='True'
-      configurations: '["Debug", "Release"]' #, "FuzzerDebug", "Release"]'
+      configurations: '["Debug", "FuzzerDebug", "Release"]'
 
-  # # Perform the native-only build.
-  # regular_native-only:
-  #   # Always run this job.
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-build.yml
-  #   with:
-  #     build_artifact: Build-x64-native-only
-  #     build_msi: true
-  #     build_nuget: true
-  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
+  # Perform the native-only build.
+  regular_native-only:
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      build_artifact: Build-x64-native-only
+      build_msi: true
+      build_nuget: true
+      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
   # Run the unit tests in GitHub.
-  u1nit_tests_appverif:
+  unit_tests_appverif:
     # Always run this job.
     needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
@@ -82,17 +82,17 @@ jobs:
       code_coverage: true
       gather_dumps: true
       capture_etw: true
-      leak_detection: false
+      leak_detection: true
 
-   #Run the unit tests in GitHub.
-  u2nit_tests_appverif:
+  # Run the unit tests in GitHub.
+  unit_tests:
     # Always run this job.
     needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
       # Exclude [processes] test that CodeCoverage can't work with.
       test_command: .\unit_tests.exe -d yes ~[processes]
       build_artifact: Build-x64
@@ -102,685 +102,462 @@ jobs:
       capture_etw: true
       leak_detection: true
 
-    #Run the unit tests in GitHub.
-  u3nit_tests_appverif:
+  # Run the netebpfext unit tests in GitHub.
+  netebpf_ext_unit_tests:
     # Always run this job.
     needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: unit_tests
-      pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      # Exclude [processes] test that CodeCoverage can't work with.
-      test_command: .\unit_tests.exe -d yes ~[processes]
+      name: netebpf_ext_unit_tests
+      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+      test_command: .\netebpfext_unit.exe -d yes
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: true
       gather_dumps: true
       capture_etw: true
-      leak_detection: false    
+      leak_detection: true
 
-  # # Run the unit tests in GitHub.
-  # no_heaps_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  # Run the bpf2c tests in GitHub.
+  bpf2c:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      test_command: .\bpf2c_tests.exe -d yes
+      name: bpf2c
+      build_artifact: Build-x64
+      environment: windows-2022
+      vs_dev: true
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
 
-  
-  # # Run the unit tests in GitHub.
-  # no_memory_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  # Run the bpf2c conformance tests in GitHub.
+  bpf2c_conformance:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+      name: bpf2c_conformance
+      build_artifact: Build-x64
+      environment: windows-2022
+      vs_dev: true
+      code_coverage: true
+      gather_dumps: true
+      capture_etw: true
 
-  # # Run the unit tests in GitHub.
-  # no_dirtystacks_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  # Run the driver tests on self-hosted runners.
+  driver_ws2019:
+    # Always run this job.
+    # Only run this on repos that have self-host runners.
+    needs: regular
+    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      name: driver_ws2019
+      build_artifact: Build-x64
+      environment: ebpf_cicd_tests_ws2019
+      # driver test copies dumps to testlog folder.
+      gather_dumps: false
+      # driver tests manually gather code coverage
+      code_coverage: false
 
+  # Run the driver tests on self-hosted runners.
+  driver_ws2022:
+    # Always run this job.
+    # Only run this on repos that have self-host runners.
+    needs: regular
+    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      name: driver_ws2022
+      build_artifact: Build-x64
+      environment: ebpf_cicd_tests_ws2022
+      # driver test copies dumps to testlog folder.
+      gather_dumps: false
+      # driver tests manually gather code coverage
+      code_coverage: false
 
+  # Run the native-only driver tests on self-hosted runners.
+  driver_native_only_ws2019:
+    # Always run this job.
+    # Only run this on repos that have self-host runners.
+    needs: regular_native-only
+    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      name: driver_native_only_ws2019
+      build_artifact: Build-x64-native-only
+      environment: ebpf_cicd_tests_ws2019
+      # driver test copies dumps to testlog folder.
+      gather_dumps: false
+      # driver tests manually gather code coverage
+      code_coverage: false
+      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
-  # # Run the unit tests in GitHub.
-  # no_heaps_memory_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Leak Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  driver_native_only_ws2022:
+    # Always run this job.
+    # Only run this on repos that have self-host runners.
+    needs: regular_native-only
+    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      name: driver_native_only_ws2022
+      build_artifact: Build-x64-native-only
+      environment: ebpf_cicd_tests_ws2022
+      # driver test copies dumps to testlog folder.
+      gather_dumps: false
+      # driver tests manually gather code coverage
+      code_coverage: false
+      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
-  # # Run the unit tests in GitHub.
-  # no_heaps_dirtystacks_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  ossar:
+    # Always run this job.
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/ossar-scan.yml
+    with:
+      build_artifact: Build-x64
 
-  # # Run the unit tests in GitHub.
-  # no_memory_dirtystacks_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  # Additional jobs to run on pull and schedule only (skip push).
+  # ---------------------------------------------------------------------------
+  # Build with C++ static analyzer.
+  analyze:
+    # Only run on schedule and pull request.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      build_artifact: Build-x64-Analyze
+      # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
+      build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
 
+  # Build with C++ address sanitizer.
+  sanitize:
+    # Only run on schedule and pull request.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      build_artifact: Build-x64-Sanitize
+      build_options: /p:AddressSanitizer='True'
 
+  bpf2c_fuzzer:
+    needs: regular
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: bpf2c_fuzzer
+      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      configurations: '["FuzzerDebug"]'
 
-  # # Run the unit tests in GitHub.
-  # unit_tests:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  bpf2c_fuzzer_scheduled:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: bpf2c_fuzzer
+      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      configurations: '["FuzzerDebug"]'
 
+  execution_context_fuzzer:
+    needs: regular
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: execution_context_fuzzer
+      test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      configurations: '["FuzzerDebug"]'
 
+  # Run the verifier fuzzer.
+  verifier_fuzzer:
+    needs: regular
+    # Always run this job.
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: verifier_fuzzer
+      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      configurations: '["FuzzerDebug"]'
 
-  # # Run the unit tests in GitHub.
-  # leak1_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Heaps Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  verifier_fuzzer_scheduled:
+    needs: regular
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: verifier_fuzzer
+      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      configurations: '["FuzzerDebug"]'
 
-  # # Run the unit tests in GitHub.
-  # leak2_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  core_helper_fuzzer:
+    needs: regular
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: core_helper_fuzzer
+      test_command: .\core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      configurations: '["FuzzerDebug"]'
 
-  # # Run the unit tests in GitHub.
-  # leak3_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Heaps Locks SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  netebpfext_fuzzer:
+    needs: regular
+    # Always run this job.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: netebpfext_fuzzer
+      test_command: .\netebpfext_fuzzer netebpfext_corpus -max_len=12 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      configurations: '["FuzzerDebug"]'
 
-  # # Run the unit tests in GitHub.
-  # leak4_unit_tests_appverif:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Heaps Locks Memory SRWLock Threadpool TLS DangerousAPIs TimeRollOver -for unit_tests.exe
-  #     # Exclude [processes] test that CodeCoverage can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true            
+  # Run Cilium regression tests in GitHub.
+  cilium_tests:
+    needs: regular
+    # Only run on schedule and pull request.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: cilium_tests
+      test_command: .\cilium_tests.exe -d yes
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
 
+  # Run the quick stress tests in GitHub.
+  stress:
+    needs: regular
+    # Only run on schedule and pull request.
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: stress
+      # Until there is a dedicated stress test, re-use the perf test.
+      test_command: .\ebpf_performance.exe -d yes
+      build_artifact: Build-x64
+      environment: windows-2022
+      # No code coverage on stress.
+      code_coverage: false
+      gather_dumps: true
 
-  # # Run the netebpfext unit tests in GitHub.
-  # netebpf_ext_unit_tests:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: netebpf_ext_unit_tests
-  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-  #     test_command: .\netebpfext_unit.exe -d yes
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
-  #     leak_detection: true
+  # Run the unit tests in GitHub with address sanitizer.
+  sanitize_unit_tests:
+    needs: sanitize
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: unit_tests
+      # Exclude [processes] test that ASAN can't work with.
+      test_command: .\unit_tests.exe -d yes ~[processes]
+      build_artifact: Build-x64-Sanitize
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      capture_etw: true
 
-  # # Run the bpf2c tests in GitHub.
-  # bpf2c:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     test_command: .\bpf2c_tests.exe -d yes
-  #     name: bpf2c
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     vs_dev: true
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
+  # Run the fault injection simulator in GitHub.
+  fault_injection:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: fault_injection
+      test_command: .\unit_tests.exe
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      fault_injection: true
+      leak_detection: true
 
-  # # Run the bpf2c conformance tests in GitHub.
-  # bpf2c_conformance:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-  #     test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
-  #     name: bpf2c_conformance
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     vs_dev: true
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     capture_etw: true
+  # Run the low memory simulator for netebpfext_unit tests.
+  fault_injection_netebpfext_unit:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: netebpfext_fault_injection
+      test_command: .\netebpfext_unit.exe
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: true
+      gather_dumps: true
+      fault_injection: true
+      leak_detection: true
 
-  # # Run the driver tests on self-hosted runners.
-  # driver_ws2019:
-  #   # Always run this job.
-  #   # Only run this on repos that have self-host runners.
-  #   needs: regular
-  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-  #     name: driver_ws2019
-  #     build_artifact: Build-x64
-  #     environment: ebpf_cicd_tests_ws2019
-  #     # driver test copies dumps to testlog folder.
-  #     gather_dumps: false
-  #     # driver tests manually gather code coverage
-  #     code_coverage: false
+  # Run a fast multi-threaded stress test pass against the usersim user-mode 'mock' framework.
+  # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
+  quick_user_mode_multi_threaded_stress_test:
+    needs: regular
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: quick_user_mode_multi_threaded_stress
+      test_command: .\ebpf_stress_tests_um -tt=8 -td=2
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      leak_detection: false
+      gather_dumps: true
+      capture_etw: true
 
-  # # Run the driver tests on self-hosted runners.
-  # driver_ws2022:
-  #   # Always run this job.
-  #   # Only run this on repos that have self-host runners.
-  #   needs: regular
-  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-  #     name: driver_ws2022
-  #     build_artifact: Build-x64
-  #     environment: ebpf_cicd_tests_ws2022
-  #     # driver test copies dumps to testlog folder.
-  #     gather_dumps: false
-  #     # driver tests manually gather code coverage
-  #     code_coverage: false
-
-  # # Run the native-only driver tests on self-hosted runners.
-  # driver_native_only_ws2019:
-  #   # Always run this job.
-  #   # Only run this on repos that have self-host runners.
-  #   needs: regular_native-only
-  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-  #     name: driver_native_only_ws2019
-  #     build_artifact: Build-x64-native-only
-  #     environment: ebpf_cicd_tests_ws2019
-  #     # driver test copies dumps to testlog folder.
-  #     gather_dumps: false
-  #     # driver tests manually gather code coverage
-  #     code_coverage: false
-  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
-
-  # driver_native_only_ws2022:
-  #   # Always run this job.
-  #   # Only run this on repos that have self-host runners.
-  #   needs: regular_native-only
-  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-  #     name: driver_native_only_ws2022
-  #     build_artifact: Build-x64-native-only
-  #     environment: ebpf_cicd_tests_ws2022
-  #     # driver test copies dumps to testlog folder.
-  #     gather_dumps: false
-  #     # driver tests manually gather code coverage
-  #     code_coverage: false
-  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
-
-  # ossar:
-  #   # Always run this job.
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/ossar-scan.yml
-  #   with:
-  #     build_artifact: Build-x64
-
-  # # Additional jobs to run on pull and schedule only (skip push).
-  # # ---------------------------------------------------------------------------
-  # # Build with C++ static analyzer.
-  # analyze:
-  #   # Only run on schedule and pull request.
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-build.yml
-  #   with:
-  #     build_artifact: Build-x64-Analyze
-  #     # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
-  #     build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
-
-  # # Build with C++ address sanitizer.
-  # sanitize:
-  #   # Only run on schedule and pull request.
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-build.yml
-  #   with:
-  #     build_artifact: Build-x64-Sanitize
-  #     build_options: /p:AddressSanitizer='True'
-
-  # bpf2c_fuzzer:
-  #   needs: regular
-  #   if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: bpf2c_fuzzer
-  #     test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     configurations: '["FuzzerDebug"]'
-
-  # bpf2c_fuzzer_scheduled:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: bpf2c_fuzzer
-  #     test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     configurations: '["FuzzerDebug"]'
-
-  # execution_context_fuzzer:
-  #   needs: regular
-  #   # Always run this job.
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: execution_context_fuzzer
-  #     test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     configurations: '["FuzzerDebug"]'
-
-  # # Run the verifier fuzzer.
-  # verifier_fuzzer:
-  #   needs: regular
-  #   # Always run this job.
-  #   if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: verifier_fuzzer
-  #     test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     configurations: '["FuzzerDebug"]'
-
-  # verifier_fuzzer_scheduled:
-  #   needs: regular
-  #   # Always run this job.
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: verifier_fuzzer
-  #     test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     configurations: '["FuzzerDebug"]'
-
-  # core_helper_fuzzer:
-  #   needs: regular
-  #   # Always run this job.
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: core_helper_fuzzer
-  #     test_command: .\core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     configurations: '["FuzzerDebug"]'
-
-  # netebpfext_fuzzer:
-  #   needs: regular
-  #   # Always run this job.
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: netebpfext_fuzzer
-  #     test_command: .\netebpfext_fuzzer netebpfext_corpus -max_len=12 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     configurations: '["FuzzerDebug"]'
-
-  # # Run Cilium regression tests in GitHub.
-  # cilium_tests:
-  #   needs: regular
-  #   # Only run on schedule and pull request.
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: cilium_tests
-  #     test_command: .\cilium_tests.exe -d yes
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-
-  # # Run the quick stress tests in GitHub.
-  # stress:
-  #   needs: regular
-  #   # Only run on schedule and pull request.
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: stress
-  #     # Until there is a dedicated stress test, re-use the perf test.
-  #     test_command: .\ebpf_performance.exe -d yes
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     # No code coverage on stress.
-  #     code_coverage: false
-  #     gather_dumps: true
-
-  # # Run the unit tests in GitHub with address sanitizer.
-  # sanitize_unit_tests:
-  #   needs: sanitize
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: unit_tests
-  #     # Exclude [processes] test that ASAN can't work with.
-  #     test_command: .\unit_tests.exe -d yes ~[processes]
-  #     build_artifact: Build-x64-Sanitize
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     capture_etw: true
-
-  # # Run the fault injection simulator in GitHub.
-  # fault_injection:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: fault_injection
-  #     test_command: .\unit_tests.exe
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     fault_injection: true
-  #     leak_detection: true
-
-  # # Run the low memory simulator for netebpfext_unit tests.
-  # fault_injection_netebpfext_unit:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: netebpfext_fault_injection
-  #     test_command: .\netebpfext_unit.exe
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: true
-  #     gather_dumps: true
-  #     fault_injection: true
-  #     leak_detection: true
-
-  # # Run a fast multi-threaded stress test pass against the usersim user-mode 'mock' framework.
-  # # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
-  # quick_user_mode_multi_threaded_stress_test:
-  #   needs: regular
-  #   if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: quick_user_mode_multi_threaded_stress
-  #     test_command: .\ebpf_stress_tests_um -tt=8 -td=2
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     leak_detection: false
-  #     gather_dumps: true
-  #     capture_etw: true
-
-  # # Additional jobs to run on a schedule only (skip push and pull request).
-  # # ---------------------------------------------------------------------------
-  # codeql:
-  #   # Only run during daily scheduled run
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-build.yml
-  #   with:
-  #     build_artifact: Build-x64-CodeQl
-  #     build_codeql: true
+  # Additional jobs to run on a schedule only (skip push and pull request).
+  # ---------------------------------------------------------------------------
+  codeql:
+    # Only run during daily scheduled run
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-build.yml
+    with:
+      build_artifact: Build-x64-CodeQl
+      build_codeql: true
 
 
-  # # Run the complete fault injection simulator in GitHub.
-  # # Runs on a schedule as this takes a long time to run.
-  # fault_injection_full:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: fault_injection_full
-  #     test_command: .\unit_tests.exe
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     fault_injection: true
-  #     leak_detection: true
+  # Run the complete fault injection simulator in GitHub.
+  # Runs on a schedule as this takes a long time to run.
+  fault_injection_full:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: fault_injection_full
+      test_command: .\unit_tests.exe
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      fault_injection: true
+      leak_detection: true
 
-  # # Run the complete fault injection simulator for netebpfext in GitHub.
-  # # Runs on a schedule as this takes a long time to run.
-  # netebpfext_fault_injection_full:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: netebpfext_fault_injection_full
-  #     test_command: .\netebpfext_unit.exe
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     gather_dumps: true
-  #     fault_injection: true
+  # Run the complete fault injection simulator for netebpfext in GitHub.
+  # Runs on a schedule as this takes a long time to run.
+  netebpfext_fault_injection_full:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: netebpfext_fault_injection_full
+      test_command: .\netebpfext_unit.exe
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      gather_dumps: true
+      fault_injection: true
 
-  # # Run multi-threaded stress tests against the user mode 'mock' framework.
-  # user_mode_multi_threaded_stress_test:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: user_mode_multi_threaded_stress
-  #     test_command: .\ebpf_stress_tests_um -tt=8 -td=10
-  #     build_artifact: Build-x64
-  #     environment: windows-2022
-  #     code_coverage: false
-  #     leak_detection: false
-  #     gather_dumps: true
-  #     capture_etw: true
+  # Run multi-threaded stress tests against the user mode 'mock' framework.
+  user_mode_multi_threaded_stress_test:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: user_mode_multi_threaded_stress
+      test_command: .\ebpf_stress_tests_um -tt=8 -td=10
+      build_artifact: Build-x64
+      environment: windows-2022
+      code_coverage: false
+      leak_detection: false
+      gather_dumps: true
+      capture_etw: true
 
-  # # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
-  # # against the kernel mode eBPF sub-system.
-  # km_mt_stress_tests:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: km_mt_stress_tests
-  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
-  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-  #     build_artifact: Build-x64
-  #     environment: ebpf_cicd_tests_ws2019
-  #     code_coverage: false
-  #     # For this test, we only want kernel mode dumps and not user mode dumps.
-  #     gather_dumps: false
+  # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
+  # against the kernel mode eBPF sub-system.
+  km_mt_stress_tests:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: km_mt_stress_tests
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      build_artifact: Build-x64
+      environment: ebpf_cicd_tests_ws2019
+      code_coverage: false
+      # For this test, we only want kernel mode dumps and not user mode dumps.
+      gather_dumps: false
 
-  # # Run multi-threaded stress tests with 'restart extension' enabled
-  # # against the kernel mode eBPF sub-system.
-  # km_mt_stress_tests_restart_extension:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: km_mt_stress_tests_restart_extension
-  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
-  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-  #     build_artifact: Build-x64
-  #     environment: ebpf_cicd_tests_ws2019
-  #     code_coverage: false
-  #     # For this test, we only want kernel mode dumps and not user mode dumps.
-  #     gather_dumps: false
+  # Run multi-threaded stress tests with 'restart extension' enabled
+  # against the kernel mode eBPF sub-system.
+  km_mt_stress_tests_restart_extension:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: km_mt_stress_tests_restart_extension
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      build_artifact: Build-x64
+      environment: ebpf_cicd_tests_ws2019
+      code_coverage: false
+      # For this test, we only want kernel mode dumps and not user mode dumps.
+      gather_dumps: false
 
-  # performance:
-  #   needs: regular
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/reusable-test.yml
-  #   with:
-  #     name: km_performance
-  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
-  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-  #     build_artifact: Build-x64
-  #     environment: ebpf_cicd_perf_ws2022
-  #     configurations: '["Release"]'
+  performance:
+    needs: regular
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: km_performance
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      build_artifact: Build-x64
+      environment: ebpf_cicd_perf_ws2022
+      configurations: '["Release"]'
 
-  # upload_perf_results:
-  #   needs: performance
-  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-  #   uses: ./.github/workflows/upload-perf-results.yml
-  #   with:
-  #     name: upload_perf_results
-  #     result_artifact: km_performance-x64-Release
-  #   secrets:
-  #     AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-  #     AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-  #     AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  upload_perf_results:
+    needs: performance
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/upload-perf-results.yml
+    with:
+      name: upload_perf_results
+      result_artifact: km_performance-x64-Release
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,7 +70,7 @@ jobs:
   unit_tests_appverif:
     # Always run this job.
     needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request' # remove PR after testing is done
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -53,24 +53,24 @@ jobs:
       build_msi: true
       build_nuget: true
       build_options: /p:ReleaseJIT='True'
-      configurations: '["Debug", "FuzzerDebug", "Release"]'
+      configurations: '["Debug", "Release"]' #, "FuzzerDebug", "Release"]'
 
-  # Perform the native-only build.
-  regular_native-only:
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-native-only
-      build_msi: true
-      build_nuget: true
-      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
+  # # Perform the native-only build.
+  # regular_native-only:
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     build_artifact: Build-x64-native-only
+  #     build_msi: true
+  #     build_nuget: true
+  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
 
   # Run the unit tests in GitHub.
-  unit_tests:
+  unit_tests_appverif:
     # Always run this job.
     needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
@@ -84,462 +84,479 @@ jobs:
       capture_etw: true
       leak_detection: true
 
-  # Run the netebpfext unit tests in GitHub.
-  netebpf_ext_unit_tests:
+  # Run the unit tests in GitHub.
+  unit_tests:
     # Always run this job.
     needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpf_ext_unit_tests
-      pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
-      test_command: .\netebpfext_unit.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-      leak_detection: true
-
-  # Run the bpf2c tests in GitHub.
-  bpf2c:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      test_command: .\bpf2c_tests.exe -d yes
-      name: bpf2c
-      build_artifact: Build-x64
-      environment: windows-2022
-      vs_dev: true
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-
-  # Run the bpf2c conformance tests in GitHub.
-  bpf2c_conformance:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
-      name: bpf2c_conformance
-      build_artifact: Build-x64
-      environment: windows-2022
-      vs_dev: true
-      code_coverage: true
-      gather_dumps: true
-      capture_etw: true
-
-  # Run the driver tests on self-hosted runners.
-  driver_ws2019:
-    # Always run this job.
-    # Only run this on repos that have self-host runners.
-    needs: regular
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      name: driver_ws2019
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      # driver test copies dumps to testlog folder.
-      gather_dumps: false
-      # driver tests manually gather code coverage
-      code_coverage: false
-
-  # Run the driver tests on self-hosted runners.
-  driver_ws2022:
-    # Always run this job.
-    # Only run this on repos that have self-host runners.
-    needs: regular
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      name: driver_ws2022
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2022
-      # driver test copies dumps to testlog folder.
-      gather_dumps: false
-      # driver tests manually gather code coverage
-      code_coverage: false
-
-  # Run the native-only driver tests on self-hosted runners.
-  driver_native_only_ws2019:
-    # Always run this job.
-    # Only run this on repos that have self-host runners.
-    needs: regular_native-only
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      name: driver_native_only_ws2019
-      build_artifact: Build-x64-native-only
-      environment: ebpf_cicd_tests_ws2019
-      # driver test copies dumps to testlog folder.
-      gather_dumps: false
-      # driver tests manually gather code coverage
-      code_coverage: false
-      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
-
-  driver_native_only_ws2022:
-    # Always run this job.
-    # Only run this on repos that have self-host runners.
-    needs: regular_native-only
-    if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      name: driver_native_only_ws2022
-      build_artifact: Build-x64-native-only
-      environment: ebpf_cicd_tests_ws2022
-      # driver test copies dumps to testlog folder.
-      gather_dumps: false
-      # driver tests manually gather code coverage
-      code_coverage: false
-      configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
-
-  ossar:
-    # Always run this job.
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/ossar-scan.yml
-    with:
-      build_artifact: Build-x64
-
-  # Additional jobs to run on pull and schedule only (skip push).
-  # ---------------------------------------------------------------------------
-  # Build with C++ static analyzer.
-  analyze:
-    # Only run on schedule and pull request.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-Analyze
-      # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
-      build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
-
-  # Build with C++ address sanitizer.
-  sanitize:
-    # Only run on schedule and pull request.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-Sanitize
-      build_options: /p:AddressSanitizer='True'
-
-  bpf2c_fuzzer:
-    needs: regular
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: bpf2c_fuzzer
-      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
-
-  bpf2c_fuzzer_scheduled:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: bpf2c_fuzzer
-      test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
-
-  execution_context_fuzzer:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: execution_context_fuzzer
-      test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
-
-  # Run the verifier fuzzer.
-  verifier_fuzzer:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: verifier_fuzzer
-      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
-
-  verifier_fuzzer_scheduled:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: verifier_fuzzer
-      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
-
-  core_helper_fuzzer:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: core_helper_fuzzer
-      test_command: .\core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
-
-  netebpfext_fuzzer:
-    needs: regular
-    # Always run this job.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpfext_fuzzer
-      test_command: .\netebpfext_fuzzer netebpfext_corpus -max_len=12 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      configurations: '["FuzzerDebug"]'
-
-  # Run Cilium regression tests in GitHub.
-  cilium_tests:
-    needs: regular
-    # Only run on schedule and pull request.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: cilium_tests
-      test_command: .\cilium_tests.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-
-  # Run the quick stress tests in GitHub.
-  stress:
-    needs: regular
-    # Only run on schedule and pull request.
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: stress
-      # Until there is a dedicated stress test, re-use the perf test.
-      test_command: .\ebpf_performance.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      # No code coverage on stress.
-      code_coverage: false
-      gather_dumps: true
-
-  # Run the unit tests in GitHub with address sanitizer.
-  sanitize_unit_tests:
-    needs: sanitize
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: unit_tests
-      # Exclude [processes] test that ASAN can't work with.
+      # Exclude [processes] test that CodeCoverage can't work with.
       test_command: .\unit_tests.exe -d yes ~[processes]
-      build_artifact: Build-x64-Sanitize
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      capture_etw: true
-
-  # Run the fault injection simulator in GitHub.
-  fault_injection:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: fault_injection
-      test_command: .\unit_tests.exe
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: true
       gather_dumps: true
-      fault_injection: true
-      leak_detection: true
-
-  # Run the low memory simulator for netebpfext_unit tests.
-  fault_injection_netebpfext_unit:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpfext_fault_injection
-      test_command: .\netebpfext_unit.exe
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: true
-      gather_dumps: true
-      fault_injection: true
-      leak_detection: true
-
-  # Run a fast multi-threaded stress test pass against the usersim user-mode 'mock' framework.
-  # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
-  quick_user_mode_multi_threaded_stress_test:
-    needs: regular
-    if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: quick_user_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_um -tt=8 -td=2
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      leak_detection: false
-      gather_dumps: true
       capture_etw: true
-
-  # Additional jobs to run on a schedule only (skip push and pull request).
-  # ---------------------------------------------------------------------------
-  codeql:
-    # Only run during daily scheduled run
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-build.yml
-    with:
-      build_artifact: Build-x64-CodeQl
-      build_codeql: true
-
-
-  # Run the complete fault injection simulator in GitHub.
-  # Runs on a schedule as this takes a long time to run.
-  fault_injection_full:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: fault_injection_full
-      test_command: .\unit_tests.exe
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      fault_injection: true
       leak_detection: true
 
-  # Run the complete fault injection simulator for netebpfext in GitHub.
-  # Runs on a schedule as this takes a long time to run.
-  netebpfext_fault_injection_full:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: netebpfext_fault_injection_full
-      test_command: .\netebpfext_unit.exe
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      gather_dumps: true
-      fault_injection: true
+  # # Run the netebpfext unit tests in GitHub.
+  # netebpf_ext_unit_tests:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: netebpf_ext_unit_tests
+  #     pre_test: appverif -enable Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver -for unit_tests.exe
+  #     test_command: .\netebpfext_unit.exe -d yes
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
+  #     leak_detection: true
 
-  # Run multi-threaded stress tests against the user mode 'mock' framework.
-  user_mode_multi_threaded_stress_test:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: user_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_um -tt=8 -td=10
-      build_artifact: Build-x64
-      environment: windows-2022
-      code_coverage: false
-      leak_detection: false
-      gather_dumps: true
-      capture_etw: true
+  # # Run the bpf2c tests in GitHub.
+  # bpf2c:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     test_command: .\bpf2c_tests.exe -d yes
+  #     name: bpf2c
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     vs_dev: true
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
 
-  # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
-  # against the kernel mode eBPF sub-system.
-  km_mt_stress_tests:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_mt_stress_tests
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      code_coverage: false
-      # For this test, we only want kernel mode dumps and not user mode dumps.
-      gather_dumps: false
+  # # Run the bpf2c conformance tests in GitHub.
+  # bpf2c_conformance:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+  #     test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+  #     name: bpf2c_conformance
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     vs_dev: true
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     capture_etw: true
 
-  # Run multi-threaded stress tests with 'restart extension' enabled
-  # against the kernel mode eBPF sub-system.
-  km_mt_stress_tests_restart_extension:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_mt_stress_tests_restart_extension
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      code_coverage: false
-      # For this test, we only want kernel mode dumps and not user mode dumps.
-      gather_dumps: false
+  # # Run the driver tests on self-hosted runners.
+  # driver_ws2019:
+  #   # Always run this job.
+  #   # Only run this on repos that have self-host runners.
+  #   needs: regular
+  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+  #     name: driver_ws2019
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_tests_ws2019
+  #     # driver test copies dumps to testlog folder.
+  #     gather_dumps: false
+  #     # driver tests manually gather code coverage
+  #     code_coverage: false
 
-  performance:
-    needs: regular
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_performance
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_perf_ws2022
-      configurations: '["Release"]'
+  # # Run the driver tests on self-hosted runners.
+  # driver_ws2022:
+  #   # Always run this job.
+  #   # Only run this on repos that have self-host runners.
+  #   needs: regular
+  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+  #     name: driver_ws2022
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_tests_ws2022
+  #     # driver test copies dumps to testlog folder.
+  #     gather_dumps: false
+  #     # driver tests manually gather code coverage
+  #     code_coverage: false
 
-  upload_perf_results:
-    needs: performance
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/upload-perf-results.yml
-    with:
-      name: upload_perf_results
-      result_artifact: km_performance-x64-Release
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  # # Run the native-only driver tests on self-hosted runners.
+  # driver_native_only_ws2019:
+  #   # Always run this job.
+  #   # Only run this on repos that have self-host runners.
+  #   needs: regular_native-only
+  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+  #     name: driver_native_only_ws2019
+  #     build_artifact: Build-x64-native-only
+  #     environment: ebpf_cicd_tests_ws2019
+  #     # driver test copies dumps to testlog folder.
+  #     gather_dumps: false
+  #     # driver tests manually gather code coverage
+  #     code_coverage: false
+  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
+
+  # driver_native_only_ws2022:
+  #   # Always run this job.
+  #   # Only run this on repos that have self-host runners.
+  #   needs: regular_native-only
+  #   if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+  #     name: driver_native_only_ws2022
+  #     build_artifact: Build-x64-native-only
+  #     environment: ebpf_cicd_tests_ws2022
+  #     # driver test copies dumps to testlog folder.
+  #     gather_dumps: false
+  #     # driver tests manually gather code coverage
+  #     code_coverage: false
+  #     configurations: '["NativeOnlyDebug", "NativeOnlyRelease"]'
+
+  # ossar:
+  #   # Always run this job.
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/ossar-scan.yml
+  #   with:
+  #     build_artifact: Build-x64
+
+  # # Additional jobs to run on pull and schedule only (skip push).
+  # # ---------------------------------------------------------------------------
+  # # Build with C++ static analyzer.
+  # analyze:
+  #   # Only run on schedule and pull request.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     build_artifact: Build-x64-Analyze
+  #     # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
+  #     build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
+
+  # # Build with C++ address sanitizer.
+  # sanitize:
+  #   # Only run on schedule and pull request.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     build_artifact: Build-x64-Sanitize
+  #     build_options: /p:AddressSanitizer='True'
+
+  # bpf2c_fuzzer:
+  #   needs: regular
+  #   if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: bpf2c_fuzzer
+  #     test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
+
+  # bpf2c_fuzzer_scheduled:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: bpf2c_fuzzer
+  #     test_command: .\bpf2c_fuzzer.exe bpf2c_fuzzer_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
+
+  # execution_context_fuzzer:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: execution_context_fuzzer
+  #     test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
+
+  # # Run the verifier fuzzer.
+  # verifier_fuzzer:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: verifier_fuzzer
+  #     test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
+
+  # verifier_fuzzer_scheduled:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: verifier_fuzzer
+  #     test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
+
+  # core_helper_fuzzer:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: core_helper_fuzzer
+  #     test_command: .\core_helper_fuzzer core_helper_corpus -max_len=139 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
+
+  # netebpfext_fuzzer:
+  #   needs: regular
+  #   # Always run this job.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: netebpfext_fuzzer
+  #     test_command: .\netebpfext_fuzzer netebpfext_corpus -max_len=12 -runs=1000 -use_value_profile=1 -artifact_prefix=Artifacts\
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     configurations: '["FuzzerDebug"]'
+
+  # # Run Cilium regression tests in GitHub.
+  # cilium_tests:
+  #   needs: regular
+  #   # Only run on schedule and pull request.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: cilium_tests
+  #     test_command: .\cilium_tests.exe -d yes
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+
+  # # Run the quick stress tests in GitHub.
+  # stress:
+  #   needs: regular
+  #   # Only run on schedule and pull request.
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: stress
+  #     # Until there is a dedicated stress test, re-use the perf test.
+  #     test_command: .\ebpf_performance.exe -d yes
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     # No code coverage on stress.
+  #     code_coverage: false
+  #     gather_dumps: true
+
+  # # Run the unit tests in GitHub with address sanitizer.
+  # sanitize_unit_tests:
+  #   needs: sanitize
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: unit_tests
+  #     # Exclude [processes] test that ASAN can't work with.
+  #     test_command: .\unit_tests.exe -d yes ~[processes]
+  #     build_artifact: Build-x64-Sanitize
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     capture_etw: true
+
+  # # Run the fault injection simulator in GitHub.
+  # fault_injection:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: fault_injection
+  #     test_command: .\unit_tests.exe
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     fault_injection: true
+  #     leak_detection: true
+
+  # # Run the low memory simulator for netebpfext_unit tests.
+  # fault_injection_netebpfext_unit:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: netebpfext_fault_injection
+  #     test_command: .\netebpfext_unit.exe
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: true
+  #     gather_dumps: true
+  #     fault_injection: true
+  #     leak_detection: true
+
+  # # Run a fast multi-threaded stress test pass against the usersim user-mode 'mock' framework.
+  # # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
+  # quick_user_mode_multi_threaded_stress_test:
+  #   needs: regular
+  #   if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: quick_user_mode_multi_threaded_stress
+  #     test_command: .\ebpf_stress_tests_um -tt=8 -td=2
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     leak_detection: false
+  #     gather_dumps: true
+  #     capture_etw: true
+
+  # # Additional jobs to run on a schedule only (skip push and pull request).
+  # # ---------------------------------------------------------------------------
+  # codeql:
+  #   # Only run during daily scheduled run
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-build.yml
+  #   with:
+  #     build_artifact: Build-x64-CodeQl
+  #     build_codeql: true
+
+
+  # # Run the complete fault injection simulator in GitHub.
+  # # Runs on a schedule as this takes a long time to run.
+  # fault_injection_full:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: fault_injection_full
+  #     test_command: .\unit_tests.exe
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     fault_injection: true
+  #     leak_detection: true
+
+  # # Run the complete fault injection simulator for netebpfext in GitHub.
+  # # Runs on a schedule as this takes a long time to run.
+  # netebpfext_fault_injection_full:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: netebpfext_fault_injection_full
+  #     test_command: .\netebpfext_unit.exe
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     gather_dumps: true
+  #     fault_injection: true
+
+  # # Run multi-threaded stress tests against the user mode 'mock' framework.
+  # user_mode_multi_threaded_stress_test:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: user_mode_multi_threaded_stress
+  #     test_command: .\ebpf_stress_tests_um -tt=8 -td=10
+  #     build_artifact: Build-x64
+  #     environment: windows-2022
+  #     code_coverage: false
+  #     leak_detection: false
+  #     gather_dumps: true
+  #     capture_etw: true
+
+  # # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
+  # # against the kernel mode eBPF sub-system.
+  # km_mt_stress_tests:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: km_mt_stress_tests
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_tests_ws2019
+  #     code_coverage: false
+  #     # For this test, we only want kernel mode dumps and not user mode dumps.
+  #     gather_dumps: false
+
+  # # Run multi-threaded stress tests with 'restart extension' enabled
+  # # against the kernel mode eBPF sub-system.
+  # km_mt_stress_tests_restart_extension:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: km_mt_stress_tests_restart_extension
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_tests_ws2019
+  #     code_coverage: false
+  #     # For this test, we only want kernel mode dumps and not user mode dumps.
+  #     gather_dumps: false
+
+  # performance:
+  #   needs: regular
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/reusable-test.yml
+  #   with:
+  #     name: km_performance
+  #     pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
+  #     test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
+  #     post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+  #     build_artifact: Build-x64
+  #     environment: ebpf_cicd_perf_ws2022
+  #     configurations: '["Release"]'
+
+  # upload_perf_results:
+  #   needs: performance
+  #   if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+  #   uses: ./.github/workflows/upload-perf-results.yml
+  #   with:
+  #     name: upload_perf_results
+  #     result_artifact: km_performance-x64-Release
+  #   secrets:
+  #     AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  #     AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  #     AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}


### PR DESCRIPTION
## Description

Fixes #2879 

Speed up PR validation by removing the `Heaps` and `Leak` AppVerifier checks in Debug PR builds.

We retain PR coverage by
- keeping `sanitize_unit_tests` job - ASAN team claims it's more effective at detecting memory violations than AppVerifier.
- keeping the leak detection from `usersim`

The nightly run remains the same and enables the following checks:
`Exceptions Handles Heaps Leak Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver`

The PR run uses these:
`Exceptions Handles Locks Memory SRWLock Threadpool TLS DangerousAPIs DirtyStacks TimeRollOver`

## Testing
Exhaustively tried all combinations of removing the Heaps, Leak, Memory, DirtyStacks options in side-by-side job runs.
Observed removing Heaps+Leak reduced run-time by 50%; removing only Heaps - 25%.
**Job time down to 11min from 22min.**
