### PR TITLE
Do not skip build when called via repository_dispatch

### DIFF
--- a/.github/workflows/reusable-build.yml
+++ b/.github/workflows/reusable-build.yml
@@ -90,6 +90,10 @@ jobs:
       with:
         cancel_others: 'false'
         paths_ignore: '["**.md", "**/docs/**"]'
+        # Do not skip the following events.
+        # Workflow_dispatch, schedule, and merge_group are the default events that are not skipped.
+        # Repository_dispatch is used for calling this workflow from another repository.
+        do_not_skip: '["workflow_dispatch", "schedule", "merge_group", "repository_dispatch"]'
 
     - name: Set MSVC Environment Variables
       shell: cmd


### PR DESCRIPTION
## Description

This pull request includes a change to the `.github/workflows/reusable-build.yml` file. The change adds a `do_not_skip` field in the `jobs:` section, specifying certain events that should not be skipped. These events include `workflow_dispatch`, `schedule`, `merge_group`, and `repository_dispatch`. This addition is important as it allows the workflow to be called from another repository and ensures that certain default events are not skipped.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
