### PR TITLE
Fix issue with > 64 cpus

### DIFF
--- a/libs/runtime/ebpf_work_queue.c
+++ b/libs/runtime/ebpf_work_queue.c
@@ -58,7 +58,11 @@ ebpf_timed_work_queue_create(
         goto Done;
     }
 
-    KeSetTargetProcessorDpcEx(&local_work_queue->dpc, &processor_number);
+    status = KeSetTargetProcessorDpcEx(&local_work_queue->dpc, &processor_number);
+    if (!NT_SUCCESS(status)) {
+        return_value = EBPF_INVALID_ARGUMENT;
+        goto Done;
+    }
 
     *work_queue = local_work_queue;
     local_work_queue = NULL;


### PR DESCRIPTION
## Description

KeSetTargetProcessorDpc should not be used on systems with > 64 CPUs. KeSetTargetProcessorDpcEx should be used instead.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
