### PR TITLE
Make results of skip_check step available to caller

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -45,6 +45,13 @@ on:
         required: false
         type: string
         default: '["Debug", "Release"]'
+    outputs:
+      should_skip:
+        description: 'Whether build was skipped due to duplicate action.'
+        value: ${{ jobs.build.outputs.should_skip }}
+      skipped_by:
+        description: 'The action that caused the skip.'
+        value: ${{ jobs.build.outputs.skipped_by }}
 
 permissions:
   contents: read
@@ -52,6 +59,10 @@ permissions:
 
 jobs:
   build:
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+      skipped_by: ${{ steps.skip_check.outputs.skipped_by }}
+
     timeout-minutes: 90
 
     strategy:


### PR DESCRIPTION
## Description


This pull request primarily involves updates to the GitHub Actions workflow file `.github/workflows/reusable-build.yml`. The changes introduce new outputs for the `build` job and the workflow itself. These outputs, `should_skip` and `skipped_by`, are designed to provide more information about whether a build was skipped and the action that caused the skip.

Here are the key changes:

* [`.github/workflows/reusable-build.yml`](diffhunk://#diff-951765131741a39f193f7387e405bafacb9b9e836a17986e6c7480d6dc448cc3R48-R65): Added new outputs `should_skip` and `skipped_by` to the `build` job and the workflow. These outputs are set with values from the `skip_check` step outputs. This will provide more detailed information about the skipping of builds.

Callers can use these outputs to determine if the build workflow was skipped and if it was skipped determine the reason for skipping it.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
