### PR TITLE
Add bpf2c support for cpu=v4 instructions

### DIFF
--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -114,7 +114,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v4 --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2022

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -143,7 +143,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.5/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v3 --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v4 --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2022

--- a/docs/isa-support.rst
+++ b/docs/isa-support.rst
@@ -203,9 +203,9 @@ opcode  src   imm   off   description                                           
 0xd4    0x0   0x40  0     dst = htole64(dst)                                         Y      Y      Y    le64
 0xd5    0x0   any   any   if dst s<= imm goto +offset                                Y      Y      Y    jsle-imm
 0xd6    0x0   any   any   if (s32)dst s<= (s32)imm goto +offset                      Y      Y      Y    jsle32-imm
-0xd7    0x0   0x10  0     dst = bswap16(dst)                                         Y      no     no   swap16
-0xd7    0x0   0x20  0     dst = bswap32(dst)                                         Y      no     no   swap32
-0xd7    0x0   0x40  0     dst = bswap64(dst)                                         Y      no     no   swap64
+0xd7    0x0   0x10  0     dst = bswap16(dst)                                         Y      no     Y    swap16
+0xd7    0x0   0x20  0     dst = bswap32(dst)                                         Y      no     Y    swap32
+0xd7    0x0   0x40  0     dst = bswap64(dst)                                         Y      no     Y    swap64
 0xdb    any   0x00  any   lock \*(u64 \*)(dst + offset) += src                       no     no     Y    lock_add
 0xdb    any   0x01  any   | lock                                                     no     no     Y    lock_fetch_add
                           | temp = \*(u64 \*)(dst + offset)

--- a/docs/isa-support.rst
+++ b/docs/isa-support.rst
@@ -149,14 +149,9 @@ opcode  src   imm   off   description                                           
 0xae    any   0x00  any   if (u32)dst < (u32)src goto +offset                        Y      Y      Y    jlt32-reg
 0xaf    any   0x00  0     dst ^= src                                                 Y      Y      Y    alu64-bit
 0xb4    0x0   any   0     dst = (u32) imm                                            Y      Y      Y    mov
-0xb4    0x0   any   8     dst = (u32) (s32) (s8) imm                                 Y      no     no   movsx832-imm
-0xb4    0x0   any   16    dst = (u32) (s32) (s16) imm                                Y      no     no   movsx1632-imm
 0xb5    0x0   any   any   if dst <= imm goto +offset                                 Y      Y      Y    jle-imm
 0xb6    0x0   any   any   if (u32)dst <= imm goto +offset                            Y      Y      Y    jle32-imm
 0xb7    0x0   any   0     dst = imm                                                  Y      Y      Y    mov64-sign-extend
-0xb7    0x0   any   8     dst = (s64) (s8) imm                                       Y      no     no   movsx864-imm
-0xb7    0x0   any   16    dst = (s64) (s16) imm                                      Y      no     no   movsx1664-imm
-0xb7    0x0   any   32    dst = (s64) (s32) imm                                      Y      no     no   movsx3264-imm
 0xbc    any   0x00  0     dst = (u32) src                                            Y      Y      Y    mov
 0xbc    any   0x00  8     dst = (u32) (s32) (s8) src                                 Y      no     no   movsx832-reg
 0xbc    any   0x00  16    dst = (u32) (s32) (s16) src                                Y      no     no   movsx1632-reg

--- a/docs/isa-support.rst
+++ b/docs/isa-support.rst
@@ -153,14 +153,14 @@ opcode  src   imm   off   description                                           
 0xb6    0x0   any   any   if (u32)dst <= imm goto +offset                            Y      Y      Y    jle32-imm
 0xb7    0x0   any   0     dst = imm                                                  Y      Y      Y    mov64-sign-extend
 0xbc    any   0x00  0     dst = (u32) src                                            Y      Y      Y    mov
-0xbc    any   0x00  8     dst = (u32) (s32) (s8) src                                 Y      no     no   movsx832-reg
-0xbc    any   0x00  16    dst = (u32) (s32) (s16) src                                Y      no     no   movsx1632-reg
+0xbc    any   0x00  8     dst = (u32) (s32) (s8) src                                 Y      no     Y    movsx832-reg
+0xbc    any   0x00  16    dst = (u32) (s32) (s16) src                                Y      no     Y    movsx1632-reg
 0xbd    any   0x00  any   if dst <= src goto +offset                                 Y      Y      Y    jle-reg
 0xbe    any   0x00  any   if (u32)dst <= (u32)src goto +offset                       Y      Y      Y    jle32-reg
 0xbf    any   0x00  0     dst = src                                                  Y      Y      Y    ldxb-all
-0xbf    any   0x00  8     dst = (s64) (s8) src                                       Y      no     no   movsx864-reg
-0xbf    any   0x00  16    dst = (s64) (s16) src                                      Y      no     no   movsx1664-reg
-0xbf    any   0x00  32    dst = (s64) (s32) src                                      Y      no     no   movsx3264-reg
+0xbf    any   0x00  8     dst = (s64) (s8) src                                       Y      no     Y    movsx864-reg
+0xbf    any   0x00  16    dst = (s64) (s16) src                                      Y      no     Y    movsx1664-reg
+0xbf    any   0x00  32    dst = (s64) (s32) src                                      Y      no     Y    movsx3264-reg
 0xc3    any   0x00  any   lock \*(u32 \*)(dst + offset) += src                       no     no     Y    lock_add32
 0xc3    any   0x01  any   | lock                                                     no     no     Y    lock_fetch_add32
                           | temp = \*(u32 \*)(dst + offset)

--- a/docs/isa-support.rst
+++ b/docs/isa-support.rst
@@ -11,7 +11,7 @@ opcode  src   imm   off   description                                           
 0x00    0x0   any   0     (additional immediate value)                               Y      Y      Y    arsh32-high-shift
 0x04    0x0   any   0     dst = (u32)((u32)dst + (u32)imm)                           Y      Y      Y    add
 0x05    0x0   0x00  any   goto +offset                                               Y      Y      Y    exit-not-last
-0x06    0x0   any   0     goto +imm                                                  Y      no     no   ja32
+0x06    0x0   any   0     goto +imm                                                  Y      no     Y    ja32
 0x07    0x0   any   0     dst += imm                                                 Y      Y      Y    add64
 0x0c    any   0x00  0     dst = (u32)((u32)dst + (u32)src)                           Y      Y      Y    add
 0x0f    any   0x00  0     dst += src                                                 Y      Y      Y    alu64-arith

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -36,9 +36,7 @@
 #define INDENT "    "
 #define LINE_BREAK_WIDTH 120
 
-#define EBPF_MODE_MASK 0xe0
 #define EBPF_MODE_ATOMIC 0xc0
-#define EBPF_MODE_MEM 0x60
 
 #define EBPF_ATOMIC_FETCH 0x01
 #define EBPF_ATOMIC_ADD 0x00
@@ -52,8 +50,8 @@
 #define EBPF_ATOMIC_XCHG (0xe0 | EBPF_ATOMIC_FETCH)
 #define EBPF_ATOMIC_CMPXCHG (0xf0 | EBPF_ATOMIC_FETCH)
 
-#define EBPF_OP_ATOMIC64 (EBPF_CLS_STX | EBPF_MODE_ATOMIC | EBPF_SIZE_DW)
-#define EBPF_OP_ATOMIC (EBPF_CLS_STX | EBPF_MODE_ATOMIC | EBPF_SIZE_W)
+#define EBPF_OP_ATOMIC64 (INST_CLS_STX | EBPF_MODE_ATOMIC | INST_SIZE_DW)
+#define EBPF_OP_ATOMIC (INST_CLS_STX | EBPF_MODE_ATOMIC | INST_SIZE_W)
 static const std::string _register_names[11] = {
     "r0",
     "r1",
@@ -160,12 +158,12 @@ static std::map<uint8_t, std::string> _opcode_name_strings = {
     ADD_OPCODE(EBPF_OP_ATOMIC64),   ADD_OPCODE(EBPF_OP_ATOMIC)};
 
 #define IS_ATOMIC_OPCODE(_opcode) \
-    (((_opcode)&EBPF_CLS_MASK) == EBPF_CLS_STX && ((_opcode)&EBPF_MODE_MASK) == EBPF_MODE_ATOMIC)
+    (((_opcode)&INST_CLS_MASK) == INST_CLS_STX && ((_opcode)&INST_MODE_MASK) == EBPF_MODE_ATOMIC)
 
 #define IS_JMP_CLASS_OPCODE(_opcode) \
-    (((_opcode)&EBPF_CLS_MASK) == EBPF_CLS_JMP || ((_opcode)&EBPF_CLS_MASK) == EBPF_CLS_JMP32)
+    (((_opcode)&INST_CLS_MASK) == INST_CLS_JMP || ((_opcode)&INST_CLS_MASK) == INST_CLS_JMP32)
 
-#define IS_JMP32_CLASS_OPCODE(_opcode) (((_opcode)&EBPF_CLS_MASK) == EBPF_CLS_JMP32)
+#define IS_JMP32_CLASS_OPCODE(_opcode) (((_opcode)&INST_CLS_MASK) == INST_CLS_JMP32)
 
 #define IS_SIGNED_CMP_OPCODE(_opcode)                                                          \
     (((_opcode) >> 4) == (EBPF_MODE_JSGT >> 4) || ((_opcode) >> 4) == (EBPF_MODE_JSGE >> 4) || \
@@ -808,10 +806,10 @@ bpf_code_generator::generate_labels()
         if (!IS_JMP_CLASS_OPCODE(output.instruction.opcode)) {
             continue;
         }
-        if (output.instruction.opcode == EBPF_OP_CALL) {
+        if (output.instruction.opcode == INST_OP_CALL) {
             continue;
         }
-        if (output.instruction.opcode == EBPF_OP_EXIT) {
+        if (output.instruction.opcode == INST_OP_EXIT) {
             continue;
         }
         if ((i + output.instruction.offset + 1) >= program_output.size()) {
@@ -838,7 +836,7 @@ bpf_code_generator::build_function_table()
     // Gather helper_functions
     size_t index = 0;
     for (auto& output : program_output) {
-        if (output.instruction.opcode != EBPF_OP_CALL) {
+        if (output.instruction.opcode != INST_OP_CALL) {
             continue;
         }
         bpf_code_generator::unsafe_string name;
@@ -867,17 +865,17 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
         auto& output = program_output[i];
         auto& inst = output.instruction;
 
-        switch (inst.opcode & EBPF_CLS_MASK) {
-        case EBPF_CLS_ALU:
-        case EBPF_CLS_ALU64: {
+        switch (inst.opcode & INST_CLS_MASK) {
+        case INST_CLS_ALU:
+        case INST_CLS_ALU64: {
             std::string destination = get_register_name(inst.dst);
             std::string source;
-            if (inst.opcode & EBPF_SRC_REG) {
+            if (inst.opcode & INST_SRC_REG) {
                 source = get_register_name(inst.src);
             } else {
                 source = "IMMEDIATE(" + std::to_string(inst.imm) + ")";
             }
-            bool is64bit = (inst.opcode & EBPF_CLS_MASK) == EBPF_CLS_ALU64;
+            bool is64bit = (inst.opcode & INST_CLS_MASK) == INST_CLS_ALU64;
             AluOperations operation = static_cast<AluOperations>(inst.opcode >> 4);
             std::string swap_function;
             std::string type;
@@ -997,7 +995,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 break;
             case AluOperations::ByteOrder: {
                 std::string size_type = "";
-                if (output.instruction.opcode & EBPF_SRC_REG) {
+                if (output.instruction.opcode & INST_SRC_REG) {
                     switch (inst.imm) {
                     case 16:
                         swap_function = "htobe16";
@@ -1045,9 +1043,9 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             }
 
         } break;
-        case EBPF_CLS_LD: {
+        case INST_CLS_LD: {
             i++;
-            if (inst.opcode != EBPF_OP_LDDW) {
+            if (inst.opcode != INST_OP_LDDW_IMM) {
                 throw bpf_code_generator_exception("invalid operand", output.instruction_offset);
             }
             if (i >= program_output.size()) {
@@ -1073,22 +1071,22 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 current_section->referenced_map_indices.insert(map_definitions[output.relocation].index);
             }
         } break;
-        case EBPF_CLS_LDX: {
+        case INST_CLS_LDX: {
             std::string size_type;
             std::string destination = get_register_name(inst.dst);
             std::string source = get_register_name(inst.src);
             std::string offset = "OFFSET(" + std::to_string(inst.offset) + ")";
-            switch (inst.opcode & EBPF_SIZE_DW) {
-            case EBPF_SIZE_B:
+            switch (inst.opcode & INST_SIZE_DW) {
+            case INST_SIZE_B:
                 size_type = "uint8_t";
                 break;
-            case EBPF_SIZE_H:
+            case INST_SIZE_H:
                 size_type = "uint16_t";
                 break;
-            case EBPF_SIZE_W:
+            case INST_SIZE_W:
                 size_type = "uint32_t";
                 break;
-            case EBPF_SIZE_DW:
+            case INST_SIZE_DW:
                 size_type = "uint64_t";
                 break;
             default:
@@ -1097,8 +1095,8 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             output.lines.push_back(
                 std::format("{} = *({}*)(uintptr_t)({} + {});", destination, size_type, source, offset));
         } break;
-        case EBPF_CLS_ST:
-        case EBPF_CLS_STX: {
+        case INST_CLS_ST:
+        case INST_CLS_STX: {
             std::string size_type;
             std::string lock_type;
             std::string size_num;
@@ -1106,24 +1104,24 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             std::string source;
             std::string raw_source;
             bool is_complex = false;
-            if ((inst.opcode & EBPF_CLS_MASK) == EBPF_CLS_ST) {
+            if ((inst.opcode & INST_CLS_MASK) == INST_CLS_ST) {
                 source = "IMMEDIATE(" + std::to_string(inst.imm) + ")";
             } else {
                 source = get_register_name(inst.src);
             }
             std::string offset = "OFFSET(" + std::to_string(inst.offset) + ")";
-            switch (inst.opcode & EBPF_SIZE_DW) {
-            case EBPF_SIZE_B:
+            switch (inst.opcode & INST_SIZE_DW) {
+            case INST_SIZE_B:
                 size_type = "uint8_t";
                 break;
-            case EBPF_SIZE_H:
+            case INST_SIZE_H:
                 size_type = "uint16_t";
                 break;
-            case EBPF_SIZE_W:
+            case INST_SIZE_W:
                 size_type = "uint32_t";
                 lock_type = "volatile long";
                 break;
-            case EBPF_SIZE_DW:
+            case INST_SIZE_DW:
                 size_num = "64";
                 size_type = "uint64_t";
                 lock_type = "volatile int64_t";
@@ -1133,7 +1131,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             }
             raw_source = source;
             source = "(" + size_type + ")" + source;
-            if ((inst.opcode & EBPF_MODE_MASK) == EBPF_MODE_ATOMIC) { // MODE_ATOMIC
+            if ((inst.opcode & INST_MODE_MASK) == EBPF_MODE_ATOMIC) {
                 auto line = std::string("");
                 switch (inst.imm) {
                 case EBPF_ATOMIC_ADD:
@@ -1205,15 +1203,15 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 } else {
                     output.lines.push_back(line);
                 }
-            } else if ((inst.opcode & EBPF_MODE_MASK) == EBPF_MODE_MEM) {
+            } else if ((inst.opcode & INST_MODE_MASK) == EBPF_MODE_MEM) {
                 output.lines.push_back(
                     std::format("*({}*)(uintptr_t)({} + {}) = {};", size_type, destination, offset, source));
             } else {
-                throw bpf_code_generator_exception("invalid atomic mode", inst.opcode & EBPF_MODE_MASK);
+                throw bpf_code_generator_exception("invalid atomic mode", inst.opcode & INST_MODE_MASK);
             }
         } break;
-        case EBPF_CLS_JMP:
-        case EBPF_CLS_JMP32: {
+        case INST_CLS_JMP:
+        case INST_CLS_JMP32: {
             std::string destination = get_register_name(inst.dst);
             std::string destination_cast;
             if (IS_JMP32_CLASS_OPCODE(inst.opcode)) {
@@ -1224,7 +1222,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
 
             std::string source;
             std::string source_cast;
-            if (inst.opcode & EBPF_SRC_REG) {
+            if (inst.opcode & INST_SRC_REG) {
                 source = get_register_name(inst.src);
                 if (IS_JMP32_CLASS_OPCODE(inst.opcode)) {
                     source_cast = IS_SIGNED_CMP_OPCODE(inst.opcode) ? "(int32_t)" : "(uint32_t)";
@@ -1239,10 +1237,12 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
             }
 
             auto& format = _predicate_format_string[inst.opcode >> 4];
-            if (inst.opcode == EBPF_OP_JA) {
+            if (inst.opcode == INST_OP_JA16) {
                 std::string target = program_output[i + inst.offset + 1].label;
                 output.lines.push_back("goto " + target + ";");
-            } else if (inst.opcode == EBPF_OP_CALL) {
+            } else if (inst.opcode == INST_OP_JA32) {
+                // TODO
+            } else if (inst.opcode == INST_OP_CALL) {
                 std::string function_name;
                 if (output.relocation.empty()) {
                     function_name = std::vformat(
@@ -1264,7 +1264,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 output.lines.push_back(
                     std::format("if (({}.tail_call) && ({} == 0))", function_name, get_register_name(0)));
                 output.lines.push_back(INDENT "return 0;");
-            } else if (inst.opcode == EBPF_OP_EXIT) {
+            } else if (inst.opcode == INST_OP_EXIT) {
                 output.lines.push_back("return " + get_register_name(0) + ";");
             } else {
                 std::string target = program_output[i + inst.offset + 1].label;

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -981,7 +981,23 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 output.lines.push_back(std::format("{} ^= {};", destination, source));
                 break;
             case AluOperations::Mov:
-                output.lines.push_back(std::format("{} = {};", destination, source));
+                type = (is64bit) ? "(uint64_t)(int64_t)" : "(uint32_t)(int32_t)";
+                switch (inst.offset) {
+                case 0:
+                    output.lines.push_back(std::format("{} = {};", destination, source));
+                    break;
+                case 8:
+                    output.lines.push_back(std::format("{} = {}(int8_t){};", destination, type, source));
+                    break;
+                case 16:
+                    output.lines.push_back(std::format("{} = {}(int16_t){};", destination, type, source));
+                    break;
+                case 32:
+                    output.lines.push_back(std::format("{} = {}(int32_t){};", destination, type, source));
+                    break;
+                default:
+                    throw bpf_code_generator_exception("invalid operand", output.instruction_offset);
+                }
                 break;
             case AluOperations::Arsh:
                 if (is64bit) {


### PR DESCRIPTION
## Description

* Update CI/CD bpf_conformance job to test cpu=v4 commands.
* Remove movsx*-imm instructions from doc.  Per latest discussion on the mailing list at
https://mailarchive.ietf.org/arch/msg/bpf/uQiqhURdtxV_ZQOTgjCdm-seh74/ the MOVSX operation is only defined to support register extension.
* Add bpf2c support for swap* instructions.
* Add bpf2c support for movsx* instructions.
* Add bpf2c support for ja32 instruction.
* Change bpf2c to use verifier's `INST_`* defines where available, to start removing dependency from bpf2c on ubpf headers, since bpf2c should not use ubpf.

## Testing

This PR includes test updates.

## Documentation

This PR includes doc updates.

## Installation

No impact.
