### PR TITLE
Reorder GH events in concurrency expression.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,7 +28,7 @@ concurrency:
   # Allow running concurrently with any commits on any other branch.
   # Using GITHUB_REF instead of GITHUB_SHA allows parallel runs on
   # different branches with the same HEAD commit.
-  group: cicd-${{ github.event.schedule || github.event.after || github.event.pull_request.number || github.ref }}
+  group: cicd-${{ github.event.schedule || github.event.pull_request.number || github.event.after || github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Description

We're seeing multiple CI runs for the same PR, while pushed updates should cancel the ongoing runs.

GH must have changed the event payload, and now the `pull_request` event contains the `before / after` fields, which previously only existed in the `push` event.

Fix: reorder the fields in the OR expression so that the calculation reaches the PR number and detects existing duplicates.