### PR TITLE
Eliminate calls with FILE_FLAG_OVERLAPPED set, but no overlapped

### DIFF
--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4472,7 +4472,8 @@ ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options)
     if (result == EBPF_PENDING) {
         unsigned long bytes_returned;
         completion_event.wait();
-        if (GetOverlappedResult(reinterpret_cast<HANDLE>(get_device_handle()), &overlapped, &bytes_returned, FALSE)) {
+        if (GetOverlappedResult(
+                reinterpret_cast<HANDLE>(get_async_device_handle()), &overlapped, &bytes_returned, FALSE)) {
             result = EBPF_SUCCESS;
         } else {
             result = win32_error_code_to_ebpf_result(GetLastError());

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -75,6 +75,11 @@ clean_up_device_handle()
         Platform::CloseHandle(_sync_device_handle);
         _sync_device_handle = ebpf_handle_invalid;
     }
+
+    if (_async_device_handle != ebpf_handle_invalid) {
+        Platform::CloseHandle(_async_device_handle);
+        _async_device_handle = ebpf_handle_invalid;
+    }
 }
 
 ebpf_handle_t

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -78,7 +78,7 @@ clean_up_device_handle()
 }
 
 ebpf_handle_t
-get_device_handle()
+get_sync_device_handle()
 {
     if (_sync_device_handle == ebpf_handle_invalid) {
         // Ignore failures.

--- a/libs/api_common/device_helper.cpp
+++ b/libs/api_common/device_helper.cpp
@@ -26,7 +26,10 @@ typedef struct _async_ioctl_completion_context
     async_ioctl_completion_callback_t callback;
 } async_ioctl_completion_context_t;
 
+// Handle used for synchronous calls to the driver.
 static ebpf_handle_t _device_handle = ebpf_handle_invalid;
+// Handle used for asynchronous calls to the driver.
+static ebpf_handle_t _async_device_handle = ebpf_handle_invalid;
 static std::mutex _mutex;
 
 _Must_inspect_result_ ebpf_result_t
@@ -38,10 +41,25 @@ initialize_device_handle()
         return EBPF_ALREADY_INITIALIZED;
     }
 
-    _device_handle = Platform::CreateFile(
-        EBPF_DEVICE_WIN32_NAME, GENERIC_READ | GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_FLAG_OVERLAPPED, 0);
+    if (_async_device_handle != ebpf_handle_invalid) {
+        return EBPF_ALREADY_INITIALIZED;
+    }
+
+    // Open the device handle without the FILE_FLAG_OVERLAPPED flag for synchronous calls.
+    _device_handle =
+        Platform::CreateFile(EBPF_DEVICE_WIN32_NAME, GENERIC_READ | GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, 0, 0);
 
     if (_device_handle == ebpf_handle_invalid) {
+        return win32_error_code_to_ebpf_result(GetLastError());
+    }
+
+    // Open the device handle with the FILE_FLAG_OVERLAPPED flag for asynchronous calls.
+    _async_device_handle = Platform::CreateFile(
+        EBPF_DEVICE_WIN32_NAME, GENERIC_READ | GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_FLAG_OVERLAPPED, 0);
+
+    if (_async_device_handle == ebpf_handle_invalid) {
+        Platform::CloseHandle(_device_handle);
+        _device_handle = ebpf_handle_invalid;
         return win32_error_code_to_ebpf_result(GetLastError());
     }
 
@@ -68,6 +86,16 @@ get_device_handle()
     }
 
     return _device_handle;
+}
+
+ebpf_handle_t
+get_async_device_handle()
+{
+    if (_async_device_handle == ebpf_handle_invalid) {
+        // Ignore failures.
+        (void)initialize_device_handle();
+    }
+    return _async_device_handle;
 }
 
 void
@@ -151,7 +179,7 @@ get_async_ioctl_result(_In_ const async_ioctl_completion_t* ioctl_completion)
 {
     unsigned long dummy;
     if (!GetOverlappedResult(
-            reinterpret_cast<HANDLE>(get_device_handle()),
+            reinterpret_cast<HANDLE>(get_async_device_handle()),
             get_async_ioctl_operation_overlapped(ioctl_completion),
             &dummy,
             FALSE))
@@ -219,5 +247,5 @@ Exit:
 bool
 cancel_async_ioctl(_Inout_opt_ OVERLAPPED* overlapped = nullptr)
 {
-    return Platform::CancelIoEx(get_device_handle(), overlapped);
+    return Platform::CancelIoEx(get_async_device_handle(), overlapped);
 }

--- a/libs/api_common/device_helper.hpp
+++ b/libs/api_common/device_helper.hpp
@@ -35,7 +35,7 @@ void
 clean_up_device_handle();
 
 ebpf_handle_t
-get_device_handle();
+get_sync_device_handle();
 
 ebpf_handle_t
 get_async_device_handle();
@@ -104,7 +104,7 @@ invoke_ioctl(request_t& request, reply_t& reply = _empty_reply, _Inout_opt_ OVER
     }
 
     auto success = Platform::DeviceIoControl(
-        overlapped ? get_async_device_handle() : get_device_handle(),
+        overlapped ? get_async_device_handle() : get_sync_device_handle(),
         IOCTL_EBPF_CTL_METHOD_BUFFERED,
         request_ptr,
         request_size,

--- a/libs/api_common/device_helper.hpp
+++ b/libs/api_common/device_helper.hpp
@@ -37,6 +37,9 @@ clean_up_device_handle();
 ebpf_handle_t
 get_device_handle();
 
+ebpf_handle_t
+get_async_device_handle();
+
 typedef ebpf_result_t (*async_ioctl_completion_callback_t)(_Inout_opt_ void* completion_context);
 
 typedef struct _async_ioctl_completion_context async_ioctl_completion_t;
@@ -101,7 +104,7 @@ invoke_ioctl(request_t& request, reply_t& reply = _empty_reply, _Inout_opt_ OVER
     }
 
     auto success = Platform::DeviceIoControl(
-        get_device_handle(),
+        overlapped ? get_async_device_handle() : get_device_handle(),
         IOCTL_EBPF_CTL_METHOD_BUFFERED,
         request_ptr,
         request_size,


### PR DESCRIPTION
Resolves: #3325

## Description

IOCTL calls from multiple threads sharing the same device handle that has FILE_FLAG_OVERLAPPED but without an OVERLAPPED can cause IOCTL calls to hang.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
