### PR TITLE
Update release yml to use new required repository parameter in the build workflow

### DIFF
--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -43,6 +43,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64
       generate_release_package: true
       build_msi: true
@@ -56,6 +57,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64-native-only
       build_msi: true
       build_nuget: true
@@ -211,6 +213,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64-Analyze
       # Analysis on external projects is conditional, as on small CI/CD VMs the compiler can run OOM
       build_options: /p:Analysis='True' /p:AnalysisOnExternal='False'
@@ -221,6 +224,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64-Sanitize
       build_options: /p:AddressSanitizer='True'
 
@@ -317,6 +321,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64-CodeQl
       build_codeql: true
 


### PR DESCRIPTION
## Description
A previous PR (#3345) added a new required parameter into the reusable-build.yml workflow. The cicd-release-validation.yml was not updated to account for this. This change address this.

## Testing
none.

## Documentation
n/a

## Installation
n/a
