### PR TITLE
Make sure all helpers are declared const

### DIFF
--- a/include/bpf_helpers.h
+++ b/include/bpf_helpers.h
@@ -49,7 +49,7 @@
 #endif
 
 #if !defined(__doxygen)
-#define EBPF_HELPER(return_type, name, args) typedef return_type(*name##_t) args
+#define EBPF_HELPER(return_type, name, args) typedef return_type(*const name##_t) args
 #endif
 
 #include "bpf_helper_defs.h"

--- a/include/ebpf_nethooks.h
+++ b/include/ebpf_nethooks.h
@@ -42,7 +42,7 @@ xdp_hook_t(xdp_md_t* context);
 #define XDP_EXT_HELPER_FN_BASE 0xFFFF
 
 #ifndef __doxygen
-#define EBPF_HELPER(return_type, name, args) typedef return_type(*name##_t) args
+#define EBPF_HELPER(return_type, name, args) typedef return_type(*const name##_t) args
 #endif
 
 typedef enum

--- a/undocked/tests/sample/ext/inc/sample_ext_helpers.h
+++ b/undocked/tests/sample/ext/inc/sample_ext_helpers.h
@@ -30,7 +30,7 @@ typedef struct _sample_program_context
 #define SAMPLE_EXT_HELPER_FN_BASE 0xFFFF
 
 #ifndef __doxygen
-#define EBPF_HELPER(return_type, name, args) typedef return_type(*name##_t) args
+#define EBPF_HELPER(return_type, name, args) typedef return_type(*const name##_t) args
 #endif
 
 /**


### PR DESCRIPTION
## Description

Make sure all helpers are declared const to avoid any cases where clang would generate callx instead of call instructions.

Fixes #3387

## Testing

Existing tests pass.

## Documentation

No impact. (callx discussion was previously removed from the tutorial.md in PR #782)

## Installation

No impact.
