### PR TITLE
Enable optimization on bpf2c generated code

### DIFF
--- a/tests/end_to_end/netsh_test.cpp
+++ b/tests/end_to_end/netsh_test.cpp
@@ -201,16 +201,21 @@ TEST_CASE("show sections bpf.sys", "[netsh][sections]")
     std::string output = _run_netsh_command(handle_ebpf_show_sections, L"bpf.sys", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
 
-    REQUIRE(
-        output == "\n"
-                  "                                    Size\n"
-                  "             Section       Type  (bytes)\n"
-                  "====================  =========  =======\n"
-                  "               .text       bind     1768\n"
-                  "\n"
-                  "                     Key  Value      Max\n"
-                  "          Map Type  Size   Size  Entries  Name\n"
-                  "==================  ====  =====  =======  ========\n");
+    const std::string expected_output = "\n"
+                                        "                                    Size\n"
+                                        "             Section       Type  (bytes)\n"
+                                        "====================  =========  =======\n"
+#if defined(NDEBUG)
+                                        "               .text       bind     1064\n"
+#else
+                                        "               .text       bind     1768\n"
+#endif
+                                        "\n"
+                                        "                     Key  Value      Max\n"
+                                        "          Map Type  Size   Size  Entries  Name\n"
+                                        "==================  ====  =====  =======  ========\n";
+
+    REQUIRE(output == expected_output);
 }
 
 // Test a DLL with multiple maps in the map section.
@@ -222,19 +227,24 @@ TEST_CASE("show sections map_reuse_um.dll", "[netsh][sections]")
     int result;
     std::string output = _run_netsh_command(handle_ebpf_show_sections, L"map_reuse_um.dll", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
-    REQUIRE(
-        output == "\n"
-                  "                                    Size\n"
-                  "             Section       Type  (bytes)\n"
-                  "====================  =========  =======\n"
-                  "          sample_ext     sample     1087\n"
-                  "\n"
-                  "                     Key  Value      Max\n"
-                  "          Map Type  Size   Size  Entries  Name\n"
-                  "==================  ====  =====  =======  ========\n"
-                  "      hash_of_maps     4      4        1  outer_map\n"
-                  "             array     4      4        1  port_map\n"
-                  "             array     4      4        1  inner_map\n");
+    const std::string expected_output = "\n"
+                                        "                                    Size\n"
+                                        "             Section       Type  (bytes)\n"
+                                        "====================  =========  =======\n"
+#if defined(NDEBUG)
+                                        "          sample_ext     sample      295\n"
+#else
+                                        "          sample_ext     sample     1087\n"
+#endif
+                                        "\n"
+                                        "                     Key  Value      Max\n"
+                                        "          Map Type  Size   Size  Entries  Name\n"
+                                        "==================  ====  =====  =======  ========\n"
+                                        "      hash_of_maps     4      4        1  outer_map\n"
+                                        "             array     4      4        1  port_map\n"
+                                        "             array     4      4        1  inner_map\n";
+
+    REQUIRE(output == expected_output);
 }
 
 // Test a .dll file with multiple programs.
@@ -247,19 +257,26 @@ TEST_CASE("show sections tail_call_multiple_um.dll", "[netsh][sections]")
     std::string output =
         _run_netsh_command(handle_ebpf_show_sections, L"tail_call_multiple_um.dll", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
-    REQUIRE(
-        output == "\n"
-                  "                                    Size\n"
-                  "             Section       Type  (bytes)\n"
-                  "====================  =========  =======\n"
-                  "          sample_ext     sample      413\n"
-                  "        sample_ext/0     sample      413\n"
-                  "        sample_ext/1     sample      190\n"
-                  "\n"
-                  "                     Key  Value      Max\n"
-                  "          Map Type  Size   Size  Entries  Name\n"
-                  "==================  ====  =====  =======  ========\n"
-                  "        prog_array     4      4       10  map\n");
+    const std::string expected_output = "\n"
+                                        "                                    Size\n"
+                                        "             Section       Type  (bytes)\n"
+                                        "====================  =========  =======\n"
+#if defined(NDEBUG)
+                                        "        sample_ext/0     sample       73\n"
+                                        "        sample_ext/1     sample        6\n"
+                                        "          sample_ext     sample       73\n"
+#else
+                                        "          sample_ext     sample      413\n"
+                                        "        sample_ext/0     sample      413\n"
+                                        "        sample_ext/1     sample      190\n"
+#endif
+                                        "\n"
+                                        "                     Key  Value      Max\n"
+                                        "          Map Type  Size   Size  Entries  Name\n"
+                                        "==================  ====  =====  =======  ========\n"
+                                        "        prog_array     4      4       10  map\n";
+
+    REQUIRE(output == expected_output);
 }
 
 // Test a .sys file with multiple programs, including ones with long names.
@@ -272,21 +289,28 @@ TEST_CASE("show sections cgroup_sock_addr.sys", "[netsh][sections]")
     std::string output =
         _run_netsh_command(handle_ebpf_show_sections, L"cgroup_sock_addr.sys", nullptr, nullptr, &result);
     REQUIRE(result == NO_ERROR);
-    REQUIRE(
-        output == "\n"
-                  "                                    Size\n"
-                  "             Section       Type  (bytes)\n"
-                  "====================  =========  =======\n"
-                  "     cgroup/connect4  sock_addr      531\n"
-                  "     cgroup/connect6  sock_addr      606\n"
-                  " cgroup/recv_accept4  sock_addr      531\n"
-                  " cgroup/recv_accept6  sock_addr      606\n"
-                  "\n"
-                  "                     Key  Value      Max\n"
-                  "          Map Type  Size   Size  Entries  Name\n"
-                  "==================  ====  =====  =======  ========\n"
-                  "              hash    56      4        1  egress_connection_policy_map\n"
-                  "              hash    56      4        1  ingress_connection_policy_map\n");
+    const std::string expected_output = "\n"
+                                        "                                    Size\n"
+                                        "             Section       Type  (bytes)\n"
+                                        "====================  =========  =======\n"
+#if defined(NDEBUG)
+                                        "     cgroup/connect4  sock_addr      193\n"
+                                        "     cgroup/connect6  sock_addr      210\n"
+                                        " cgroup/recv_accept4  sock_addr      193\n"
+                                        " cgroup/recv_accept6  sock_addr      210\n"
+#else
+                                        "     cgroup/connect4  sock_addr      531\n"
+                                        "     cgroup/connect6  sock_addr      606\n"
+                                        " cgroup/recv_accept4  sock_addr      531\n"
+                                        " cgroup/recv_accept6  sock_addr      606\n"
+#endif
+                                        "\n"
+                                        "                     Key  Value      Max\n"
+                                        "          Map Type  Size   Size  Entries  Name\n"
+                                        "==================  ====  =====  =======  ========\n"
+                                        "              hash    56      4        1  egress_connection_policy_map\n"
+                                        "              hash    56      4        1  ingress_connection_policy_map\n";
+    REQUIRE(output == expected_output);
 }
 
 TEST_CASE("show verification nosuchfile.o", "[netsh][verification]")

--- a/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/kernel_mode_bpf2c.vcxproj
@@ -88,6 +88,13 @@
   <ItemGroup>
     <ClCompile Include="$(FileName)_driver.c" />
   </ItemGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
   </ImportGroup>

--- a/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
@@ -151,6 +151,13 @@
       <Command>$(BinDir)bpf2c.exe --bpf $(FileName).o --dll $(FileName)_dll.c $(AdditionalOptions)</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)'=='Release'">
+    <ClCompile>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemGroup Condition="$(ResourceFile)!=''">
     <ResourceCompile Include="$(ResourceFile)" />
   </ItemGroup>

--- a/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
+++ b/tools/bpf2c/templates/user_mode_bpf2c.vcxproj
@@ -156,6 +156,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup Condition="$(ResourceFile)!=''">


### PR DESCRIPTION
## Description

Enable optimization flag when generating release versions of native binaries.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
