### PR TITLE
Enable interlocked tests in bpf2c conformance

### DIFF
--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -114,7 +114,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v4 --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v4 --exclude_regex local --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2022

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -142,8 +142,8 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.5/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
-      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v4 --exclude_regex lock* --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
+      pre_test: gci env:*; Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.5/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+      test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v4 --exclude_regex local --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64
       environment: windows-2022

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -142,7 +142,7 @@ jobs:
     if: github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: gci env:*; Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.5/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.5/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
       test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v4 --exclude_regex local --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64

--- a/include/bpf2c.h
+++ b/include/bpf2c.h
@@ -19,7 +19,6 @@ typedef unsigned long long uint64_t;
 #define UINT32_MAX ((uint32_t)0xFFFFFFFF)
 
 #else
-#include <intrin.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>

--- a/tests/bpf2c_plugin/bpf2c_plugin.cpp
+++ b/tests/bpf2c_plugin/bpf2c_plugin.cpp
@@ -94,10 +94,10 @@ generate_c_file(const std::vector<ebpf_inst>& program, const std::filesystem::pa
 {
     std::filesystem::path c_file_path = file_path.string() + ".cpp";
     std::ofstream c_file(c_file_path);
+    emit_skeleton("test", bpf2c_plugin, c_file);
     bpf_code_generator code("test", program);
     code.generate("test");
     code.emit_c_code(c_file);
-    emit_skeleton("test", bpf2c_plugin, c_file);
     c_file.flush();
     c_file.close();
 }

--- a/tests/bpf2c_plugin/bpf2c_test.cpp
+++ b/tests/bpf2c_plugin/bpf2c_test.cpp
@@ -15,6 +15,7 @@
 #include <stdio.h>
 #include <string>
 #include <vector>
+#include <winnt.h>
 
 #define metadata_table ___METADATA_TABLE___##_metadata_table
 extern metadata_table_t metadata_table;

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_dll.c
@@ -135,7 +135,7 @@ func(void* context)
     r1 = IMMEDIATE(1);
     // EBPF_OP_ATOMIC64_ADD pc=9 dst=r0 src=r1 offset=0 imm=0
 #line 30 "sample/undocked/atomic_instruction_fetch_add.c"
-    _InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r0 + OFFSET(0)), (uint64_t)r1);
+    InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r0 + OFFSET(0)), (uint64_t)r1);
 label_1:
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 32 "sample/undocked/atomic_instruction_fetch_add.c"

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_raw.c
@@ -109,7 +109,7 @@ func(void* context)
     r1 = IMMEDIATE(1);
     // EBPF_OP_ATOMIC64_ADD pc=9 dst=r0 src=r1 offset=0 imm=0
 #line 30 "sample/undocked/atomic_instruction_fetch_add.c"
-    _InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r0 + OFFSET(0)), (uint64_t)r1);
+    InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r0 + OFFSET(0)), (uint64_t)r1);
 label_1:
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 32 "sample/undocked/atomic_instruction_fetch_add.c"

--- a/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_fetch_add_sys.c
@@ -270,7 +270,7 @@ func(void* context)
     r1 = IMMEDIATE(1);
     // EBPF_OP_ATOMIC64_ADD pc=9 dst=r0 src=r1 offset=0 imm=0
 #line 30 "sample/undocked/atomic_instruction_fetch_add.c"
-    _InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r0 + OFFSET(0)), (uint64_t)r1);
+    InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r0 + OFFSET(0)), (uint64_t)r1);
 label_1:
     // EBPF_OP_MOV64_IMM pc=10 dst=r0 src=r0 offset=0 imm=0
 #line 32 "sample/undocked/atomic_instruction_fetch_add.c"

--- a/tests/bpf2c_tests/expected/atomic_instruction_others_dll.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_others_dll.c
@@ -88,31 +88,31 @@ test(void* context)
     // EBPF_OP_MOV64_REG pc=12 dst=r2 src=r1 offset=0 imm=0
     r2 = r1;
     // EBPF_OP_ATOMIC64_ADD_FETCH pc=13 dst=r10 src=r2 offset=-16 imm=1
-    r2 = (uint64_t)_InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_IMM pc=14 dst=r2 src=r0 offset=0 imm=2
     r2 = IMMEDIATE(2);
     // EBPF_OP_ATOMIC64_OR_FETCH pc=15 dst=r10 src=r2 offset=-16 imm=65
-    r2 = (uint64_t)_InterlockedOr64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedOr64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r0 offset=0 imm=0
     r2 = r0;
     // EBPF_OP_ATOMIC64_AND_FETCH pc=17 dst=r10 src=r2 offset=-16 imm=81
-    r2 = (uint64_t)_InterlockedAnd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedAnd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_IMM pc=18 dst=r2 src=r0 offset=0 imm=4
     r2 = IMMEDIATE(4);
     // EBPF_OP_ATOMIC64_XOR pc=19 dst=r10 src=r2 offset=-16 imm=160
-    _InterlockedXor64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    InterlockedXor64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_ATOMIC_OR pc=20 dst=r10 src=r1 offset=-36 imm=64
-    _InterlockedOr((volatile long*)(uintptr_t)(r10 + OFFSET(-36)), (uint32_t)r1);
+    InterlockedOr((volatile long*)(uintptr_t)(r10 + OFFSET(-36)), (uint32_t)r1);
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-24 imm=0
     r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24));
     // EBPF_OP_ATOMIC64_XCHG pc=22 dst=r10 src=r1 offset=-16 imm=225
-    _InterlockedExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1);
+    InterlockedExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1);
     // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-32 imm=0
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_MOV64_IMM pc=24 dst=r1 src=r0 offset=0 imm=5
     r1 = IMMEDIATE(5);
     // EBPF_OP_ATOMIC64_CMPXCHG pc=25 dst=r10 src=r1 offset=-16 imm=241
-    r0 = (uint64_t)_InterlockedCompareExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1, r0);
+    r0 = (uint64_t)InterlockedCompareExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1, r0);
     // EBPF_OP_LDXDW pc=26 dst=r0 src=r10 offset=-56 imm=0
     r0 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56));
     // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/atomic_instruction_others_raw.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_others_raw.c
@@ -62,31 +62,31 @@ test(void* context)
     // EBPF_OP_MOV64_REG pc=12 dst=r2 src=r1 offset=0 imm=0
     r2 = r1;
     // EBPF_OP_ATOMIC64_ADD_FETCH pc=13 dst=r10 src=r2 offset=-16 imm=1
-    r2 = (uint64_t)_InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_IMM pc=14 dst=r2 src=r0 offset=0 imm=2
     r2 = IMMEDIATE(2);
     // EBPF_OP_ATOMIC64_OR_FETCH pc=15 dst=r10 src=r2 offset=-16 imm=65
-    r2 = (uint64_t)_InterlockedOr64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedOr64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r0 offset=0 imm=0
     r2 = r0;
     // EBPF_OP_ATOMIC64_AND_FETCH pc=17 dst=r10 src=r2 offset=-16 imm=81
-    r2 = (uint64_t)_InterlockedAnd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedAnd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_IMM pc=18 dst=r2 src=r0 offset=0 imm=4
     r2 = IMMEDIATE(4);
     // EBPF_OP_ATOMIC64_XOR pc=19 dst=r10 src=r2 offset=-16 imm=160
-    _InterlockedXor64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    InterlockedXor64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_ATOMIC_OR pc=20 dst=r10 src=r1 offset=-36 imm=64
-    _InterlockedOr((volatile long*)(uintptr_t)(r10 + OFFSET(-36)), (uint32_t)r1);
+    InterlockedOr((volatile long*)(uintptr_t)(r10 + OFFSET(-36)), (uint32_t)r1);
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-24 imm=0
     r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24));
     // EBPF_OP_ATOMIC64_XCHG pc=22 dst=r10 src=r1 offset=-16 imm=225
-    _InterlockedExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1);
+    InterlockedExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1);
     // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-32 imm=0
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_MOV64_IMM pc=24 dst=r1 src=r0 offset=0 imm=5
     r1 = IMMEDIATE(5);
     // EBPF_OP_ATOMIC64_CMPXCHG pc=25 dst=r10 src=r1 offset=-16 imm=241
-    r0 = (uint64_t)_InterlockedCompareExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1, r0);
+    r0 = (uint64_t)InterlockedCompareExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1, r0);
     // EBPF_OP_LDXDW pc=26 dst=r0 src=r10 offset=-56 imm=0
     r0 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56));
     // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0

--- a/tests/bpf2c_tests/expected/atomic_instruction_others_sys.c
+++ b/tests/bpf2c_tests/expected/atomic_instruction_others_sys.c
@@ -223,31 +223,31 @@ test(void* context)
     // EBPF_OP_MOV64_REG pc=12 dst=r2 src=r1 offset=0 imm=0
     r2 = r1;
     // EBPF_OP_ATOMIC64_ADD_FETCH pc=13 dst=r10 src=r2 offset=-16 imm=1
-    r2 = (uint64_t)_InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedExchangeAdd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_IMM pc=14 dst=r2 src=r0 offset=0 imm=2
     r2 = IMMEDIATE(2);
     // EBPF_OP_ATOMIC64_OR_FETCH pc=15 dst=r10 src=r2 offset=-16 imm=65
-    r2 = (uint64_t)_InterlockedOr64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedOr64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_REG pc=16 dst=r2 src=r0 offset=0 imm=0
     r2 = r0;
     // EBPF_OP_ATOMIC64_AND_FETCH pc=17 dst=r10 src=r2 offset=-16 imm=81
-    r2 = (uint64_t)_InterlockedAnd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    r2 = (uint64_t)InterlockedAnd64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_MOV64_IMM pc=18 dst=r2 src=r0 offset=0 imm=4
     r2 = IMMEDIATE(4);
     // EBPF_OP_ATOMIC64_XOR pc=19 dst=r10 src=r2 offset=-16 imm=160
-    _InterlockedXor64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
+    InterlockedXor64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r2);
     // EBPF_OP_ATOMIC_OR pc=20 dst=r10 src=r1 offset=-36 imm=64
-    _InterlockedOr((volatile long*)(uintptr_t)(r10 + OFFSET(-36)), (uint32_t)r1);
+    InterlockedOr((volatile long*)(uintptr_t)(r10 + OFFSET(-36)), (uint32_t)r1);
     // EBPF_OP_LDXDW pc=21 dst=r1 src=r10 offset=-24 imm=0
     r1 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-24));
     // EBPF_OP_ATOMIC64_XCHG pc=22 dst=r10 src=r1 offset=-16 imm=225
-    _InterlockedExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1);
+    InterlockedExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1);
     // EBPF_OP_STXDW pc=23 dst=r10 src=r1 offset=-32 imm=0
     *(uint64_t*)(uintptr_t)(r10 + OFFSET(-32)) = (uint64_t)r1;
     // EBPF_OP_MOV64_IMM pc=24 dst=r1 src=r0 offset=0 imm=5
     r1 = IMMEDIATE(5);
     // EBPF_OP_ATOMIC64_CMPXCHG pc=25 dst=r10 src=r1 offset=-16 imm=241
-    r0 = (uint64_t)_InterlockedCompareExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1, r0);
+    r0 = (uint64_t)InterlockedCompareExchange64((volatile int64_t*)(uintptr_t)(r10 + OFFSET(-16)), (uint64_t)r1, r0);
     // EBPF_OP_LDXDW pc=26 dst=r0 src=r10 offset=-56 imm=0
     r0 = *(uint64_t*)(uintptr_t)(r10 + OFFSET(-56));
     // EBPF_OP_EXIT pc=27 dst=r0 src=r0 offset=0 imm=0

--- a/tools/bpf2c/bpf_code_generator.cpp
+++ b/tools/bpf2c/bpf_code_generator.cpp
@@ -1191,7 +1191,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 case EBPF_ATOMIC_ADD:
                 case EBPF_ATOMIC_ADD_FETCH:
                     line = std::format(
-                        "_InterlockedExchangeAdd{}(({}*)(uintptr_t)({} + {}), {});",
+                        "InterlockedExchangeAdd{}(({}*)(uintptr_t)({} + {}), {});",
                         size_num,
                         lock_type,
                         destination,
@@ -1201,7 +1201,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 case EBPF_ATOMIC_OR:
                 case EBPF_ATOMIC_OR_FETCH:
                     line = std::format(
-                        "_InterlockedOr{}(({}*)(uintptr_t)({} + {}), {});",
+                        "InterlockedOr{}(({}*)(uintptr_t)({} + {}), {});",
                         size_num,
                         lock_type,
                         destination,
@@ -1211,7 +1211,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 case EBPF_ATOMIC_AND:
                 case EBPF_ATOMIC_AND_FETCH:
                     line = std::format(
-                        "_InterlockedAnd{}(({}*)(uintptr_t)({} + {}), {});",
+                        "InterlockedAnd{}(({}*)(uintptr_t)({} + {}), {});",
                         size_num,
                         lock_type,
                         destination,
@@ -1221,7 +1221,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 case EBPF_ATOMIC_XOR:
                 case EBPF_ATOMIC_XOR_FETCH:
                     line = std::format(
-                        "_InterlockedXor{}(({}*)(uintptr_t)({} + {}), {});",
+                        "InterlockedXor{}(({}*)(uintptr_t)({} + {}), {});",
                         size_num,
                         lock_type,
                         destination,
@@ -1231,7 +1231,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 case EBPF_ATOMIC_XCHG:
                     is_complex = true;
                     line = std::format(
-                        "_InterlockedExchange{}(({}*)(uintptr_t)({} + {}), {});",
+                        "InterlockedExchange{}(({}*)(uintptr_t)({} + {}), {});",
                         size_num,
                         lock_type,
                         destination,
@@ -1241,7 +1241,7 @@ bpf_code_generator::encode_instructions(const bpf_code_generator::unsafe_string&
                 case EBPF_ATOMIC_CMPXCHG:
                     is_complex = true;
                     line = std::format(
-                        "r0 = ({})_InterlockedCompareExchange{}(({}*)(uintptr_t)({} + {}), {}, r0);",
+                        "r0 = ({})InterlockedCompareExchange{}(({}*)(uintptr_t)({} + {}), {}, r0);",
                         size_type,
                         size_num,
                         lock_type,


### PR DESCRIPTION
Resolves: #3188

## Description

Switch from intrinsic form of interlocked instructions to function call version (supported in user mode and kernel mode).

## Testing

CI/CD

## Documentation

No.

## Installation

_Is there any installer impact for this change?_
