### PR TITLE
Workaround ASAN issue with environment variable

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -74,6 +74,7 @@ jobs:
         call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
         powershell.exe "echo 'msvc_tools_path=%VCToolsInstallDir%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
         powershell.exe "echo 'msvc_tools_version=%VCToolsVersion%' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
+        powershell.exe "echo 'ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
 
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       if: steps.skip_check.outputs.should_skip != 'true'

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -193,6 +193,7 @@ jobs:
       run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
           set EBPF_ENABLE_WER_REPORT=yes
+          set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
           OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
 
     - name: Run test with Code Coverage and low resource simulation
@@ -201,6 +202,7 @@ jobs:
       shell: cmd
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
+          set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
           OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 4
 
     - name: Run test with low resource simulation
@@ -210,6 +212,7 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
+          set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
           powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 16
 
     - name: Run test with Code Coverage
@@ -218,6 +221,7 @@ jobs:
       shell: cmd
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
+          set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
           OpenCppCoverage.exe -q --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell .\Run-Test.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}}
 
     - name: Run test on self-hosted runner
@@ -225,6 +229,7 @@ jobs:
       id: run_test_self_hosted
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
+        [System.Environment]::SetEnvironmentVariable('ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE', 'true')
         ${{env.TEST_COMMAND}} -LogFileName ${{ runner.name }}.log -SelfHostedRunnerName ${{ runner.name }}
 
     - name: Run test without Code Coverage
@@ -233,6 +238,7 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       shell: cmd
       run: |
+        set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
         cd /d ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}
         powershell.exe .\Run-Test.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}}
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -162,12 +162,17 @@ jobs:
         mkdir ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\TestLogs
         wpr.exe -start ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\ebpfforwindows.wprp -filemode
 
+    - name: Set ASAN Environment Variable
+      if: steps.skip_check.outputs.should_skip != 'true'
+      id: set_asan_env_var
+      run: |
+        echo "ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true" >> "$GITHUB_ENV"
+
     - name: Configure eBPF store
       if: steps.skip_check.outputs.should_skip != 'true'
       id: configure_ebpf_store
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        [System.Environment]::SetEnvironmentVariable('ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE', 'true')
         .\export_program_info.exe --clear
         .\export_program_info.exe
 
@@ -193,7 +198,6 @@ jobs:
       run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat"
           set EBPF_ENABLE_WER_REPORT=yes
-          set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
           OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}\${{env.TEST_COMMAND}}
 
     - name: Run test with Code Coverage and low resource simulation
@@ -202,7 +206,6 @@ jobs:
       shell: cmd
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
-          set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
           OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 4
 
     - name: Run test with low resource simulation
@@ -212,7 +215,6 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
-          set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
           powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 16
 
     - name: Run test with Code Coverage
@@ -221,7 +223,6 @@ jobs:
       shell: cmd
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
-          set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
           OpenCppCoverage.exe -q --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell .\Run-Test.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}}
 
     - name: Run test on self-hosted runner
@@ -229,7 +230,6 @@ jobs:
       id: run_test_self_hosted
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        [System.Environment]::SetEnvironmentVariable('ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE', 'true')
         ${{env.TEST_COMMAND}} -LogFileName ${{ runner.name }}.log -SelfHostedRunnerName ${{ runner.name }}
 
     - name: Run test without Code Coverage
@@ -238,7 +238,6 @@ jobs:
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       shell: cmd
       run: |
-        set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
         cd /d ${{github.workspace}}\${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}}
         powershell.exe .\Run-Test.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}}
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -167,7 +167,7 @@ jobs:
       id: configure_ebpf_store
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        set  ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
+        set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
         .\export_program_info.exe --clear
         .\export_program_info.exe
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -167,6 +167,7 @@ jobs:
       id: configure_ebpf_store
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
+        set  ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
         .\export_program_info.exe --clear
         .\export_program_info.exe
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -167,7 +167,7 @@ jobs:
       id: configure_ebpf_store
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        [System.Environment]::SetEnvironmentVariable("ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE", "true", [System.EnvironmentVariableTarget]::Machine)
+        [System.Environment]::SetEnvironmentVariable('ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE', 'true')
         .\export_program_info.exe --clear
         .\export_program_info.exe
 

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -165,8 +165,9 @@ jobs:
     - name: Set ASAN Environment Variable
       if: steps.skip_check.outputs.should_skip != 'true'
       id: set_asan_env_var
+      shell: cmd
       run: |
-        echo "ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true" >> "$GITHUB_ENV"
+        powershell.exe "echo 'ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append"
 
     - name: Configure eBPF store
       if: steps.skip_check.outputs.should_skip != 'true'

--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -167,7 +167,7 @@ jobs:
       id: configure_ebpf_store
       working-directory: ./${{env.BUILD_PLATFORM}}/${{env.BUILD_CONFIGURATION}}
       run: |
-        set ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE=true
+        [System.Environment]::SetEnvironmentVariable("ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE", "true", [System.EnvironmentVariableTarget]::Machine)
         .\export_program_info.exe --clear
         .\export_program_info.exe
 


### PR DESCRIPTION
## Description
There is an issue with the latest version of ASAN which makes it incompatible with the latest version of Windows. To workaround this issue (while an ASAN fixed is worked on), we can set the environment variable for ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE.

## Testing
CI/CD

## Documentation
N/A

## Installation
N/A