### PR TITLE
Memset is defined as taking destination, c, count

### DIFF
--- a/include/bpf_helper_defs.h
+++ b/include/bpf_helper_defs.h
@@ -409,7 +409,7 @@ EBPF_HELPER(
 #if __clang__
 #define memcpy(dest, src, dest_size) bpf_memcpy(dest, dest_size, src, dest_size)
 #define memcmp(mem1, mem2, mem1_size) bpf_memcmp(mem1, mem1_size, mem2, mem1_size)
-#define memset(mem, mem_size, value) bpf_memset(mem, mem_size, value)
+#define memset(mem, value, mem_size) bpf_memset(mem, mem_size, value)
 #define memmove(dest, src, dest_size) bpf_memmove(dest, dest_size, src, dest_size)
 #define memcpy_s bpf_memcpy
 #define memmove_s bpf_memmove

--- a/tests/sample/utility.c
+++ b/tests/sample/utility.c
@@ -61,7 +61,7 @@ UtilityTest(bind_md_t* ctx)
     }
 
     // Verify that memset overwrites the first string with 0.
-    if (memset(test1, 4, 0) == 0) {
+    if (memset(test1, 0, 4) == 0) {
         return 6;
     }
 


### PR DESCRIPTION
## Description

Memset was incorrectly declared in the header as taking (destination, size, value), but the standard C memset takes (destination, value, size). Fix the definition to match the standard C version to avoid developer confusion.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
