### PR TITLE
Switch synchronous thread to thread_local storage

### DIFF
--- a/ebpfapi/dllmain.cpp
+++ b/ebpfapi/dllmain.cpp
@@ -23,6 +23,7 @@ DllMain(HMODULE hModule, unsigned long ul_reason_for_call, void* lpReserved)
     case DLL_THREAD_ATTACH:
         break;
     case DLL_THREAD_DETACH:
+        ebpf_clear_thread_local_storage();
         break;
     case DLL_PROCESS_DETACH:
         ebpf_api_terminate();

--- a/ebpfapi/dllmain.cpp
+++ b/ebpfapi/dllmain.cpp
@@ -21,9 +21,10 @@ DllMain(HMODULE hModule, unsigned long ul_reason_for_call, void* lpReserved)
         }
         break;
     case DLL_THREAD_ATTACH:
+        ebpf_api_thread_local_initialize();
         break;
     case DLL_THREAD_DETACH:
-        ebpf_clear_thread_local_storage();
+        ebpf_api_thread_local_cleanup();
         break;
     case DLL_PROCESS_DETACH:
         ebpf_api_terminate();

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -714,3 +714,15 @@ get_bpf_program_type(_In_ const ebpf_program_type_t* program_type) noexcept;
  */
 bpf_attach_type_t
 get_bpf_attach_type(_In_ const ebpf_attach_type_t* ebpf_attach_type) noexcept;
+
+/**
+ * @brief Initialize the eBPF library's thread local storage.
+ */
+void
+ebpf_api_thread_local_cleanup() noexcept;
+
+/**
+ * @brief Cleanup the eBPF library's thread local storage.
+ */
+void
+ebpf_api_thread_local_initialize() noexcept;

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -4513,3 +4513,16 @@ ebpf_program_test_run(fd_t program_fd, _Inout_ ebpf_test_run_options_t* options)
     EBPF_RETURN_RESULT(result);
 }
 CATCH_NO_MEMORY_EBPF_RESULT
+
+void
+ebpf_api_thread_local_cleanup() noexcept
+{
+    clean_up_sync_device_handle();
+}
+
+void
+ebpf_api_thread_local_initialize() noexcept
+{
+    // Nothing to do.
+    // Added for symmetry with ebpf_api_thread_local_cleanup.
+}

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -232,7 +232,7 @@ ebpf_api_initiate() NO_EXCEPT_TRY
 
     // This is best effort. If device handle does not initialize,
     // it will be re-attempted before an IOCTL call is made.
-    (void)initialize_device_handle();
+    (void)initialize_async_device_handle();
 
     EBPF_RETURN_RESULT(EBPF_SUCCESS);
 }
@@ -243,7 +243,7 @@ ebpf_api_terminate() noexcept
 {
     clear_ebpf_provider_data();
     _clean_up_ebpf_objects();
-    clean_up_device_handle();
+    clean_up_async_device_handle();
 #if !defined(CONFIG_BPF_JIT_DISABLED) || !defined(CONFIG_BPF_INTERPRETER_DISABLED)
     clean_up_rpc_binding();
 #endif

--- a/libs/api_common/api_common.cpp
+++ b/libs/api_common/api_common.cpp
@@ -154,4 +154,5 @@ ebpf_clear_thread_local_storage() noexcept
     clear_program_info_cache();
     set_program_under_verification(ebpf_handle_invalid);
     set_verification_in_progress(false);
+    clean_up_sync_device_handle();
 }

--- a/libs/api_common/device_helper.hpp
+++ b/libs/api_common/device_helper.hpp
@@ -29,10 +29,16 @@ typedef struct empty_reply
 static empty_reply_t _empty_reply;
 
 _Must_inspect_result_ ebpf_result_t
-initialize_device_handle();
+initialize_sync_device_handle();
+
+_Must_inspect_result_ ebpf_result_t
+initialize_async_device_handle();
 
 void
-clean_up_device_handle();
+clean_up_sync_device_handle();
+
+void
+clean_up_async_device_handle();
 
 ebpf_handle_t
 get_sync_device_handle();

--- a/libs/service/api_service.cpp
+++ b/libs/service/api_service.cpp
@@ -421,7 +421,7 @@ ebpf_service_initialize() noexcept
     // it will be re-attempted before an IOCTL call is made.
     // This is needed to ensure the service can successfully start
     // even if the driver is not installed.
-    (void)initialize_device_handle();
+    (void)initialize_async_device_handle();
 
     return ERROR_SUCCESS;
 }
@@ -429,5 +429,5 @@ ebpf_service_initialize() noexcept
 void
 ebpf_service_cleanup() noexcept
 {
-    clean_up_device_handle();
+    clean_up_async_device_handle();
 }

--- a/tests/api_test/api_test.cpp
+++ b/tests/api_test/api_test.cpp
@@ -1122,4 +1122,110 @@ TEST_CASE("load_native_program_invalid5", "[native][negative]")
     _load_invalid_program("invalid_maps3.sys", EBPF_EXECUTION_NATIVE, -EINVAL);
 }
 
+TEST_CASE("ioctl_stress", "[stress]")
+{
+    // Load bindmonitor_ringbuf.sys
+
+    struct bpf_object* object = nullptr;
+    fd_t program_fd;
+
+    REQUIRE(
+        _program_load_helper(
+            "bindmonitor_ringbuf.sys", BPF_PROG_TYPE_BIND, EBPF_EXECUTION_NATIVE, &object, &program_fd) == 0);
+
+    // Create a test array map to provide target for the ioctl stress test.
+    fd_t test_map_fd = bpf_map_create(BPF_MAP_TYPE_ARRAY, "test_map", sizeof(uint32_t), sizeof(uint32_t), 1, nullptr);
+
+    // Get fd of process_map map
+    fd_t process_map_fd = bpf_object__find_map_fd_by_name(object, "process_map");
+
+    // Subscribe to the ring buffer with empty callback
+    auto ring = ring_buffer__new(
+        process_map_fd, [](void*, void*, size_t) { return 0; }, nullptr, nullptr);
+
+    // Run 4 threads per cpu
+    // Get cpu count
+    SYSTEM_INFO sysinfo;
+    GetSystemInfo(&sysinfo);
+
+    std::atomic<size_t> failure_count = 0;
+    std::vector<std::jthread> threads;
+    std::atomic<bool> stop_requested;
+    for (DWORD i = 0; i < sysinfo.dwNumberOfProcessors; i++) {
+        for (int j = 0; j < 4; j++) {
+            threads.emplace_back([&]() {
+                while (!stop_requested) {
+                    int test_case = rand() % 4;
+                    uint32_t key = 0;
+                    uint32_t value;
+                    bpf_test_run_opts opts = {};
+                    bind_md_t ctx = {};
+                    int result;
+                    switch (test_case) {
+                    case 0:
+                        // Test bpf_map_lookup_elem
+                        result = bpf_map_lookup_elem(test_map_fd, &key, &value);
+                        if (result != 0) {
+                            std::cout << "bpf_map_lookup_elem failed with " << result << std::endl;
+                            failure_count++;
+                        }
+                        break;
+                    case 1:
+                        // Test bpf_map_update_elem
+                        result = bpf_map_update_elem(test_map_fd, &key, &value, 0);
+                        if (result != 0) {
+                            std::cout << "bpf_map_update_elem failed with " << result << std::endl;
+                            failure_count++;
+                        }
+                        break;
+                    case 2:
+                        // Test bpf_map_delete_elem
+                        result = bpf_map_delete_elem(test_map_fd, &key);
+                        if (result != 0) {
+                            std::cout << "bpf_map_delete_elem failed with " << result << std::endl;
+                            failure_count++;
+                        }
+                        break;
+                    case 3:
+                        // Run the program to trigger a ring buffer event
+                        std::string app_id = "api_test.exe";
+
+                        opts.ctx_in = &ctx;
+                        opts.ctx_size_in = sizeof(ctx);
+                        opts.ctx_out = &ctx;
+                        opts.ctx_size_out = sizeof(ctx);
+                        opts.data_in = app_id.data();
+                        opts.data_size_in = static_cast<uint32_t>(app_id.size());
+                        opts.data_out = app_id.data();
+                        opts.data_size_out = static_cast<uint32_t>(app_id.size());
+
+                        result = bpf_prog_test_run_opts(program_fd, &opts);
+                        if (result != 0) {
+                            std::cout << "bpf_prog_test_run_opts failed with " << result << std::endl;
+                            failure_count++;
+                        }
+                        break;
+                    }
+                };
+            });
+        }
+    }
+
+    // Wait for 10 seconds
+    std::this_thread::sleep_for(std::chrono::seconds(60));
+
+    stop_requested = true;
+
+    for (auto& t : threads) {
+        t.join();
+    }
+    REQUIRE(failure_count == 0);
+
+    // Unsubscribe from the ring buffer
+    ring_buffer__free(ring);
+
+    // Clean up
+    bpf_object__close(object);
+}
+
 #endif


### PR DESCRIPTION
## Description

IOCTLs sent via a file handle that is opened without the FILE_FLAG_OVERLAPPED flag are serialized in the file object. This will affect performance if multiple user mode threads are making concurrent IOCTL requests.

This change switches the synchronous handle to being per-thread, with the handle being closed on thread detach.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
