### PR TITLE
Eliminate unneeded interlocked operation on LPM updates

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -1651,7 +1651,10 @@ _update_lpm_map_entry(
 
     ebpf_result_t result = _update_hash_map_entry(map, key, data, option);
     if (result == EBPF_SUCCESS) {
-        ebpf_bitmap_set_bit((ebpf_bitmap_t*)trie_map->data, prefix_length, true);
+        // Test if the bit is set before setting it. This avoids the overhead of a the interlocked operation.
+        if (!ebpf_bitmap_test_bit((ebpf_bitmap_t*)trie_map->data, prefix_length)) {
+            ebpf_bitmap_set_bit((ebpf_bitmap_t*)trie_map->data, prefix_length, true);
+        }
     }
     return result;
 }


### PR DESCRIPTION
## Description

LPM tracks prefix lengths stored in the hash-table via a bitmap. This bitmap is only ever added to (never removed) so unconditionally doing an interlocked test and set is excessive.

Possibly related to: #3016

## Testing

CI/CD

## Documentation

No.

## Installation

No.
