### PR TITLE
Improve documentation for running the port_quota demo.

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -199,9 +199,13 @@ This section shows how to use eBPF for Windows in a demo that lets us control a 
 
 #### Prep
 
-1. Build the ``port_leak`` and ``port_quota`` applications from under the tools project.
-1. Copy both the exe's to a machine that has eBPF installed. See
-   [Installing eBPF for Windows](#installing-ebpf-for-windows)
+1. Build the solution with the Release configuration. (Debug will also work for the usermode components.)
+1. Copy the entire contents of the build folder to your test machine; this is more than is minimally necessary, but
+   reduces the risk of missing necessary binaries.
+1. Install eBPF on the test machine; see [Installing eBPF for Windows](#installing-ebpf-for-windows), using method 2.
+
+If the script mechanism is unavailable, install the MSI that you copied over, then run `ebpfSvc.exe install` to register
+the usermode service, which is required for `port_quota.exe` to work.
 
 #### Demo
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -200,12 +200,13 @@ This section shows how to use eBPF for Windows in a demo that lets us control a 
 #### Prep
 
 1. Build the solution with the Release configuration. (Debug will also work for the usermode components.)
-1. Copy the entire contents of the build folder to your test machine; this is more than is minimally necessary, but
-   reduces the risk of missing necessary binaries.
-1. Install eBPF on the test machine; see [Installing eBPF for Windows](#installing-ebpf-for-windows), using method 2.
+1. Install eBPF on the test machine; see [Installing eBPF for Windows](#installing-ebpf-for-windows), using [Method 2](InstallEbpf.md#method-2-install-files-you-built-yourself)
 
-If the script mechanism is unavailable, install the MSI that you copied over, then run `ebpfSvc.exe install` to register
-the usermode service, which is required for `port_quota.exe` to work.
+> [!NOTE]
+> If Method 2 will not work for your envrionment for whatever reason (you aren't using a local Hyper-V VM, for instance),
+> manually copy over the contents of the build folder, then proceed with the instructions above from the target VM. If the
+> script is unavailable, install the MSI that you copied over on the VM, then run `ebpfSvc.exe install` to register
+> the usermode service, which is required for `port_quota.exe` to work.
 
 #### Demo
 


### PR DESCRIPTION
Resolves: #3192

## Description

This change expands the documentation of the port_quota example to work around a number of potential issues a new user may encounter when attempting to run the demo, because the existing documentation was very incomplete.
 
## Testing

This change does not include any code changes.

## Documentation

_Is there any documentation impact for this change?_ Yes, see description.

## Installation

_Is there any installer impact for this change?_ No. This is a docs-only change.
