### PR TITLE
Add permissions to `release-scheduler.yml` workflow.

### DIFF
--- a/.github/workflows/release-scheduler.yml
+++ b/.github/workflows/release-scheduler.yml
@@ -8,6 +8,9 @@ on:
   schedule:
     - cron: 0 0 1 * *
 
+permissions:
+  contents: read
+
 jobs:
   create_release_issue:
     name: Create release task


### PR DESCRIPTION
Fixes #3119

## Description

Adds read-only permissions to `release-scheduler.yml`.

## Testing

CICD

## Documentation

n.a.

## Installation

n.a.
