### PR TITLE
Integrate with netperf repo.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -578,6 +578,16 @@ jobs:
       environment: ebpf_cicd_perf_ws2022
       configurations: '["Release"]'
 
+  netperf:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/netperf.yml
+    with:
+      sha: ${{ github.sha }}
+      ref: ${{ github.ref }}
+      pull_request: ${{ github.event.pull_request.number }}
+    secrets:
+      NET_PERF_TRIGGER: ${{ secrets.NET_PERF_TRIGGER }}
+
   upload_perf_results:
     needs: performance
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
@@ -585,6 +595,45 @@ jobs:
     with:
       name: upload_perf_results
       result_artifact: km_performance-x64-Release
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  upload_netperf_results_azure_2022:
+    needs: netperf
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/upload-perf-results.yml
+    with:
+      name: upload_netperf_results_azure_2022
+      result_artifact: bpf_performance_native_azure_2022_x64
+      platform: Azure Windows 2022
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  upload_netperf_results_azure_2025:
+    needs: netperf
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/upload-perf-results.yml
+    with:
+      name: upload_netperf_results_azure_2025
+      result_artifact: bpf_performance_native_azure_2025_x64
+      platform: Azure Windows 2025
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  upload_netperf_results_lab_2022:
+    needs: netperf
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/upload-perf-results.yml
+    with:
+      name: upload_netperf_results_lab_2022
+      result_artifact: bpf_performance_native_lab_2022_x64
+      platform: Lab Windows 2022
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation
+# SPDX-License-Identifier: MIT
+
+# This is a workflow which runs the performance tests with profiling enabled.
+
+name: Performance Tests on netperf
+
+on:
+  # Permit manual runs of the workflow.
+  workflow_call:
+    inputs:
+      sha:
+        description: 'SHA of the commit'
+        required: true
+        type: string
+      ref:
+        description: 'Ref of the commit'
+        required: true
+        type: string
+      pull_request:
+        description: 'Pull request number'
+        required: true
+        type: string
+    secrets:
+      NET_PERF_TRIGGER:
+        description: 'Token to trigger the NetPerf workflow'
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+    netperf:
+      runs-on: windows-latest
+      steps:
+      - name: Run NetPerf Workflow
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $url = "https://raw.githubusercontent.com/microsoft/netperf/main/run-workflow.ps1"
+          if ('${{ secrets.NET_PERF_TRIGGER }}' -eq '') {
+              Write-Host "Not able to run because no secrets are available!"
+              return
+          }
+          $run_id = iex "& { $(irm $url) } ${{ secrets.NET_PERF_TRIGGER }} ebpf ${{ inputs.sha }} ${{ inputs.ref }} ${{ inputs.pull_request.number }}"
+          echo "NetPerf run id: $run_id"
+          gh run download $run_id --dir netperf --pattern bpf_performance_native* --repo microsoft/netperf
+
+      - name: upload_results_azure_2022_x64
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+            name: Test-Logs-bpf_performance_native_azure_2022_x64
+            path: netperf/bpf_performance_native_azure_2022_x64/bpf_performance_native.csv
+
+      - name: upload_results_azure_2025_x64
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+            name: Test-Logs-bpf_performance_native_azure_2025_x64
+            path: netperf/bpf_performance_native_azure_2025_x64/bpf_performance_native.csv
+
+      - name: upload_results_lab_2022_x64
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        with:
+            name: Test-Logs-bpf_performance_native_lab_2022_x64
+            path: netperf/bpf_performance_native_lab_2022_x64/bpf_performance_native.csv

--- a/.github/workflows/upload-perf-results.yml
+++ b/.github/workflows/upload-perf-results.yml
@@ -14,6 +14,10 @@ on:
       result_artifact:
         required: true
         type: string
+      platform:
+        required: false
+        type: string
+        default: "Windows 2019"
     secrets:
       AZURE_CLIENT_ID:
         required: true
@@ -57,7 +61,7 @@ jobs:
         # Compare hash of downloaded script.
         sha256sum process_results.py | grep dc616f27b6d345e8086de451ffd3f73cc71b5d51d18894ce08c02db56d67e0f4 -q || exit 1
         # Run script to convert CSV to SQL.
-        python3 ./process_results.py --csv-directory ${{github.workspace}}/results/${{github.sha}} --sql-script-file ${{github.workspace}}/results/upload.sql --commit_id ${{github.sha}} --platform "Windows 2019" --repository ${{github.repository}}
+        python3 ./process_results.py --csv-directory ${{github.workspace}}/results/${{github.sha}} --sql-script-file ${{github.workspace}}/results/upload.sql --commit_id ${{github.sha}} --platform "${{inputs.platform}}" --repository ${{github.repository}}
 
     # Grab the output from the results directory and upload it as an artifact to debug failures.
     - name: Upload data as artifacts for debugging


### PR DESCRIPTION
## Description

This pull request mainly focuses on enhancing the CI/CD workflow by introducing a new `netperf` job, adding new jobs for uploading `netperf` results, and modifying the existing `upload-perf-results` workflow. The changes also include the addition of a new `netperf.yml` workflow and some modifications to the `upload-perf-results.yml` workflow.

Here are the key changes:

New Jobs:

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0R581-R590): A new `netperf` job has been added which uses the `netperf.yml` workflow. This job is triggered either on a schedule or when a workflow is dispatched.
* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0R602-R640): Three new jobs have been added for uploading `netperf` results for different platforms. These jobs are dependent on the `netperf` job and are also triggered either on a schedule or when a workflow is dispatched.

New Workflow:

* [`.github/workflows/netperf.yml`](diffhunk://#diff-f2ba71ce9002e907f7355bdaf9e43385e451541fd886c97f1d89f80cf9697a46R1-R66): This new workflow runs performance tests on `netperf`. It includes a `netperf` job that runs the `netperf` workflow and uploads the results for different platforms.

Modifications to Existing Workflow:

* [`.github/workflows/upload-perf-results.yml`](diffhunk://#diff-88e0670dc528bb3547c4ca7dfeca2c6f0d0c345cb778802a3eb7d9f2db4be040R17-R20): The `on:` section of the workflow has been modified to include a new `platform` input. This input is not required and defaults to "Windows 2019".
* [`.github/workflows/upload-perf-results.yml`](diffhunk://#diff-88e0670dc528bb3547c4ca7dfeca2c6f0d0c345cb778802a3eb7d9f2db4be040L60-R64): The `jobs:` section has been modified to use the `platform` input when running the `process_results.py` script.

## Testing

CI/CD.
Scheduled a run of the CICD workflow and confirmed it dispatched to netperf repo and the results are correctly uploaded as artifacts, converted to SQL. Unable to confirm upload to dashboard as uploads are restricted to main branch of this repo.

## Documentation

No.

## Installation

No.
