### PR TITLE
Zero initialize batch context state

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -322,7 +322,7 @@ post execution.
 
 In cases where the same eBPF program will be invoked sequentially with different context data (aka batch invocation),
 the caller can reduce the overhead of by using the batch invocation APIs. Prior to the first invocation, the batch
-begin API is called, which caches state used by the eBPf program and prevents the program from being unloaded. The
+begin API is called, which caches state used by the eBPF program and prevents the program from being unloaded. The
 caller is responsible for providing storage large enough to store an instance of ebpf_execution_context_state_t and
 ensuring that it remain valid until calling the batch end API. Between the begin and end calls, the caller may call
 the batch invoke API multiple times to invoke the BPF program with minimal overhead. Callers must limit the length

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -248,7 +248,7 @@ the provider must free the per-client context passed in via `ProviderBindingCont
 
 ### 2.5 Invoking an eBPF program from Hook NPI Provider
 To invoke an eBPF program, the extension uses the dispatch table supplied by the Hook NPI client during attaching.
-The client dispatch table contains the four functions, with the following type prototypes:
+The client dispatch table contains the functions, with the following type prototypes:
 
 ```
 /**

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -269,7 +269,8 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
  * @brief Prepare the eBPF program for batch invocation.
  *
  * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
- * @param[in] state_size The size of the state to be allocated.
+ * @param[in] state_size The size of the state to be allocated, should be greater than or equal to
+ * sizeof(ebpf_execution_context_state_t).
  * @param[out] state The state to be used for batch invocation.
  *
  * @retval EBPF_SUCCESS if successful or an appropriate error code.
@@ -322,9 +323,12 @@ post execution.
 In cases where the same eBPF program will be invoked sequentially with different context data (aka batch invocation),
 the caller can reduce the overhead of by using the batch invocation APIs. Prior to the first invocation, the batch
 begin API is called, which caches state used by the eBPf program and prevents the program from being unloaded. The
-caller is responsible for providing storage of large enough to store an instance of ebpf_execution_context_state_t and
+caller is responsible for providing storage arge enough to store an instance of ebpf_execution_context_state_t and
 ensuring that it remain valid until calling the batch end API. Between the begin and end calls, the caller may call
-the batch invoke API multiple times to invoke the BPF program with minimal overhead.
+the batch invoke API multiple times to invoke the BPF program with minimal overhead. Callers must limit the length
+of time a batch is open and must not change IRQL between calling batch begin and end. Batch end cost may scale with
+the number of times the program has been invoked, so callers should limit the number of calls within a batch to
+prevent long delays in batch end.
 
 ### 2.6 Authoring Helper Functions
 An extension can provide an implementation of helper functions that can be invoked by the eBPF programs. The helper

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -248,16 +248,65 @@ the provider must free the per-client context passed in via `ProviderBindingCont
 
 ### 2.5 Invoking an eBPF program from Hook NPI Provider
 To invoke an eBPF program, the extension uses the dispatch table supplied by the Hook NPI client during attaching.
-There is only one function in the client dispatch table, which is of the following type:
+The client dispatch table contains the four functions, with the following type prototypes:
 
 ```
 /**
- *  @brief This is the only mandatory function in the eBPF Hook NPI client dispatch table.
+ * @brief Invoke the eBPF program.
+ *
+ * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
+ * @param[in,out] program_context The context for this invocation of the eBPF program.
+ * @param[out] result The result of the eBPF program.
+ *
+ * @retval EBPF_SUCCESS if successful or an appropriate error code.
+ * @retval EBPF_NO_MEMORY if memory allocation fails.
+ * @retval EBPF_EXTENSION_FAILED_TO_LOAD if required extension is not loaded.
  */
 typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
-    _In_ const void* client_binding_context, _In_ const void* context, _Out_ uint32_t* result);
+    _In_ const void* extension_client_binding_context, _Inout_ void* program_context, _Out_ uint32_t* result);
 
+/**
+ * @brief Prepare the eBPF program for batch invocation.
+ *
+ * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
+ * @param[in] state_size The size of the state to be allocated.
+ * @param[out] state The state to be used for batch invocation.
+ *
+ * @retval EBPF_SUCCESS if successful or an appropriate error code.
+ * @retval EBPF_NO_MEMORY if memory allocation fails.
+ * @retval EBPF_EXTENSION_FAILED_TO_LOAD if required extension is not loaded.
+ */
+typedef ebpf_result_t (*ebpf_program_batch_begin_invoke_function_t)(
+    _In_ const void* extension_client_binding_context, size_t state_size, _Out_writes_(state_size) void* state);
+
+/**
+ * @brief Invoke the eBPF program in batch mode.
+ *
+ * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
+ * @param[in,out] program_context The context for this invocation of the eBPF program.
+ * @param[out] result The result of the eBPF program.
+ * @param[in] state The state to be used for batch invocation.
+ *
+ * @retval EBPF_SUCCESS.
+ */
+typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
+    _In_ const void* extension_client_binding_context,
+    _Inout_ void* program_context,
+    _Out_ uint32_t* result,
+    _In_ const void* state);
+
+/**
+ * @brief Cleanup the eBPF program after batch invocation.
+ *
+ * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
+ * @param[in,out] state The state to be used for batch invocation.
+ *
+ * @retval EBPF_SUCCESS.
+ */
+typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(
+    _In_ const void* extension_client_binding_context, _Inout_ void* state);
 ```
+
 The function pointer can be obtained from the client dispatch table as follows:
 ```
 invoke_program = (ebpf_program_invoke_function_t)client_dispatch_table->function[0];
@@ -269,6 +318,13 @@ must pass the program type specific context data structure. Note that the Progra
 the context descriptor (using the `ebpf_context_descriptor_t` type) to the eBPF verifier and JIT-compiler via the NPI
 client hosted by the Execution Context. The `result` output parameter holds the return value from the eBPF program
 post execution.
+
+In cases where the same eBPF program will be invoked sequentially with different context data (aka batch invocation),
+the caller can reduce the overhead of by using the batch invocation APIs. Prior to the first invocation, the batch
+begin API is called, which caches state used by the eBPf program and prevents the program from being unloaded. The
+caller is responsible for providing storage of large enough to store an instance of ebpf_execution_context_state_t and
+ensuring that it remain valid until calling the batch end API. Between the begin and end calls, the caller may call
+the batch invoke API multiple times to invoke the BPF program with minimal overhead.
 
 ### 2.6 Authoring Helper Functions
 An extension can provide an implementation of helper functions that can be invoked by the eBPF programs. The helper

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -323,7 +323,7 @@ post execution.
 In cases where the same eBPF program will be invoked sequentially with different context data (aka batch invocation),
 the caller can reduce the overhead of by using the batch invocation APIs. Prior to the first invocation, the batch
 begin API is called, which caches state used by the eBPf program and prevents the program from being unloaded. The
-caller is responsible for providing storage arge enough to store an instance of ebpf_execution_context_state_t and
+caller is responsible for providing storage large enough to store an instance of ebpf_execution_context_state_t and
 ensuring that it remain valid until calling the batch end API. Between the begin and end calls, the caller may call
 the batch invoke API multiple times to invoke the BPF program with minimal overhead. Callers must limit the length
 of time a batch is open and must not change IRQL between calling batch begin and end. Batch end cost may scale with

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -321,7 +321,7 @@ client hosted by the Execution Context. The `result` output parameter holds the 
 post execution.
 
 In cases where the same eBPF program will be invoked sequentially with different context data (aka batch invocation),
-the caller can reduce the overhead of by using the batch invocation APIs. Prior to the first invocation, the batch
+the caller can reduce the overhead by using the batch invocation APIs. Prior to the first invocation, the batch
 begin API is called, which caches state used by the eBPF program and prevents the program from being unloaded. The
 caller is responsible for providing storage large enough to store an instance of ebpf_execution_context_state_t and
 ensuring that it remain valid until calling the batch end API. Between the begin and end calls, the caller may call

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -297,7 +297,7 @@ typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
     _In_ const void* state);
 
 /**
- * @brief Cleanup the eBPF program after batch invocation.
+ * @brief Clean up the eBPF program after batch invocation.
  *
  * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
  * @param[in,out] state The state to be used for batch invocation.

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -269,7 +269,7 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
  * @brief Prepare the eBPF program for batch invocation.
  *
  * @param[in] extension_client_binding_context The context provided by the extension client when the binding was created.
- * @param[in] state_size The size of the state to be allocated, should be greater than or equal to
+ * @param[in] state_size The size of the state to be allocated, which should be greater than or equal to
  * sizeof(ebpf_execution_context_state_t).
  * @param[out] state The state to be used for batch invocation.
  *

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -35,7 +35,8 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
  *
  * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
  * created.
- * @param[in] state_size The size of the state to be allocated.
+ * @param[in] state_size The size of the state to be allocated, should be greater than or equal to
+ * sizeof(ebpf_execution_context_state_t).
  * @param[out] state The state to be used for batch invocation.
  *
  * @retval EBPF_SUCCESS if successful or an appropriate error code.

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -23,9 +23,9 @@ typedef struct _ebpf_extension_dispatch_table
  * @param[in,out] program_context The context for this invocation of the eBPF program.
  * @param[out] result The result of the eBPF program.
  *
- * @retval EBPF_SUCCESS if successful or an appropriate error code.
- * @retval EBPF_NO_MEMORY if memory allocation fails.
- * @retval EBPF_EXTENSION_FAILED_TO_LOAD if required extension is not loaded.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_NO_MEMORY The operation failed due to lack of memory.
+ * @retval EBPF_EXTENSION_FAILED_TO_LOAD The required extension is not loaded.
  */
 typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
     _In_ const void* extension_client_binding_context, _Inout_ void* program_context, _Out_ uint32_t* result);
@@ -39,9 +39,9 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
  * sizeof(ebpf_execution_context_state_t).
  * @param[out] state The state to be used for batch invocation.
  *
- * @retval EBPF_SUCCESS if successful or an appropriate error code.
- * @retval EBPF_NO_MEMORY if memory allocation fails.
- * @retval EBPF_EXTENSION_FAILED_TO_LOAD if required extension is not loaded.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_NO_MEMORY The operation failed due to lack of memory.
+ * @retval EBPF_EXTENSION_FAILED_TO_LOAD The required extension is not loaded.
  */
 typedef ebpf_result_t (*ebpf_program_batch_begin_invoke_function_t)(
     _In_ const void* extension_client_binding_context, size_t state_size, _Out_writes_(state_size) void* state);
@@ -55,7 +55,7 @@ typedef ebpf_result_t (*ebpf_program_batch_begin_invoke_function_t)(
  * @param[out] result The result of the eBPF program.
  * @param[in] state The state to be used for batch invocation.
  *
- * @retval EBPF_SUCCESS.
+ * @retval EBPF_SUCCESS The operation was successful.
  */
 typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
     _In_ const void* extension_client_binding_context,
@@ -70,7 +70,7 @@ typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
  * created.
  * @param[in,out] state The state to be used for batch invocation.
  *
- * @retval EBPF_SUCCESS.
+ * @retval EBPF_SUCCESS The operation was successful.
  */
 typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(
     _In_ const void* extension_client_binding_context, _Inout_ void* state);

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -35,7 +35,7 @@ typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
  *
  * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
  * created.
- * @param[in] state_size The size of the state to be allocated, should be greater than or equal to
+ * @param[in] state_size The size of the state to be allocated, which should be greater than or equal to
  * sizeof(ebpf_execution_context_state_t).
  * @param[out] state The state to be used for batch invocation.
  *

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -15,18 +15,62 @@ typedef struct _ebpf_extension_dispatch_table
     _Field_size_(count) _ebpf_extension_dispatch_function function[1];
 } ebpf_extension_dispatch_table_t;
 
+/**
+ * @brief Invoke the eBPF program.
+ *
+ * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
+ * created.
+ * @param[in,out] program_context The context for this invocation of the eBPF program.
+ * @param[out] result The result of the eBPF program.
+ *
+ * @retval EBPF_SUCCESS if successful or an appropriate error code.
+ * @retval EBPF_NO_MEMORY if memory allocation fails.
+ * @retval EBPF_EXTENSION_FAILED_TO_LOAD if required extension is not loaded.
+ */
 typedef ebpf_result_t (*ebpf_program_invoke_function_t)(
     _In_ const void* extension_client_binding_context, _Inout_ void* program_context, _Out_ uint32_t* result);
 
+/**
+ * @brief Prepare the eBPF program for batch invocation.
+ *
+ * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
+ * created.
+ * @param[in] state_size The size of the state to be allocated.
+ * @param[out] state The state to be used for batch invocation.
+ *
+ * @retval EBPF_SUCCESS if successful or an appropriate error code.
+ * @retval EBPF_NO_MEMORY if memory allocation fails.
+ * @retval EBPF_EXTENSION_FAILED_TO_LOAD if required extension is not loaded.
+ */
 typedef ebpf_result_t (*ebpf_program_batch_begin_invoke_function_t)(
     _In_ const void* extension_client_binding_context, size_t state_size, _Out_writes_(state_size) void* state);
 
+/**
+ * @brief Invoke the eBPF program in batch mode.
+ *
+ * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
+ * created.
+ * @param[in,out] program_context The context for this invocation of the eBPF program.
+ * @param[out] result The result of the eBPF program.
+ * @param[in] state The state to be used for batch invocation.
+ *
+ * @retval EBPF_SUCCESS.
+ */
 typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
     _In_ const void* extension_client_binding_context,
     _Inout_ void* program_context,
     _Out_ uint32_t* result,
     _In_ const void* state);
 
+/**
+ * @brief Cleanup the eBPF program after batch invocation.
+ *
+ * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
+ * created.
+ * @param[in,out] state The state to be used for batch invocation.
+ *
+ * @retval EBPF_SUCCESS.
+ */
 typedef ebpf_result_t (*ebpf_program_batch_end_invoke_function_t)(
     _In_ const void* extension_client_binding_context, _Inout_ void* state);
 

--- a/include/ebpf_extension.h
+++ b/include/ebpf_extension.h
@@ -64,7 +64,7 @@ typedef ebpf_result_t (*ebpf_program_batch_invoke_function_t)(
     _In_ const void* state);
 
 /**
- * @brief Cleanup the eBPF program after batch invocation.
+ * @brief Clean up the eBPF program after batch invocation.
  *
  * @param[in] extension_client_binding_context The context provided by the extension client when the binding was
  * created.

--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -485,6 +485,8 @@ _ebpf_link_instance_invoke_batch_begin(
         goto Done;
     }
 
+    memset(execution_context_state, 0, sizeof(ebpf_execution_context_state_t));
+
     ebpf_get_execution_context_state(execution_context_state);
     return_value = ebpf_state_store(ebpf_program_get_state_index(), (uintptr_t)state, execution_context_state);
     if (return_value != EBPF_SUCCESS) {


### PR DESCRIPTION
Resolves: #3057

## Description

Batch invoke begin is passed a state field. It was assuming that the memory was zero initialized, but that doesn't match the SAL annotation.

The fix is to zero initialize the state field.

## Testing

CI/CD

## Documentation

Documented the batch API semantics.

## Installation

No.
