### PR TITLE
Ensure that LPM's prefix bitmap is always 64bit aligned

### DIFF
--- a/libs/execution_context/ebpf_maps.c
+++ b/libs/execution_context/ebpf_maps.c
@@ -104,7 +104,7 @@ typedef struct _ebpf_core_lpm_map
     ebpf_core_map_t core_map;
     uint32_t max_prefix;
     // Bitmap of prefix lengths inserted into the map.
-    uint8_t data[1];
+    uint64_t data[1];
 } ebpf_core_lpm_map_t;
 
 typedef struct _ebpf_core_ring_buffer_map


### PR DESCRIPTION
## Description

The LPM map tracks prefix lengths in a bitmap. Updates to the bitmap are done using 64bit interlocked operations. If the bitmap isn't 64bit aligned, then this can result in 64bit interlocked operations that cross cache lines, which cause a system wide memory stall (due to interlocked operation needing to lock the bus).

## Testing

CI/CD

## Documentation

No.

## Installation

No.
