### PR TITLE
Set required_irql in sockops and sockaddr program information

### DIFF
--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -73,7 +73,7 @@ functions that override the global helper functions provided by the eBPF runtime
 structure from provided data and context buffers.
 * `context_destroy`: Pointer to `ebpf_program_context_destroy_t` function that destroys a program type specific
 context structure and populates the returned data and context buffers.
-* `required_irql`: IRQL that the eBPF program runs at when being invoked via bpf_prog_test_run_opts.
+* `required_irql`: IRQL at which the eBPF program is invoked by bpf_prog_test_run_opts.
 
 #### `ebpf_program_info_t` Struct
 The various fields of this structure should be set as follows:

--- a/docs/eBpfExtensions.md
+++ b/docs/eBpfExtensions.md
@@ -73,7 +73,7 @@ functions that override the global helper functions provided by the eBPF runtime
 structure from provided data and context buffers.
 * `context_destroy`: Pointer to `ebpf_program_context_destroy_t` function that destroys a program type specific
 context structure and populates the returned data and context buffers.
-* `required_irql`: IRQL that the eBPF program runs at.
+* `required_irql`: IRQL that the eBPF program runs at when being invoked via bpf_prog_test_run_opts.
 
 #### `ebpf_program_info_t` Struct
 The various fields of this structure should be set as follows:

--- a/netebpfext/net_ebpf_ext_sock_addr.c
+++ b/netebpfext/net_ebpf_ext_sock_addr.c
@@ -483,7 +483,9 @@ static ebpf_program_data_t _ebpf_sock_addr_program_data = {
     .program_type_specific_helper_function_addresses = &_ebpf_sock_addr_specific_helper_function_address_table,
     .global_helper_function_addresses = &_ebpf_sock_addr_global_helper_function_address_table,
     .context_create = &_ebpf_sock_addr_context_create,
-    .context_destroy = &_ebpf_sock_addr_context_destroy};
+    .context_destroy = &_ebpf_sock_addr_context_destroy,
+    .required_irql = DISPATCH_LEVEL,
+};
 
 static ebpf_extension_data_t _ebpf_sock_addr_program_info_provider_data = {
     NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_sock_addr_program_data), &_ebpf_sock_addr_program_data};

--- a/netebpfext/net_ebpf_ext_sock_ops.c
+++ b/netebpfext/net_ebpf_ext_sock_ops.c
@@ -81,7 +81,9 @@ _ebpf_sock_ops_context_destroy(
 static ebpf_program_data_t _ebpf_sock_ops_program_data = {
     .program_info = &_ebpf_sock_ops_program_info,
     .context_create = &_ebpf_sock_ops_context_create,
-    .context_destroy = &_ebpf_sock_ops_context_destroy};
+    .context_destroy = &_ebpf_sock_ops_context_destroy,
+    .required_irql = DISPATCH_LEVEL,
+};
 
 static ebpf_extension_data_t _ebpf_sock_ops_program_info_provider_data = {
     NET_EBPF_EXTENSION_NPI_PROVIDER_VERSION, sizeof(_ebpf_sock_ops_program_data), &_ebpf_sock_ops_program_data};


### PR DESCRIPTION
## Description

The sockops and sockaddr program information are missing the required_irql fields. This causes bpf_prog_test_run_opts to invoke them at IRQL == PASSIVE_LEVEL instead of IRQL == DISPATCH_LEVEL.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
