### PR TITLE
Use specified primary repository (for self-hosted runner setups)

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -49,6 +49,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64
       generate_release_package: true
       build_msi: true
@@ -63,6 +64,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64-native-only
       build_msi: true
       build_nuget: true
@@ -266,6 +268,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64-Analyze
       # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
       build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
@@ -277,6 +280,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64-Sanitize
       build_options: /p:AddressSanitizer='True'
 
@@ -476,6 +480,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64-CodeQl
       build_codeql: true
 

--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -11,6 +11,10 @@ on:
       ref:
         required: true
         type: string
+      # repository to be used (needed for self-hosted runner setups)
+      repository:
+        required: true
+        type: string
       # Name associated with the output of this build.
       build_artifact:
         required: true
@@ -87,7 +91,7 @@ jobs:
     - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       if: steps.skip_check.outputs.should_skip != 'true'
       with:
-        repository: microsoft/ebpf-for-windows
+        repository: ${{inputs.repository}}
         submodules: 'recursive'
         ref: ${{inputs.ref}}
 


### PR DESCRIPTION
## Description

This PR adds support to ensure that the CI/CD workflow checks out sources for the specified branch from the github-provided input specifying the repository to use.

(Details in linked issue)

## Testing

Tested with a custom self-hosted runner setup for the `https://github.com/dv-msft/ebpf-for-windows` down-stream fork.

## Documentation

No doc changes.

## Installation

No installer impact.

Fixes #3346 