### PR TITLE
Update Release process to get the Debug version.

### DIFF
--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -119,14 +119,12 @@ As a result of creating new release or servicing an existing one, the following 
 1. Click on the "`Choose a tag`" combo box and select the tag with new "`Release vX.Y.Z`" version number, as created earlier.
 1. Fill in the release title as "`vX.Y.Z`" (replace "`X.Y.Z`" with the version number being released).
 1. Manually enter release notes or click "`Generate release notes`" and then edit as desired.
-1. Attach the `.msi`, the (non-redist) `.nupkg`, and the `Build-x64-native-only-[Release|Debug].X.Y.Z.zip` build (from the CI/CD artifacts) for both Release and Debug, by dropping them in the "`Attach binaries by dropping them here or selecting them.`" area. For example, the file list for `v0.11.0` should be:
+1. Attach the `.msi`, the (non-redist) `.nupkg`, and the `Build-x64-native-only-[Release|Debug].X.Y.Z.zip` build (from the CI/CD artifacts), by dropping them in the "`Attach binaries by dropping them here or selecting them.`" area. For example, the file list for `v0.11.0` should be:
 
     - *Build-x64-native-only-Release.0.11.0.zip*
     - *ebpf-for-windows.0.11.0.msi*
     - *eBPF-for-Windows.0.11.0.nupkg*
     - *Build-x64-native-only-Debug.0.11.0.zip*
-    - *ebpf-for-windows-debug.0.11.0.msi*
-    - *eBPF-for-Windows-debug.0.11.0.nupkg*
 
 1. Check the "`Set as a pre-release`" checkbox, unless the release is production-signed.
 1. Once the uploads are complete, click "`Publish release`".

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -119,11 +119,14 @@ As a result of creating new release or servicing an existing one, the following 
 1. Click on the "`Choose a tag`" combo box and select the tag with new "`Release vX.Y.Z`" version number, as created earlier.
 1. Fill in the release title as "`vX.Y.Z`" (replace "`X.Y.Z`" with the version number being released).
 1. Manually enter release notes or click "`Generate release notes`" and then edit as desired.
-1. Attach the `.msi`, the (non-redist) `.nupkg`, and the `Build-x64-native-only-Release.X.Y.Z.zip` build (from the CI/CD artifacts), by dropping them in the "`Attach binaries by dropping them here or selecting them.`" area. For example, the file list for `v0.11.0` should be:
+1. Attach the `.msi`, the (non-redist) `.nupkg`, and the `Build-x64-native-only-[Release|Debug].X.Y.Z.zip` build (from the CI/CD artifacts) for both Release and Debug, by dropping them in the "`Attach binaries by dropping them here or selecting them.`" area. For example, the file list for `v0.11.0` should be:
 
     - *Build-x64-native-only-Release.0.11.0.zip*
     - *ebpf-for-windows.0.11.0.msi*
     - *eBPF-for-Windows.0.11.0.nupkg*
+    - *Build-x64-native-only-Debug.0.11.0.zip*
+    - *ebpf-for-windows-debug.0.11.0.msi*
+    - *eBPF-for-Windows-debug.0.11.0.nupkg*
 
 1. Check the "`Set as a pre-release`" checkbox, unless the release is production-signed.
 1. Once the uploads are complete, click "`Publish release`".

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -121,10 +121,10 @@ As a result of creating new release or servicing an existing one, the following 
 1. Manually enter release notes or click "`Generate release notes`" and then edit as desired.
 1. Attach the `.msi`, the (non-redist) `.nupkg`, and the `Build-x64-native-only-[Release|Debug].X.Y.Z.zip` build (from the CI/CD artifacts), by dropping them in the "`Attach binaries by dropping them here or selecting them.`" area. For example, the file list for `v0.11.0` should be:
 
+    - *Build-x64-native-only-Debug.0.11.0.zip*
     - *Build-x64-native-only-Release.0.11.0.zip*
     - *ebpf-for-windows.0.11.0.msi*
     - *eBPF-for-Windows.0.11.0.nupkg*
-    - *Build-x64-native-only-Debug.0.11.0.zip*
 
 1. Check the "`Set as a pre-release`" checkbox, unless the release is production-signed.
 1. Once the uploads are complete, click "`Publish release`".


### PR DESCRIPTION
## Description

There is a requirement to have ebpf-for-windows debug binaries. Hence we need the below in the ebpf release.

- Build-x64-native-only-Debug.0.13.0.zip*

## Testing

_Do any existing tests cover this change? N/A
Are new tests needed? N/A

## Documentation

_Is there any documentation impact for this change? Yes

## Installation

_Is there any installer impact for this change? No.
