### PR TITLE
ISA support updates

### DIFF
--- a/docs/isa-support.rst
+++ b/docs/isa-support.rst
@@ -30,70 +30,44 @@ opcode  src   imm   off   description                                           
 0x1d    any   0x00  any   if dst == src goto +offset                                 Y      Y      Y    jeq-reg
 0x1e    any   0x00  any   if (u32)dst == (u32)src goto +offset                       Y      Y      Y    jeq32-reg
 0x1f    any   0x00  0     dst -= src                                                 Y      Y      Y    alu64-arith
-0x20    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x21    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x22    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x23    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
+0x20    any   any   any   (deprecated, implementation-specific)                      Y      no     no   (none)
 0x24    0x0   any   0     dst = (u32)(dst \* imm)                                    Y      Y      Y    mul32-imm
 0x25    0x0   any   any   if dst > imm goto +offset                                  Y      Y      Y    jgt-imm
 0x26    0x0   any   any   if (u32)dst > imm goto +offset                             Y      Y      Y    jgt32-imm
 0x27    0x0   any   0     dst \*= imm                                                Y      Y      Y    mul64-imm
-0x28    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x29    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x2a    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x2b    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
+0x28    any   any   any   (deprecated, implementation-specific)                      Y      no     no   (none)
 0x2c    any   0x00  0     dst = (u32)(dst \* src)                                    Y      Y      Y    mul32-reg
 0x2d    any   0x00  any   if dst > src goto +offset                                  Y      Y      Y    jgt-reg
 0x2e    any   0x00  any   if (u32)dst > (u32)src goto +offset                        Y      Y      Y    jgt32-reg
 0x2f    any   0x00  0     dst \*= src                                                Y      Y      Y    mul64-reg
-0x30    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x31    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x32    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x33    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
+0x30    any   any   any   (deprecated, implementation-specific)                      Y      no     no   (none)
 0x34    0x0   any   0     dst = (u32)((imm != 0) ? ((u32)dst / (u32)imm) : 0)        Y      Y      Y    alu-arith
 0x34    0x0   any   1     dst = (u32)((imm != 0) ? ((s32)dst s/ imm) : 0)            Y      no     Y    sdiv32-imm
 0x35    0x0   any   any   if dst >= imm goto +offset                                 Y      Y      Y    jge-imm
 0x36    0x0   any   any   if (u32)dst >= imm goto +offset                            Y      Y      Y    jge32-imm
 0x37    0x0   any   0     dst = (imm != 0) ? (dst / (u32)imm) : 0                    Y      Y      Y    alu64-arith
 0x37    0x0   any   1     dst = (imm != 0) ? (dst s/ imm) : 0                        Y      no     Y    sdiv64-imm
-0x38    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x39    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x3a    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x3b    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
 0x3c    any   0x00  0     dst = (u32)((src != 0) ? ((u32)dst / (u32)src) : 0)        Y      Y      Y    alu-arith
 0x3c    any   0x00  1     dst = (u32)((src != 0) ? ((s32)dst s/ (s32)src) : 0)       Y      no     Y    sdiv32-reg
 0x3d    any   0x00  any   if dst >= src goto +offset                                 Y      Y      Y    prime
 0x3e    any   0x00  any   if (u32)dst >= (u32)src goto +offset                       Y      Y      Y    jge32-reg
 0x3f    any   0x00  0     dst = (src !+ 0) ? (dst / src) : 0                         Y      Y      Y    alu64-arith
 0x3f    any   0x00  1     dst = (src !+ 0) ? (dst s/ src) : 0                        Y      no     Y    sdiv64-reg
-0x40    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x41    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x42    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x43    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
+0x40    any   any   any   (deprecated, implementation-specific)                      Y      no     no   (none)
 0x44    0x0   any   0     dst = (u32)(dst \| imm)                                    Y      Y      Y    alu-bit
 0x45    0x0   any   any   if dst & imm goto +offset                                  Y      Y      Y    jset-imm
 0x46    0x0   any   any   if (u32)dst & imm goto +offset                             Y      Y      Y    jset32-imm
 0x47    0x0   any   0     dst \|= imm                                                Y      Y      Y    alu64-bit
-0x48    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x49    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x4a    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x4b    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
+0x48    any   any   any   (deprecated, implementation-specific)                      Y      no     no   (none)
 0x4c    any   0x00  0     dst = (u32)(dst \| src)                                    Y      Y      Y    alu-bit
 0x4d    any   0x00  any   if dst & src goto +offset                                  Y      Y      Y    jset-reg
 0x4e    any   0x00  any   if (u32)dst & (u32)src goto +offset                        Y      Y      Y    jset32-reg
 0x4f    any   0x00  0     dst \|= src                                                Y      Y      Y    alu64-bit
-0x50    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x51    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x52    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x53    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
+0x50    any   any   any   (deprecated, implementation-specific)                      Y      no     no   (none)
 0x54    0x0   any   0     dst = (u32)(dst & imm)                                     Y      Y      Y    alu-bit
 0x55    0x0   any   any   if dst != imm goto +offset                                 Y      Y      Y    alu-arith
 0x56    0x0   any   any   if (u32)dst != imm goto +offset                            Y      Y      Y    jne32-imm
 0x57    0x0   any   0     dst &= imm                                                 Y      Y      Y    alu64-bit
-0x58    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x59    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x5a    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
-0x5b    any   any   any   (deprecated, implementation-specific)                      no     no     no   (none)
 0x5c    any   0x00  0     dst = (u32)(dst & src)                                     Y      Y      Y    alu-bit
 0x5d    any   0x00  any   if dst != src goto +offset                                 Y      Y      Y    jne-reg
 0x5e    any   0x00  any   if (u32)dst != (u32)src goto +offset                       Y      Y      Y    jne32-reg
@@ -162,34 +136,15 @@ opcode  src   imm   off   description                                           
 0xbf    any   0x00  16    dst = (s64) (s16) src                                      Y      no     Y    movsx1664-reg
 0xbf    any   0x00  32    dst = (s64) (s32) src                                      Y      no     Y    movsx3264-reg
 0xc3    any   0x00  any   lock \*(u32 \*)(dst + offset) += src                       no     no     Y    lock_add32
-0xc3    any   0x01  any   | lock                                                     no     no     Y    lock_fetch_add32
-                          | temp = \*(u32 \*)(dst + offset)
-                          | \*(u32 \*)(dst + offset) += src
-                          | src = temp
+0xc3    any   0x01  any   src = atomic_fetch_add_32((u32 \*)(dst + offset), src)     no     no     Y    lock_fetch_add32
 0xc3    any   0x40  any   lock \*(u32 \*)(dst + offset) \|= src                      no     no     Y    lock_or32
-0xc3    any   0x41  any   | lock                                                     no     no     Y    lock_fetch_or32
-                          | temp = \*(u32 \*)(dst + offset)
-                          | \*(u32 \*)(dst + offset) |= src
-                          | src = temp
+0xc3    any   0x41  any   src = atomic_fetch_or_32((u32 \*)(dst + offset), src)      no     no     Y    lock_fetch_or32
 0xc3    any   0x50  any   lock \*(u32 \*)(dst + offset) &= src                       no     no     Y    lock_and32
-0xc3    any   0x51  any   | lock                                                     no     no     Y    lock_fetch_and32
-                          | temp = \*(u32 \*)(dst + offset)
-                          | \*(u32 *)(dst + offset) &= src
-                          | src = temp
+0xc3    any   0x51  any   src = atomic_fetch_and_32((u32 \*)(dst + offset), src)     no     no     Y    lock_fetch_and32
 0xc3    any   0xa0  any   lock \*(u32 \*)(dst + offset) ^= src                       no     no     Y    lock_xor32
-0xc3    any   0xa1  any   | lock                                                     no     no     Y    lock_fetch_xor32
-                          | temp = \*(u32 \*)(dst + offset)
-                          | \*(u32 \*)(dst + offset) ^= src
-                          | src = temp
-0xc3    any   0xe1  any   | lock                                                     no     no     Y    lock_xchg32
-                          | temp = \*(u32 \*)(dst + offset)
-                          | \*(u32 \*)(dst + offset) = src
-                          | src = temp
-0xc3    any   0xf1  any   | lock                                                     no     no     Y    lock_cmpxchg32
-                          | temp = \*(u32 \*)(dst + offset)
-                          | if \*(u32)(dst + offset) == R0
-                          |    \*(u32)(dst + offset) = src
-                          | R0 = temp
+0xc3    any   0xa1  any   src = atomic_fetch_xor_32((u32 \*)(dst + offset), src)     no     no     Y    lock_fetch_xor32
+0xc3    any   0xe1  any   src = xchg_32((u32 \*)(dst + offset), src)                 no     no     Y    lock_xchg32
+0xc3    any   0xf1  any   r0 = cmpxchg_32((u32 \*)(dst + offset), r0, src)           no     no     Y    lock_cmpxchg32
 0xc4    0x0   any   0     dst = (u32)(dst s>> imm)                                   Y      Y      Y    arsh
 0xc5    0x0   any   any   if dst s< imm goto +offset                                 Y      Y      Y    jslt-imm
 0xc6    0x0   any   any   if (s32)dst s< (s32)imm goto +offset                       Y      Y      Y    jslt32-imm
@@ -207,46 +162,24 @@ opcode  src   imm   off   description                                           
 0xd7    0x0   0x20  0     dst = bswap32(dst)                                         Y      no     Y    swap32
 0xd7    0x0   0x40  0     dst = bswap64(dst)                                         Y      no     Y    swap64
 0xdb    any   0x00  any   lock \*(u64 \*)(dst + offset) += src                       no     no     Y    lock_add
-0xdb    any   0x01  any   | lock                                                     no     no     Y    lock_fetch_add
-                          | temp = \*(u64 \*)(dst + offset)
-                          | \*(u64 \*)(dst + offset) += src
-                          | src = temp
+0xdb    any   0x01  any   src = atomic_fetch_add_64((u64 \*)(dst + offset), src)     no     no     Y    lock_fetch_add
 0xdb    any   0x40  any   lock \*(u64 \*)(dst + offset) \|= src                      no     no     Y    lock_or
-0xdb    any   0x41  any   | lock                                                     no     no     Y    lock_fetch_or
-                          | temp = \*(u64 \*)(dst + offset)
-                          | \*(u64 \*)(dst + offset) |= src
-                          | src = temp
+0xdb    any   0x41  any   src = atomic_fetch_or_64((u64 \*)(dst + offset), src)      no     no     Y    lock_fetch_or
 0xdb    any   0x50  any   lock \*(u64 \*)(dst + offset) &= src                       no     no     Y    lock_and
-0xdb    any   0x51  any   | lock                                                     no     no     Y    lock_fetch_and
-                          | temp = \*(u64 \*)(dst + offset)
-                          | \*(u64 \*)(dst + offset) &= src
-                          | src = temp
+0xdb    any   0x51  any   src = atomic_fetch_and_64((u64 \*)(dst + offset), src)     no     no     Y    lock_fetch_and
 0xdb    any   0xa0  any   lock \*(u64 \*)(dst + offset) ^= src                       no     no     Y    lock_xor
-0xdb    any   0xa1  any   | lock                                                     no     no     Y    lock_fetch_xor
-                          | temp = \*(u64 \*)(dst + offset)
-                          | \*(u64 \*)(dst + offset) ^= src
-                          | src = temp
-0xdb    any   0xe1  any   | lock                                                     no     no     Y    lock_xchg
-                          | temp = \*(u64 \*)(dst + offset)
-                          | \*(u64 \*)(dst + offset) = src
-                          | src = temp
-0xdb    any   0xf1  any   | lock                                                     no     no     Y    lock_cmpxchg
-                          | temp = \*(u64 \*)(dst + offset)
-                          | if \*(u64)(dst + offset) == R0
-                          |    \*(u64)(dst + offset) = src
-                          | R0 = temp
-0xdc    0x0   0x10  0     dst = htobe16(dst)                                         Y      Y     Y     be16
-0xdc    0x0   0x20  0     dst = htobe32(dst)                                         Y      Y     Y     be32
-0xdc    0x0   0x40  0     dst = htobe64(dst)                                         Y      Y     Y     be64
-0xdd    any   0x00  any   if dst s<= src goto +offset                                Y      Y     Y     jsle-reg
-0xde    any   0x00  any   if (s32)dst s<= (s32)src goto +offset                      Y      Y     Y     jsle32-reg
+0xdb    any   0xa1  any   src = atomic_fetch_xor_64((u64 \*)(dst + offset), src)     no     no     Y    lock_fetch_xor
+0xdb    any   0xe1  any   src = xchg_64((u64 \*)(dst + offset), src)                 no     no     Y    lock_xchg
+0xdb    any   0xf1  any   r0 = cmpxchg_64((u64 \*)(dst + offset), r0, src)           no     no     Y    lock_cmpxchg
+0xdc    0x0   0x10  0     dst = htobe16(dst)                                         Y      Y      Y    be16
+0xdc    0x0   0x20  0     dst = htobe32(dst)                                         Y      Y      Y    be32
+0xdc    0x0   0x40  0     dst = htobe64(dst)                                         Y      Y      Y    be64
+0xdd    any   0x00  any   if dst s<= src goto +offset                                Y      Y      Y    jsle-reg
+0xde    any   0x00  any   if (s32)dst s<= (s32)src goto +offset                      Y      Y      Y    jsle32-reg
 ======  ====  ====  ====  ======================================================  =======  ====  =====  ======================
 
 **Some takeaways:**
 
-* Some ldx instruction conformance issues still exist in the PREVAIL verifier, where instructions
-  fail verification that shouldn't.  This is not a security issue, it might simply prevent some valid
-  programs from being verified (https://github.com/vbpf/ebpf-verifier/issues/420).
 * Atomic instructions are not supported by any of the components, though this is not a major problem
   as they will not be generated by clang when an older "cpu version" is specified on the command line.
 * The conformance suite does not support most 64-bit immediate instructions


### PR DESCRIPTION
## Description

Changes to match latest draft-ietf-bpf-isa

Also correct legacy packet instruction lines to show that PREVAIL does support them.  https://github.com/vbpf/ebpf-verifier/pull/577 will update the verifier so make such support a platform specific property but that hasn't been merged yet so this PR reflects current state.

## Testing

No impact.

## Documentation

This is a documentation change.

## Installation

No impact.