### PR TITLE
Implement bpf_object__open_mem

### DIFF
--- a/ebpfapi/Source.def
+++ b/ebpfapi/Source.def
@@ -57,6 +57,7 @@ EXPORTS
     bpf_object__next_program
     bpf_object__open
     bpf_object__open_file
+    bpf_object__open_mem
     bpf_object__pin
     bpf_object__pin_maps
     bpf_object__pin_programs

--- a/libs/api/Verifier.h
+++ b/libs/api/Verifier.h
@@ -8,12 +8,15 @@
 #include "ebpf_program_types.h"
 #include "ebpf_result.h"
 #include "platform.hpp"
+
+#include <variant>
+
 typedef int (*map_create_fp)(
     uint32_t map_type, uint32_t key_size, uint32_t value_size, uint32_t max_entries, ebpf_verifier_options_t options);
 
 _Must_inspect_result_ ebpf_result_t
 load_byte_code(
-    _In_z_ const char* filename,
+    std::variant<std::string, std::vector<uint8_t>>& file_or_buffer,
     _In_opt_z_ const char* section_name,
     _In_ const ebpf_verifier_options_t* verifier_options,
     _In_z_ const char* pin_root_path,

--- a/libs/api/api_internal.h
+++ b/libs/api/api_internal.h
@@ -573,6 +573,38 @@ ebpf_object_open(
     _Outptr_result_maybenull_z_ const char** error_message) noexcept;
 
 /**
+ * @brief Open a ELF file from memory without loading the programs.
+ *
+ * @param[in] buffer Pointer to the buffer containing the ELF file.
+ * @param[in] buffer_size Size of the buffer containing the ELF file.
+ * @param[in] object_name Optional object name to override file name
+ * as the object name.
+ * @param[in] pin_root_path Optional root path for automatic pinning of maps.
+ * @param[in] program_type Optional program type for all programs.
+ * If NULL, the program type is derived from the section names.
+ * @param[in] attach_type Default attach type for all programs.
+ * If NULL, the attach type is derived from the section names.
+ * @param[out] object Returns a pointer to the object created.
+ * @param[out] error_message Error message string, which
+ * the caller must free using ebpf_free_string().
+ *
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_INVALID_ARGUMENT One or more parameters are wrong.
+ * @retval EBPF_NO_MEMORY Out of memory.
+ */
+EBPF_API_LOCKING
+_Must_inspect_result_ ebpf_result_t
+ebpf_object_open_memory(
+    _In_reads_(buffer_size) const uint8_t* buffer,
+    size_t buffer_size,
+    _In_opt_z_ const char* object_name,
+    _In_opt_z_ const char* pin_root_path,
+    _In_opt_ const ebpf_program_type_t* program_type,
+    _In_opt_ const ebpf_attach_type_t* attach_type,
+    _Outptr_ struct bpf_object** object,
+    _Outptr_result_maybenull_z_ const char** error_message) noexcept;
+
+/**
  * @brief Load all the programs in a given object.
  *
  * @param[in, out] object Object from which to load programs.

--- a/libs/api/ebpf_api.cpp
+++ b/libs/api/ebpf_api.cpp
@@ -2279,20 +2279,19 @@ CATCH_NO_MEMORY_EBPF_RESULT
 
 static ebpf_result_t
 _initialize_ebpf_object_from_elf(
-    _In_z_ const char* file_name,
+    std::variant<std::string, std::vector<uint8_t>>& file_or_data,
     _In_opt_z_ const char* pin_root_path,
     _Inout_ ebpf_object_t& object,
     _Outptr_result_maybenull_z_ const char** error_message) NO_EXCEPT_TRY
 {
     EBPF_LOG_ENTRY();
-    ebpf_assert(file_name);
     ebpf_assert(error_message);
 
     ebpf_result_t result = EBPF_SUCCESS;
 
     ebpf_verifier_options_t verifier_options{false, false, false, false, false};
     result = load_byte_code(
-        file_name,
+        file_or_data,
         nullptr,
         &verifier_options,
         pin_root_path ? pin_root_path : DEFAULT_PIN_ROOT_PATH,
@@ -2314,7 +2313,7 @@ CATCH_NO_MEMORY_EBPF_RESULT
 
 static ebpf_result_t
 _initialize_ebpf_object_from_file(
-    _In_z_ const char* path,
+    std::variant<std::string, std::vector<uint8_t>> file_or_data,
     _In_opt_z_ const char* object_name,
     _In_opt_z_ const char* pin_root_path,
     _Out_ ebpf_object_t* new_object,
@@ -2323,22 +2322,32 @@ _initialize_ebpf_object_from_file(
     EBPF_LOG_ENTRY();
     ebpf_result_t result = EBPF_SUCCESS;
 
-    new_object->file_name = cxplat_duplicate_string(path);
+    if (std::holds_alternative<std::string>(file_or_data)) {
+        std::string path = std::get<std::string>(file_or_data);
+        new_object->file_name = cxplat_duplicate_string(path.c_str());
+    } else {
+        new_object->file_name = cxplat_duplicate_string("memory");
+    }
     if (new_object->file_name == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Done;
     }
 
-    new_object->object_name = cxplat_duplicate_string(object_name ? object_name : path);
+    new_object->object_name = cxplat_duplicate_string(object_name ? object_name : new_object->file_name);
     if (new_object->object_name == nullptr) {
         result = EBPF_NO_MEMORY;
         goto Done;
     }
 
-    if (Platform::_is_native_program(path)) {
-        result = _initialize_ebpf_object_from_native_file(path, pin_root_path, *new_object, error_message);
+    // If file_or_data is a string, it is a file path.
+    // If it is a vector, it is the ELF data.
+
+    if (std::holds_alternative<std::string>(file_or_data) &&
+        Platform::_is_native_program(std::get<std::string>(file_or_data).c_str())) {
+        result = _initialize_ebpf_object_from_native_file(
+            std::get<std::string>(file_or_data).c_str(), pin_root_path, *new_object, error_message);
     } else {
-        result = _initialize_ebpf_object_from_elf(path, pin_root_path, *new_object, error_message);
+        result = _initialize_ebpf_object_from_elf(file_or_data, pin_root_path, *new_object, error_message);
     }
     if (result != EBPF_SUCCESS) {
         goto Done;
@@ -2858,6 +2867,72 @@ Done:
                 EBPF_TRACELOG_LEVEL_ERROR,
                 EBPF_TRACELOG_KEYWORD_API,
                 "ebpf_object_open failed (error_message)",
+                *error_message);
+        }
+    }
+    EBPF_RETURN_RESULT(result);
+}
+CATCH_NO_MEMORY_EBPF_RESULT
+
+EBPF_API_LOCKING
+_Must_inspect_result_ ebpf_result_t
+ebpf_object_open_memory(
+    _In_reads_(buffer_size) const uint8_t* buffer,
+    size_t buffer_size,
+    _In_opt_z_ const char* object_name,
+    _In_opt_z_ const char* pin_root_path,
+    _In_opt_ const ebpf_program_type_t* program_type,
+    _In_opt_ const ebpf_attach_type_t* attach_type,
+    _Outptr_ struct bpf_object** object,
+    _Outptr_result_maybenull_z_ const char** error_message) NO_EXCEPT_TRY
+{
+    EBPF_LOG_ENTRY();
+    ebpf_assert(buffer);
+    ebpf_assert(object);
+    ebpf_assert(error_message);
+    *error_message = nullptr;
+
+    EBPF_LOG_MESSAGE(
+        EBPF_TRACELOG_LEVEL_INFO, EBPF_TRACELOG_KEYWORD_API, "ebpf_object_open_memory: loading from memory");
+
+    ebpf_object_t* new_object = new (std::nothrow) ebpf_object_t();
+    if (new_object == nullptr) {
+        EBPF_RETURN_RESULT(EBPF_NO_MEMORY);
+    }
+
+    set_global_program_and_attach_type(program_type, attach_type);
+
+    std::vector<uint8_t> data(buffer, buffer + buffer_size);
+
+    ebpf_result_t result =
+        _initialize_ebpf_object_from_file(data, object_name, pin_root_path, new_object, error_message);
+    if (result != EBPF_SUCCESS) {
+        std::string log_message = "ebpf_object_open_memory: error loading memory:";
+        log_message += ", error message:";
+        log_message += *error_message != NULL ? *error_message : "none";
+        EBPF_LOG_MESSAGE_STRING(
+            EBPF_TRACELOG_LEVEL_ERROR, EBPF_TRACELOG_KEYWORD_API, "*** ERROR *** ", log_message.c_str());
+        goto Done;
+    }
+
+    *object = new_object;
+    {
+        std::unique_lock lock(_ebpf_state_mutex);
+        _ebpf_objects.emplace_back(*object);
+    }
+
+Done:
+    clear_map_descriptors();
+    if (result != EBPF_SUCCESS) {
+        _clean_up_ebpf_object(new_object);
+
+        // Libbpf API absorbs the error message string.
+        // Print it here for debugging purposes.
+        if (*error_message) {
+            EBPF_LOG_MESSAGE_STRING(
+                EBPF_TRACELOG_LEVEL_ERROR,
+                EBPF_TRACELOG_KEYWORD_API,
+                "ebpf_object_open_memory failed (error_message)",
                 *error_message);
         }
     }

--- a/libs/api/libbpf_object.cpp
+++ b/libs/api/libbpf_object.cpp
@@ -115,6 +115,29 @@ bpf_object__open_file(const char* path, const struct bpf_object_open_opts* opts)
     return object;
 }
 
+struct bpf_object*
+bpf_object__open_mem(const void* buffer, size_t buffer_size, const struct bpf_object_open_opts* opts)
+{
+    if (!buffer) {
+        return (struct bpf_object*)libbpf_err_ptr(-EINVAL);
+    }
+
+    struct bpf_object* object = nullptr;
+    const char* error_message;
+    ebpf_result_t result = ebpf_object_open_memory(
+        reinterpret_cast<const uint8_t*>(buffer),
+        buffer_size,
+        ((opts) ? opts->object_name : nullptr),
+        ((opts) ? opts->pin_root_path : nullptr),
+        nullptr,
+        nullptr,
+        &object,
+        &error_message);
+    ebpf_free_string(error_message);
+    libbpf_result_err(result); // Set errno.
+    return object;
+}
+
 int
 bpf_object__load_xattr(struct bpf_object_load_attr* attr)
 {

--- a/tests/unit/libbpf_test.cpp
+++ b/tests/unit/libbpf_test.cpp
@@ -18,6 +18,7 @@
 #include "test_helper.hpp"
 
 #include <chrono>
+#include <fstream>
 #include <stop_token>
 #include <thread>
 
@@ -2521,6 +2522,79 @@ TEST_CASE("bpf_object__load with .o", "[libbpf]")
     struct bpf_object_open_opts opts = {0};
     opts.object_name = my_object_name;
     struct bpf_object* object = bpf_object__open_file("droppacket.o", &opts);
+    REQUIRE(object != nullptr);
+
+    REQUIRE(strcmp(bpf_object__name(object), my_object_name) == 0);
+
+    struct bpf_program* program = bpf_object__find_program_by_name(object, "DropPacket");
+    REQUIRE(program != nullptr);
+
+    REQUIRE(bpf_program__fd(program) == ebpf_fd_invalid);
+    REQUIRE(bpf_program__type(program) == BPF_PROG_TYPE_XDP);
+
+    // Make sure we can override the program type if desired.
+    REQUIRE(bpf_program__set_type(program, BPF_PROG_TYPE_BIND) == 0);
+    REQUIRE(bpf_program__type(program) == BPF_PROG_TYPE_BIND);
+
+    REQUIRE(bpf_program__set_type(program, BPF_PROG_TYPE_XDP) == 0);
+
+    struct bpf_map* map = bpf_object__next_map(object, nullptr);
+    REQUIRE(map != nullptr);
+    REQUIRE(strcmp(bpf_map__name(map), "dropped_packet_map") == 0);
+    REQUIRE(bpf_map__fd(map) == ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(strcmp(bpf_map__name(map), "interface_index_map") == 0);
+    REQUIRE(bpf_map__fd(map) == ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(map == nullptr);
+
+    // Trying to attach the program should fail since it's not loaded yet.
+    bpf_link_ptr link(bpf_program__attach(program));
+    REQUIRE(link == nullptr);
+    REQUIRE(libbpf_get_error(link.get()) == -EINVAL);
+
+    // Load the program.
+    REQUIRE(bpf_object__load(object) == 0);
+
+    // Attach should now succeed.
+    link.reset(bpf_program__attach(program));
+    REQUIRE(link != nullptr);
+
+    // The maps should now have FDs.
+    map = bpf_object__next_map(object, nullptr);
+    REQUIRE(map != nullptr);
+    REQUIRE(strcmp(bpf_map__name(map), "dropped_packet_map") == 0);
+    REQUIRE(bpf_map__fd(map) != ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(strcmp(bpf_map__name(map), "interface_index_map") == 0);
+    REQUIRE(bpf_map__fd(map) != ebpf_fd_invalid);
+    map = bpf_object__next_map(object, map);
+    REQUIRE(map == nullptr);
+
+    REQUIRE(bpf_link__destroy(link.release()) == 0);
+    bpf_object__close(object);
+}
+
+TEST_CASE("bpf_object__load with .o from memory", "[libbpf]")
+{
+    _test_helper_libbpf test_helper;
+    test_helper.initialize();
+
+    const char* my_object_name = "my_object_name";
+    struct bpf_object_open_opts opts = {0};
+    opts.object_name = my_object_name;
+
+    // Read droppacket.o into a std::vector.
+    std::vector<uint8_t> object_data;
+    std::fstream file("droppacket.o", std::ios::in | std::ios::binary);
+    REQUIRE(file.is_open());
+    file.seekg(0, std::ios::end);
+    object_data.resize(file.tellg());
+    file.seekg(0, std::ios::beg);
+    file.read((char*)object_data.data(), object_data.size());
+    file.close();
+
+    struct bpf_object* object = bpf_object__open_mem(object_data.data(), object_data.size(), &opts);
     REQUIRE(object != nullptr);
 
     REQUIRE(strcmp(bpf_object__name(object), my_object_name) == 0);


### PR DESCRIPTION
Resolves: #3352 

## Description

This pull request introduces changes that allow the EBPF verifier to load EBPF programs not only from files but also from memory. This is achieved by using `std::variant` to hold either a file path or a memory buffer. The most significant changes include adding a new method `bpf_object__open_mem` for opening an ELF file from memory, modifying several methods in `libs/api/Verifier.cpp` and `libs/api/ebpf_api.cpp` to handle the variant type, and adding a new test case for loading an EBPF program from memory.

Changes to the API:

* [`ebpfapi/Source.def`](diffhunk://#diff-2f82d1ff51a61fb435467ba5290591820cb88e359100a25e9b9a8e7913c6577cR60): Added a new function `bpf_object__open_mem` to the exports.
* [`libs/api/api_internal.h`](diffhunk://#diff-545d6b59394e62a7162e59b142ddf08db2534ef3072a47b414e5cda5b311bca6R575-R606): Defined a new function `ebpf_object_open_memory` that opens an ELF file from memory without loading the programs.
* [`libs/api/libbpf_object.cpp`](diffhunk://#diff-91af4554cf2831a775b4de416aff1ab4fc022732599494f6328a0c4fd46bdad4R118-R140): Implemented `bpf_object__open_mem` that uses `ebpf_object_open_memory` to open an ELF file from memory.

Changes to the Verifier:

* `libs/api/Verifier.cpp` and `libs/api/Verifier.h`: Modified `_get_program_and_map_names` and `load_byte_code` to accept a `std::variant` that can be either a file path or a memory buffer. [[1]](diffhunk://#diff-c7cabf550a3d7ec7f53d5aaf8ea0e8a77d949e886b3c0f492ebd75228756b40fL258-R275) [[2]](diffhunk://#diff-c7cabf550a3d7ec7f53d5aaf8ea0e8a77d949e886b3c0f492ebd75228756b40fL320-R329) [[3]](diffhunk://#diff-c7cabf550a3d7ec7f53d5aaf8ea0e8a77d949e886b3c0f492ebd75228756b40fL338-R365) [[4]](diffhunk://#diff-c7cabf550a3d7ec7f53d5aaf8ea0e8a77d949e886b3c0f492ebd75228756b40fL426-R447) [[5]](diffhunk://#diff-585b4c81e431b998895c94f5c9df5936894ba773e86c908df31d1d734afe5670R11-R19)

Changes to the EBPF API:

* [`libs/api/ebpf_api.cpp`](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL2282-R2294): Added the implementation for `ebpf_object_open_memory` and modified `_initialize_ebpf_object_from_elf`, `_initialize_ebpf_object_from_file` and other related methods to handle the `std::variant` type. [[1]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL2282-R2294) [[2]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL2317-R2316) [[3]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeL2326-R2350) [[4]](diffhunk://#diff-5838f7744d41bcd6c7dc0e9b88628baa36b2a2645824c76aa15f01955ac9cefeR2877-R2942)

Changes to the test suite:

* [`tests/unit/libbpf_test.cpp`](diffhunk://#diff-90142b90fe7dce2a02d7411d25add1d8361f894156d688912f86fefb117570c0R2578-R2650): Added a new test case for loading an EBPF program from memory.

## Testing

CI/CD + new tests.

## Documentation

No.

## Installation

No.
