### PR TITLE
Update cicd-release-validation.yml (#3245)

### DIFF
--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -113,7 +113,7 @@ jobs:
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.4/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
+      pre_test: Invoke-WebRequest https://github.com/Alan-Jowett/bpf_conformance/releases/download/v0.0.5/bpf_conformance_runner.exe -OutFile bpf_conformance_runner.exe
       test_command: .\bpf_conformance_runner.exe --test_file_directory %SOURCE_ROOT%\external\ebpf-verifier\external\bpf_conformance\tests --cpu_version v4 --exclude_regex local --plugin_path bpf2c_plugin.exe --debug true --plugin_options "--include %SOURCE_ROOT%\include"
       name: bpf2c_conformance
       build_artifact: Build-x64


### PR DESCRIPTION
The file cicd-release-validation.yml wasn't updated to match cicd.yml.

## Description

Update the CI/CD pipeline in release/0.14.0 branch.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
