### PR TITLE
Fix xdp_md struct name

### DIFF
--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -7,7 +7,7 @@
 // exposed by netebpfext.sys for use by eBPF programs.
 
 // XDP_TEST hook.  We use "struct xdp_md" for cross-platform compatibility.
-typedef struct xdp_md_
+typedef struct xdp_md
 {
     void* data;               ///< Pointer to start of packet data.
     void* data_end;           ///< Pointer to end of packet data.


### PR DESCRIPTION
Fixes #3128

## Description

Fixes the xdp_md struct name.

## Testing

Manually tested programs which were dependent on older name.

## Documentation

NA

## Installation

No.
