### PR TITLE
fix sock_ops test.

### DIFF
--- a/libs/api_common/api_common.hpp
+++ b/libs/api_common/api_common.hpp
@@ -159,6 +159,10 @@ ebpf_result_to_errno(ebpf_result_t result)
         error = EFAULT;
         break;
 
+    case EBPF_OUT_OF_SPACE:
+        error = ENOSPC;
+        break;
+
     default:
         error = EOTHER;
         break;

--- a/libs/execution_context/ebpf_core.c
+++ b/libs/execution_context/ebpf_core.c
@@ -96,7 +96,7 @@ static const void* _ebpf_general_helpers[] = {
     (void*)&_ebpf_core_get_time_ns,
     (void*)&ebpf_core_csum_diff,
     // Ring buffer output.
-    (void*)&ebpf_ring_buffer_map_output,
+    (void*)&_ebpf_core_ring_buffer_output,
     (void*)&_ebpf_core_trace_printk2,
     (void*)&_ebpf_core_trace_printk3,
     (void*)&_ebpf_core_trace_printk4,

--- a/tests/bpf2c_tests/expected/sockops_dll.c
+++ b/tests/bpf2c_tests/expected/sockops_dll.c
@@ -45,10 +45,10 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_HASH, // Type of map.
          56,                // Size in bytes of a map key.
          4,                 // Size in bytes of a map value.
-         1,                 // Maximum number of entries allowed in the map.
+         2,                 // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         19,                // Identifier for a map template.
+         21,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "connection_map"},
@@ -60,7 +60,7 @@ static map_entry_t _maps[] = {
          262144,               // Maximum number of entries allowed in the map.
          0,                    // Inner map index.
          LIBBPF_PIN_NONE,      // Pinning type for the map.
-         25,                   // Identifier for a map template.
+         27,                   // Identifier for a map template.
          0,                    // The id of the inner map template.
      },
      "audit_map"},
@@ -91,769 +91,567 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
 {
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     // Prologue
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r0 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r1 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r2 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r3 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r4 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r5 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r6 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r7 = 0;
-#line 71 "sample/sockops.c"
-    register uint64_t r8 = 0;
-#line 71 "sample/sockops.c"
-    register uint64_t r9 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r10 = 0;
 
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     r1 = (uintptr_t)context;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-    // EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=2
-#line 71 "sample/sockops.c"
-    r7 = IMMEDIATE(2);
-    // EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 71 "sample/sockops.c"
-    r4 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
-#line 76 "sample/sockops.c"
-    if (r2 == IMMEDIATE(0))
-#line 76 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=0 dst=r2 src=r0 offset=0 imm=2
+#line 72 "sample/sockops.c"
+    r2 = IMMEDIATE(2);
+    // EBPF_OP_MOV64_IMM pc=1 dst=r3 src=r0 offset=0 imm=1
+#line 72 "sample/sockops.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=2 dst=r4 src=r1 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_JEQ_IMM pc=3 dst=r4 src=r0 offset=8 imm=0
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(0))
+#line 77 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
-#line 76 "sample/sockops.c"
-    if (r2 == IMMEDIATE(2))
-#line 76 "sample/sockops.c"
+        // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(2))
+#line 77 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
-#line 76 "sample/sockops.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=217 imm=1
-#line 76 "sample/sockops.c"
-    if (r2 != IMMEDIATE(1))
-#line 76 "sample/sockops.c"
-        goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
+        // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
+#line 77 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=7 dst=r4 src=r0 offset=162 imm=1
+#line 77 "sample/sockops.c"
+    if (r4 != IMMEDIATE(1))
+#line 77 "sample/sockops.c"
+        goto label_5;
+        // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 76 "sample/sockops.c"
+#line 77 "sample/sockops.c"
     goto label_2;
 label_1:
-    // EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r7 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r7 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
-#line 93 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
-    // EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=50 imm=2
-#line 93 "sample/sockops.c"
-    if (r2 != IMMEDIATE(2))
-#line 93 "sample/sockops.c"
-        goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
-#line 93 "sample/sockops.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=15 dst=r10 src=r6 offset=-8 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r6 offset=-16 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r6 offset=-24 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=18 dst=r10 src=r6 offset=-32 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r6 offset=-40 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=20 dst=r10 src=r6 offset=-48 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=21 dst=r10 src=r6 offset=-56 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=22 dst=r10 src=r6 offset=-64 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r6;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r2 src=r0 offset=0 imm=28
-#line 26 "sample/sockops.c"
-    r2 = IMMEDIATE(28);
-    // EBPF_OP_MOV64_IMM pc=24 dst=r5 src=r0 offset=0 imm=8
-#line 28 "sample/sockops.c"
-    r5 = IMMEDIATE(8);
-    // EBPF_OP_JNE_IMM pc=25 dst=r4 src=r0 offset=1 imm=0
-#line 28 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 28 "sample/sockops.c"
-        goto label_3;
-    // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
-#line 28 "sample/sockops.c"
-    r5 = IMMEDIATE(28);
-label_3:
-    // EBPF_OP_MOV64_REG pc=27 dst=r3 src=r1 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=28 dst=r3 src=r5 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 += r5;
-    // EBPF_OP_LDXW pc=29 dst=r3 src=r3 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_STXW pc=30 dst=r10 src=r3 offset=-64 imm=0
-#line 28 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r3;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r0 src=r0 offset=0 imm=44
-#line 28 "sample/sockops.c"
-    r0 = IMMEDIATE(44);
-    // EBPF_OP_MOV64_IMM pc=32 dst=r3 src=r0 offset=0 imm=24
-#line 29 "sample/sockops.c"
-    r3 = IMMEDIATE(24);
-    // EBPF_OP_JNE_IMM pc=33 dst=r4 src=r0 offset=1 imm=0
-#line 29 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 29 "sample/sockops.c"
-        goto label_4;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
-#line 29 "sample/sockops.c"
-    r3 = IMMEDIATE(44);
-label_4:
-    // EBPF_OP_MOV64_REG pc=35 dst=r5 src=r1 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r5 = r1;
-    // EBPF_OP_ADD64_REG pc=36 dst=r5 src=r3 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r5 += r3;
-    // EBPF_OP_LDXW pc=37 dst=r3 src=r5 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r5 + OFFSET(0));
-    // EBPF_OP_STXH pc=38 dst=r10 src=r3 offset=-48 imm=0
-#line 29 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
-    // EBPF_OP_JNE_IMM pc=39 dst=r4 src=r0 offset=1 imm=0
-#line 31 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 31 "sample/sockops.c"
-        goto label_5;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
-#line 31 "sample/sockops.c"
-    r0 = IMMEDIATE(24);
-label_5:
-    // EBPF_OP_JNE_IMM pc=41 dst=r4 src=r0 offset=1 imm=0
-#line 30 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 30 "sample/sockops.c"
-        goto label_6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
-#line 30 "sample/sockops.c"
-    r2 = IMMEDIATE(8);
-label_6:
-    // EBPF_OP_OR64_REG pc=43 dst=r7 src=r4 offset=0 imm=0
-#line 34 "sample/sockops.c"
-    r7 |= r4;
-    // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r1 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=45 dst=r3 src=r2 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r3 += r2;
-    // EBPF_OP_LDXW pc=46 dst=r2 src=r3 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_STXW pc=47 dst=r10 src=r2 offset=-44 imm=0
-#line 30 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r2;
-    // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r1 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 = r1;
-    // EBPF_OP_ADD64_REG pc=49 dst=r2 src=r0 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 += r0;
-    // EBPF_OP_LDXW pc=50 dst=r2 src=r2 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXH pc=51 dst=r10 src=r2 offset=-28 imm=0
-#line 31 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r2;
-    // EBPF_OP_LDXB pc=52 dst=r2 src=r1 offset=48 imm=0
-#line 32 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=53 dst=r10 src=r2 offset=-24 imm=0
-#line 32 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
-    // EBPF_OP_LDXDW pc=54 dst=r1 src=r1 offset=56 imm=0
-#line 33 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=55 dst=r10 src=r7 offset=-8 imm=0
-#line 35 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r7;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-16 imm=0
-#line 33 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=57 dst=r2 src=r10 offset=0 imm=0
-#line 33 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r2 src=r0 offset=0 imm=-64
-#line 34 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=0
-#line 37 "sample/sockops.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=1
-#line 37 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
-#line 37 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
-#line 37 "sample/sockops.c"
-        return 0;
-    // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
-#line 37 "sample/sockops.c"
-    if (r0 == IMMEDIATE(0))
-#line 37 "sample/sockops.c"
-        goto label_13;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
-#line 37 "sample/sockops.c"
-    goto label_12;
-label_7:
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r7 offset=-72 imm=0
-#line 37 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r7;
-    // EBPF_OP_MOV64_IMM pc=65 dst=r2 src=r0 offset=0 imm=0
-#line 37 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=10 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
     r2 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=66 dst=r10 src=r2 offset=-8 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=67 dst=r10 src=r2 offset=-16 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r2 offset=-24 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=69 dst=r10 src=r2 offset=-32 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=70 dst=r10 src=r2 offset=-40 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r2 offset=-48 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r2;
-    // EBPF_OP_MOV64_REG pc=72 dst=r3 src=r1 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r3 src=r0 offset=0 imm=28
-#line 51 "sample/sockops.c"
-    r3 += IMMEDIATE(28);
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r1 offset=-96 imm=0
-#line 51 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r0 = r1;
-    // EBPF_OP_ADD64_IMM pc=76 dst=r0 src=r0 offset=0 imm=8
-#line 51 "sample/sockops.c"
-    r0 += IMMEDIATE(8);
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r0 offset=-120 imm=0
-#line 51 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120)) = (uint64_t)r0;
-    // EBPF_OP_JNE_IMM pc=78 dst=r4 src=r0 offset=1 imm=0
-#line 51 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 51 "sample/sockops.c"
-        goto label_8;
-    // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r0 = r3;
-label_8:
-    // EBPF_OP_LDXB pc=80 dst=r2 src=r0 offset=13 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=81 dst=r2 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=82 dst=r1 src=r0 offset=12 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(12));
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r1 offset=-80 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDXB pc=84 dst=r8 src=r0 offset=15 imm=0
-#line 52 "sample/sockops.c"
-    r8 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=85 dst=r8 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=86 dst=r5 src=r0 offset=14 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(14));
-    // EBPF_OP_OR64_REG pc=87 dst=r8 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r8 |= r5;
-    // EBPF_OP_LDXB pc=88 dst=r6 src=r0 offset=9 imm=0
-#line 52 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=89 dst=r6 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=90 dst=r1 src=r0 offset=8 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(8));
-    // EBPF_OP_STXDW pc=91 dst=r10 src=r1 offset=-88 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDXB pc=92 dst=r9 src=r0 offset=11 imm=0
-#line 52 "sample/sockops.c"
-    r9 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=93 dst=r9 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r9 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=10 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(10));
-    // EBPF_OP_OR64_REG pc=95 dst=r9 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r9 |= r5;
-    // EBPF_OP_LDXB pc=96 dst=r5 src=r0 offset=1 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(1));
-    // EBPF_OP_LDXB pc=97 dst=r7 src=r0 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_STXDW pc=98 dst=r10 src=r7 offset=-104 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r7;
-    // EBPF_OP_LDXB pc=99 dst=r7 src=r0 offset=3 imm=0
-#line 52 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(3));
-    // EBPF_OP_LDXB pc=100 dst=r1 src=r0 offset=2 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(2));
-    // EBPF_OP_STXDW pc=101 dst=r10 src=r1 offset=-112 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-112)) = (uint64_t)r1;
-    // EBPF_OP_JNE_IMM pc=102 dst=r4 src=r0 offset=1 imm=0
-#line 53 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 53 "sample/sockops.c"
-        goto label_9;
-    // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
-#line 53 "sample/sockops.c"
-    r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120));
-label_9:
-    // EBPF_OP_LDXDW pc=104 dst=r1 src=r10 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80));
-    // EBPF_OP_OR64_REG pc=105 dst=r2 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r2 |= r1;
-    // EBPF_OP_LDXDW pc=106 dst=r1 src=r10 offset=-88 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88));
-    // EBPF_OP_OR64_REG pc=107 dst=r6 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r6 |= r1;
-    // EBPF_OP_LSH64_IMM pc=108 dst=r9 src=r0 offset=0 imm=16
-#line 53 "sample/sockops.c"
-    r9 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LSH64_IMM pc=109 dst=r8 src=r0 offset=0 imm=16
-#line 53 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LSH64_IMM pc=110 dst=r5 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LSH64_IMM pc=111 dst=r7 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=44
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(44);
-    // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-88 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=24
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(24);
-    // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_JNE_IMM pc=116 dst=r4 src=r0 offset=2 imm=0
-#line 53 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 53 "sample/sockops.c"
-        goto label_10;
-    // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(44);
-    // EBPF_OP_STXDW pc=118 dst=r10 src=r1 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-label_10:
-    // EBPF_OP_OR64_REG pc=119 dst=r9 src=r6 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r9 |= r6;
-    // EBPF_OP_OR64_REG pc=120 dst=r8 src=r2 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r8 |= r2;
-    // EBPF_OP_LDXDW pc=121 dst=r1 src=r10 offset=-104 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104));
-    // EBPF_OP_OR64_REG pc=122 dst=r5 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r5 |= r1;
-    // EBPF_OP_LDXDW pc=123 dst=r1 src=r10 offset=-112 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-112));
-    // EBPF_OP_OR64_REG pc=124 dst=r7 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r7 |= r1;
-    // EBPF_OP_JNE_IMM pc=125 dst=r4 src=r0 offset=2 imm=0
-#line 56 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 56 "sample/sockops.c"
-        goto label_11;
-    // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
-#line 56 "sample/sockops.c"
-    r1 = IMMEDIATE(24);
-    // EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-88 imm=0
-#line 56 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-label_11:
-    // EBPF_OP_LDXDW pc=128 dst=r2 src=r10 offset=-72 imm=0
-#line 56 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72));
-    // EBPF_OP_OR64_REG pc=129 dst=r2 src=r4 offset=0 imm=0
-#line 59 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_STXDW pc=130 dst=r10 src=r2 offset=-72 imm=0
-#line 59 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
-    // EBPF_OP_LSH64_IMM pc=131 dst=r8 src=r0 offset=0 imm=32
-#line 52 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=132 dst=r8 src=r9 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r8 |= r9;
-    // EBPF_OP_STXDW pc=133 dst=r10 src=r8 offset=-56 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_LSH64_IMM pc=134 dst=r7 src=r0 offset=0 imm=16
-#line 52 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=135 dst=r7 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r7 |= r5;
-    // EBPF_OP_LDXB pc=136 dst=r1 src=r0 offset=5 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=137 dst=r1 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=138 dst=r2 src=r0 offset=4 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=139 dst=r1 src=r2 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r1 |= r2;
-    // EBPF_OP_LDXB pc=140 dst=r2 src=r0 offset=6 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(6));
-    // EBPF_OP_LDXB pc=141 dst=r4 src=r0 offset=7 imm=0
-#line 52 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=142 dst=r4 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_OR64_REG pc=143 dst=r4 src=r2 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r2;
-    // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=145 dst=r4 src=r1 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r1;
-    // EBPF_OP_LSH64_IMM pc=146 dst=r4 src=r0 offset=0 imm=32
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=147 dst=r4 src=r7 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r7;
-    // EBPF_OP_STXDW pc=148 dst=r10 src=r4 offset=-64 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
-    // EBPF_OP_LDXDW pc=149 dst=r6 src=r10 offset=-96 imm=0
-#line 52 "sample/sockops.c"
-    r6 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96));
-    // EBPF_OP_MOV64_REG pc=150 dst=r1 src=r6 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 = r6;
-    // EBPF_OP_LDXDW pc=151 dst=r2 src=r10 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80));
-    // EBPF_OP_ADD64_REG pc=152 dst=r1 src=r2 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 += r2;
-    // EBPF_OP_LDXW pc=153 dst=r1 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_STXH pc=154 dst=r10 src=r1 offset=-48 imm=0
-#line 53 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r1;
-    // EBPF_OP_LDXB pc=155 dst=r4 src=r3 offset=13 imm=0
-#line 55 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=156 dst=r4 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=157 dst=r1 src=r3 offset=12 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=158 dst=r4 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r4 |= r1;
-    // EBPF_OP_LDXB pc=159 dst=r2 src=r3 offset=15 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=160 dst=r2 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=161 dst=r1 src=r3 offset=14 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
-    // EBPF_OP_OR64_REG pc=162 dst=r2 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r2 |= r1;
-    // EBPF_OP_LDXB pc=163 dst=r5 src=r3 offset=1 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
-    // EBPF_OP_LSH64_IMM pc=164 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=165 dst=r1 src=r3 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_OR64_REG pc=166 dst=r5 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r1;
-    // EBPF_OP_LDXB pc=167 dst=r1 src=r3 offset=3 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
-    // EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=169 dst=r0 src=r3 offset=2 imm=0
-#line 55 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
-    // EBPF_OP_OR64_REG pc=170 dst=r1 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r0;
-    // EBPF_OP_LSH64_IMM pc=171 dst=r1 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=172 dst=r1 src=r5 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r5;
-    // EBPF_OP_LSH64_IMM pc=173 dst=r2 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=174 dst=r2 src=r4 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_LDXB pc=175 dst=r4 src=r3 offset=9 imm=0
-#line 55 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=177 dst=r5 src=r3 offset=8 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=178 dst=r4 src=r5 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=179 dst=r5 src=r3 offset=11 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=181 dst=r0 src=r3 offset=10 imm=0
-#line 55 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
-    // EBPF_OP_OR64_REG pc=182 dst=r5 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r0;
-    // EBPF_OP_LSH64_IMM pc=183 dst=r5 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=184 dst=r5 src=r4 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r4;
-    // EBPF_OP_STXW pc=185 dst=r10 src=r5 offset=-36 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r5;
-    // EBPF_OP_STXW pc=186 dst=r10 src=r2 offset=-32 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
-    // EBPF_OP_STXW pc=187 dst=r10 src=r1 offset=-44 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r1;
-    // EBPF_OP_LDXB pc=188 dst=r1 src=r3 offset=5 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=189 dst=r1 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=190 dst=r2 src=r3 offset=4 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=191 dst=r1 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r2;
-    // EBPF_OP_LDXB pc=192 dst=r2 src=r3 offset=6 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(6));
-    // EBPF_OP_LDXB pc=193 dst=r3 src=r3 offset=7 imm=0
-#line 55 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_OR64_REG pc=195 dst=r3 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r3 |= r2;
-    // EBPF_OP_LSH64_IMM pc=196 dst=r3 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=197 dst=r3 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r3 |= r1;
-    // EBPF_OP_STXW pc=198 dst=r10 src=r3 offset=-40 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r3;
-    // EBPF_OP_MOV64_REG pc=199 dst=r1 src=r6 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 = r6;
-    // EBPF_OP_LDXDW pc=200 dst=r2 src=r10 offset=-88 imm=0
-#line 56 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88));
-    // EBPF_OP_ADD64_REG pc=201 dst=r1 src=r2 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 += r2;
-    // EBPF_OP_LDXW pc=202 dst=r1 src=r1 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_STXH pc=203 dst=r10 src=r1 offset=-28 imm=0
-#line 56 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r1;
-    // EBPF_OP_LDXB pc=204 dst=r1 src=r6 offset=48 imm=0
-#line 57 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r6 + OFFSET(48));
-    // EBPF_OP_STXW pc=205 dst=r10 src=r1 offset=-24 imm=0
-#line 57 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r1;
-    // EBPF_OP_LDXDW pc=206 dst=r1 src=r6 offset=56 imm=0
-#line 58 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(56));
-    // EBPF_OP_LDXDW pc=207 dst=r2 src=r10 offset=-72 imm=0
-#line 60 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72));
-    // EBPF_OP_STXB pc=208 dst=r10 src=r2 offset=-8 imm=0
-#line 60 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=209 dst=r10 src=r1 offset=-16 imm=0
-#line 58 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=210 dst=r2 src=r10 offset=0 imm=0
-#line 58 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=211 dst=r2 src=r0 offset=0 imm=-64
-#line 59 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=212 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=214 dst=r0 src=r0 offset=0 imm=1
-#line 62 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
-#line 62 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
-#line 62 "sample/sockops.c"
-        return 0;
-    // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=216 dst=r0 src=r0 offset=8 imm=0
-#line 62 "sample/sockops.c"
-    if (r0 == IMMEDIATE(0))
-#line 62 "sample/sockops.c"
-        goto label_13;
-label_12:
-    // EBPF_OP_MOV64_REG pc=217 dst=r2 src=r10 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=218 dst=r2 src=r0 offset=0 imm=-64
-#line 62 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=219 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=221 dst=r3 src=r0 offset=0 imm=64
-#line 62 "sample/sockops.c"
-    r3 = IMMEDIATE(64);
-    // EBPF_OP_MOV64_IMM pc=222 dst=r4 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
+label_2:
+    // EBPF_OP_LDXW pc=12 dst=r4 src=r1 offset=4 imm=0
+#line 94 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=33 imm=2
+#line 94 "sample/sockops.c"
+    if (r4 != IMMEDIATE(2))
+#line 94 "sample/sockops.c"
+        goto label_3;
+        // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
+#line 94 "sample/sockops.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=223 dst=r0 src=r0 offset=0 imm=11
-#line 62 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address
-#line 62 "sample/sockops.c"
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r4 offset=-8 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r4 offset=-16 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r4 offset=-24 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=18 dst=r10 src=r4 offset=-32 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r4 offset=-40 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=20 dst=r10 src=r4 offset=-48 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r4 offset=-56 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=22 dst=r10 src=r4 offset=-64 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
+    // EBPF_OP_LDXW pc=23 dst=r4 src=r1 offset=8 imm=0
+#line 38 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXW pc=24 dst=r10 src=r4 offset=-64 imm=0
+#line 38 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r4;
+    // EBPF_OP_LDXW pc=25 dst=r4 src=r1 offset=24 imm=0
+#line 39 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=26 dst=r10 src=r4 offset=-48 imm=0
+#line 39 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r4;
+    // EBPF_OP_LDXW pc=27 dst=r4 src=r1 offset=28 imm=0
+#line 40 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXW pc=28 dst=r10 src=r4 offset=-44 imm=0
+#line 40 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r4;
+    // EBPF_OP_OR64_REG pc=29 dst=r2 src=r3 offset=0 imm=0
+#line 44 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_LDXW pc=30 dst=r3 src=r1 offset=44 imm=0
+#line 41 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=31 dst=r10 src=r3 offset=-28 imm=0
+#line 41 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=32 dst=r3 src=r1 offset=48 imm=0
+#line 42 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-24 imm=0
+#line 42 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
+    // EBPF_OP_LDXDW pc=34 dst=r1 src=r1 offset=56 imm=0
+#line 43 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=35 dst=r10 src=r2 offset=-8 imm=0
+#line 45 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-16 imm=0
+#line 43 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-64
+#line 43 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address
+#line 26 "sample/sockops.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
-#line 62 "sample/sockops.c"
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = r0;
+    // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
+#line 26 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=124 imm=0
+#line 26 "sample/sockops.c"
+    if (r1 == IMMEDIATE(0))
+#line 26 "sample/sockops.c"
+        goto label_5;
+        // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
+#line 26 "sample/sockops.c"
+    goto label_4;
+label_3:
+    // EBPF_OP_MOV64_IMM pc=47 dst=r4 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=48 dst=r10 src=r4 offset=-8 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r4 offset=-16 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r4 offset=-24 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=51 dst=r10 src=r4 offset=-32 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r4 offset=-40 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r4 offset=-48 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_LDXB pc=54 dst=r5 src=r1 offset=21 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_LSH64_IMM pc=55 dst=r5 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=56 dst=r4 src=r1 offset=20 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_OR64_REG pc=57 dst=r5 src=r4 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r4;
+    // EBPF_OP_LDXB pc=58 dst=r4 src=r1 offset=23 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_LSH64_IMM pc=59 dst=r4 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=60 dst=r0 src=r1 offset=22 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_OR64_REG pc=61 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=62 dst=r6 src=r1 offset=17 imm=0
+#line 57 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_LSH64_IMM pc=63 dst=r6 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r6 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=64 dst=r0 src=r1 offset=16 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_OR64_REG pc=65 dst=r6 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r6 |= r0;
+    // EBPF_OP_LDXB pc=66 dst=r0 src=r1 offset=19 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_LSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=68 dst=r7 src=r1 offset=18 imm=0
+#line 57 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_OR64_REG pc=69 dst=r0 src=r7 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r0 |= r7;
+    // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=71 dst=r0 src=r6 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r0 |= r6;
+    // EBPF_OP_LSH64_IMM pc=72 dst=r4 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=73 dst=r4 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_LDXB pc=74 dst=r6 src=r1 offset=9 imm=0
+#line 57 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=75 dst=r6 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r6 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=76 dst=r5 src=r1 offset=8 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=77 dst=r6 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r6 |= r5;
+    // EBPF_OP_LDXB pc=78 dst=r5 src=r1 offset=11 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=79 dst=r5 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=80 dst=r7 src=r1 offset=10 imm=0
+#line 57 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_OR64_REG pc=81 dst=r5 src=r7 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=82 dst=r2 src=r3 offset=0 imm=0
+#line 64 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_LSH64_IMM pc=83 dst=r4 src=r0 offset=0 imm=32
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=84 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r4 offset=-56 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_LSH64_IMM pc=86 dst=r5 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=87 dst=r5 src=r6 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r6;
+    // EBPF_OP_LDXB pc=88 dst=r3 src=r1 offset=13 imm=0
+#line 57 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=89 dst=r3 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=90 dst=r4 src=r1 offset=12 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=91 dst=r3 src=r4 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=92 dst=r4 src=r1 offset=15 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=93 dst=r4 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=94 dst=r0 src=r1 offset=14 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_OR64_REG pc=95 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LSH64_IMM pc=96 dst=r4 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=97 dst=r4 src=r3 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_LSH64_IMM pc=98 dst=r4 src=r0 offset=0 imm=32
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=99 dst=r4 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_STXDW pc=100 dst=r10 src=r4 offset=-64 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
+    // EBPF_OP_LDXW pc=101 dst=r3 src=r1 offset=24 imm=0
+#line 58 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=102 dst=r10 src=r3 offset=-48 imm=0
+#line 58 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=103 dst=r5 src=r1 offset=41 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=105 dst=r3 src=r1 offset=40 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_OR64_REG pc=106 dst=r5 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r5 |= r3;
+    // EBPF_OP_LDXB pc=107 dst=r3 src=r1 offset=43 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_LSH64_IMM pc=108 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=109 dst=r4 src=r1 offset=42 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_OR64_REG pc=110 dst=r3 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=111 dst=r0 src=r1 offset=29 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_LSH64_IMM pc=112 dst=r0 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=113 dst=r4 src=r1 offset=28 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_OR64_REG pc=114 dst=r0 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r4;
+    // EBPF_OP_LDXB pc=115 dst=r4 src=r1 offset=31 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_LSH64_IMM pc=116 dst=r4 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=117 dst=r6 src=r1 offset=30 imm=0
+#line 60 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_OR64_REG pc=118 dst=r4 src=r6 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r6;
+    // EBPF_OP_LSH64_IMM pc=119 dst=r4 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=120 dst=r4 src=r0 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LSH64_IMM pc=121 dst=r3 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=122 dst=r3 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r5;
+    // EBPF_OP_LDXB pc=123 dst=r5 src=r1 offset=37 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_LSH64_IMM pc=124 dst=r5 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=125 dst=r0 src=r1 offset=36 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_OR64_REG pc=126 dst=r5 src=r0 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r5 |= r0;
+    // EBPF_OP_LDXB pc=127 dst=r0 src=r1 offset=39 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_LSH64_IMM pc=128 dst=r0 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=129 dst=r6 src=r1 offset=38 imm=0
+#line 60 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_OR64_REG pc=130 dst=r0 src=r6 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r6;
+    // EBPF_OP_LSH64_IMM pc=131 dst=r0 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=132 dst=r0 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_STXW pc=133 dst=r10 src=r0 offset=-36 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r0;
+    // EBPF_OP_STXW pc=134 dst=r10 src=r3 offset=-32 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r3;
+    // EBPF_OP_STXW pc=135 dst=r10 src=r4 offset=-44 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r4;
+    // EBPF_OP_LDXB pc=136 dst=r3 src=r1 offset=33 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_LSH64_IMM pc=137 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=138 dst=r4 src=r1 offset=32 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=139 dst=r3 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=140 dst=r4 src=r1 offset=35 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=142 dst=r5 src=r1 offset=34 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_OR64_REG pc=143 dst=r4 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=145 dst=r4 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_STXW pc=146 dst=r10 src=r4 offset=-40 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r4;
+    // EBPF_OP_LDXW pc=147 dst=r3 src=r1 offset=44 imm=0
+#line 61 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=148 dst=r10 src=r3 offset=-28 imm=0
+#line 61 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=149 dst=r3 src=r1 offset=48 imm=0
 #line 62 "sample/sockops.c"
-    r6 = r0;
-label_13:
-    // EBPF_OP_MOV64_REG pc=225 dst=r0 src=r6 offset=0 imm=0
-#line 96 "sample/sockops.c"
-    r0 = r6;
-    // EBPF_OP_EXIT pc=226 dst=r0 src=r0 offset=0 imm=0
-#line 96 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=150 dst=r10 src=r3 offset=-24 imm=0
+#line 62 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
+    // EBPF_OP_LDXDW pc=151 dst=r1 src=r1 offset=56 imm=0
+#line 63 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=152 dst=r10 src=r2 offset=-8 imm=0
+#line 65 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
+    // EBPF_OP_STXDW pc=153 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=154 dst=r2 src=r10 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=155 dst=r2 src=r0 offset=0 imm=-64
+#line 63 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=156 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address
+#line 26 "sample/sockops.c"
+         (r1, r2, r3, r4, r5);
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = r0;
+    // EBPF_OP_LDDW pc=160 dst=r0 src=r0 offset=0 imm=-1
+#line 26 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JEQ_IMM pc=162 dst=r1 src=r0 offset=7 imm=0
+#line 26 "sample/sockops.c"
+    if (r1 == IMMEDIATE(0))
+#line 26 "sample/sockops.c"
+        goto label_5;
+label_4:
+    // EBPF_OP_MOV64_REG pc=163 dst=r2 src=r10 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=164 dst=r2 src=r0 offset=0 imm=-64
+#line 26 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=165 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[1].address);
+    // EBPF_OP_MOV64_IMM pc=167 dst=r3 src=r0 offset=0 imm=64
+#line 26 "sample/sockops.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_MOV64_IMM pc=168 dst=r4 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=169 dst=r0 src=r0 offset=0 imm=11
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[1].address
+#line 26 "sample/sockops.c"
+         (r1, r2, r3, r4, r5);
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
+        return 0;
+label_5:
+    // EBPF_OP_EXIT pc=170 dst=r0 src=r0 offset=0 imm=0
+#line 97 "sample/sockops.c"
     return r0;
-#line 96 "sample/sockops.c"
+#line 97 "sample/sockops.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -870,7 +668,7 @@ static program_entry_t _programs[] = {
         2,
         connection_monitor_helpers,
         2,
-        227,
+        171,
         &connection_monitor_program_type_guid,
         &connection_monitor_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/sockops_raw.c
+++ b/tests/bpf2c_tests/expected/sockops_raw.c
@@ -19,10 +19,10 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_HASH, // Type of map.
          56,                // Size in bytes of a map key.
          4,                 // Size in bytes of a map value.
-         1,                 // Maximum number of entries allowed in the map.
+         2,                 // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         19,                // Identifier for a map template.
+         21,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "connection_map"},
@@ -34,7 +34,7 @@ static map_entry_t _maps[] = {
          262144,               // Maximum number of entries allowed in the map.
          0,                    // Inner map index.
          LIBBPF_PIN_NONE,      // Pinning type for the map.
-         25,                   // Identifier for a map template.
+         27,                   // Identifier for a map template.
          0,                    // The id of the inner map template.
      },
      "audit_map"},
@@ -65,769 +65,567 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
 {
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     // Prologue
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r0 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r1 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r2 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r3 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r4 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r5 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r6 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r7 = 0;
-#line 71 "sample/sockops.c"
-    register uint64_t r8 = 0;
-#line 71 "sample/sockops.c"
-    register uint64_t r9 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r10 = 0;
 
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     r1 = (uintptr_t)context;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-    // EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=2
-#line 71 "sample/sockops.c"
-    r7 = IMMEDIATE(2);
-    // EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 71 "sample/sockops.c"
-    r4 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
-#line 76 "sample/sockops.c"
-    if (r2 == IMMEDIATE(0))
-#line 76 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=0 dst=r2 src=r0 offset=0 imm=2
+#line 72 "sample/sockops.c"
+    r2 = IMMEDIATE(2);
+    // EBPF_OP_MOV64_IMM pc=1 dst=r3 src=r0 offset=0 imm=1
+#line 72 "sample/sockops.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=2 dst=r4 src=r1 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_JEQ_IMM pc=3 dst=r4 src=r0 offset=8 imm=0
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(0))
+#line 77 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
-#line 76 "sample/sockops.c"
-    if (r2 == IMMEDIATE(2))
-#line 76 "sample/sockops.c"
+        // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(2))
+#line 77 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
-#line 76 "sample/sockops.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=217 imm=1
-#line 76 "sample/sockops.c"
-    if (r2 != IMMEDIATE(1))
-#line 76 "sample/sockops.c"
-        goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
+        // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
+#line 77 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=7 dst=r4 src=r0 offset=162 imm=1
+#line 77 "sample/sockops.c"
+    if (r4 != IMMEDIATE(1))
+#line 77 "sample/sockops.c"
+        goto label_5;
+        // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 76 "sample/sockops.c"
+#line 77 "sample/sockops.c"
     goto label_2;
 label_1:
-    // EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r7 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r7 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
-#line 93 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
-    // EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=50 imm=2
-#line 93 "sample/sockops.c"
-    if (r2 != IMMEDIATE(2))
-#line 93 "sample/sockops.c"
-        goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
-#line 93 "sample/sockops.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=15 dst=r10 src=r6 offset=-8 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r6 offset=-16 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r6 offset=-24 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=18 dst=r10 src=r6 offset=-32 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r6 offset=-40 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=20 dst=r10 src=r6 offset=-48 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=21 dst=r10 src=r6 offset=-56 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=22 dst=r10 src=r6 offset=-64 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r6;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r2 src=r0 offset=0 imm=28
-#line 26 "sample/sockops.c"
-    r2 = IMMEDIATE(28);
-    // EBPF_OP_MOV64_IMM pc=24 dst=r5 src=r0 offset=0 imm=8
-#line 28 "sample/sockops.c"
-    r5 = IMMEDIATE(8);
-    // EBPF_OP_JNE_IMM pc=25 dst=r4 src=r0 offset=1 imm=0
-#line 28 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 28 "sample/sockops.c"
-        goto label_3;
-    // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
-#line 28 "sample/sockops.c"
-    r5 = IMMEDIATE(28);
-label_3:
-    // EBPF_OP_MOV64_REG pc=27 dst=r3 src=r1 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=28 dst=r3 src=r5 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 += r5;
-    // EBPF_OP_LDXW pc=29 dst=r3 src=r3 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_STXW pc=30 dst=r10 src=r3 offset=-64 imm=0
-#line 28 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r3;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r0 src=r0 offset=0 imm=44
-#line 28 "sample/sockops.c"
-    r0 = IMMEDIATE(44);
-    // EBPF_OP_MOV64_IMM pc=32 dst=r3 src=r0 offset=0 imm=24
-#line 29 "sample/sockops.c"
-    r3 = IMMEDIATE(24);
-    // EBPF_OP_JNE_IMM pc=33 dst=r4 src=r0 offset=1 imm=0
-#line 29 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 29 "sample/sockops.c"
-        goto label_4;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
-#line 29 "sample/sockops.c"
-    r3 = IMMEDIATE(44);
-label_4:
-    // EBPF_OP_MOV64_REG pc=35 dst=r5 src=r1 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r5 = r1;
-    // EBPF_OP_ADD64_REG pc=36 dst=r5 src=r3 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r5 += r3;
-    // EBPF_OP_LDXW pc=37 dst=r3 src=r5 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r5 + OFFSET(0));
-    // EBPF_OP_STXH pc=38 dst=r10 src=r3 offset=-48 imm=0
-#line 29 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
-    // EBPF_OP_JNE_IMM pc=39 dst=r4 src=r0 offset=1 imm=0
-#line 31 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 31 "sample/sockops.c"
-        goto label_5;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
-#line 31 "sample/sockops.c"
-    r0 = IMMEDIATE(24);
-label_5:
-    // EBPF_OP_JNE_IMM pc=41 dst=r4 src=r0 offset=1 imm=0
-#line 30 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 30 "sample/sockops.c"
-        goto label_6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
-#line 30 "sample/sockops.c"
-    r2 = IMMEDIATE(8);
-label_6:
-    // EBPF_OP_OR64_REG pc=43 dst=r7 src=r4 offset=0 imm=0
-#line 34 "sample/sockops.c"
-    r7 |= r4;
-    // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r1 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=45 dst=r3 src=r2 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r3 += r2;
-    // EBPF_OP_LDXW pc=46 dst=r2 src=r3 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_STXW pc=47 dst=r10 src=r2 offset=-44 imm=0
-#line 30 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r2;
-    // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r1 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 = r1;
-    // EBPF_OP_ADD64_REG pc=49 dst=r2 src=r0 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 += r0;
-    // EBPF_OP_LDXW pc=50 dst=r2 src=r2 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXH pc=51 dst=r10 src=r2 offset=-28 imm=0
-#line 31 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r2;
-    // EBPF_OP_LDXB pc=52 dst=r2 src=r1 offset=48 imm=0
-#line 32 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=53 dst=r10 src=r2 offset=-24 imm=0
-#line 32 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
-    // EBPF_OP_LDXDW pc=54 dst=r1 src=r1 offset=56 imm=0
-#line 33 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=55 dst=r10 src=r7 offset=-8 imm=0
-#line 35 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r7;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-16 imm=0
-#line 33 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=57 dst=r2 src=r10 offset=0 imm=0
-#line 33 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r2 src=r0 offset=0 imm=-64
-#line 34 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=0
-#line 37 "sample/sockops.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=1
-#line 37 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
-#line 37 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
-#line 37 "sample/sockops.c"
-        return 0;
-    // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
-#line 37 "sample/sockops.c"
-    if (r0 == IMMEDIATE(0))
-#line 37 "sample/sockops.c"
-        goto label_13;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
-#line 37 "sample/sockops.c"
-    goto label_12;
-label_7:
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r7 offset=-72 imm=0
-#line 37 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r7;
-    // EBPF_OP_MOV64_IMM pc=65 dst=r2 src=r0 offset=0 imm=0
-#line 37 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=10 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
     r2 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=66 dst=r10 src=r2 offset=-8 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=67 dst=r10 src=r2 offset=-16 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r2 offset=-24 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=69 dst=r10 src=r2 offset=-32 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=70 dst=r10 src=r2 offset=-40 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r2 offset=-48 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r2;
-    // EBPF_OP_MOV64_REG pc=72 dst=r3 src=r1 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r3 src=r0 offset=0 imm=28
-#line 51 "sample/sockops.c"
-    r3 += IMMEDIATE(28);
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r1 offset=-96 imm=0
-#line 51 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r0 = r1;
-    // EBPF_OP_ADD64_IMM pc=76 dst=r0 src=r0 offset=0 imm=8
-#line 51 "sample/sockops.c"
-    r0 += IMMEDIATE(8);
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r0 offset=-120 imm=0
-#line 51 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120)) = (uint64_t)r0;
-    // EBPF_OP_JNE_IMM pc=78 dst=r4 src=r0 offset=1 imm=0
-#line 51 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 51 "sample/sockops.c"
-        goto label_8;
-    // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r0 = r3;
-label_8:
-    // EBPF_OP_LDXB pc=80 dst=r2 src=r0 offset=13 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=81 dst=r2 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=82 dst=r1 src=r0 offset=12 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(12));
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r1 offset=-80 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDXB pc=84 dst=r8 src=r0 offset=15 imm=0
-#line 52 "sample/sockops.c"
-    r8 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=85 dst=r8 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=86 dst=r5 src=r0 offset=14 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(14));
-    // EBPF_OP_OR64_REG pc=87 dst=r8 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r8 |= r5;
-    // EBPF_OP_LDXB pc=88 dst=r6 src=r0 offset=9 imm=0
-#line 52 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=89 dst=r6 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=90 dst=r1 src=r0 offset=8 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(8));
-    // EBPF_OP_STXDW pc=91 dst=r10 src=r1 offset=-88 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDXB pc=92 dst=r9 src=r0 offset=11 imm=0
-#line 52 "sample/sockops.c"
-    r9 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=93 dst=r9 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r9 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=10 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(10));
-    // EBPF_OP_OR64_REG pc=95 dst=r9 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r9 |= r5;
-    // EBPF_OP_LDXB pc=96 dst=r5 src=r0 offset=1 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(1));
-    // EBPF_OP_LDXB pc=97 dst=r7 src=r0 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_STXDW pc=98 dst=r10 src=r7 offset=-104 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r7;
-    // EBPF_OP_LDXB pc=99 dst=r7 src=r0 offset=3 imm=0
-#line 52 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(3));
-    // EBPF_OP_LDXB pc=100 dst=r1 src=r0 offset=2 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(2));
-    // EBPF_OP_STXDW pc=101 dst=r10 src=r1 offset=-112 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-112)) = (uint64_t)r1;
-    // EBPF_OP_JNE_IMM pc=102 dst=r4 src=r0 offset=1 imm=0
-#line 53 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 53 "sample/sockops.c"
-        goto label_9;
-    // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
-#line 53 "sample/sockops.c"
-    r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120));
-label_9:
-    // EBPF_OP_LDXDW pc=104 dst=r1 src=r10 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80));
-    // EBPF_OP_OR64_REG pc=105 dst=r2 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r2 |= r1;
-    // EBPF_OP_LDXDW pc=106 dst=r1 src=r10 offset=-88 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88));
-    // EBPF_OP_OR64_REG pc=107 dst=r6 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r6 |= r1;
-    // EBPF_OP_LSH64_IMM pc=108 dst=r9 src=r0 offset=0 imm=16
-#line 53 "sample/sockops.c"
-    r9 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LSH64_IMM pc=109 dst=r8 src=r0 offset=0 imm=16
-#line 53 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LSH64_IMM pc=110 dst=r5 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LSH64_IMM pc=111 dst=r7 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=44
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(44);
-    // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-88 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=24
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(24);
-    // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_JNE_IMM pc=116 dst=r4 src=r0 offset=2 imm=0
-#line 53 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 53 "sample/sockops.c"
-        goto label_10;
-    // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(44);
-    // EBPF_OP_STXDW pc=118 dst=r10 src=r1 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-label_10:
-    // EBPF_OP_OR64_REG pc=119 dst=r9 src=r6 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r9 |= r6;
-    // EBPF_OP_OR64_REG pc=120 dst=r8 src=r2 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r8 |= r2;
-    // EBPF_OP_LDXDW pc=121 dst=r1 src=r10 offset=-104 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104));
-    // EBPF_OP_OR64_REG pc=122 dst=r5 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r5 |= r1;
-    // EBPF_OP_LDXDW pc=123 dst=r1 src=r10 offset=-112 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-112));
-    // EBPF_OP_OR64_REG pc=124 dst=r7 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r7 |= r1;
-    // EBPF_OP_JNE_IMM pc=125 dst=r4 src=r0 offset=2 imm=0
-#line 56 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 56 "sample/sockops.c"
-        goto label_11;
-    // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
-#line 56 "sample/sockops.c"
-    r1 = IMMEDIATE(24);
-    // EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-88 imm=0
-#line 56 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-label_11:
-    // EBPF_OP_LDXDW pc=128 dst=r2 src=r10 offset=-72 imm=0
-#line 56 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72));
-    // EBPF_OP_OR64_REG pc=129 dst=r2 src=r4 offset=0 imm=0
-#line 59 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_STXDW pc=130 dst=r10 src=r2 offset=-72 imm=0
-#line 59 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
-    // EBPF_OP_LSH64_IMM pc=131 dst=r8 src=r0 offset=0 imm=32
-#line 52 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=132 dst=r8 src=r9 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r8 |= r9;
-    // EBPF_OP_STXDW pc=133 dst=r10 src=r8 offset=-56 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_LSH64_IMM pc=134 dst=r7 src=r0 offset=0 imm=16
-#line 52 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=135 dst=r7 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r7 |= r5;
-    // EBPF_OP_LDXB pc=136 dst=r1 src=r0 offset=5 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=137 dst=r1 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=138 dst=r2 src=r0 offset=4 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=139 dst=r1 src=r2 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r1 |= r2;
-    // EBPF_OP_LDXB pc=140 dst=r2 src=r0 offset=6 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(6));
-    // EBPF_OP_LDXB pc=141 dst=r4 src=r0 offset=7 imm=0
-#line 52 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=142 dst=r4 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_OR64_REG pc=143 dst=r4 src=r2 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r2;
-    // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=145 dst=r4 src=r1 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r1;
-    // EBPF_OP_LSH64_IMM pc=146 dst=r4 src=r0 offset=0 imm=32
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=147 dst=r4 src=r7 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r7;
-    // EBPF_OP_STXDW pc=148 dst=r10 src=r4 offset=-64 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
-    // EBPF_OP_LDXDW pc=149 dst=r6 src=r10 offset=-96 imm=0
-#line 52 "sample/sockops.c"
-    r6 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96));
-    // EBPF_OP_MOV64_REG pc=150 dst=r1 src=r6 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 = r6;
-    // EBPF_OP_LDXDW pc=151 dst=r2 src=r10 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80));
-    // EBPF_OP_ADD64_REG pc=152 dst=r1 src=r2 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 += r2;
-    // EBPF_OP_LDXW pc=153 dst=r1 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_STXH pc=154 dst=r10 src=r1 offset=-48 imm=0
-#line 53 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r1;
-    // EBPF_OP_LDXB pc=155 dst=r4 src=r3 offset=13 imm=0
-#line 55 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=156 dst=r4 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=157 dst=r1 src=r3 offset=12 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=158 dst=r4 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r4 |= r1;
-    // EBPF_OP_LDXB pc=159 dst=r2 src=r3 offset=15 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=160 dst=r2 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=161 dst=r1 src=r3 offset=14 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
-    // EBPF_OP_OR64_REG pc=162 dst=r2 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r2 |= r1;
-    // EBPF_OP_LDXB pc=163 dst=r5 src=r3 offset=1 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
-    // EBPF_OP_LSH64_IMM pc=164 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=165 dst=r1 src=r3 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_OR64_REG pc=166 dst=r5 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r1;
-    // EBPF_OP_LDXB pc=167 dst=r1 src=r3 offset=3 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
-    // EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=169 dst=r0 src=r3 offset=2 imm=0
-#line 55 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
-    // EBPF_OP_OR64_REG pc=170 dst=r1 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r0;
-    // EBPF_OP_LSH64_IMM pc=171 dst=r1 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=172 dst=r1 src=r5 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r5;
-    // EBPF_OP_LSH64_IMM pc=173 dst=r2 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=174 dst=r2 src=r4 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_LDXB pc=175 dst=r4 src=r3 offset=9 imm=0
-#line 55 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=177 dst=r5 src=r3 offset=8 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=178 dst=r4 src=r5 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=179 dst=r5 src=r3 offset=11 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=181 dst=r0 src=r3 offset=10 imm=0
-#line 55 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
-    // EBPF_OP_OR64_REG pc=182 dst=r5 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r0;
-    // EBPF_OP_LSH64_IMM pc=183 dst=r5 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=184 dst=r5 src=r4 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r4;
-    // EBPF_OP_STXW pc=185 dst=r10 src=r5 offset=-36 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r5;
-    // EBPF_OP_STXW pc=186 dst=r10 src=r2 offset=-32 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
-    // EBPF_OP_STXW pc=187 dst=r10 src=r1 offset=-44 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r1;
-    // EBPF_OP_LDXB pc=188 dst=r1 src=r3 offset=5 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=189 dst=r1 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=190 dst=r2 src=r3 offset=4 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=191 dst=r1 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r2;
-    // EBPF_OP_LDXB pc=192 dst=r2 src=r3 offset=6 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(6));
-    // EBPF_OP_LDXB pc=193 dst=r3 src=r3 offset=7 imm=0
-#line 55 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_OR64_REG pc=195 dst=r3 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r3 |= r2;
-    // EBPF_OP_LSH64_IMM pc=196 dst=r3 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=197 dst=r3 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r3 |= r1;
-    // EBPF_OP_STXW pc=198 dst=r10 src=r3 offset=-40 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r3;
-    // EBPF_OP_MOV64_REG pc=199 dst=r1 src=r6 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 = r6;
-    // EBPF_OP_LDXDW pc=200 dst=r2 src=r10 offset=-88 imm=0
-#line 56 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88));
-    // EBPF_OP_ADD64_REG pc=201 dst=r1 src=r2 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 += r2;
-    // EBPF_OP_LDXW pc=202 dst=r1 src=r1 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_STXH pc=203 dst=r10 src=r1 offset=-28 imm=0
-#line 56 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r1;
-    // EBPF_OP_LDXB pc=204 dst=r1 src=r6 offset=48 imm=0
-#line 57 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r6 + OFFSET(48));
-    // EBPF_OP_STXW pc=205 dst=r10 src=r1 offset=-24 imm=0
-#line 57 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r1;
-    // EBPF_OP_LDXDW pc=206 dst=r1 src=r6 offset=56 imm=0
-#line 58 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(56));
-    // EBPF_OP_LDXDW pc=207 dst=r2 src=r10 offset=-72 imm=0
-#line 60 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72));
-    // EBPF_OP_STXB pc=208 dst=r10 src=r2 offset=-8 imm=0
-#line 60 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=209 dst=r10 src=r1 offset=-16 imm=0
-#line 58 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=210 dst=r2 src=r10 offset=0 imm=0
-#line 58 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=211 dst=r2 src=r0 offset=0 imm=-64
-#line 59 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=212 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=214 dst=r0 src=r0 offset=0 imm=1
-#line 62 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
-#line 62 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
-#line 62 "sample/sockops.c"
-        return 0;
-    // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=216 dst=r0 src=r0 offset=8 imm=0
-#line 62 "sample/sockops.c"
-    if (r0 == IMMEDIATE(0))
-#line 62 "sample/sockops.c"
-        goto label_13;
-label_12:
-    // EBPF_OP_MOV64_REG pc=217 dst=r2 src=r10 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=218 dst=r2 src=r0 offset=0 imm=-64
-#line 62 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=219 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=221 dst=r3 src=r0 offset=0 imm=64
-#line 62 "sample/sockops.c"
-    r3 = IMMEDIATE(64);
-    // EBPF_OP_MOV64_IMM pc=222 dst=r4 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
+label_2:
+    // EBPF_OP_LDXW pc=12 dst=r4 src=r1 offset=4 imm=0
+#line 94 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=33 imm=2
+#line 94 "sample/sockops.c"
+    if (r4 != IMMEDIATE(2))
+#line 94 "sample/sockops.c"
+        goto label_3;
+        // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
+#line 94 "sample/sockops.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=223 dst=r0 src=r0 offset=0 imm=11
-#line 62 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address
-#line 62 "sample/sockops.c"
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r4 offset=-8 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r4 offset=-16 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r4 offset=-24 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=18 dst=r10 src=r4 offset=-32 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r4 offset=-40 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=20 dst=r10 src=r4 offset=-48 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r4 offset=-56 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=22 dst=r10 src=r4 offset=-64 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
+    // EBPF_OP_LDXW pc=23 dst=r4 src=r1 offset=8 imm=0
+#line 38 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXW pc=24 dst=r10 src=r4 offset=-64 imm=0
+#line 38 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r4;
+    // EBPF_OP_LDXW pc=25 dst=r4 src=r1 offset=24 imm=0
+#line 39 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=26 dst=r10 src=r4 offset=-48 imm=0
+#line 39 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r4;
+    // EBPF_OP_LDXW pc=27 dst=r4 src=r1 offset=28 imm=0
+#line 40 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXW pc=28 dst=r10 src=r4 offset=-44 imm=0
+#line 40 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r4;
+    // EBPF_OP_OR64_REG pc=29 dst=r2 src=r3 offset=0 imm=0
+#line 44 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_LDXW pc=30 dst=r3 src=r1 offset=44 imm=0
+#line 41 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=31 dst=r10 src=r3 offset=-28 imm=0
+#line 41 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=32 dst=r3 src=r1 offset=48 imm=0
+#line 42 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-24 imm=0
+#line 42 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
+    // EBPF_OP_LDXDW pc=34 dst=r1 src=r1 offset=56 imm=0
+#line 43 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=35 dst=r10 src=r2 offset=-8 imm=0
+#line 45 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-16 imm=0
+#line 43 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-64
+#line 43 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address
+#line 26 "sample/sockops.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
-#line 62 "sample/sockops.c"
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = r0;
+    // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
+#line 26 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=124 imm=0
+#line 26 "sample/sockops.c"
+    if (r1 == IMMEDIATE(0))
+#line 26 "sample/sockops.c"
+        goto label_5;
+        // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
+#line 26 "sample/sockops.c"
+    goto label_4;
+label_3:
+    // EBPF_OP_MOV64_IMM pc=47 dst=r4 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=48 dst=r10 src=r4 offset=-8 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r4 offset=-16 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r4 offset=-24 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=51 dst=r10 src=r4 offset=-32 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r4 offset=-40 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r4 offset=-48 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_LDXB pc=54 dst=r5 src=r1 offset=21 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_LSH64_IMM pc=55 dst=r5 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=56 dst=r4 src=r1 offset=20 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_OR64_REG pc=57 dst=r5 src=r4 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r4;
+    // EBPF_OP_LDXB pc=58 dst=r4 src=r1 offset=23 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_LSH64_IMM pc=59 dst=r4 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=60 dst=r0 src=r1 offset=22 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_OR64_REG pc=61 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=62 dst=r6 src=r1 offset=17 imm=0
+#line 57 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_LSH64_IMM pc=63 dst=r6 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r6 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=64 dst=r0 src=r1 offset=16 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_OR64_REG pc=65 dst=r6 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r6 |= r0;
+    // EBPF_OP_LDXB pc=66 dst=r0 src=r1 offset=19 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_LSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=68 dst=r7 src=r1 offset=18 imm=0
+#line 57 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_OR64_REG pc=69 dst=r0 src=r7 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r0 |= r7;
+    // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=71 dst=r0 src=r6 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r0 |= r6;
+    // EBPF_OP_LSH64_IMM pc=72 dst=r4 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=73 dst=r4 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_LDXB pc=74 dst=r6 src=r1 offset=9 imm=0
+#line 57 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=75 dst=r6 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r6 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=76 dst=r5 src=r1 offset=8 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=77 dst=r6 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r6 |= r5;
+    // EBPF_OP_LDXB pc=78 dst=r5 src=r1 offset=11 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=79 dst=r5 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=80 dst=r7 src=r1 offset=10 imm=0
+#line 57 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_OR64_REG pc=81 dst=r5 src=r7 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=82 dst=r2 src=r3 offset=0 imm=0
+#line 64 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_LSH64_IMM pc=83 dst=r4 src=r0 offset=0 imm=32
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=84 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r4 offset=-56 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_LSH64_IMM pc=86 dst=r5 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=87 dst=r5 src=r6 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r6;
+    // EBPF_OP_LDXB pc=88 dst=r3 src=r1 offset=13 imm=0
+#line 57 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=89 dst=r3 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=90 dst=r4 src=r1 offset=12 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=91 dst=r3 src=r4 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=92 dst=r4 src=r1 offset=15 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=93 dst=r4 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=94 dst=r0 src=r1 offset=14 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_OR64_REG pc=95 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LSH64_IMM pc=96 dst=r4 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=97 dst=r4 src=r3 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_LSH64_IMM pc=98 dst=r4 src=r0 offset=0 imm=32
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=99 dst=r4 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_STXDW pc=100 dst=r10 src=r4 offset=-64 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
+    // EBPF_OP_LDXW pc=101 dst=r3 src=r1 offset=24 imm=0
+#line 58 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=102 dst=r10 src=r3 offset=-48 imm=0
+#line 58 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=103 dst=r5 src=r1 offset=41 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=105 dst=r3 src=r1 offset=40 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_OR64_REG pc=106 dst=r5 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r5 |= r3;
+    // EBPF_OP_LDXB pc=107 dst=r3 src=r1 offset=43 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_LSH64_IMM pc=108 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=109 dst=r4 src=r1 offset=42 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_OR64_REG pc=110 dst=r3 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=111 dst=r0 src=r1 offset=29 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_LSH64_IMM pc=112 dst=r0 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=113 dst=r4 src=r1 offset=28 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_OR64_REG pc=114 dst=r0 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r4;
+    // EBPF_OP_LDXB pc=115 dst=r4 src=r1 offset=31 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_LSH64_IMM pc=116 dst=r4 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=117 dst=r6 src=r1 offset=30 imm=0
+#line 60 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_OR64_REG pc=118 dst=r4 src=r6 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r6;
+    // EBPF_OP_LSH64_IMM pc=119 dst=r4 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=120 dst=r4 src=r0 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LSH64_IMM pc=121 dst=r3 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=122 dst=r3 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r5;
+    // EBPF_OP_LDXB pc=123 dst=r5 src=r1 offset=37 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_LSH64_IMM pc=124 dst=r5 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=125 dst=r0 src=r1 offset=36 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_OR64_REG pc=126 dst=r5 src=r0 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r5 |= r0;
+    // EBPF_OP_LDXB pc=127 dst=r0 src=r1 offset=39 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_LSH64_IMM pc=128 dst=r0 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=129 dst=r6 src=r1 offset=38 imm=0
+#line 60 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_OR64_REG pc=130 dst=r0 src=r6 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r6;
+    // EBPF_OP_LSH64_IMM pc=131 dst=r0 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=132 dst=r0 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_STXW pc=133 dst=r10 src=r0 offset=-36 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r0;
+    // EBPF_OP_STXW pc=134 dst=r10 src=r3 offset=-32 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r3;
+    // EBPF_OP_STXW pc=135 dst=r10 src=r4 offset=-44 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r4;
+    // EBPF_OP_LDXB pc=136 dst=r3 src=r1 offset=33 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_LSH64_IMM pc=137 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=138 dst=r4 src=r1 offset=32 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=139 dst=r3 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=140 dst=r4 src=r1 offset=35 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=142 dst=r5 src=r1 offset=34 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_OR64_REG pc=143 dst=r4 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=145 dst=r4 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_STXW pc=146 dst=r10 src=r4 offset=-40 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r4;
+    // EBPF_OP_LDXW pc=147 dst=r3 src=r1 offset=44 imm=0
+#line 61 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=148 dst=r10 src=r3 offset=-28 imm=0
+#line 61 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=149 dst=r3 src=r1 offset=48 imm=0
 #line 62 "sample/sockops.c"
-    r6 = r0;
-label_13:
-    // EBPF_OP_MOV64_REG pc=225 dst=r0 src=r6 offset=0 imm=0
-#line 96 "sample/sockops.c"
-    r0 = r6;
-    // EBPF_OP_EXIT pc=226 dst=r0 src=r0 offset=0 imm=0
-#line 96 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=150 dst=r10 src=r3 offset=-24 imm=0
+#line 62 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
+    // EBPF_OP_LDXDW pc=151 dst=r1 src=r1 offset=56 imm=0
+#line 63 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=152 dst=r10 src=r2 offset=-8 imm=0
+#line 65 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
+    // EBPF_OP_STXDW pc=153 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=154 dst=r2 src=r10 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=155 dst=r2 src=r0 offset=0 imm=-64
+#line 63 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=156 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address
+#line 26 "sample/sockops.c"
+         (r1, r2, r3, r4, r5);
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = r0;
+    // EBPF_OP_LDDW pc=160 dst=r0 src=r0 offset=0 imm=-1
+#line 26 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JEQ_IMM pc=162 dst=r1 src=r0 offset=7 imm=0
+#line 26 "sample/sockops.c"
+    if (r1 == IMMEDIATE(0))
+#line 26 "sample/sockops.c"
+        goto label_5;
+label_4:
+    // EBPF_OP_MOV64_REG pc=163 dst=r2 src=r10 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=164 dst=r2 src=r0 offset=0 imm=-64
+#line 26 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=165 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[1].address);
+    // EBPF_OP_MOV64_IMM pc=167 dst=r3 src=r0 offset=0 imm=64
+#line 26 "sample/sockops.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_MOV64_IMM pc=168 dst=r4 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=169 dst=r0 src=r0 offset=0 imm=11
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[1].address
+#line 26 "sample/sockops.c"
+         (r1, r2, r3, r4, r5);
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
+        return 0;
+label_5:
+    // EBPF_OP_EXIT pc=170 dst=r0 src=r0 offset=0 imm=0
+#line 97 "sample/sockops.c"
     return r0;
-#line 96 "sample/sockops.c"
+#line 97 "sample/sockops.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -844,7 +642,7 @@ static program_entry_t _programs[] = {
         2,
         connection_monitor_helpers,
         2,
-        227,
+        171,
         &connection_monitor_program_type_guid,
         &connection_monitor_attach_type_guid,
     },

--- a/tests/bpf2c_tests/expected/sockops_sys.c
+++ b/tests/bpf2c_tests/expected/sockops_sys.c
@@ -180,10 +180,10 @@ static map_entry_t _maps[] = {
          BPF_MAP_TYPE_HASH, // Type of map.
          56,                // Size in bytes of a map key.
          4,                 // Size in bytes of a map value.
-         1,                 // Maximum number of entries allowed in the map.
+         2,                 // Maximum number of entries allowed in the map.
          0,                 // Inner map index.
          LIBBPF_PIN_NONE,   // Pinning type for the map.
-         19,                // Identifier for a map template.
+         21,                // Identifier for a map template.
          0,                 // The id of the inner map template.
      },
      "connection_map"},
@@ -195,7 +195,7 @@ static map_entry_t _maps[] = {
          262144,               // Maximum number of entries allowed in the map.
          0,                    // Inner map index.
          LIBBPF_PIN_NONE,      // Pinning type for the map.
-         25,                   // Identifier for a map template.
+         27,                   // Identifier for a map template.
          0,                    // The id of the inner map template.
      },
      "audit_map"},
@@ -226,769 +226,567 @@ static uint16_t connection_monitor_maps[] = {
 #pragma code_seg(push, "sockops")
 static uint64_t
 connection_monitor(void* context)
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
 {
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     // Prologue
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     uint64_t stack[(UBPF_STACK_SIZE + 7) / 8];
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r0 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r1 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r2 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r3 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r4 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r5 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r6 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r7 = 0;
-#line 71 "sample/sockops.c"
-    register uint64_t r8 = 0;
-#line 71 "sample/sockops.c"
-    register uint64_t r9 = 0;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     register uint64_t r10 = 0;
 
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     r1 = (uintptr_t)context;
-#line 71 "sample/sockops.c"
+#line 72 "sample/sockops.c"
     r10 = (uintptr_t)((uint8_t*)stack + sizeof(stack));
 
-    // EBPF_OP_MOV64_IMM pc=0 dst=r7 src=r0 offset=0 imm=2
-#line 71 "sample/sockops.c"
-    r7 = IMMEDIATE(2);
-    // EBPF_OP_MOV64_IMM pc=1 dst=r4 src=r0 offset=0 imm=1
-#line 71 "sample/sockops.c"
-    r4 = IMMEDIATE(1);
-    // EBPF_OP_LDXW pc=2 dst=r2 src=r1 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_JEQ_IMM pc=3 dst=r2 src=r0 offset=8 imm=0
-#line 76 "sample/sockops.c"
-    if (r2 == IMMEDIATE(0))
-#line 76 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=0 dst=r2 src=r0 offset=0 imm=2
+#line 72 "sample/sockops.c"
+    r2 = IMMEDIATE(2);
+    // EBPF_OP_MOV64_IMM pc=1 dst=r3 src=r0 offset=0 imm=1
+#line 72 "sample/sockops.c"
+    r3 = IMMEDIATE(1);
+    // EBPF_OP_LDXW pc=2 dst=r4 src=r1 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
+    // EBPF_OP_JEQ_IMM pc=3 dst=r4 src=r0 offset=8 imm=0
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(0))
+#line 77 "sample/sockops.c"
         goto label_2;
-    // EBPF_OP_JEQ_IMM pc=4 dst=r2 src=r0 offset=5 imm=2
-#line 76 "sample/sockops.c"
-    if (r2 == IMMEDIATE(2))
-#line 76 "sample/sockops.c"
+        // EBPF_OP_JEQ_IMM pc=4 dst=r4 src=r0 offset=5 imm=2
+#line 77 "sample/sockops.c"
+    if (r4 == IMMEDIATE(2))
+#line 77 "sample/sockops.c"
         goto label_1;
-    // EBPF_OP_LDDW pc=5 dst=r6 src=r0 offset=0 imm=-1
-#line 76 "sample/sockops.c"
-    r6 = (uint64_t)4294967295;
-    // EBPF_OP_JNE_IMM pc=7 dst=r2 src=r0 offset=217 imm=1
-#line 76 "sample/sockops.c"
-    if (r2 != IMMEDIATE(1))
-#line 76 "sample/sockops.c"
-        goto label_13;
-    // EBPF_OP_MOV64_IMM pc=8 dst=r4 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
+        // EBPF_OP_LDDW pc=5 dst=r0 src=r0 offset=0 imm=-1
+#line 77 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JNE_IMM pc=7 dst=r4 src=r0 offset=162 imm=1
+#line 77 "sample/sockops.c"
+    if (r4 != IMMEDIATE(1))
+#line 77 "sample/sockops.c"
+        goto label_5;
+        // EBPF_OP_MOV64_IMM pc=8 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
     // EBPF_OP_JA pc=9 dst=r0 src=r0 offset=2 imm=0
-#line 76 "sample/sockops.c"
+#line 77 "sample/sockops.c"
     goto label_2;
 label_1:
-    // EBPF_OP_MOV64_IMM pc=10 dst=r4 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r4 = IMMEDIATE(0);
-    // EBPF_OP_MOV64_IMM pc=11 dst=r7 src=r0 offset=0 imm=0
-#line 76 "sample/sockops.c"
-    r7 = IMMEDIATE(0);
-label_2:
-    // EBPF_OP_LDXW pc=12 dst=r2 src=r1 offset=4 imm=0
-#line 93 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
-    // EBPF_OP_JNE_IMM pc=13 dst=r2 src=r0 offset=50 imm=2
-#line 93 "sample/sockops.c"
-    if (r2 != IMMEDIATE(2))
-#line 93 "sample/sockops.c"
-        goto label_7;
-    // EBPF_OP_MOV64_IMM pc=14 dst=r6 src=r0 offset=0 imm=0
-#line 93 "sample/sockops.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=15 dst=r10 src=r6 offset=-8 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=16 dst=r10 src=r6 offset=-16 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=17 dst=r10 src=r6 offset=-24 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=18 dst=r10 src=r6 offset=-32 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=19 dst=r10 src=r6 offset=-40 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=20 dst=r10 src=r6 offset=-48 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=21 dst=r10 src=r6 offset=-56 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r6;
-    // EBPF_OP_STXDW pc=22 dst=r10 src=r6 offset=-64 imm=0
-#line 26 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r6;
-    // EBPF_OP_MOV64_IMM pc=23 dst=r2 src=r0 offset=0 imm=28
-#line 26 "sample/sockops.c"
-    r2 = IMMEDIATE(28);
-    // EBPF_OP_MOV64_IMM pc=24 dst=r5 src=r0 offset=0 imm=8
-#line 28 "sample/sockops.c"
-    r5 = IMMEDIATE(8);
-    // EBPF_OP_JNE_IMM pc=25 dst=r4 src=r0 offset=1 imm=0
-#line 28 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 28 "sample/sockops.c"
-        goto label_3;
-    // EBPF_OP_MOV64_IMM pc=26 dst=r5 src=r0 offset=0 imm=28
-#line 28 "sample/sockops.c"
-    r5 = IMMEDIATE(28);
-label_3:
-    // EBPF_OP_MOV64_REG pc=27 dst=r3 src=r1 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=28 dst=r3 src=r5 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 += r5;
-    // EBPF_OP_LDXW pc=29 dst=r3 src=r3 offset=0 imm=0
-#line 28 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_STXW pc=30 dst=r10 src=r3 offset=-64 imm=0
-#line 28 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r3;
-    // EBPF_OP_MOV64_IMM pc=31 dst=r0 src=r0 offset=0 imm=44
-#line 28 "sample/sockops.c"
-    r0 = IMMEDIATE(44);
-    // EBPF_OP_MOV64_IMM pc=32 dst=r3 src=r0 offset=0 imm=24
-#line 29 "sample/sockops.c"
-    r3 = IMMEDIATE(24);
-    // EBPF_OP_JNE_IMM pc=33 dst=r4 src=r0 offset=1 imm=0
-#line 29 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 29 "sample/sockops.c"
-        goto label_4;
-    // EBPF_OP_MOV64_IMM pc=34 dst=r3 src=r0 offset=0 imm=44
-#line 29 "sample/sockops.c"
-    r3 = IMMEDIATE(44);
-label_4:
-    // EBPF_OP_MOV64_REG pc=35 dst=r5 src=r1 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r5 = r1;
-    // EBPF_OP_ADD64_REG pc=36 dst=r5 src=r3 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r5 += r3;
-    // EBPF_OP_LDXW pc=37 dst=r3 src=r5 offset=0 imm=0
-#line 29 "sample/sockops.c"
-    r3 = *(uint32_t*)(uintptr_t)(r5 + OFFSET(0));
-    // EBPF_OP_STXH pc=38 dst=r10 src=r3 offset=-48 imm=0
-#line 29 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
-    // EBPF_OP_JNE_IMM pc=39 dst=r4 src=r0 offset=1 imm=0
-#line 31 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 31 "sample/sockops.c"
-        goto label_5;
-    // EBPF_OP_MOV64_IMM pc=40 dst=r0 src=r0 offset=0 imm=24
-#line 31 "sample/sockops.c"
-    r0 = IMMEDIATE(24);
-label_5:
-    // EBPF_OP_JNE_IMM pc=41 dst=r4 src=r0 offset=1 imm=0
-#line 30 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 30 "sample/sockops.c"
-        goto label_6;
-    // EBPF_OP_MOV64_IMM pc=42 dst=r2 src=r0 offset=0 imm=8
-#line 30 "sample/sockops.c"
-    r2 = IMMEDIATE(8);
-label_6:
-    // EBPF_OP_OR64_REG pc=43 dst=r7 src=r4 offset=0 imm=0
-#line 34 "sample/sockops.c"
-    r7 |= r4;
-    // EBPF_OP_MOV64_REG pc=44 dst=r3 src=r1 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_REG pc=45 dst=r3 src=r2 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r3 += r2;
-    // EBPF_OP_LDXW pc=46 dst=r2 src=r3 offset=0 imm=0
-#line 30 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_STXW pc=47 dst=r10 src=r2 offset=-44 imm=0
-#line 30 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r2;
-    // EBPF_OP_MOV64_REG pc=48 dst=r2 src=r1 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 = r1;
-    // EBPF_OP_ADD64_REG pc=49 dst=r2 src=r0 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 += r0;
-    // EBPF_OP_LDXW pc=50 dst=r2 src=r2 offset=0 imm=0
-#line 31 "sample/sockops.c"
-    r2 = *(uint32_t*)(uintptr_t)(r2 + OFFSET(0));
-    // EBPF_OP_STXH pc=51 dst=r10 src=r2 offset=-28 imm=0
-#line 31 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r2;
-    // EBPF_OP_LDXB pc=52 dst=r2 src=r1 offset=48 imm=0
-#line 32 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
-    // EBPF_OP_STXW pc=53 dst=r10 src=r2 offset=-24 imm=0
-#line 32 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r2;
-    // EBPF_OP_LDXDW pc=54 dst=r1 src=r1 offset=56 imm=0
-#line 33 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
-    // EBPF_OP_STXB pc=55 dst=r10 src=r7 offset=-8 imm=0
-#line 35 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r7;
-    // EBPF_OP_STXDW pc=56 dst=r10 src=r1 offset=-16 imm=0
-#line 33 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=57 dst=r2 src=r10 offset=0 imm=0
-#line 33 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=58 dst=r2 src=r0 offset=0 imm=-64
-#line 34 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=59 dst=r1 src=r0 offset=0 imm=0
-#line 37 "sample/sockops.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=61 dst=r0 src=r0 offset=0 imm=1
-#line 37 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
-#line 37 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 37 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
-#line 37 "sample/sockops.c"
-        return 0;
-    // EBPF_OP_JEQ_IMM pc=62 dst=r0 src=r0 offset=162 imm=0
-#line 37 "sample/sockops.c"
-    if (r0 == IMMEDIATE(0))
-#line 37 "sample/sockops.c"
-        goto label_13;
-    // EBPF_OP_JA pc=63 dst=r0 src=r0 offset=153 imm=0
-#line 37 "sample/sockops.c"
-    goto label_12;
-label_7:
-    // EBPF_OP_STXDW pc=64 dst=r10 src=r7 offset=-72 imm=0
-#line 37 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r7;
-    // EBPF_OP_MOV64_IMM pc=65 dst=r2 src=r0 offset=0 imm=0
-#line 37 "sample/sockops.c"
+    // EBPF_OP_MOV64_IMM pc=10 dst=r3 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
+    r3 = IMMEDIATE(0);
+    // EBPF_OP_MOV64_IMM pc=11 dst=r2 src=r0 offset=0 imm=0
+#line 77 "sample/sockops.c"
     r2 = IMMEDIATE(0);
-    // EBPF_OP_STXDW pc=66 dst=r10 src=r2 offset=-8 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=67 dst=r10 src=r2 offset=-16 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=68 dst=r10 src=r2 offset=-24 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=69 dst=r10 src=r2 offset=-32 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=70 dst=r10 src=r2 offset=-40 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r2;
-    // EBPF_OP_STXDW pc=71 dst=r10 src=r2 offset=-48 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r2;
-    // EBPF_OP_MOV64_REG pc=72 dst=r3 src=r1 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r3 = r1;
-    // EBPF_OP_ADD64_IMM pc=73 dst=r3 src=r0 offset=0 imm=28
-#line 51 "sample/sockops.c"
-    r3 += IMMEDIATE(28);
-    // EBPF_OP_STXDW pc=74 dst=r10 src=r1 offset=-96 imm=0
-#line 51 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=75 dst=r0 src=r1 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r0 = r1;
-    // EBPF_OP_ADD64_IMM pc=76 dst=r0 src=r0 offset=0 imm=8
-#line 51 "sample/sockops.c"
-    r0 += IMMEDIATE(8);
-    // EBPF_OP_STXDW pc=77 dst=r10 src=r0 offset=-120 imm=0
-#line 51 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120)) = (uint64_t)r0;
-    // EBPF_OP_JNE_IMM pc=78 dst=r4 src=r0 offset=1 imm=0
-#line 51 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 51 "sample/sockops.c"
-        goto label_8;
-    // EBPF_OP_MOV64_REG pc=79 dst=r0 src=r3 offset=0 imm=0
-#line 51 "sample/sockops.c"
-    r0 = r3;
-label_8:
-    // EBPF_OP_LDXB pc=80 dst=r2 src=r0 offset=13 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=81 dst=r2 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=82 dst=r1 src=r0 offset=12 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(12));
-    // EBPF_OP_STXDW pc=83 dst=r10 src=r1 offset=-80 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_LDXB pc=84 dst=r8 src=r0 offset=15 imm=0
-#line 52 "sample/sockops.c"
-    r8 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=85 dst=r8 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=86 dst=r5 src=r0 offset=14 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(14));
-    // EBPF_OP_OR64_REG pc=87 dst=r8 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r8 |= r5;
-    // EBPF_OP_LDXB pc=88 dst=r6 src=r0 offset=9 imm=0
-#line 52 "sample/sockops.c"
-    r6 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=89 dst=r6 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r6 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=90 dst=r1 src=r0 offset=8 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(8));
-    // EBPF_OP_STXDW pc=91 dst=r10 src=r1 offset=-88 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_LDXB pc=92 dst=r9 src=r0 offset=11 imm=0
-#line 52 "sample/sockops.c"
-    r9 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=93 dst=r9 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r9 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=94 dst=r5 src=r0 offset=10 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(10));
-    // EBPF_OP_OR64_REG pc=95 dst=r9 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r9 |= r5;
-    // EBPF_OP_LDXB pc=96 dst=r5 src=r0 offset=1 imm=0
-#line 52 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(1));
-    // EBPF_OP_LDXB pc=97 dst=r7 src=r0 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(0));
-    // EBPF_OP_STXDW pc=98 dst=r10 src=r7 offset=-104 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104)) = (uint64_t)r7;
-    // EBPF_OP_LDXB pc=99 dst=r7 src=r0 offset=3 imm=0
-#line 52 "sample/sockops.c"
-    r7 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(3));
-    // EBPF_OP_LDXB pc=100 dst=r1 src=r0 offset=2 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(2));
-    // EBPF_OP_STXDW pc=101 dst=r10 src=r1 offset=-112 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-112)) = (uint64_t)r1;
-    // EBPF_OP_JNE_IMM pc=102 dst=r4 src=r0 offset=1 imm=0
-#line 53 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 53 "sample/sockops.c"
-        goto label_9;
-    // EBPF_OP_LDXDW pc=103 dst=r3 src=r10 offset=-120 imm=0
-#line 53 "sample/sockops.c"
-    r3 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-120));
-label_9:
-    // EBPF_OP_LDXDW pc=104 dst=r1 src=r10 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80));
-    // EBPF_OP_OR64_REG pc=105 dst=r2 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r2 |= r1;
-    // EBPF_OP_LDXDW pc=106 dst=r1 src=r10 offset=-88 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88));
-    // EBPF_OP_OR64_REG pc=107 dst=r6 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r6 |= r1;
-    // EBPF_OP_LSH64_IMM pc=108 dst=r9 src=r0 offset=0 imm=16
-#line 53 "sample/sockops.c"
-    r9 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LSH64_IMM pc=109 dst=r8 src=r0 offset=0 imm=16
-#line 53 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_LSH64_IMM pc=110 dst=r5 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LSH64_IMM pc=111 dst=r7 src=r0 offset=0 imm=8
-#line 53 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_MOV64_IMM pc=112 dst=r1 src=r0 offset=0 imm=44
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(44);
-    // EBPF_OP_STXDW pc=113 dst=r10 src=r1 offset=-88 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_IMM pc=114 dst=r1 src=r0 offset=0 imm=24
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(24);
-    // EBPF_OP_STXDW pc=115 dst=r10 src=r1 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-    // EBPF_OP_JNE_IMM pc=116 dst=r4 src=r0 offset=2 imm=0
-#line 53 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 53 "sample/sockops.c"
-        goto label_10;
-    // EBPF_OP_MOV64_IMM pc=117 dst=r1 src=r0 offset=0 imm=44
-#line 53 "sample/sockops.c"
-    r1 = IMMEDIATE(44);
-    // EBPF_OP_STXDW pc=118 dst=r10 src=r1 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80)) = (uint64_t)r1;
-label_10:
-    // EBPF_OP_OR64_REG pc=119 dst=r9 src=r6 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r9 |= r6;
-    // EBPF_OP_OR64_REG pc=120 dst=r8 src=r2 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r8 |= r2;
-    // EBPF_OP_LDXDW pc=121 dst=r1 src=r10 offset=-104 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-104));
-    // EBPF_OP_OR64_REG pc=122 dst=r5 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r5 |= r1;
-    // EBPF_OP_LDXDW pc=123 dst=r1 src=r10 offset=-112 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-112));
-    // EBPF_OP_OR64_REG pc=124 dst=r7 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r7 |= r1;
-    // EBPF_OP_JNE_IMM pc=125 dst=r4 src=r0 offset=2 imm=0
-#line 56 "sample/sockops.c"
-    if (r4 != IMMEDIATE(0))
-#line 56 "sample/sockops.c"
-        goto label_11;
-    // EBPF_OP_MOV64_IMM pc=126 dst=r1 src=r0 offset=0 imm=24
-#line 56 "sample/sockops.c"
-    r1 = IMMEDIATE(24);
-    // EBPF_OP_STXDW pc=127 dst=r10 src=r1 offset=-88 imm=0
-#line 56 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88)) = (uint64_t)r1;
-label_11:
-    // EBPF_OP_LDXDW pc=128 dst=r2 src=r10 offset=-72 imm=0
-#line 56 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72));
-    // EBPF_OP_OR64_REG pc=129 dst=r2 src=r4 offset=0 imm=0
-#line 59 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_STXDW pc=130 dst=r10 src=r2 offset=-72 imm=0
-#line 59 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72)) = (uint64_t)r2;
-    // EBPF_OP_LSH64_IMM pc=131 dst=r8 src=r0 offset=0 imm=32
-#line 52 "sample/sockops.c"
-    r8 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=132 dst=r8 src=r9 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r8 |= r9;
-    // EBPF_OP_STXDW pc=133 dst=r10 src=r8 offset=-56 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r8;
-    // EBPF_OP_LSH64_IMM pc=134 dst=r7 src=r0 offset=0 imm=16
-#line 52 "sample/sockops.c"
-    r7 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=135 dst=r7 src=r5 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r7 |= r5;
-    // EBPF_OP_LDXB pc=136 dst=r1 src=r0 offset=5 imm=0
-#line 52 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=137 dst=r1 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=138 dst=r2 src=r0 offset=4 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=139 dst=r1 src=r2 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r1 |= r2;
-    // EBPF_OP_LDXB pc=140 dst=r2 src=r0 offset=6 imm=0
-#line 52 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(6));
-    // EBPF_OP_LDXB pc=141 dst=r4 src=r0 offset=7 imm=0
-#line 52 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r0 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=142 dst=r4 src=r0 offset=0 imm=8
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_OR64_REG pc=143 dst=r4 src=r2 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r2;
-    // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=145 dst=r4 src=r1 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r1;
-    // EBPF_OP_LSH64_IMM pc=146 dst=r4 src=r0 offset=0 imm=32
-#line 52 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(32) & 63);
-    // EBPF_OP_OR64_REG pc=147 dst=r4 src=r7 offset=0 imm=0
-#line 52 "sample/sockops.c"
-    r4 |= r7;
-    // EBPF_OP_STXDW pc=148 dst=r10 src=r4 offset=-64 imm=0
-#line 52 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
-    // EBPF_OP_LDXDW pc=149 dst=r6 src=r10 offset=-96 imm=0
-#line 52 "sample/sockops.c"
-    r6 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-96));
-    // EBPF_OP_MOV64_REG pc=150 dst=r1 src=r6 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 = r6;
-    // EBPF_OP_LDXDW pc=151 dst=r2 src=r10 offset=-80 imm=0
-#line 53 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-80));
-    // EBPF_OP_ADD64_REG pc=152 dst=r1 src=r2 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 += r2;
-    // EBPF_OP_LDXW pc=153 dst=r1 src=r1 offset=0 imm=0
-#line 53 "sample/sockops.c"
-    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_STXH pc=154 dst=r10 src=r1 offset=-48 imm=0
-#line 53 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r1;
-    // EBPF_OP_LDXB pc=155 dst=r4 src=r3 offset=13 imm=0
-#line 55 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(13));
-    // EBPF_OP_LSH64_IMM pc=156 dst=r4 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=157 dst=r1 src=r3 offset=12 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(12));
-    // EBPF_OP_OR64_REG pc=158 dst=r4 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r4 |= r1;
-    // EBPF_OP_LDXB pc=159 dst=r2 src=r3 offset=15 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(15));
-    // EBPF_OP_LSH64_IMM pc=160 dst=r2 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=161 dst=r1 src=r3 offset=14 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(14));
-    // EBPF_OP_OR64_REG pc=162 dst=r2 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r2 |= r1;
-    // EBPF_OP_LDXB pc=163 dst=r5 src=r3 offset=1 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(1));
-    // EBPF_OP_LSH64_IMM pc=164 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=165 dst=r1 src=r3 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(0));
-    // EBPF_OP_OR64_REG pc=166 dst=r5 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r1;
-    // EBPF_OP_LDXB pc=167 dst=r1 src=r3 offset=3 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(3));
-    // EBPF_OP_LSH64_IMM pc=168 dst=r1 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=169 dst=r0 src=r3 offset=2 imm=0
-#line 55 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(2));
-    // EBPF_OP_OR64_REG pc=170 dst=r1 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r0;
-    // EBPF_OP_LSH64_IMM pc=171 dst=r1 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=172 dst=r1 src=r5 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r5;
-    // EBPF_OP_LSH64_IMM pc=173 dst=r2 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r2 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=174 dst=r2 src=r4 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r2 |= r4;
-    // EBPF_OP_LDXB pc=175 dst=r4 src=r3 offset=9 imm=0
-#line 55 "sample/sockops.c"
-    r4 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(9));
-    // EBPF_OP_LSH64_IMM pc=176 dst=r4 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r4 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=177 dst=r5 src=r3 offset=8 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(8));
-    // EBPF_OP_OR64_REG pc=178 dst=r4 src=r5 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r4 |= r5;
-    // EBPF_OP_LDXB pc=179 dst=r5 src=r3 offset=11 imm=0
-#line 55 "sample/sockops.c"
-    r5 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(11));
-    // EBPF_OP_LSH64_IMM pc=180 dst=r5 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=181 dst=r0 src=r3 offset=10 imm=0
-#line 55 "sample/sockops.c"
-    r0 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(10));
-    // EBPF_OP_OR64_REG pc=182 dst=r5 src=r0 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r0;
-    // EBPF_OP_LSH64_IMM pc=183 dst=r5 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r5 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=184 dst=r5 src=r4 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r5 |= r4;
-    // EBPF_OP_STXW pc=185 dst=r10 src=r5 offset=-36 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r5;
-    // EBPF_OP_STXW pc=186 dst=r10 src=r2 offset=-32 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r2;
-    // EBPF_OP_STXW pc=187 dst=r10 src=r1 offset=-44 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r1;
-    // EBPF_OP_LDXB pc=188 dst=r1 src=r3 offset=5 imm=0
-#line 55 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(5));
-    // EBPF_OP_LSH64_IMM pc=189 dst=r1 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r1 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_LDXB pc=190 dst=r2 src=r3 offset=4 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(4));
-    // EBPF_OP_OR64_REG pc=191 dst=r1 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r1 |= r2;
-    // EBPF_OP_LDXB pc=192 dst=r2 src=r3 offset=6 imm=0
-#line 55 "sample/sockops.c"
-    r2 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(6));
-    // EBPF_OP_LDXB pc=193 dst=r3 src=r3 offset=7 imm=0
-#line 55 "sample/sockops.c"
-    r3 = *(uint8_t*)(uintptr_t)(r3 + OFFSET(7));
-    // EBPF_OP_LSH64_IMM pc=194 dst=r3 src=r0 offset=0 imm=8
-#line 55 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(8) & 63);
-    // EBPF_OP_OR64_REG pc=195 dst=r3 src=r2 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r3 |= r2;
-    // EBPF_OP_LSH64_IMM pc=196 dst=r3 src=r0 offset=0 imm=16
-#line 55 "sample/sockops.c"
-    r3 <<= (IMMEDIATE(16) & 63);
-    // EBPF_OP_OR64_REG pc=197 dst=r3 src=r1 offset=0 imm=0
-#line 55 "sample/sockops.c"
-    r3 |= r1;
-    // EBPF_OP_STXW pc=198 dst=r10 src=r3 offset=-40 imm=0
-#line 55 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r3;
-    // EBPF_OP_MOV64_REG pc=199 dst=r1 src=r6 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 = r6;
-    // EBPF_OP_LDXDW pc=200 dst=r2 src=r10 offset=-88 imm=0
-#line 56 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-88));
-    // EBPF_OP_ADD64_REG pc=201 dst=r1 src=r2 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 += r2;
-    // EBPF_OP_LDXW pc=202 dst=r1 src=r1 offset=0 imm=0
-#line 56 "sample/sockops.c"
-    r1 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(0));
-    // EBPF_OP_STXH pc=203 dst=r10 src=r1 offset=-28 imm=0
-#line 56 "sample/sockops.c"
-    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r1;
-    // EBPF_OP_LDXB pc=204 dst=r1 src=r6 offset=48 imm=0
-#line 57 "sample/sockops.c"
-    r1 = *(uint8_t*)(uintptr_t)(r6 + OFFSET(48));
-    // EBPF_OP_STXW pc=205 dst=r10 src=r1 offset=-24 imm=0
-#line 57 "sample/sockops.c"
-    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r1;
-    // EBPF_OP_LDXDW pc=206 dst=r1 src=r6 offset=56 imm=0
-#line 58 "sample/sockops.c"
-    r1 = *(uint64_t*)(uintptr_t)(r6 + OFFSET(56));
-    // EBPF_OP_LDXDW pc=207 dst=r2 src=r10 offset=-72 imm=0
-#line 60 "sample/sockops.c"
-    r2 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-72));
-    // EBPF_OP_STXB pc=208 dst=r10 src=r2 offset=-8 imm=0
-#line 60 "sample/sockops.c"
-    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
-    // EBPF_OP_STXDW pc=209 dst=r10 src=r1 offset=-16 imm=0
-#line 58 "sample/sockops.c"
-    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
-    // EBPF_OP_MOV64_REG pc=210 dst=r2 src=r10 offset=0 imm=0
-#line 58 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=211 dst=r2 src=r0 offset=0 imm=-64
-#line 59 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=212 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r1 = POINTER(_maps[0].address);
-    // EBPF_OP_CALL pc=214 dst=r0 src=r0 offset=0 imm=1
-#line 62 "sample/sockops.c"
-    r0 = connection_monitor_helpers[0].address
-#line 62 "sample/sockops.c"
-         (r1, r2, r3, r4, r5);
-#line 62 "sample/sockops.c"
-    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
-#line 62 "sample/sockops.c"
-        return 0;
-    // EBPF_OP_MOV64_IMM pc=215 dst=r6 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r6 = IMMEDIATE(0);
-    // EBPF_OP_JEQ_IMM pc=216 dst=r0 src=r0 offset=8 imm=0
-#line 62 "sample/sockops.c"
-    if (r0 == IMMEDIATE(0))
-#line 62 "sample/sockops.c"
-        goto label_13;
-label_12:
-    // EBPF_OP_MOV64_REG pc=217 dst=r2 src=r10 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r2 = r10;
-    // EBPF_OP_ADD64_IMM pc=218 dst=r2 src=r0 offset=0 imm=-64
-#line 62 "sample/sockops.c"
-    r2 += IMMEDIATE(-64);
-    // EBPF_OP_LDDW pc=219 dst=r1 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
-    r1 = POINTER(_maps[1].address);
-    // EBPF_OP_MOV64_IMM pc=221 dst=r3 src=r0 offset=0 imm=64
-#line 62 "sample/sockops.c"
-    r3 = IMMEDIATE(64);
-    // EBPF_OP_MOV64_IMM pc=222 dst=r4 src=r0 offset=0 imm=0
-#line 62 "sample/sockops.c"
+label_2:
+    // EBPF_OP_LDXW pc=12 dst=r4 src=r1 offset=4 imm=0
+#line 94 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(4));
+    // EBPF_OP_JNE_IMM pc=13 dst=r4 src=r0 offset=33 imm=2
+#line 94 "sample/sockops.c"
+    if (r4 != IMMEDIATE(2))
+#line 94 "sample/sockops.c"
+        goto label_3;
+        // EBPF_OP_MOV64_IMM pc=14 dst=r4 src=r0 offset=0 imm=0
+#line 94 "sample/sockops.c"
     r4 = IMMEDIATE(0);
-    // EBPF_OP_CALL pc=223 dst=r0 src=r0 offset=0 imm=11
-#line 62 "sample/sockops.c"
-    r0 = connection_monitor_helpers[1].address
-#line 62 "sample/sockops.c"
+    // EBPF_OP_STXDW pc=15 dst=r10 src=r4 offset=-8 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=16 dst=r10 src=r4 offset=-16 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=17 dst=r10 src=r4 offset=-24 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=18 dst=r10 src=r4 offset=-32 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=19 dst=r10 src=r4 offset=-40 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=20 dst=r10 src=r4 offset=-48 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=21 dst=r10 src=r4 offset=-56 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=22 dst=r10 src=r4 offset=-64 imm=0
+#line 36 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
+    // EBPF_OP_LDXW pc=23 dst=r4 src=r1 offset=8 imm=0
+#line 38 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_STXW pc=24 dst=r10 src=r4 offset=-64 imm=0
+#line 38 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint32_t)r4;
+    // EBPF_OP_LDXW pc=25 dst=r4 src=r1 offset=24 imm=0
+#line 39 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=26 dst=r10 src=r4 offset=-48 imm=0
+#line 39 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r4;
+    // EBPF_OP_LDXW pc=27 dst=r4 src=r1 offset=28 imm=0
+#line 40 "sample/sockops.c"
+    r4 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_STXW pc=28 dst=r10 src=r4 offset=-44 imm=0
+#line 40 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r4;
+    // EBPF_OP_OR64_REG pc=29 dst=r2 src=r3 offset=0 imm=0
+#line 44 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_LDXW pc=30 dst=r3 src=r1 offset=44 imm=0
+#line 41 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=31 dst=r10 src=r3 offset=-28 imm=0
+#line 41 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=32 dst=r3 src=r1 offset=48 imm=0
+#line 42 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=33 dst=r10 src=r3 offset=-24 imm=0
+#line 42 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
+    // EBPF_OP_LDXDW pc=34 dst=r1 src=r1 offset=56 imm=0
+#line 43 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=35 dst=r10 src=r2 offset=-8 imm=0
+#line 45 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
+    // EBPF_OP_STXDW pc=36 dst=r10 src=r1 offset=-16 imm=0
+#line 43 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=37 dst=r2 src=r10 offset=0 imm=0
+#line 43 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=38 dst=r2 src=r0 offset=0 imm=-64
+#line 43 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=39 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=41 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address
+#line 26 "sample/sockops.c"
          (r1, r2, r3, r4, r5);
-#line 62 "sample/sockops.c"
-    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
-#line 62 "sample/sockops.c"
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
         return 0;
-    // EBPF_OP_MOV64_REG pc=224 dst=r6 src=r0 offset=0 imm=0
+        // EBPF_OP_MOV64_REG pc=42 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = r0;
+    // EBPF_OP_LDDW pc=43 dst=r0 src=r0 offset=0 imm=-1
+#line 26 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JEQ_IMM pc=45 dst=r1 src=r0 offset=124 imm=0
+#line 26 "sample/sockops.c"
+    if (r1 == IMMEDIATE(0))
+#line 26 "sample/sockops.c"
+        goto label_5;
+        // EBPF_OP_JA pc=46 dst=r0 src=r0 offset=116 imm=0
+#line 26 "sample/sockops.c"
+    goto label_4;
+label_3:
+    // EBPF_OP_MOV64_IMM pc=47 dst=r4 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_STXDW pc=48 dst=r10 src=r4 offset=-8 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=49 dst=r10 src=r4 offset=-16 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=50 dst=r10 src=r4 offset=-24 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=51 dst=r10 src=r4 offset=-32 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=52 dst=r10 src=r4 offset=-40 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint64_t)r4;
+    // EBPF_OP_STXDW pc=53 dst=r10 src=r4 offset=-48 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint64_t)r4;
+    // EBPF_OP_LDXB pc=54 dst=r5 src=r1 offset=21 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(21));
+    // EBPF_OP_LSH64_IMM pc=55 dst=r5 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=56 dst=r4 src=r1 offset=20 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(20));
+    // EBPF_OP_OR64_REG pc=57 dst=r5 src=r4 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r4;
+    // EBPF_OP_LDXB pc=58 dst=r4 src=r1 offset=23 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(23));
+    // EBPF_OP_LSH64_IMM pc=59 dst=r4 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=60 dst=r0 src=r1 offset=22 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(22));
+    // EBPF_OP_OR64_REG pc=61 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LDXB pc=62 dst=r6 src=r1 offset=17 imm=0
+#line 57 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(17));
+    // EBPF_OP_LSH64_IMM pc=63 dst=r6 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r6 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=64 dst=r0 src=r1 offset=16 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(16));
+    // EBPF_OP_OR64_REG pc=65 dst=r6 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r6 |= r0;
+    // EBPF_OP_LDXB pc=66 dst=r0 src=r1 offset=19 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(19));
+    // EBPF_OP_LSH64_IMM pc=67 dst=r0 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=68 dst=r7 src=r1 offset=18 imm=0
+#line 57 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(18));
+    // EBPF_OP_OR64_REG pc=69 dst=r0 src=r7 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r0 |= r7;
+    // EBPF_OP_LSH64_IMM pc=70 dst=r0 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=71 dst=r0 src=r6 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r0 |= r6;
+    // EBPF_OP_LSH64_IMM pc=72 dst=r4 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=73 dst=r4 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_LDXB pc=74 dst=r6 src=r1 offset=9 imm=0
+#line 57 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(9));
+    // EBPF_OP_LSH64_IMM pc=75 dst=r6 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r6 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=76 dst=r5 src=r1 offset=8 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(8));
+    // EBPF_OP_OR64_REG pc=77 dst=r6 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r6 |= r5;
+    // EBPF_OP_LDXB pc=78 dst=r5 src=r1 offset=11 imm=0
+#line 57 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(11));
+    // EBPF_OP_LSH64_IMM pc=79 dst=r5 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=80 dst=r7 src=r1 offset=10 imm=0
+#line 57 "sample/sockops.c"
+    r7 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(10));
+    // EBPF_OP_OR64_REG pc=81 dst=r5 src=r7 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r7;
+    // EBPF_OP_OR64_REG pc=82 dst=r2 src=r3 offset=0 imm=0
+#line 64 "sample/sockops.c"
+    r2 |= r3;
+    // EBPF_OP_LSH64_IMM pc=83 dst=r4 src=r0 offset=0 imm=32
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=84 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_STXDW pc=85 dst=r10 src=r4 offset=-56 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56)) = (uint64_t)r4;
+    // EBPF_OP_LSH64_IMM pc=86 dst=r5 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=87 dst=r5 src=r6 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r5 |= r6;
+    // EBPF_OP_LDXB pc=88 dst=r3 src=r1 offset=13 imm=0
+#line 57 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(13));
+    // EBPF_OP_LSH64_IMM pc=89 dst=r3 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=90 dst=r4 src=r1 offset=12 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(12));
+    // EBPF_OP_OR64_REG pc=91 dst=r3 src=r4 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=92 dst=r4 src=r1 offset=15 imm=0
+#line 57 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(15));
+    // EBPF_OP_LSH64_IMM pc=93 dst=r4 src=r0 offset=0 imm=8
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=94 dst=r0 src=r1 offset=14 imm=0
+#line 57 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(14));
+    // EBPF_OP_OR64_REG pc=95 dst=r4 src=r0 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LSH64_IMM pc=96 dst=r4 src=r0 offset=0 imm=16
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=97 dst=r4 src=r3 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_LSH64_IMM pc=98 dst=r4 src=r0 offset=0 imm=32
+#line 57 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(32) & 63);
+    // EBPF_OP_OR64_REG pc=99 dst=r4 src=r5 offset=0 imm=0
+#line 57 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_STXDW pc=100 dst=r10 src=r4 offset=-64 imm=0
+#line 57 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-64)) = (uint64_t)r4;
+    // EBPF_OP_LDXW pc=101 dst=r3 src=r1 offset=24 imm=0
+#line 58 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(24));
+    // EBPF_OP_STXH pc=102 dst=r10 src=r3 offset=-48 imm=0
+#line 58 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-48)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=103 dst=r5 src=r1 offset=41 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(41));
+    // EBPF_OP_LSH64_IMM pc=104 dst=r5 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=105 dst=r3 src=r1 offset=40 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(40));
+    // EBPF_OP_OR64_REG pc=106 dst=r5 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r5 |= r3;
+    // EBPF_OP_LDXB pc=107 dst=r3 src=r1 offset=43 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(43));
+    // EBPF_OP_LSH64_IMM pc=108 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=109 dst=r4 src=r1 offset=42 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(42));
+    // EBPF_OP_OR64_REG pc=110 dst=r3 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=111 dst=r0 src=r1 offset=29 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(29));
+    // EBPF_OP_LSH64_IMM pc=112 dst=r0 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=113 dst=r4 src=r1 offset=28 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(28));
+    // EBPF_OP_OR64_REG pc=114 dst=r0 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r4;
+    // EBPF_OP_LDXB pc=115 dst=r4 src=r1 offset=31 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(31));
+    // EBPF_OP_LSH64_IMM pc=116 dst=r4 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=117 dst=r6 src=r1 offset=30 imm=0
+#line 60 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(30));
+    // EBPF_OP_OR64_REG pc=118 dst=r4 src=r6 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r6;
+    // EBPF_OP_LSH64_IMM pc=119 dst=r4 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=120 dst=r4 src=r0 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r0;
+    // EBPF_OP_LSH64_IMM pc=121 dst=r3 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=122 dst=r3 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r5;
+    // EBPF_OP_LDXB pc=123 dst=r5 src=r1 offset=37 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(37));
+    // EBPF_OP_LSH64_IMM pc=124 dst=r5 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r5 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=125 dst=r0 src=r1 offset=36 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(36));
+    // EBPF_OP_OR64_REG pc=126 dst=r5 src=r0 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r5 |= r0;
+    // EBPF_OP_LDXB pc=127 dst=r0 src=r1 offset=39 imm=0
+#line 60 "sample/sockops.c"
+    r0 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(39));
+    // EBPF_OP_LSH64_IMM pc=128 dst=r0 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=129 dst=r6 src=r1 offset=38 imm=0
+#line 60 "sample/sockops.c"
+    r6 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(38));
+    // EBPF_OP_OR64_REG pc=130 dst=r0 src=r6 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r6;
+    // EBPF_OP_LSH64_IMM pc=131 dst=r0 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r0 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=132 dst=r0 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r0 |= r5;
+    // EBPF_OP_STXW pc=133 dst=r10 src=r0 offset=-36 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-36)) = (uint32_t)r0;
+    // EBPF_OP_STXW pc=134 dst=r10 src=r3 offset=-32 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint32_t)r3;
+    // EBPF_OP_STXW pc=135 dst=r10 src=r4 offset=-44 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-44)) = (uint32_t)r4;
+    // EBPF_OP_LDXB pc=136 dst=r3 src=r1 offset=33 imm=0
+#line 60 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(33));
+    // EBPF_OP_LSH64_IMM pc=137 dst=r3 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r3 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=138 dst=r4 src=r1 offset=32 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(32));
+    // EBPF_OP_OR64_REG pc=139 dst=r3 src=r4 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r3 |= r4;
+    // EBPF_OP_LDXB pc=140 dst=r4 src=r1 offset=35 imm=0
+#line 60 "sample/sockops.c"
+    r4 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(35));
+    // EBPF_OP_LSH64_IMM pc=141 dst=r4 src=r0 offset=0 imm=8
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(8) & 63);
+    // EBPF_OP_LDXB pc=142 dst=r5 src=r1 offset=34 imm=0
+#line 60 "sample/sockops.c"
+    r5 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(34));
+    // EBPF_OP_OR64_REG pc=143 dst=r4 src=r5 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r5;
+    // EBPF_OP_LSH64_IMM pc=144 dst=r4 src=r0 offset=0 imm=16
+#line 60 "sample/sockops.c"
+    r4 <<= (IMMEDIATE(16) & 63);
+    // EBPF_OP_OR64_REG pc=145 dst=r4 src=r3 offset=0 imm=0
+#line 60 "sample/sockops.c"
+    r4 |= r3;
+    // EBPF_OP_STXW pc=146 dst=r10 src=r4 offset=-40 imm=0
+#line 60 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-40)) = (uint32_t)r4;
+    // EBPF_OP_LDXW pc=147 dst=r3 src=r1 offset=44 imm=0
+#line 61 "sample/sockops.c"
+    r3 = *(uint32_t*)(uintptr_t)(r1 + OFFSET(44));
+    // EBPF_OP_STXH pc=148 dst=r10 src=r3 offset=-28 imm=0
+#line 61 "sample/sockops.c"
+    *(uint16_t*)(uintptr_t)(r10 + OFFSET(-28)) = (uint16_t)r3;
+    // EBPF_OP_LDXB pc=149 dst=r3 src=r1 offset=48 imm=0
 #line 62 "sample/sockops.c"
-    r6 = r0;
-label_13:
-    // EBPF_OP_MOV64_REG pc=225 dst=r0 src=r6 offset=0 imm=0
-#line 96 "sample/sockops.c"
-    r0 = r6;
-    // EBPF_OP_EXIT pc=226 dst=r0 src=r0 offset=0 imm=0
-#line 96 "sample/sockops.c"
+    r3 = *(uint8_t*)(uintptr_t)(r1 + OFFSET(48));
+    // EBPF_OP_STXW pc=150 dst=r10 src=r3 offset=-24 imm=0
+#line 62 "sample/sockops.c"
+    *(uint32_t*)(uintptr_t)(r10 + OFFSET(-24)) = (uint32_t)r3;
+    // EBPF_OP_LDXDW pc=151 dst=r1 src=r1 offset=56 imm=0
+#line 63 "sample/sockops.c"
+    r1 = *(uint64_t*)(uintptr_t)(r1 + OFFSET(56));
+    // EBPF_OP_STXB pc=152 dst=r10 src=r2 offset=-8 imm=0
+#line 65 "sample/sockops.c"
+    *(uint8_t*)(uintptr_t)(r10 + OFFSET(-8)) = (uint8_t)r2;
+    // EBPF_OP_STXDW pc=153 dst=r10 src=r1 offset=-16 imm=0
+#line 63 "sample/sockops.c"
+    *(uint64_t*)(uintptr_t)(r10 + OFFSET(-16)) = (uint64_t)r1;
+    // EBPF_OP_MOV64_REG pc=154 dst=r2 src=r10 offset=0 imm=0
+#line 63 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=155 dst=r2 src=r0 offset=0 imm=-64
+#line 63 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=156 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[0].address);
+    // EBPF_OP_CALL pc=158 dst=r0 src=r0 offset=0 imm=1
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[0].address
+#line 26 "sample/sockops.c"
+         (r1, r2, r3, r4, r5);
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[0].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
+        return 0;
+        // EBPF_OP_MOV64_REG pc=159 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = r0;
+    // EBPF_OP_LDDW pc=160 dst=r0 src=r0 offset=0 imm=-1
+#line 26 "sample/sockops.c"
+    r0 = (uint64_t)4294967295;
+    // EBPF_OP_JEQ_IMM pc=162 dst=r1 src=r0 offset=7 imm=0
+#line 26 "sample/sockops.c"
+    if (r1 == IMMEDIATE(0))
+#line 26 "sample/sockops.c"
+        goto label_5;
+label_4:
+    // EBPF_OP_MOV64_REG pc=163 dst=r2 src=r10 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r2 = r10;
+    // EBPF_OP_ADD64_IMM pc=164 dst=r2 src=r0 offset=0 imm=-64
+#line 26 "sample/sockops.c"
+    r2 += IMMEDIATE(-64);
+    // EBPF_OP_LDDW pc=165 dst=r1 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r1 = POINTER(_maps[1].address);
+    // EBPF_OP_MOV64_IMM pc=167 dst=r3 src=r0 offset=0 imm=64
+#line 26 "sample/sockops.c"
+    r3 = IMMEDIATE(64);
+    // EBPF_OP_MOV64_IMM pc=168 dst=r4 src=r0 offset=0 imm=0
+#line 26 "sample/sockops.c"
+    r4 = IMMEDIATE(0);
+    // EBPF_OP_CALL pc=169 dst=r0 src=r0 offset=0 imm=11
+#line 26 "sample/sockops.c"
+    r0 = connection_monitor_helpers[1].address
+#line 26 "sample/sockops.c"
+         (r1, r2, r3, r4, r5);
+#line 26 "sample/sockops.c"
+    if ((connection_monitor_helpers[1].tail_call) && (r0 == 0))
+#line 26 "sample/sockops.c"
+        return 0;
+label_5:
+    // EBPF_OP_EXIT pc=170 dst=r0 src=r0 offset=0 imm=0
+#line 97 "sample/sockops.c"
     return r0;
-#line 96 "sample/sockops.c"
+#line 97 "sample/sockops.c"
 }
 #pragma code_seg(pop)
 #line __LINE__ __FILE__
@@ -1005,7 +803,7 @@ static program_entry_t _programs[] = {
         2,
         connection_monitor_helpers,
         2,
-        227,
+        171,
         &connection_monitor_program_type_guid,
         &connection_monitor_attach_type_guid,
     },

--- a/tests/sample/cgroup_sock_addr.c
+++ b/tests/sample/cgroup_sock_addr.c
@@ -36,8 +36,8 @@ authorize_v4(bpf_sock_addr_t* ctx, void* connection_policy_map)
     connection_tuple_t tuple_key = {0};
     int* verdict = NULL;
 
-    tuple_key.dst_ip.ipv4 = ctx->user_ip4;
-    tuple_key.dst_port = ctx->user_port;
+    tuple_key.remote_ip.ipv4 = ctx->user_ip4;
+    tuple_key.remote_port = ctx->user_port;
     tuple_key.protocol = ctx->protocol;
 
     verdict = bpf_map_lookup_elem(connection_policy_map, &tuple_key);
@@ -50,8 +50,8 @@ authorize_v6(bpf_sock_addr_t* ctx, void* connection_policy_map)
 {
     connection_tuple_t tuple_key = {0};
     int* verdict;
-    __builtin_memcpy(tuple_key.dst_ip.ipv6, ctx->user_ip6, sizeof(ctx->user_ip6));
-    tuple_key.dst_port = ctx->user_port;
+    __builtin_memcpy(tuple_key.remote_ip.ipv6, ctx->user_ip6, sizeof(ctx->user_ip6));
+    tuple_key.remote_port = ctx->user_port;
     tuple_key.protocol = ctx->protocol;
 
     verdict = bpf_map_lookup_elem(connection_policy_map, &tuple_key);

--- a/tests/sample/sockops.c
+++ b/tests/sample/sockops.c
@@ -10,7 +10,7 @@ struct
     __uint(type, BPF_MAP_TYPE_HASH);
     __type(key, connection_tuple_t);
     __type(value, uint32_t);
-    __uint(max_entries, 1);
+    __uint(max_entries, 2);
 } connection_map SEC(".maps");
 
 struct
@@ -20,50 +20,51 @@ struct
 } audit_map SEC(".maps");
 
 inline int
+update_audit_map(audit_entry_t* audit_entry)
+{
+    int result = -1;
+    if (bpf_map_lookup_elem(&connection_map, &audit_entry->tuple) != NULL) {
+        result = bpf_ringbuf_output(&audit_map, audit_entry, sizeof(*audit_entry), 0);
+    }
+    return result;
+}
+
+inline int
 handle_v4(bpf_sock_ops_t* ctx, bool outbound, bool connected)
 {
     int result = 0;
     audit_entry_t audit_entry = {0};
 
-    audit_entry.tuple.src_ip.ipv4 = (outbound) ? ctx->local_ip4 : ctx->remote_ip4;
-    audit_entry.tuple.src_port = (outbound) ? ctx->local_port : ctx->remote_port;
-    audit_entry.tuple.dst_ip.ipv4 = (outbound) ? ctx->remote_ip4 : ctx->local_ip4;
-    audit_entry.tuple.dst_port = (outbound) ? ctx->remote_port : ctx->local_port;
+    audit_entry.tuple.local_ip.ipv4 = ctx->local_ip4;
+    audit_entry.tuple.local_port = ctx->local_port;
+    audit_entry.tuple.remote_ip.ipv4 = ctx->remote_ip4;
+    audit_entry.tuple.remote_port = ctx->remote_port;
     audit_entry.tuple.protocol = ctx->protocol;
     audit_entry.tuple.interface_luid = ctx->interface_luid;
     audit_entry.outbound = outbound;
     audit_entry.connected = connected;
 
-    if (bpf_map_lookup_elem(&connection_map, &audit_entry.tuple) != NULL) {
-        result = bpf_ringbuf_output(&audit_map, &audit_entry, sizeof(audit_entry), 0);
-    }
-
-    return result;
+    return update_audit_map(&audit_entry);
 }
 
 inline int
 handle_v6(bpf_sock_ops_t* ctx, bool outbound, bool connected)
 {
-    int result = 0;
     audit_entry_t audit_entry = {0};
     void* ip6 = NULL;
 
-    ip6 = (outbound) ? ctx->local_ip6 : ctx->remote_ip6;
-    __builtin_memcpy(audit_entry.tuple.src_ip.ipv6, ip6, sizeof(uint32_t) * 4);
-    audit_entry.tuple.src_port = (outbound) ? ctx->local_port : ctx->remote_port;
-    ip6 = (outbound) ? ctx->remote_ip6 : ctx->local_ip6;
-    __builtin_memcpy(audit_entry.tuple.dst_ip.ipv6, ip6, sizeof(uint32_t) * 4);
-    audit_entry.tuple.dst_port = (outbound) ? ctx->remote_port : ctx->local_port;
+    ip6 = ctx->local_ip6;
+    __builtin_memcpy(audit_entry.tuple.local_ip.ipv6, ip6, sizeof(uint32_t) * 4);
+    audit_entry.tuple.local_port = ctx->local_port;
+    ip6 = ctx->remote_ip6;
+    __builtin_memcpy(audit_entry.tuple.remote_ip.ipv6, ip6, sizeof(uint32_t) * 4);
+    audit_entry.tuple.remote_port = ctx->remote_port;
     audit_entry.tuple.protocol = ctx->protocol;
     audit_entry.tuple.interface_luid = ctx->interface_luid;
     audit_entry.outbound = outbound;
     audit_entry.connected = connected;
 
-    if (bpf_map_lookup_elem(&connection_map, &audit_entry.tuple) != NULL) {
-        result = bpf_ringbuf_output(&audit_map, &audit_entry, sizeof(audit_entry), 0);
-    }
-
-    return result;
+    return update_audit_map(&audit_entry);
 }
 
 SEC("sockops")

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -271,7 +271,7 @@ connection_monitor_test(
 
     // Ring buffer event callback context.
     std::unique_ptr<ring_buffer_test_event_context_t> context = std::make_unique<ring_buffer_test_event_context_t>();
-    context->test_event_count = disconnect ? 3 : 2;
+    context->test_event_count = disconnect ? 4 : 2;
 
     bpf_program* _program = bpf_object__find_program_by_name(object, "connection_monitor");
     REQUIRE(_program != nullptr);

--- a/tests/socket/socket_tests.cpp
+++ b/tests/socket/socket_tests.cpp
@@ -60,13 +60,13 @@ connection_test(
 
     connection_tuple_t tuple = {0};
     if (address_family == AF_INET) {
-        tuple.dst_ip.ipv4 = htonl(INADDR_LOOPBACK);
-        printf("tuple.dst_ip.ipv4 = %x\n", tuple.dst_ip.ipv4);
+        tuple.remote_ip.ipv4 = htonl(INADDR_LOOPBACK);
+        printf("tuple.remote_ip.ipv4 = %x\n", tuple.remote_ip.ipv4);
     } else {
-        memcpy(tuple.dst_ip.ipv6, &in6addr_loopback, sizeof(tuple.dst_ip.ipv6));
+        memcpy(tuple.remote_ip.ipv6, &in6addr_loopback, sizeof(tuple.remote_ip.ipv6));
     }
-    tuple.dst_port = htons(SOCKET_TEST_PORT);
-    printf("tuple.dst_port = %x\n", tuple.dst_port);
+    tuple.remote_port = htons(SOCKET_TEST_PORT);
+    printf("tuple.remote_port = %x\n", tuple.remote_port);
     tuple.protocol = protocol;
 
     bpf_map* ingress_connection_policy_map = bpf_object__find_map_by_name(object, "ingress_connection_policy_map");
@@ -271,9 +271,6 @@ connection_monitor_test(
 
     // Ring buffer event callback context.
     std::unique_ptr<ring_buffer_test_event_context_t> context = std::make_unique<ring_buffer_test_event_context_t>();
-    // Issue: https://github.com/microsoft/ebpf-for-windows/issues/2706
-    // Should there be a disconnect event for both inbound and outbound connections?
-    // Should the local and remote addresses be swapped for inbound vs outbound connections?
     context->test_event_count = disconnect ? 3 : 2;
 
     bpf_program* _program = bpf_object__find_program_by_name(object, "connection_monitor");
@@ -283,23 +280,30 @@ connection_monitor_test(
     int local_address_length = 0;
     sender_socket.get_local_address(local_address, local_address_length);
 
-    connection_tuple_t tuple{};
+    connection_tuple_t tuple{}, reverse_tuple{};
     if (address_family == AF_INET) {
-        tuple.src_ip.ipv4 = htonl(INADDR_LOOPBACK);
-        tuple.dst_ip.ipv4 = htonl(INADDR_LOOPBACK);
+        tuple.local_ip.ipv4 = htonl(INADDR_LOOPBACK);
+        tuple.remote_ip.ipv4 = htonl(INADDR_LOOPBACK);
     } else {
-        memcpy(tuple.src_ip.ipv6, &in6addr_loopback, sizeof(tuple.src_ip.ipv6));
-        memcpy(tuple.dst_ip.ipv6, &in6addr_loopback, sizeof(tuple.src_ip.ipv6));
+        memcpy(tuple.local_ip.ipv6, &in6addr_loopback, sizeof(tuple.local_ip.ipv6));
+        memcpy(tuple.remote_ip.ipv6, &in6addr_loopback, sizeof(tuple.local_ip.ipv6));
     }
-    tuple.src_port = INETADDR_PORT(local_address);
-    tuple.dst_port = htons(SOCKET_TEST_PORT);
+    tuple.local_port = INETADDR_PORT(local_address);
+    tuple.remote_port = htons(SOCKET_TEST_PORT);
     tuple.protocol = protocol;
     NET_LUID net_luid = {};
     net_luid.Info.IfType = IF_TYPE_SOFTWARE_LOOPBACK;
     tuple.interface_luid = net_luid.Value;
 
+    reverse_tuple.local_ip = tuple.remote_ip;
+    reverse_tuple.remote_ip = tuple.local_ip;
+    reverse_tuple.local_port = tuple.remote_port;
+    reverse_tuple.remote_port = tuple.local_port;
+    reverse_tuple.protocol = tuple.protocol;
+    reverse_tuple.interface_luid = tuple.interface_luid;
+
     std::vector<std::vector<char>> audit_entry_list;
-    audit_entry_t audit_entries[3] = {0};
+    audit_entry_t audit_entries[4] = {0};
 
     // Connect outbound.
     audit_entries[0].tuple = tuple;
@@ -309,17 +313,25 @@ connection_monitor_test(
     audit_entry_list.push_back(std::vector<char>(p, p + sizeof(audit_entry_t)));
 
     // Connect inbound.
-    audit_entries[1].tuple = tuple;
+    audit_entries[1].tuple = reverse_tuple;
     audit_entries[1].connected = true;
     audit_entries[1].outbound = false;
     p = reinterpret_cast<char*>(&audit_entries[1]);
     audit_entry_list.push_back(std::vector<char>(p, p + sizeof(audit_entry_t)));
 
-    // Disconnect.
+    // Create an audit entry for the disconnect case.
+    // The direction bit is set to false.
     audit_entries[2].tuple = tuple;
     audit_entries[2].connected = false;
     audit_entries[2].outbound = false;
     p = reinterpret_cast<char*>(&audit_entries[2]);
+    audit_entry_list.push_back(std::vector<char>(p, p + sizeof(audit_entry_t)));
+
+    // Create another audit entry for the disconnect event with the reverse packet tuple.
+    audit_entries[3].tuple = reverse_tuple;
+    audit_entries[3].connected = false;
+    audit_entries[3].outbound = false;
+    p = reinterpret_cast<char*>(&audit_entries[3]);
     audit_entry_list.push_back(std::vector<char>(p, p + sizeof(audit_entry_t)));
 
     context->records = &audit_entry_list;
@@ -338,9 +350,10 @@ connection_monitor_test(
     bpf_map* connection_map = bpf_object__find_map_by_name(object, "connection_map");
     REQUIRE(connection_map != nullptr);
 
-    // Update connection map with loopback packet tuple.
+    // Update connection map with loopback packet tuples.
     uint32_t verdict = BPF_SOCK_ADDR_VERDICT_REJECT;
     REQUIRE(bpf_map_update_elem(bpf_map__fd(connection_map), &tuple, &verdict, EBPF_ANY) == 0);
+    REQUIRE(bpf_map_update_elem(bpf_map__fd(connection_map), &reverse_tuple, &verdict, EBPF_ANY) == 0);
 
     // Post an asynchronous receive on the receiver socket.
     receiver_socket.post_async_receive();

--- a/tests/socket/socket_tests_common.h
+++ b/tests/socket/socket_tests_common.h
@@ -20,10 +20,10 @@ typedef struct _ip_address
 
 typedef struct _connection_tuple
 {
-    ip_address_t src_ip;
-    uint16_t src_port;
-    ip_address_t dst_ip;
-    uint16_t dst_port;
+    ip_address_t local_ip;
+    uint16_t local_port;
+    ip_address_t remote_ip;
+    uint16_t remote_port;
     uint32_t protocol;
     uint64_t interface_luid;
 } connection_tuple_t;


### PR DESCRIPTION
## Description

This PR fixes #2706 . 
This turned out to be a test issue, not a defect in feature code.  The test eBPF program flipped the local and remote IP addresses on the connection based on the direction of the connection to look up a connection table populated by the user mode test app. Since the direction is not available in connection deletion case, it failed to look up the connection and did not update the ring buffer.

The `connection_tuple_t` struct has been modified to use local/remote IP instead of source and destination so that the eBPF program do not need to flip them based on direction. Instead two entries have been added to the connection table for each direction.

There was a incidental finding in a lack of mapping from `ebpf_error` to `errno` which is fixed.
The eBPF core was also pointing to an incorrect version of ringbuf helper, which is fixed.

## Testing

Existing CI is enough.

## Documentation

No changes.

## Installation

No impact.