### PR TITLE
Fix `bpf obj get()` behavior.

### DIFF
--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -535,9 +535,9 @@ ebpf_object_pin(fd_t fd, _In_z_ const char* path) noexcept;
 /**
  * @brief Get fd for a pinned object by pin path.
  * @param[in] path Pin path for the object.
- * @param[out] fd file descriptor for the pinned object, -1 if not found.
+ * @param[out] fd File descriptor for the pinned object, -1 if not found.
  *
- * @return EBPF_SUCCESS on success, or an error code on failure.
+ * @retval EBPF_SUCCESS on success, or an error code on failure.
  */
 ebpf_result_t
 ebpf_object_get(_In_z_ const char* path, _Out_ fd_t* fd) noexcept;

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -535,11 +535,12 @@ ebpf_object_pin(fd_t fd, _In_z_ const char* path) noexcept;
 /**
  * @brief Get fd for a pinned object by pin path.
  * @param[in] path Pin path for the object.
+ * @param[out] fd file descriptor for the pinned object, -1 if not found.
  *
- * @return File descriptor for the pinned object, -1 if not found.
+ * @return EBPF_SUCCESS on success, or an error code on failure.
  */
-fd_t
-ebpf_object_get(_In_z_ const char* path) noexcept;
+ebpf_result_t
+ebpf_object_get(_In_z_ const char* path, _Out_ fd_t* fd) noexcept;
 
 /**
  * @brief Open a file without loading the programs.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2966,7 +2966,7 @@ _ebpf_object_reuse_map(_Inout_ ebpf_map_t* map) NO_EXCEPT_TRY
     // If there is no map at this pin path, then we can (re)use the map.
     fd_t map_fd = ebpf_fd_invalid;
     result = ebpf_object_get(map->pin_path, &map_fd);
-    if (map_fd == ebpf_fd_invalid) {
+    if (result != EBPF_SUCCESS) {
         EBPF_RETURN_RESULT(EBPF_SUCCESS);
     }
 

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2961,7 +2961,7 @@ _ebpf_object_reuse_map(_Inout_ ebpf_map_t* map) NO_EXCEPT_TRY
 
     ebpf_assert(map);
 
-    // Check if a map is already present with this pin path.
+    // If there is no map at this pin path, then we can (re)use the map.
     fd_t map_fd = ebpf_fd_invalid;
     result = ebpf_object_get(map->pin_path, &map_fd);
     if (map_fd == ebpf_fd_invalid) {

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1409,10 +1409,12 @@ ebpf_map_unpin(_In_ struct bpf_map* map, _In_opt_z_ const char* path) NO_EXCEPT_
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 
-fd_t
-ebpf_object_get(_In_z_ const char* path) NO_EXCEPT_TRY
+ebpf_result_t
+ebpf_object_get(_In_z_ const char* path, _Out_ fd_t* fd) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
+    ebpf_assert(fd);
+
     size_t path_length = strlen(path);
     ebpf_protocol_buffer_t request_buffer(offsetof(ebpf_operation_get_pinned_object_request_t, path) + path_length);
     auto request = reinterpret_cast<ebpf_operation_get_pinned_object_request_t*>(request_buffer.data());
@@ -1424,19 +1426,20 @@ ebpf_object_get(_In_z_ const char* path) NO_EXCEPT_TRY
     std::copy(path, path + path_length, request->path);
     auto result = invoke_ioctl(request_buffer, reply);
     if (result != ERROR_SUCCESS) {
-        EBPF_RETURN_FD(ebpf_fd_invalid);
+        *fd = (fd_t)ebpf_fd_invalid;
+        EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(result));
     }
 
     ebpf_assert(reply.header.id == ebpf_operation_id_t::EBPF_OPERATION_GET_PINNED_OBJECT);
 
     ebpf_handle_t handle = reply.handle;
-    fd_t fd = _create_file_descriptor_for_handle(handle);
-    if (fd == ebpf_fd_invalid) {
+    *fd = _create_file_descriptor_for_handle(handle);
+    if (*fd == ebpf_fd_invalid) {
         Platform::CloseHandle(handle);
     }
-    EBPF_RETURN_FD(fd);
+    EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(GetLastError()));
 }
-CATCH_NO_MEMORY_FD
+CATCH_NO_MEMORY_EBPF_RESULT
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_program_query_info(
@@ -2959,7 +2962,8 @@ _ebpf_object_reuse_map(_Inout_ ebpf_map_t* map) NO_EXCEPT_TRY
     ebpf_assert(map);
 
     // Check if a map is already present with this pin path.
-    fd_t map_fd = ebpf_object_get(map->pin_path);
+    fd_t map_fd = ebpf_fd_invalid;
+    result = ebpf_object_get(map->pin_path, &map_fd);
     if (map_fd == ebpf_fd_invalid) {
         EBPF_RETURN_RESULT(EBPF_SUCCESS);
     }

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -1436,8 +1436,10 @@ ebpf_object_get(_In_z_ const char* path, _Out_ fd_t* fd) NO_EXCEPT_TRY
     *fd = _create_file_descriptor_for_handle(handle);
     if (*fd == ebpf_fd_invalid) {
         Platform::CloseHandle(handle);
+        result = EBPF_NO_MEMORY;
     }
-    EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(GetLastError()));
+
+    EBPF_RETURN_RESULT(win32_error_code_to_ebpf_result(result));
 }
 CATCH_NO_MEMORY_EBPF_RESULT
 

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -82,7 +82,9 @@ bpf_obj_pin(int fd, const char* pathname)
 int
 bpf_obj_get(const char* pathname)
 {
-    return (int)ebpf_object_get(pathname);
+    fd_t fd = -1;
+    libbpf_result_err(ebpf_object_get(pathname, &fd)); // set the errno
+    return fd;
 }
 
 struct bpf_object*

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -511,6 +511,7 @@ TEST_CASE("libbpf program pinning", "[libbpf]")
     _test_helper_libbpf test_helper;
     test_helper.initialize();
     const char* pin_path = "\\temp\\test";
+    const char* bad_pin_path = "\\bad\\path";
 
     struct bpf_object* object = bpf_object__open("test_sample_ebpf.o");
     REQUIRE(object != nullptr);
@@ -528,6 +529,14 @@ TEST_CASE("libbpf program pinning", "[libbpf]")
     result = bpf_program__pin(program, pin_path);
     REQUIRE(result < 0);
     REQUIRE(errno == EEXIST);
+
+    // Test bpf_obj_get() to return the fd and correctly set 'errno'
+    fd_t obj_fd = bpf_obj_get(pin_path);
+    REQUIRE(obj_fd != ebpf_fd_invalid);
+    REQUIRE(errno == 0);
+    obj_fd = bpf_obj_get(bad_pin_path);
+    REQUIRE(obj_fd == ebpf_fd_invalid);
+    REQUIRE(errno == ENOENT);
 
     result = bpf_program__unpin(program, pin_path);
     REQUIRE(result == 0);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -530,7 +530,7 @@ TEST_CASE("libbpf program pinning", "[libbpf]")
     REQUIRE(result < 0);
     REQUIRE(errno == EEXIST);
 
-    // Test bpf_obj_get() to return the fd and correctly set 'errno'
+    // Test bpf_obj_get() to return the fd and correctly set 'errno'.
     fd_t obj_fd = bpf_obj_get(pin_path);
     REQUIRE(obj_fd != ebpf_fd_invalid);
     REQUIRE(errno == EEXIST);

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -533,7 +533,7 @@ TEST_CASE("libbpf program pinning", "[libbpf]")
     // Test bpf_obj_get() to return the fd and correctly set 'errno'
     fd_t obj_fd = bpf_obj_get(pin_path);
     REQUIRE(obj_fd != ebpf_fd_invalid);
-    REQUIRE(errno == 0);
+    REQUIRE(errno == EEXIST);
     obj_fd = bpf_obj_get(bad_pin_path);
     REQUIRE(obj_fd == ebpf_fd_invalid);
     REQUIRE(errno == ENOENT);


### PR DESCRIPTION
Fixes #3234

## Description
Fixes the behavior of `bpf_obj_get()` to comply with the official specs: https://docs.kernel.org/userspace-api/ebpf/syscall.html

## Testing

CI/CD

## Documentation

n.a.

## Installation

n.a.
