### PR TITLE
fix tracing.

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -347,6 +347,12 @@ ebpf_link_attach_program(_Inout_ ebpf_link_t* link, _Inout_ ebpf_program_t* prog
     lock_held = true;
 
     if (!link->provider_attached) {
+        EBPF_LOG_MESSAGE_GUID_GUID(
+            EBPF_TRACELOG_LEVEL_INFO,
+            EBPF_TRACELOG_KEYWORD_LINK,
+            "Program failed to attach to extension hook.",
+            &link->program_type,
+            &link->attach_type);
         return_value = EBPF_EXTENSION_FAILED_TO_LOAD;
         goto Done;
     }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -792,7 +792,7 @@ ebpf_program_create(_In_ const ebpf_program_parameters_t* program_parameters, _O
         EBPF_LOG_MESSAGE_GUID_GUID(
             EBPF_TRACELOG_LEVEL_INFO,
             EBPF_TRACELOG_KEYWORD_PROGRAM,
-            "Program type and Attach type:",
+            "Failed to load program information.",
             &program_parameters->program_type,
             &program_parameters->expected_attach_type);
         retval = EBPF_EXTENSION_FAILED_TO_LOAD;

--- a/libs/shared/ebpf_tracelog.h
+++ b/libs/shared/ebpf_tracelog.h
@@ -87,16 +87,15 @@ extern "C"
             TraceLoggingString(__FUNCTION__ " returned success", "Message"));                   \
     }
 
-#define EBPF_LOG_FUNCTION_ERROR(result)                                                         \
-    if (TraceLoggingProviderEnabled(                                                            \
-            ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_VERBOSE, EBPF_TRACELOG_KEYWORD_BASE)) { \
-        TraceLoggingWrite(                                                                      \
-            ebpf_tracelog_provider,                                                             \
-            EBPF_TRACELOG_EVENT_GENERIC_ERROR,                                                  \
-            TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                            \
-            TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_BASE),                                    \
-            TraceLoggingString(__FUNCTION__ " returned error", "ErrorMessage"),                 \
-            TraceLoggingLong(result, "Error"));                                                 \
+#define EBPF_LOG_FUNCTION_ERROR(result)                                                                               \
+    if (TraceLoggingProviderEnabled(ebpf_tracelog_provider, EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_BASE)) { \
+        TraceLoggingWrite(                                                                                            \
+            ebpf_tracelog_provider,                                                                                   \
+            EBPF_TRACELOG_EVENT_GENERIC_ERROR,                                                                        \
+            TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                                                  \
+            TraceLoggingKeyword(EBPF_TRACELOG_KEYWORD_BASE),                                                          \
+            TraceLoggingString(__FUNCTION__ " returned error", "ErrorMessage"),                                       \
+            TraceLoggingLong(result, "Error"));                                                                       \
     }
 
 #define EBPF_LOG_FUNCTION_RESULT(result)                                                        \

--- a/netebpfext/net_ebpf_ext_tracelog.h
+++ b/netebpfext/net_ebpf_ext_tracelog.h
@@ -66,18 +66,16 @@ typedef enum _net_ebpf_ext_tracelog_level
             TraceLoggingString(__FUNCTION__ " returned success", "Message")); \
     }
 
-#define NET_EBPF_EXT_LOG_FUNCTION_ERROR(result)                                 \
-    if (TraceLoggingProviderEnabled(                                            \
-            net_ebpf_ext_tracelog_provider,                                     \
-            NET_EBPF_EXT_TRACELOG_LEVEL_VERBOSE,                                \
-            NET_EBPF_EXT_TRACELOG_KEYWORD_BASE)) {                              \
-        TraceLoggingWrite(                                                      \
-            net_ebpf_ext_tracelog_provider,                                     \
-            NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_ERROR,                          \
-            TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                            \
-            TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_BASE),            \
-            TraceLoggingString(__FUNCTION__ " returned error", "ErrorMessage"), \
-            TraceLoggingLong(result, "Error"));                                 \
+#define NET_EBPF_EXT_LOG_FUNCTION_ERROR(result)                                                                       \
+    if (TraceLoggingProviderEnabled(                                                                                  \
+            net_ebpf_ext_tracelog_provider, NET_EBPF_EXT_TRACELOG_LEVEL_ERROR, NET_EBPF_EXT_TRACELOG_KEYWORD_BASE)) { \
+        TraceLoggingWrite(                                                                                            \
+            net_ebpf_ext_tracelog_provider,                                                                           \
+            NET_EBPF_EXT_TRACELOG_EVENT_GENERIC_ERROR,                                                                \
+            TraceLoggingLevel(WINEVENT_LEVEL_ERROR),                                                                  \
+            TraceLoggingKeyword(NET_EBPF_EXT_TRACELOG_KEYWORD_BASE),                                                  \
+            TraceLoggingString(__FUNCTION__ " returned error", "ErrorMessage"),                                       \
+            TraceLoggingLong(result, "Error"));                                                                       \
     }
 
 #define NET_EBPF_EXT_LOG_ENTRY()                                                    \


### PR DESCRIPTION
## Description

The tracelog macros had incorrect check for trace level for error messages. The trace for extensions failing to attach did not have correct message string.

## Testing

CI.

## Documentation

N/A.

## Installation

N/A.