### PR TITLE
Fix scorecards workflow runs

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -40,7 +40,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             api.osv.dev:443
-            bestpractices.coreinfrastructure.org:443
+            www.bestpractices.dev:443
             github.com:443
 
       - name: "Checkout code"


### PR DESCRIPTION
## Description

https://github.com/microsoft/ebpf-for-windows/actions/workflows/scorecards-analysis.yml?query=branch%3Amain shows that the scorecards workflow is consistently failing in main.

As can be seen at
https://app.stepsecurity.io/github/microsoft/ebpf-for-windows/actions/runs/8052805389 we are hitting the errors because the score card action tries to access www.bestpractices.dev.  This is the new name of
bestpractices.coreinfrastructure.org which was allowed (indeed if you try to go to that site in a browser, it now redirects to www.bestpractices.dev).  This updates the ACL with the new domain name.

## Testing

Covered by CI/CD.

## Documentation

No impact.

## Installation

No impact.
