### PR TITLE
Clean up stale nuget packages in build step

### DIFF
--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -102,6 +102,11 @@ xcopy $(OutDir)*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>pushd $(OutDir)
+del ebpf-for-windows.*.nupkg
+popd $(OutDir)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyDebug|x64'">
     <ClCompile>
@@ -122,6 +127,11 @@ xcopy $(OutDir)*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>pushd $(OutDir)
+del ebpf-for-windows.*.nupkg
+popd $(OutDir)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
@@ -146,6 +156,11 @@ xcopy $(OutDir)*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>pushd $(OutDir)
+del ebpf-for-windows.*.nupkg
+popd $(OutDir)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='NativeOnlyRelease|x64'">
     <ClCompile>
@@ -170,6 +185,11 @@ xcopy $(OutDir)*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
+    <PreBuildEvent>
+      <Command>pushd $(OutDir)
+del ebpf-for-windows.*.nupkg
+popd $(OutDir)</Command>
+    </PreBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>
     <CustomBuild Include="ebpf-for-windows.nuspec.in">

--- a/tools/nuget/nuget.vcxproj
+++ b/tools/nuget/nuget.vcxproj
@@ -98,7 +98,7 @@
       <Command>pushd $(OutDir)
 if not exist "$(OutDir)undocked" mkdir "$(OutDir)undocked"
 type nul &gt; $(OutDir)undocked\ebpf-for-windows.zip
-xcopy $(OutDir)*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
+xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
@@ -123,7 +123,7 @@ popd $(OutDir)</Command>
       <Command>pushd $(OutDir)
 if not exist "$(OutDir)undocked" mkdir "$(OutDir)undocked"
 type nul &gt; $(OutDir)undocked\ebpf-for-windows.zip
-xcopy $(OutDir)*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
+xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
@@ -152,7 +152,7 @@ popd $(OutDir)</Command>
       <Command>pushd $(OutDir)
 if not exist "$(OutDir)undocked" mkdir "$(OutDir)undocked"
 type nul &gt; $(OutDir)undocked\ebpf-for-windows.zip
-xcopy $(OutDir)*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
+xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>
@@ -181,7 +181,7 @@ popd $(OutDir)</Command>
       <Command>pushd $(OutDir)
 if not exist "$(OutDir)undocked" mkdir "$(OutDir)undocked"
 type nul &gt; $(OutDir)undocked\ebpf-for-windows.zip
-xcopy $(OutDir)*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
+xcopy $(OutDir)eBPF-for-Windows.*.nupkg /F /Y $(OutDir)undocked\ebpf-for-windows.zip
 powershell -NonInteractive -ExecutionPolicy Unrestricted -command "Expand-Archive $(OutDir)undocked\ebpf-for-windows.zip -DestinationPath $(OutDir)undocked\ebpf-for-windows -Force"
 popd $(OutDir)</Command>
     </PostBuildEvent>


### PR DESCRIPTION
Fixes #3385
## Description

This PR deletes any old / stale nuget packages from the build directory when `nuget` project is built.

## Testing

Existing CICD

## Documentation

No

## Installation

No
