### PR TITLE
Fix ebpf library linkage when using props file

### DIFF
--- a/tools/nuget/ebpf-for-windows.props
+++ b/tools/nuget/ebpf-for-windows.props
@@ -4,14 +4,8 @@
 -->
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003"
         ToolsVersion="15.0">
-  <PropertyGroup>
-    <LibraryType Condition="'$(Configuration)'=='Debug'">mdd</LibraryType>
-    <LibraryType Condition="'$(Configuration)'=='NativeOnlyDebug'">mdd</LibraryType>
-    <LibraryType Condition="'$(Configuration)'=='Release'">md</LibraryType>
-    <LibraryType Condition="'$(Configuration)'=='NativeOnlyRelease'">md</LibraryType>
-  </PropertyGroup>
   <ItemGroup>
-    <EbpfLibs Include="$(MSBuildThisFileDirectory)\lib\x86_64\$(LibraryType)\*.lib" />
+    <EbpfLibs Include="$(MSBuildThisFileDirectory)\lib\*.lib" />
   </ItemGroup>
   <PropertyGroup>
     <EbpfLibraries>@(EbpfLibs)</EbpfLibraries>


### PR DESCRIPTION
## Description

The eBPF props file in the nuget package is intended to automatically link to eBPF libraries, but this doesn't work. It looks like eBPF at some point shipped libs with different CRT linkages, which is no longer.

## Testing

Tested locally. CI should provide some regression coverage, and hopefully future undocked sample code will take a build dependency on the props file.

## Documentation

N/A.

## Installation

No.
