### PR TITLE
Fix user, kernel dump harvesting regression

### DIFF
--- a/scripts/Run-Self-Hosted-Runner-Test.ps1
+++ b/scripts/Run-Self-Hosted-Runner-Test.ps1
@@ -118,12 +118,11 @@ Write-Log "`n"
 REG ADD HKCU\Software\Sysinternals /v EulaAccepted /t REG_DWORD /d 1 /f | Out-Null
 
 # The following 'Set-ItemProperty' command enables a full memory dump.
-# Not enabled yet as it needs a VM with an explicitly created page file of at least (physical_memory + 1MB) in size.
+# NOTE: This needs a VM with an explicitly created page file of *AT LEAST* (physical_memory + 1MB) in size.
 # The default value of the 'CrashDumpEnabled' key is 7 ('automatic' sizing of dump file size (system determined)).
 # https://learn.microsoft.com/en-us/troubleshoot/windows-server/performance/memory-dump-file-options
-#
-# Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl' -Name 'CrashDumpEnabled' -Value 1
-#
+Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\CrashControl' -Name 'CrashDumpEnabled' -Value 1
+
 if ($VerbosePreference -eq 'Continue') {
     # Dump current kernel mode dump settings.
     Write-Log "`n"

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -214,7 +214,6 @@ function Export-BuildArtifactsToVMs
 #
 # Install eBPF components on VM.
 #
-
 function Install-eBPFComponentsOnVM
 {
     param([parameter(Mandatory=$true)][string] $VMName,
@@ -255,6 +254,36 @@ function Uninstall-eBPFComponentsOnVM
         Uninstall-eBPFComponents
     } -ArgumentList ("eBPF", $LogFileName) -ErrorAction Stop
     Write-Log "eBPF components uninstalled on $VMName" -ForegroundColor Green
+}
+
+function Stop-eBPFComponentsOnVM
+{
+    param([parameter(Mandatory=$true)][string] $VMName)
+
+    Write-Log "Stopping eBPF components on $VMName"
+    $TestCredential = New-Credential -Username $Admin -AdminPassword $AdminPassword
+
+    Invoke-Command `
+        -VMName $VMName `
+        -Credential $TestCredential `
+        -ScriptBlock {
+            param([Parameter(Mandatory=$True)] [string] $WorkingDirectory,
+                  [Parameter(Mandatory=$True)] [string] $LogFileName
+            )
+
+            $WorkingDirectory = "$env:SystemDrive\$WorkingDirectory"
+            Import-Module $WorkingDirectory\common.psm1 `
+                -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
+
+            Import-Module $WorkingDirectory\install_ebpf.psm1 `
+                -ArgumentList($WorkingDirectory, $LogFileName) `
+                -Force -WarningAction SilentlyContinue
+
+            Stop-eBPFComponents
+
+        } -ArgumentList ("eBPF", $LogFileName) -ErrorAction Stop
+
+    Write-Log "eBPF components stopped on $VMName" -ForegroundColor Green
 }
 
 function ArchiveKernelModeDumpOnVM


### PR DESCRIPTION
## Description

This PR fixes the regression that broke user, kernel mode dump harvesting.

## Testing

Tested for both paths ('on drivers' CI/CD tests, 'on-drivers' kernel mode multi-threaded stress tests):
- locally on the dev machine across a local VM (in close approximation of the CI/CD workflow)
- on a dedicated private self-hosted runner
- on the usual CI/CD workflow

'on-drivers' CI/CD test result (output fragment):
```
<SNIP>

.\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true -LogFileName TK5-3WP07R0703_WS2019_3.log -SelfHostedRunnerName TK5-3WP07R0703_WS2019_3
  shell: C:\Windows\System[3](https://github.com/microsoft/ebpf-for-windows/actions/runs/8448844584/job/23142117260#step:27:3)2\WindowsPowerShell\v1.0\powershell.EXE -command ". '{0}'"
  env:
    SOURCE_ROOT: C:\actions_runner_2019_3\_work\ebpf-for-windows\ebpf-for-windows
    NAME: driver_native_only_ws2019
    BUILD_CONFIGURATION: NativeOnlyDebug
    BUILD_PLATFORM: x6[4](https://github.com/microsoft/ebpf-for-windows/actions/runs/8448844584/job/23142117260#step:27:4)
    TEST_COMMAND: .\execute_ebpf_cicd_tests.ps1 -TestMode "CI/CD"
    PRE_COMMAND: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file"
    POST_COMMAND: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
    CXPLAT_MEMORY_LEAK_DETECTION: false
    DUMP_PATH: c:/dumps/x[6](https://github.com/microsoft/ebpf-for-windows/actions/runs/8448844584/job/23142117260#step:27:6)4/NativeOnlyDebug
    TEST_TIMEOUT: 3600
    ASAN_WIN_CONTINUE_ON_INTERCEPTION_FAILURE: true
[02:31:1[8](https://github.com/microsoft/ebpf-for-windows/actions/runs/8448844584/job/23142117260#step:27:8)] :: Heartbeat OK on vm3_ws201[9](https://github.com/microsoft/ebpf-for-windows/actions/runs/8448844584/job/23142117260#step:27:9)
[02:31:18] :: Poking vm3_ws2019 to see if it is ready to accept commands
[02:31:19] :: VM vm3_ws2019 is ready
[02:31:19] :: Guest services already enabled on vm3_ws2019
[02:31:19] :: Stopping eBPF components on vm3_ws2019
[02:31:20] :: 'eBPFSvc' service is not present (i.e., release build), skipping stopping.
[02:31:20] :: NetEbpfExt driver stopped.
[02:31:20] :: EbpfCore driver stopped.
[02:31:20] :: SampleEbpfExt driver stopped.
[02:31:20] :: eBPF components stopped on vm3_ws2019
[02:31:20] :: Heartbeat OK on vm3_ws20[19](https://github.com/microsoft/ebpf-for-windows/actions/runs/8448844584/job/23142117260#step:27:20)
[02:31:20] :: Poking vm3_ws2019 to see if it is ready to accept commands
[02:31:[20](https://github.com/microsoft/ebpf-for-windows/actions/runs/8448844584/job/23142117260#step:27:21)] :: VM vm3_ws2019 is ready
[02:31:20] :: Guest services already enabled on vm3_ws2019
[02:31:20] :: Importing TestLogs from vm3_ws2019

<SNIP>
```

User, Kernel mode dump harvesting test result (output fragment):
_This is a forced dump creation enabled by setting the 'test hang timeout' to 30 seconds, well below the actual test run time._
```
<SNIP>

[01:16:30] :: Staring Test command: C:\eBPF\ebpf_stress_tests_km -tt=8 -td=5 -erd=1000 -er=1
[01:16:30] :: Test hang timeout: 30 (seconds)
[01:16:30] ::

[01:17:00] ::

[01:17:00] :: *** ERROR *** Test execution hang timeout (30 seconds) expired.

[01:17:00] :: User mode Dumpfile name: ebpf_stress_tests_km_2024-03-27_01-17-00.dmp
[01:17:00] :: User mode Dumpfile Path: C:\Dumps\ebpf_stress_tests_km_2024-03-27_01-17-00.dmp
[01:17:01] :: Current available disk space: 17.47 GB
                                                                                                                                                                                                                                                                              [01:17:01] :: Test Command:ebpf_stress_tests_km, Id:4428                                                                                                                                                                                                                      [01:17:01] :: Creating User mode dump @ C:\Dumps\ebpf_stress_tests_km_2024-03-27_01-17-00.dmp                                                                                                                                                                                 [01:17:01] :: Dump Command: C:\eBPF\procdump64.exe -r -ma 4428 C:\Dumps\ebpf_stress_tests_km_2024-03-27_01-17-00.dmp                                                                                                                                                          [01:17:05] :: Waiting for user mode dump to complete...                                                                                                                                                                                                                       [01:17:05] :: C:\eBPF\procdump64.exe completed with exit code: 1                                                                                                                                                                                                              
[01:17:05] :: User mode dump completed. Flushing disk buffers...
[01:17:17] ::


[01:17:17] :: Created C:\Dumps\ebpf_stress_tests_km_2024-03-27_01-17-00.dmp, size: 29.12 MB
[01:17:17] ::


[01:17:17] :: Creating kernel dump...

[01:17:23] :: Heartbeat OK on CICD-WS19
[01:17:23] :: Poking CICD-WS19 to see if it is ready to accept commands
[01:17:37] :: Waiting 10 seconds for CICD-WS19 to be responsive.
[01:17:48] :: Poking CICD-WS19 to see if it is ready to accept commands
[01:17:51] :: VM CICD-WS19 is ready
[01:17:51] :: Guest services already enabled on CICD-WS19

=== Post-crash reboot detected on VM CICD-WS19 ===

[01:17:56] :: Heartbeat OK on CICD-WS19
[01:17:56] :: Poking CICD-WS19 to see if it is ready to accept commands
[01:17:59] :: VM CICD-WS19 is ready
[01:17:59] :: Guest services already enabled on CICD-WS19
[01:17:59] :: Importing TestLogs from CICD-WS19

    Directory:  D:\wrk\ebpf-for-windows\x64\Debug

Mode                LastWriteTime     Length Name
----                -------------     ------ ----
d-----        3/27/2024   1:17 AM        1   CICD-WS19
[01:18:02] :: Processing kernel mode dump (if any) on VM CICD-WS19
Creating C:\KernelDumps directory.
Found kernel mode dump(s) in C:\Windows:
        Name:MEMORY.DMP, Size:378.17 MB


Compressing kernel dump files: C:\Windows -> C:\KernelDumps
Found compressed kernel mode dump file in C:\KernelDumps:
        Name:km_dumps.zip, Size:51.40 MB
[01:18:20] ::

[01:18:20] :: Local copy of kernel mode dump archive in .\TestLogs\CICD-WS19\KernelDumps for VM CICD-WS19:
[01:18:20] ::   Name:km_dumps.zip, Size:51.40 MB

<SNIP>

```


## Documentation

No doc changes.

## Installation

No installer impact.

Fixes #3386 