### PR TITLE
CI/CD user, kernel dump harvesting fixes

### DIFF
--- a/scripts/Run-Self-Hosted-Runner-Test.ps1
+++ b/scripts/Run-Self-Hosted-Runner-Test.ps1
@@ -179,8 +179,16 @@ if (-not $WaitResult) {
     $DriveFreeSpaceGB = GetDriveFreeSpaceGB -DriveSpecification $Env:SystemDrive
     Write-Log "Current available disk space: $DriveFreeSpaceGB GB`n"
 
+    # $TestProcess refers to 'cmd.exe' which ends up running the real test application.
+    # (This is done so that we can capture the stdout and stderr outputs from the test application
+    # itself. I have not been able to get Powershell's 'built-in' redirection mechanisms for the
+    # 'Process' object to play well in our scenario).
+    # We therefore need pass the test application's id to procdump64.exe
+    $TestCommandId = (Get-Process -Name $TestCommand).Id
+    Write-Log "Test Command:$TestCommand, Id:$TestCommandId"
+
     Write-Log "Creating User mode dump @ $UserModeDumpFilePath"
-    $ProcDumpArguments = "-r -ma $($TestProcess.Id) $UserModeDumpFilePath"
+    $ProcDumpArguments = "-r -ma $($TestCommandId) $UserModeDumpFilePath"
     Write-Log "Dump Command: $ProcDumpBinaryPath $ProcDumpArguments"
     $ProcDumpProcess = Start-Process -NoNewWindow `
         -FilePath $ProcDumpBinaryPath `


### PR DESCRIPTION
## Description

This PR contains:
1. Streamlining and adding additional trace statements during kernel mode dump harvesting.
2. Fixing the issue where we were passing the incorrect process id to procdump64.exe

## Testing

This is an enhancement to the existing test infrastructure itself.  Tested via manual verification locally as well as on private 'self-hosted runners' setup.

## Documentation

No doc changes.

## Installation

No installer impact.

Fixes #3371 