### PR TITLE
Helper reallocate packet

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -130,6 +130,7 @@ Helper function IDs for different program types need not be unique.
 * `return_type`: Set the appropriate value for the `ebpf_return_type_t` enum that represents the return type of the
 helper function.
 * `arguments`: Array of (at most) five helper function arguments of type `ebpf_argument_type_t`.
+* `reallocate_packet`: Flag indicating if this helper function performs packet reallocation.
 
 #### `ebpf_argument_type_t` Enum
 This enum describes the various argument types that can be passed to an eBPF helper function. This is defined in the

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -13,6 +13,7 @@ typedef unsigned char uint8_t;
 typedef unsigned int uint32_t;
 typedef unsigned long long uint64_t;
 typedef unsigned short wchar_t;
+#define bool _Bool
 #endif
 
 #define EBPF_MAX_PROGRAM_DESCRIPTOR_NAME_LENGTH 256
@@ -33,6 +34,7 @@ typedef struct _ebpf_helper_function_prototype
     const char* name;
     ebpf_return_type_t return_type;
     ebpf_argument_type_t arguments[5];
+    bool reallocate_packet : 1;
 } ebpf_helper_function_prototype_t;
 
 typedef struct _ebpf_program_info

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -29,6 +29,8 @@ typedef struct _ebpf_program_type_descriptor
     char is_privileged;
 } ebpf_program_type_descriptor_t;
 
+#define HELPER_FUNCTION_REALLOCATE_PACKET 0x1
+
 typedef struct _ebpf_helper_function_prototype
 {
     uint32_t helper_id;

--- a/include/ebpf_program_types.h
+++ b/include/ebpf_program_types.h
@@ -7,6 +7,7 @@
 
 #include <guiddef.h>
 #if !defined(NO_CRT) && !defined(_NO_CRT_STDIO_INLINE)
+#include <stdbool.h>
 #include <stdint.h>
 #else
 typedef unsigned char uint8_t;

--- a/libs/api_common/store_helper_internal.cpp
+++ b/libs/api_common/store_helper_internal.cpp
@@ -50,8 +50,9 @@ _load_helper_prototype(
 
         // Read serialized helper prototype information.
         char serialized_data[sizeof(ebpf_helper_function_prototype_t)] = {0};
+        bool reallocate_packet = false;
         size_t expected_size = sizeof(helper_prototype->helper_id) + sizeof(helper_prototype->return_type) +
-                               sizeof(helper_prototype->arguments);
+                               sizeof(helper_prototype->arguments) + sizeof(reallocate_packet);
 
         status = ebpf_read_registry_value_binary(
             helper_info_key, EBPF_HELPER_DATA_PROTOTYPE, (uint8_t*)serialized_data, expected_size);
@@ -70,6 +71,10 @@ _load_helper_prototype(
 
         memcpy(&helper_prototype->arguments, serialized_data + offset, sizeof(helper_prototype->arguments));
         offset += sizeof(helper_prototype->arguments);
+
+        memcpy(&reallocate_packet, serialized_data + offset, sizeof(reallocate_packet));
+        helper_prototype->reallocate_packet = reallocate_packet ? HELPER_FUNCTION_REALLOCATE_PACKET : 0;
+        offset += sizeof(reallocate_packet);
 
         helper_prototype->name =
             cxplat_duplicate_string(ebpf_down_cast_from_wstring(std::wstring(helper_name)).c_str());

--- a/libs/api_common/windows_helpers.cpp
+++ b/libs/api_common/windows_helpers.cpp
@@ -61,5 +61,7 @@ get_helper_prototype_windows(int32_t n)
         verifier_prototype.argument_type[i] = raw_prototype->arguments[i];
     }
 
+    verifier_prototype.reallocate_packet = raw_prototype->reallocate_packet == TRUE;
+
     return verifier_prototype;
 }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2131,7 +2131,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_pr
         }
 
         if (helper_function_prototype->reallocate_packet) {
-            result = EBPF_CRYPTOGRAPHIC_HASH_APPEND_VALUE(cryptographic_hash, "reallocate_packet");
+            result = EBPF_CRYPTOGRAPHIC_HASH_APPEND_STR(cryptographic_hash, "reallocate_packet");
             if (result != EBPF_SUCCESS) {
                 goto Exit;
             }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -2063,6 +2063,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_pr
     //   b. Helper name.
     //   c. Helper return type.
     //   d. Helper argument types.
+    //   e. reallocate_packet flag (if set).
 
     // Note:
     // Order and fields being hashed is important. The order and fields being hashed must match the order and fields
@@ -2124,6 +2125,13 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static ebpf_result_t _ebpf_program_compute_pr
 
         for (uint32_t j = 0; j < EBPF_COUNT_OF(helper_function_prototype->arguments); j++) {
             result = EBPF_CRYPTOGRAPHIC_HASH_APPEND_VALUE(cryptographic_hash, helper_function_prototype->arguments[j]);
+            if (result != EBPF_SUCCESS) {
+                goto Exit;
+            }
+        }
+
+        if (helper_function_prototype->reallocate_packet) {
+            result = EBPF_CRYPTOGRAPHIC_HASH_APPEND_VALUE(cryptographic_hash, "reallocate_packet");
             if (result != EBPF_SUCCESS) {
                 goto Exit;
             }

--- a/libs/shared/ebpf_serialize.c
+++ b/libs/shared/ebpf_serialize.c
@@ -29,6 +29,7 @@ typedef struct _ebpf_serialized_helper_function_prototype
     uint32_t helper_id;
     ebpf_return_type_t return_type;
     ebpf_argument_type_t arguments[5];
+    uint8_t reallocate_packet;
     size_t name_length;
     uint8_t name[1];
 } ebpf_serialized_helper_function_prototype_t;
@@ -462,6 +463,8 @@ ebpf_serialize_program_info(
             for (uint16_t index = 0; index < EBPF_COUNT_OF(helper_prototype->arguments); index++) {
                 serialized_helper_prototype->arguments[index] = helper_prototype->arguments[index];
             }
+            serialized_helper_prototype->reallocate_packet =
+                helper_prototype->reallocate_packet ? HELPER_FUNCTION_REALLOCATE_PACKET : 0;
             serialized_helper_prototype->name_length = helper_function_name_length;
             // Copy the program type descriptor name buffer.
             memcpy(serialized_helper_prototype->name, helper_prototype->name, helper_function_name_length);
@@ -627,12 +630,14 @@ ebpf_deserialize_program_info(
             goto Exit;
         }
 
-        // Serialize helper prototype.
+        // Deserialize helper prototype.
         helper_prototype->helper_id = serialized_helper_prototype->helper_id;
         helper_prototype->return_type = serialized_helper_prototype->return_type;
         for (int i = 0; i < EBPF_COUNT_OF(helper_prototype->arguments); i++) {
             helper_prototype->arguments[i] = serialized_helper_prototype->arguments[i];
         }
+        helper_prototype->reallocate_packet =
+            serialized_helper_prototype->reallocate_packet == HELPER_FUNCTION_REALLOCATE_PACKET;
 
         // Adjust remaining buffer length.
         result = ebpf_safe_size_t_subtract(

--- a/libs/store_helper/ebpf_store_helper.c
+++ b/libs/store_helper/ebpf_store_helper.c
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation
 // SPDX-License-Identifier: MIT
 
-#include "ebpf_program_types.h"
 #include "ebpf_registry_helper.h"
 #include "ebpf_store_helper.h"
 #include "ebpf_windows.h"

--- a/libs/store_helper/ebpf_store_helper.c
+++ b/libs/store_helper/ebpf_store_helper.c
@@ -40,6 +40,7 @@ _ebpf_store_update_helper_prototype(
     uint32_t offset;
     ebpf_store_key_t helper_function_key = NULL;
     char serialized_data[sizeof(ebpf_helper_function_prototype_t)] = {0};
+    const bool reallocate_packet = helper_info->reallocate_packet;
 
     wchar_t* wide_helper_name = ebpf_get_wstring_from_string(helper_info->name);
     if (wide_helper_name == NULL) {
@@ -61,6 +62,9 @@ _ebpf_store_update_helper_prototype(
 
     memcpy(serialized_data + offset, helper_info->arguments, sizeof(helper_info->arguments));
     offset += sizeof(helper_info->arguments);
+
+    memcpy(serialized_data + offset, &reallocate_packet, sizeof(reallocate_packet));
+    offset += sizeof(reallocate_packet);
 
     // Save the helper prototype data.
     result = ebpf_write_registry_value_binary(

--- a/libs/store_helper/kernel/ebpf_store_helper_km.vcxproj
+++ b/libs/store_helper/kernel/ebpf_store_helper_km.vcxproj
@@ -113,7 +113,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;_NO_CRT_STDIO_INLINE=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalIncludeDirectories>$(SolutionDir)libs/shared;$(SolutionDir)libs/shared/kernel;$(SolutionDir)libs/runtime;$(SolutionDir)libs/runtime/kernel;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winkernel;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -127,7 +127,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;_LIB;_NO_CRT_STDIO_INLINE=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalIncludeDirectories>$(SolutionDir)libs/shared;$(SolutionDir)libs/shared/kernel;$(SolutionDir)libs/runtime;$(SolutionDir)libs/runtime/kernel;$(SolutionDir)external\usersim\cxplat\inc;$(SolutionDir)external\usersim\cxplat\inc\winkernel;$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -9,8 +9,6 @@
 
 #define XDP_EXT_HELPER_FUNCTION_START EBPF_MAX_GENERAL_HELPER_FUNCTION
 
-#define HELPER_FUNCTION_REALLOCATE_PACKET 1
-
 // XDP_TEST helper function prototype descriptors.
 static const ebpf_helper_function_prototype_t _xdp_test_ebpf_extension_helper_function_prototype[] = {
     {XDP_EXT_HELPER_FUNCTION_START + 1,

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -7,9 +7,9 @@
 #include "ebpf_program_types.h"
 #include "ebpf_shared_framework.h"
 
-#define TRUE 1
-
 #define XDP_EXT_HELPER_FUNCTION_START EBPF_MAX_GENERAL_HELPER_FUNCTION
+
+#define HELPER_FUNCTION_REALLOCATE_PACKET 1
 
 // XDP_TEST helper function prototype descriptors.
 static const ebpf_helper_function_prototype_t _xdp_test_ebpf_extension_helper_function_prototype[] = {
@@ -17,7 +17,7 @@ static const ebpf_helper_function_prototype_t _xdp_test_ebpf_extension_helper_fu
      "bpf_xdp_adjust_head",
      EBPF_RETURN_TYPE_INTEGER,
      {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_ANYTHING},
-     TRUE}};
+     HELPER_FUNCTION_REALLOCATE_PACKET}};
 
 // XDP_TEST program information.
 static const ebpf_context_descriptor_t _ebpf_xdp_test_context_descriptor = {

--- a/netebpfext/net_ebpf_ext_program_info.h
+++ b/netebpfext/net_ebpf_ext_program_info.h
@@ -7,6 +7,8 @@
 #include "ebpf_program_types.h"
 #include "ebpf_shared_framework.h"
 
+#define TRUE 1
+
 #define XDP_EXT_HELPER_FUNCTION_START EBPF_MAX_GENERAL_HELPER_FUNCTION
 
 // XDP_TEST helper function prototype descriptors.
@@ -14,7 +16,8 @@ static const ebpf_helper_function_prototype_t _xdp_test_ebpf_extension_helper_fu
     {XDP_EXT_HELPER_FUNCTION_START + 1,
      "bpf_xdp_adjust_head",
      EBPF_RETURN_TYPE_INTEGER,
-     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_ANYTHING}}};
+     {EBPF_ARGUMENT_TYPE_PTR_TO_CTX, EBPF_ARGUMENT_TYPE_ANYTHING},
+     TRUE}};
 
 // XDP_TEST program information.
 static const ebpf_context_descriptor_t _ebpf_xdp_test_context_descriptor = {

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -371,9 +371,9 @@ TEST_CASE("show verification xdp_adjust_head_unsafe.o", "[netsh][verification]")
                   "\n"
                   "Verification report:\n"
                   "\n"
-                  "; ./tests/sample/unsafe/xdp_adjust_head_unsafe.c:38\n"
+                  "; ./tests/sample/unsafe/xdp_adjust_head_unsafe.c:42\n"
                   ";     ethernet_header->Type = 0x0800;\n"
-                  "16: Upper bound must be at most packet_size (valid_access(r1.offset+26, width=2) for write)\n"
+                  "17: Upper bound must be at most packet_size (valid_access(r1.offset+12, width=2) for write)\n"
                   "\n"
                   "1 errors\n"
                   "\n");

--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -356,6 +356,29 @@ TEST_CASE("show verification droppacket_unsafe.o", "[netsh][verification]")
                   "\n");
 }
 
+TEST_CASE("show verification xdp_adjust_head_unsafe.o", "[netsh][verification]")
+{
+    _test_helper_netsh test_helper;
+    test_helper.initialize();
+
+    int result;
+    std::string output =
+        _run_netsh_command(handle_ebpf_show_verification, L"xdp_adjust_head_unsafe.o", L"xdp", nullptr, &result);
+    REQUIRE(result == ERROR_SUPPRESS_OUTPUT);
+    output = strip_paths(output);
+    REQUIRE(
+        output == "Verification failed\n"
+                  "\n"
+                  "Verification report:\n"
+                  "\n"
+                  "; ./tests/sample/unsafe/xdp_adjust_head_unsafe.c:38\n"
+                  ";     ethernet_header->Type = 0x0800;\n"
+                  "16: Upper bound must be at most packet_size (valid_access(r1.offset+26, width=2) for write)\n"
+                  "\n"
+                  "1 errors\n"
+                  "\n");
+}
+
 TEST_CASE("show verification printk_unsafe.o", "[netsh][verification]")
 {
     _test_helper_netsh test_helper;

--- a/tests/sample/unsafe/xdp_adjust_head_unsafe.c
+++ b/tests/sample/unsafe/xdp_adjust_head_unsafe.c
@@ -12,7 +12,7 @@
 #include "net/ip.h"
 #include "net/udp.h"
 
-SEC("xdp/xdp_adjust_head_unsafe")
+SEC("xdp")
 int
 xdp_adjust_head_unsafe(xdp_md_t* ctx)
 {

--- a/tests/sample/unsafe/xdp_adjust_head_unsafe.c
+++ b/tests/sample/unsafe/xdp_adjust_head_unsafe.c
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation
+// SPDX-License-Identifier: MIT
+
+// clang -O2 -Werror -c xdp_adjust_head_unsafe.c -o xdp_adjust_head_unsafe_jit.o
+//
+// For bpf code: clang -target bpf -O2 -Werror -c xdp_adjust_head_unsafe.c -o xdp_adjust_head_unsafe.o
+//
+
+#include "bpf_endian.h"
+#include "bpf_helpers.h"
+#include "net/if_ether.h"
+#include "net/ip.h"
+#include "net/udp.h"
+
+SEC("xdp/xdp_adjust_head_unsafe")
+int
+xdp_adjust_head_unsafe(xdp_md_t* ctx)
+{
+    int rc = XDP_PASS;
+
+    ETHERNET_HEADER* ethernet_header = NULL;
+    char* next_header = (char*)ctx->data;
+    if (next_header + sizeof(ETHERNET_HEADER) > (char*)ctx->data_end) {
+        goto Done;
+    }
+
+    // Adjust the head of the packet
+    if (bpf_xdp_adjust_head(ctx, sizeof(ETHERNET_HEADER) < 0)) {
+        rc = XDP_DROP;
+        goto Done;
+    }
+
+    // Access the packet without checking for safety.
+    next_header = (char*)ctx->data + sizeof(ETHERNET_HEADER);
+    ethernet_header = (ETHERNET_HEADER*)next_header;
+
+    // Access the Ethernet header fields.
+    ethernet_header->Type = 0x0800;
+Done:
+    return rc;
+}

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -116,6 +116,9 @@ get_program_info_type_hash(const std::vector<int32_t>& actual_helper_ids, const 
                 hash_t::append_byte_range(
                     byte_range, program_info->program_type_specific_helper_prototype[index].arguments[argument]);
             }
+            if (program_info->program_type_specific_helper_prototype[index].reallocate_packet) {
+                hash_t::append_byte_range(byte_range, "reallocate_packet");
+            }
         }
     }
     hash_t hash(algorithm);

--- a/tools/bpf2c/bpf2c.cpp
+++ b/tools/bpf2c/bpf2c.cpp
@@ -117,7 +117,7 @@ get_program_info_type_hash(const std::vector<int32_t>& actual_helper_ids, const 
                     byte_range, program_info->program_type_specific_helper_prototype[index].arguments[argument]);
             }
             if (program_info->program_type_specific_helper_prototype[index].reallocate_packet) {
-                hash_t::append_byte_range(byte_range, "reallocate_packet");
+                hash_t::append_byte_range(byte_range, reinterpret_cast<const char*>("reallocate_packet"));
             }
         }
     }

--- a/tools/bpf2c/bpf2c.vcxproj
+++ b/tools/bpf2c/bpf2c.vcxproj
@@ -86,13 +86,13 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>true</LinkIncremental>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyDebug|x64'">
-    <LinkIncremental>true</LinkIncremental>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='FuzzerDebug|x64'">
-    <LinkIncremental>true</LinkIncremental>
+    <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
@@ -108,7 +108,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>$(FuzzerLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
@@ -126,7 +126,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>$(FuzzerLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
@@ -141,7 +141,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>$(FuzzerLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
@@ -159,7 +159,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>$(FuzzerLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
@@ -177,7 +177,7 @@
       <SubSystem>Console</SubSystem>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <GenerateDebugInformation>DebugFull</GenerateDebugInformation>
       <AdditionalDependencies>$(FuzzerLibs);%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>


### PR DESCRIPTION
## Description

This fixes #3090. A `reallocate_packet` flag is added to the helper function prototype metadata, to pass onto the PREVAIL verifier, to validate programs that uses any helper function that may change the packet pointers such as `xdp_adjust_head`.

## Testing

A new netsh tests is added that tries to load an unsafe XDP program and fails.

## Documentation

Updated extension documentation.

## Installation

No changes to installation.
