### PR TITLE
Swallow wpr cancel error in uninstallation path.

### DIFF
--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -338,6 +338,6 @@ function Uninstall-eBPFComponents
     wpr.exe -cancel
     if ($LASTEXITCODE -ne 0) {
         Write-Log("Failed to stop WPR session with error: $LASTEXITCODE")
-        exit 0
+        $LASTEXITCODE = 0
     }
 }

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -336,4 +336,8 @@ function Uninstall-eBPFComponents
 
     # Stop KM tracing.
     wpr.exe -cancel
+    if ($LASTEXITCODE -ne 0) {
+        Write-Log("Failed to stop WPR session with error: $LASTEXITCODE")
+        exit 0
+    }
 }

--- a/scripts/install_ebpf.psm1
+++ b/scripts/install_ebpf.psm1
@@ -335,9 +335,8 @@ function Uninstall-eBPFComponents
     Write-Log("MSI uninstallation completed successfully!") -ForegroundColor Green
 
     # Stop KM tracing.
-    wpr.exe -cancel
-    if ($LASTEXITCODE -ne 0) {
-        Write-Log("Failed to stop WPR session with error: $LASTEXITCODE")
-        $LASTEXITCODE = 0
+    $process = Start-Process -FilePath wpr.exe -ArgumentList "-cancel" -NoNewWindow -Wait -PassThru
+    if ($process.ExitCode -ne 0) {
+        Write-Log("Failed to stop WPR session with error: $($process.ExitCode)")
     }
 }


### PR DESCRIPTION
## Description
Fixes recent regression where a duplicate call to 'wpr.exe -cancel' returns an error and causes the post-test cleanup to fail, which shows up as the whole job failing and causes test results not to be gathered.

## Testing

Manually scheduled run - perf job passed.
https://github.com/microsoft/ebpf-for-windows/actions/runs/8457367236/job/23169744149

