### PR TITLE
add reallocate_packet flag to helper prototype struct.

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -130,6 +130,7 @@ Helper function IDs for different program types need not be unique.
 * `return_type`: Set the appropriate value for the `ebpf_return_type_t` enum that represents the return type of the
 helper function.
 * `arguments`: Array of (at most) five helper function arguments of type `ebpf_argument_type_t`.
+* `reallocate_packet`: Flag indicating if this helper function performs packet reallocation.
 
 #### `ebpf_argument_type_t` Enum
 This enum describes the various argument types that can be passed to an eBPF helper function. This is defined in the

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -6,6 +6,13 @@
 #include "ebpf_result.h"
 
 #include <guiddef.h>
+
+#if !defined(NO_CRT) && !defined(_NO_CRT_STDIO_INLINE)
+#include <stdbool.h>
+#else
+#define bool _Bool
+#endif
+
 #include <stdint.h>
 
 #define EBPF_MAX_PROGRAM_DESCRIPTOR_NAME_LENGTH 256
@@ -26,6 +33,7 @@ typedef struct _ebpf_helper_function_prototype
     const char* name;
     ebpf_return_type_t return_type;
     ebpf_argument_type_t arguments[5];
+    bool reallocate_packet : 1;
 } ebpf_helper_function_prototype_t;
 
 typedef struct _ebpf_program_info

--- a/libs/api_common/windows_helpers.cpp
+++ b/libs/api_common/windows_helpers.cpp
@@ -61,5 +61,7 @@ get_helper_prototype_windows(int32_t n)
         verifier_prototype.argument_type[i] = raw_prototype->arguments[i];
     }
 
+    verifier_prototype.reallocate_packet = raw_prototype->reallocate_packet == TRUE;
+
     return verifier_prototype;
 }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2065,6 +2065,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_pr
     //   b. Helper name.
     //   c. Helper return type.
     //   d. Helper argument types.
+    //   e. reallocate_packet flag (if set).
 
     // Note:
     // Order and fields being hashed is important. The order and fields being hashed must match the order and fields
@@ -2126,6 +2127,13 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_pr
 
         for (uint32_t j = 0; j < EBPF_COUNT_OF(helper_function_prototype->arguments); j++) {
             result = EBPF_CRYPTOGRAPHIC_HASH_APPEND_VALUE(cryptographic_hash, helper_function_prototype->arguments[j]);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+        }
+
+        if (helper_function_prototype->reallocate_packet) {
+            result = EBPF_CRYPTOGRAPHIC_HASH_APPEND_VALUE(cryptographic_hash, "reallocate_packet");
             if (result != EBPF_SUCCESS) {
                 goto Exit;
             }

--- a/libs/store_helper/ebpf_store_helper.c
+++ b/libs/store_helper/ebpf_store_helper.c
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#include "ebpf_program_types.h"
 #include "ebpf_registry_helper.h"
 #include "ebpf_store_helper.h"
 #include "ebpf_windows.h"

--- a/libs/store_helper/kernel/ebpf_store_helper_km.vcxproj
+++ b/libs/store_helper/kernel/ebpf_store_helper_km.vcxproj
@@ -113,7 +113,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;_NO_CRT_STDIO_INLINE=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalIncludeDirectories>$(SolutionDir)libs/shared;$(SolutionDir)libs/shared/kernel;$(SolutionDir)libs/runtime;$(SolutionDir)libs/runtime/kernel;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winkernel;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -127,7 +127,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;_NO_CRT_STDIO_INLINE=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalIncludeDirectories>$(SolutionDir)libs/shared;$(SolutionDir)libs/shared/kernel;$(SolutionDir)libs/runtime;$(SolutionDir)libs/runtime/kernel;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winkernel;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -7,6 +7,8 @@
 #include "ebpf_program_types.h"
 #include "ebpf_shared_framework.h"
 
+#define TRUE 1
+
 #define XDP_EXT_HELPER_FUNCTION_START EBPF_MAX_GENERAL_HELPER_FUNCTION
 
 // XDP helper function prototype descriptors.
@@ -14,7 +16,8 @@ static const ebpf_helper_function_prototype_t _xdp_ebpf_extension_helper_functio
     {XDP_EXT_HELPER_FUNCTION_START + 1,
      "bpf_xdp_adjust_head",
      EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_ANYTHING}}};
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_ANYTHING},
+     TRUE}};
 
 // XDP program information.
 static const ebpf_context_descriptor_t _ebpf_xdp_context_descriptor = {

--- a/tests/sample/unsafe/xdp_adjust_head_unsafe.c
+++ b/tests/sample/unsafe/xdp_adjust_head_unsafe.c
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// clang -O2 -Werror -c xdp_adjust_head_unsafe.c -o xdp_adjust_head_unsafe_jit.o
+//
+// For bpf code: clang -target bpf -O2 -Werror -c xdp_adjust_head_unsafe.c -o xdp_adjust_head_unsafe.o
+//
+
+#include "bpf_endian.h"
+#include "bpf_helpers.h"
+#include "net/if_ether.h"
+#include "net/ip.h"
+#include "net/udp.h"
+
+SEC("xdp/xdp_adjust_head_unsafe")
+int
+xdp_adjust_head_unsafe(xdp_md_t* ctx)
+{
+    int rc = XDP_PASS;
+
+    ETHERNET_HEADER* ethernet_header = NULL;
+    char* next_header = (char*)ctx->data;
+    if (next_header + sizeof(ETHERNET_HEADER) > (char*)ctx->data_end) {
+        goto Done;
+    }
+
+    // Adjust the head of the packet
+    if (bpf_xdp_adjust_head(ctx, sizeof(ETHERNET_HEADER) < 0)) {
+        rc = XDP_DROP;
+        goto Done;
+    }
+
+    // Access the packet without checking for safety.
+    next_header = (char*)ctx->data + sizeof(ETHERNET_HEADER);
+    ethernet_header = (ETHERNET_HEADER*)next_header;
+
+    // Access the Ethernet header fields.
+    ethernet_header->Type = 0x0800;
+Done:
+    return rc;
+}

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -116,6 +116,9 @@ get_program_info_type_hash(const std::vector<int32_t>& actual_helper_ids, const 
                 hash_t::append_byte_range(
                     byte_range, program_info->program_type_specific_helper_prototype[index].arguments[argument]);
             }
+            if (program_info->program_type_specific_helper_prototype[index].reallocate_packet) {
+                hash_t::append_byte_range(byte_range, "reallocate_packet");
+            }
         }
     }
     hash_t hash(algorithm);


### PR DESCRIPTION
## Description

This fixes #3090 by adding a `reallocate_packet` field in the `ebpf_helper_function_prototype_t` struct that is passed on the PREVAIL verifier in `EbpfHelperPrototype`. The metadata for the lone helper function that modifies the packet pointer `bpf_xdp_adjust_head` has been updated.

## Testing

No new tests are needed. Verifier passes for XDP sample programs that invoke `bpf_xdp_adjust_head` helper function.

## Documentation

Documentation updated.

## Installation

_Is there any installer impact for this change?_
