### PR TITLE
Fix perf-log upload in release validation workflow.

### DIFF
--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -469,7 +469,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_performance
+      name: km_performance-1
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
@@ -483,7 +483,7 @@ jobs:
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_perf_results
-      result_artifact: km_performance-x64-Release-1
+      result_artifact: km_performance-1-x64-Release
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -495,7 +495,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_performance
+      name: km_performance-2
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
@@ -509,7 +509,7 @@ jobs:
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_perf_results
-      result_artifact: km_performance-x64-Release-1
+      result_artifact: km_performance-2-x64-Release
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -521,7 +521,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_performance
+      name: km_performance-3
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
@@ -535,7 +535,7 @@ jobs:
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_perf_results
-      result_artifact: km_performance-x64-Release-3
+      result_artifact: km_performance-3-x64-Release
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -469,7 +469,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_performance-1
+      name: km_performance_1
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
@@ -483,7 +483,7 @@ jobs:
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_perf_results
-      result_artifact: km_performance-1-x64-Release
+      result_artifact: km_performance_1-x64-Release
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -495,7 +495,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_performance-2
+      name: km_performance_2
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
@@ -509,7 +509,7 @@ jobs:
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_perf_results
-      result_artifact: km_performance-2-x64-Release
+      result_artifact: km_performance_2-x64-Release
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -521,7 +521,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_performance-3
+      name: km_performance_3
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Performance"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
@@ -535,7 +535,7 @@ jobs:
     uses: ./.github/workflows/upload-perf-results.yml
     with:
       name: upload_perf_results
-      result_artifact: km_performance-3-x64-Release
+      result_artifact: km_performance_3-x64-Release
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Description

Fix file name error in uploading perf-logs in the release validation ci/cd workflow.

## Testing

CI/CD.

## Documentation

n.a.

## Installation

n.a.
