### PR TITLE
If setting initial value of maps fails, ebpf native module leaks handles

### DIFF
--- a/libs/execution_context/ebpf_native.c
+++ b/libs/execution_context/ebpf_native.c
@@ -1675,6 +1675,7 @@ ebpf_native_load_programs(
     wchar_t* local_service_name = NULL;
     bool module_referenced = false;
     bool maps_created = false;
+    bool programs_created = false;
     bool cleanup_context_created = false;
 
     if ((count_of_map_handles > 0 && map_handles == NULL) ||
@@ -1770,6 +1771,7 @@ ebpf_native_load_programs(
             module_id);
         goto Done;
     }
+    programs_created = true;
 
     // Set initial map values.
     result = _ebpf_native_set_initial_map_values(module);
@@ -1821,6 +1823,16 @@ Done:
             module->maps = NULL;
             module->map_count = 0;
         }
+
+        if (programs_created) {
+            for (uint32_t i = 0; i < module->program_count; i++) {
+                module->handle_cleanup_context.handle_information->program_handles[i] = module->programs[i].handle;
+            }
+            _ebpf_native_clean_up_programs(module->programs, module->program_count, false);
+            module->programs = NULL;
+            module->program_count = 0;
+        }
+
         ebpf_free(local_service_name);
 
         if (cleanup_context_created) {


### PR DESCRIPTION
## Description

The function ebpf_native_load_programs leaks handles if initialization of native modules fails.

## Testing

CI/CD + fault injection.

## Documentation

No.

## Installation

No.
