### PR TITLE
Default to 1 repeat count if zero is specified

### DIFF
--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -1061,7 +1061,7 @@ _ebpf_core_protocol_program_test_run(
     options->context_size_in = context_size_in;
     options->context_size_out = context_size_out;
     options->data_size_out = data_size_out;
-    options->repeat_count = request->repeat_count;
+    options->repeat_count = request->repeat_count ? request->repeat_count : 1;
     options->flags = request->flags;
     options->cpu = request->cpu;
     options->batch_size = request->batch_size;


### PR DESCRIPTION
Resolves: #3049 

## Description

Default to 1 repeat count if zero is specified

## Testing

CI/CD

## Documentation

No.

## Installation

No.
