### PR TITLE
Various fixes to the extension version logic.

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -259,7 +259,7 @@ jobs:
     if: github.repository == 'microsoft/ebpf-for-windows' && (github.event_name == 'schedule' || github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'merge_group' || github.event_name == 'workflow_dispatch')
     uses: ./.github/workflows/reusable-test.yml
     with:
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file" -TestMode "Regression" -RegressionArtifactsVersion "0.15.0"
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "file" -TestMode "Regression" -RegressionArtifactsVersion "0.15.1"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Regression"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       name: driver_ws2022

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -560,7 +560,10 @@ _ebpf_program_type_specific_program_information_detach_provider(void* client_bin
     ExWaitForRundownProtectionRelease(&program->program_information_rundown_reference);
 
     ebpf_lock_state_t state = ebpf_lock_lock(&program->lock);
-    program->extension_program_data = NULL;
+    if (program->extension_program_data != NULL) {
+        ebpf_program_data_free((ebpf_program_data_t*)program->extension_program_data);
+        program->extension_program_data = NULL;
+    }
     ebpf_lock_unlock(&program->lock, state);
     return STATUS_SUCCESS;
 }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -501,10 +501,11 @@ _ebpf_program_type_specific_program_information_attach_provider(
 
     // Unblock calls to use the program information.
     program->extension_program_data = extension_program_data;
+    extension_program_data = NULL;
     ExInitializeRundownProtection(&program->program_information_rundown_reference);
 
     program->program_type_specific_helper_function_count =
-        extension_program_data->program_info->count_of_program_type_specific_helpers;
+        program->extension_program_data->program_info->count_of_program_type_specific_helpers;
 
     if (_ebpf_program_update_helpers(program) != EBPF_SUCCESS) {
         EBPF_LOG_MESSAGE(
@@ -513,8 +514,7 @@ _ebpf_program_type_specific_program_information_attach_provider(
         goto Done;
     }
 
-    program->bpf_prog_type = extension_program_data->program_info->program_type_descriptor->bpf_prog_type;
-    extension_program_data = NULL;
+    program->bpf_prog_type = program->extension_program_data->program_info->program_type_descriptor->bpf_prog_type;
 
     ebpf_lock_unlock(&program->lock, state);
     lock_held = false;
@@ -549,9 +549,7 @@ Done:
     if (lock_held) {
         ebpf_lock_unlock(&program->lock, state);
     }
-    if (extension_program_data) {
-        ebpf_program_data_free((ebpf_program_data_t*)extension_program_data);
-    }
+    ebpf_program_data_free((ebpf_program_data_t*)extension_program_data);
 
     return status;
 }
@@ -564,10 +562,8 @@ _ebpf_program_type_specific_program_information_detach_provider(void* client_bin
     ExWaitForRundownProtectionRelease(&program->program_information_rundown_reference);
 
     ebpf_lock_state_t state = ebpf_lock_lock(&program->lock);
-    if (program->extension_program_data != NULL) {
-        ebpf_program_data_free((ebpf_program_data_t*)program->extension_program_data);
-        program->extension_program_data = NULL;
-    }
+    ebpf_program_data_free((ebpf_program_data_t*)program->extension_program_data);
+    program->extension_program_data = NULL;
     ebpf_lock_unlock(&program->lock, state);
     return STATUS_SUCCESS;
 }
@@ -646,10 +642,7 @@ _IRQL_requires_max_(PASSIVE_LEVEL) static void _ebpf_program_free(_In_opt_ _Post
         }
     }
 
-    if (program->extension_program_data != NULL) {
-        ebpf_program_data_free((ebpf_program_data_t*)program->extension_program_data);
-    }
-
+    ebpf_program_data_free((ebpf_program_data_t*)program->extension_program_data);
     ebpf_lock_destroy(&program->lock);
 
     switch (program->parameters.code_type) {

--- a/libs/shared/ebpf_serialize.c
+++ b/libs/shared/ebpf_serialize.c
@@ -5,6 +5,7 @@
 // various eBPF structures to/from ebpf_operation_*_request/reply_t structures.
 #include "ebpf_program_types.h"
 #include "ebpf_serialize.h"
+#include "ebpf_shared_framework.h"
 #include "ebpf_tracelog.h"
 
 /**
@@ -254,39 +255,6 @@ Exit:
     EBPF_RETURN_RESULT(result);
 }
 #pragma warning(pop)
-
-void
-ebpf_program_info_free(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info)
-{
-    EBPF_LOG_ENTRY();
-    if (program_info != NULL) {
-        if (program_info->program_type_descriptor != NULL) {
-            ebpf_free((void*)program_info->program_type_descriptor->context_descriptor);
-            ebpf_free((void*)program_info->program_type_descriptor->name);
-            ebpf_free((void*)program_info->program_type_descriptor);
-        }
-        if (program_info->program_type_specific_helper_prototype != NULL) {
-            for (uint32_t i = 0; i < program_info->count_of_program_type_specific_helpers; i++) {
-                const ebpf_helper_function_prototype_t* helper_prototype =
-                    &program_info->program_type_specific_helper_prototype[i];
-                void* name = (void*)helper_prototype->name;
-                ebpf_free(name);
-            }
-        }
-        if (program_info->global_helper_prototype != NULL) {
-            for (uint32_t i = 0; i < program_info->count_of_global_helpers; i++) {
-                const ebpf_helper_function_prototype_t* helper_prototype = &program_info->global_helper_prototype[i];
-                void* name = (void*)helper_prototype->name;
-                ebpf_free(name);
-            }
-        }
-
-        ebpf_free((void*)program_info->program_type_specific_helper_prototype);
-        ebpf_free((void*)program_info->global_helper_prototype);
-        ebpf_free(program_info);
-    }
-    EBPF_RETURN_VOID();
-}
 
 _Must_inspect_result_ ebpf_result_t
 ebpf_serialize_program_info(

--- a/libs/shared/ebpf_serialize.h
+++ b/libs/shared/ebpf_serialize.h
@@ -8,7 +8,6 @@
 
 #include "cxplat.h"
 #include "ebpf_core_structs.h"
-
 // Everything in this file must be usable in both user mode and kernel mode,
 // and not rely on ebpf_platform.h.
 
@@ -125,15 +124,6 @@ extern "C"
         size_t input_buffer_length,
         _In_reads_bytes_(input_buffer_length) const uint8_t* input_buffer,
         _Outptr_ ebpf_program_info_t** program_info);
-
-    /**
-     * @brief Helper Function to free ebpf_program_info_t allocated by
-     * ebpf_deserialize_program_info().
-     *
-     * @param[in] program_info Program info to be freed.
-     */
-    void
-    ebpf_program_info_free(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info);
 
 #ifdef __cplusplus
 }

--- a/libs/shared/ebpf_shared_framework.h
+++ b/libs/shared/ebpf_shared_framework.h
@@ -110,4 +110,43 @@ bool
 ebpf_validate_helper_function_prototype_array(
     _In_reads_(count) const ebpf_helper_function_prototype_t* helper_prototype, uint32_t count);
 
+/**
+ * @brief Helper Function to free ebpf_program_info_t.
+ *
+ * @param[in] program_info Program info to be freed.
+ */
+void
+ebpf_program_info_free(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info);
+
+/**
+ * @brief Helper Function to duplicate ebpf_program_info_t to the latest version with safe defaults.
+ *
+ * @param[in] info Program info to be duplicated.
+ * @param[out] new_info Duplicated program info.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_NO_MEMORY Out of memory.
+ */
+ebpf_result_t
+ebpf_duplicate_program_info(_In_ const ebpf_program_info_t* info, _Outptr_ ebpf_program_info_t** new_info);
+
+/**
+ * @brief Helper Function to free ebpf_program_data_t.
+ *
+ * @param[in] program_data Program data to be freed.
+ */
+void
+ebpf_program_data_free(_In_opt_ ebpf_program_data_t* program_data);
+
+/**
+ * @brief Helper Function to duplicate ebpf_program_data_t to the latest version with safe defaults.
+ *
+ * @param[in] program_data Program data to be duplicated.
+ * @param[out] new_program_data Duplicated program data.
+ * @retval EBPF_SUCCESS The operation was successful.
+ * @retval EBPF_NO_MEMORY Out of memory.
+ */
+ebpf_result_t
+ebpf_duplicate_program_data(
+    _In_ const ebpf_program_data_t* program_data, _Outptr_ ebpf_program_data_t** new_program_data);
+
 CXPLAT_EXTERN_C_END

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: MIT
 
 #include "ebpf_program_types.h"
+#include "ebpf_serialize.h"
 #include "ebpf_shared_framework.h"
+#include "ebpf_tracelog.h"
 
 enum _extension_object_type
 {
@@ -117,11 +119,14 @@ _ebpf_validate_helper_function_prototype(const ebpf_helper_function_prototype_t*
 
 bool
 ebpf_validate_helper_function_prototype_array(
-    _In_reads_(count) const ebpf_helper_function_prototype_t* helper_prototype, uint32_t count)
+    _In_reads_(count) const ebpf_helper_function_prototype_t* helper_prototype_array, uint32_t count)
 {
     if (count > 0) {
+        size_t helper_prototype_size = EBPF_PAD_8(helper_prototype_array[0].header.size);
         for (uint32_t i = 0; i < count; i++) {
-            if (!_ebpf_validate_helper_function_prototype(&helper_prototype[i])) {
+            ebpf_helper_function_prototype_t* helper_prototype =
+                (ebpf_helper_function_prototype_t*)((uint8_t*)helper_prototype_array + i * helper_prototype_size);
+            if (!_ebpf_validate_helper_function_prototype(helper_prototype)) {
                 return false;
             }
         }
@@ -202,4 +207,299 @@ ebpf_result_from_cxplat_status(cxplat_status_t status)
     default:
         return EBPF_FAILED;
     }
+}
+
+static ebpf_result_t
+_duplicate_program_descriptor(
+    _In_ const ebpf_program_type_descriptor_t* program_type_descriptor,
+    _Out_ ebpf_program_type_descriptor_t** new_program_type_descriptor)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_program_type_descriptor_t* program_type_descriptor_copy = NULL;
+    ebpf_context_descriptor_t* context_descriptor_copy = NULL;
+
+    program_type_descriptor_copy =
+        (ebpf_program_type_descriptor_t*)ebpf_allocate(sizeof(ebpf_program_type_descriptor_t));
+    if (program_type_descriptor_copy == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    memcpy(program_type_descriptor_copy, program_type_descriptor, program_type_descriptor->header.size);
+    program_type_descriptor_copy->header.version = EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION;
+    program_type_descriptor_copy->header.size = EBPF_PROGRAM_TYPE_DESCRIPTOR_CURRENT_VERSION_SIZE;
+
+    program_type_descriptor_copy->name = cxplat_duplicate_string(program_type_descriptor->name);
+    if (program_type_descriptor_copy->name == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    context_descriptor_copy = (ebpf_context_descriptor_t*)ebpf_allocate(sizeof(ebpf_context_descriptor_t));
+    if (context_descriptor_copy == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    memcpy(context_descriptor_copy, program_type_descriptor->context_descriptor, sizeof(ebpf_context_descriptor_t));
+    program_type_descriptor_copy->context_descriptor = context_descriptor_copy;
+    context_descriptor_copy = NULL;
+
+    *new_program_type_descriptor = program_type_descriptor_copy;
+    program_type_descriptor_copy = NULL;
+
+Exit:
+    ebpf_free(program_type_descriptor_copy);
+    ebpf_free(context_descriptor_copy);
+
+    return result;
+}
+
+static ebpf_result_t
+_duplicate_helper_function_prototype_array(
+    _In_reads_(count) const ebpf_helper_function_prototype_t* helper_prototype_array,
+    uint32_t count,
+    _Outptr_result_buffer_maybenull_(count) ebpf_helper_function_prototype_t** new_helper_prototype_array)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_helper_function_prototype_t* local_helper_prototype_array = NULL;
+    size_t helper_prototype_size = 0;
+
+    if (count == 0) {
+        *new_helper_prototype_array = NULL;
+        goto Exit;
+    }
+
+    helper_prototype_size = EBPF_PAD_8(helper_prototype_array[0].header.size);
+
+    local_helper_prototype_array =
+        (ebpf_helper_function_prototype_t*)ebpf_allocate(count * sizeof(ebpf_helper_function_prototype_t));
+    if (local_helper_prototype_array == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    for (uint32_t i = 0; i < count; i++) {
+        ebpf_helper_function_prototype_t* helper_prototype =
+            (ebpf_helper_function_prototype_t*)((uint8_t*)helper_prototype_array + i * helper_prototype_size);
+        memcpy(&local_helper_prototype_array[i], helper_prototype, helper_prototype_size);
+        local_helper_prototype_array[i].header.version = EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION;
+        local_helper_prototype_array[i].header.size = EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION_SIZE;
+        local_helper_prototype_array[i].name = cxplat_duplicate_string(helper_prototype->name);
+        if (local_helper_prototype_array[i].name == NULL) {
+            result = EBPF_NO_MEMORY;
+            goto Exit;
+        }
+        if (local_helper_prototype_array[i].header.size == EBPF_HELPER_FUNCTION_PROTOTYPE_CURRENT_VERSION) {
+            local_helper_prototype_array[i].flags = helper_prototype[i].flags;
+        }
+    }
+
+    *new_helper_prototype_array = local_helper_prototype_array;
+    local_helper_prototype_array = NULL;
+
+Exit:
+    if (local_helper_prototype_array != NULL) {
+        for (uint32_t i = 0; i < count; i++) {
+            ebpf_free((void*)local_helper_prototype_array[i].name);
+        }
+        ebpf_free(local_helper_prototype_array);
+    }
+
+    return result;
+}
+
+void
+ebpf_program_info_free(_In_opt_ _Post_invalid_ ebpf_program_info_t* program_info)
+{
+    if (program_info != NULL) {
+        if (program_info->program_type_descriptor != NULL) {
+            ebpf_free((void*)program_info->program_type_descriptor->context_descriptor);
+            ebpf_free((void*)program_info->program_type_descriptor->name);
+            ebpf_free((void*)program_info->program_type_descriptor);
+        }
+        if (program_info->program_type_specific_helper_prototype != NULL) {
+            for (uint32_t i = 0; i < program_info->count_of_program_type_specific_helpers; i++) {
+                const ebpf_helper_function_prototype_t* helper_prototype =
+                    &program_info->program_type_specific_helper_prototype[i];
+                void* name = (void*)helper_prototype->name;
+                ebpf_free(name);
+            }
+        }
+        if (program_info->global_helper_prototype != NULL) {
+            for (uint32_t i = 0; i < program_info->count_of_global_helpers; i++) {
+                const ebpf_helper_function_prototype_t* helper_prototype = &program_info->global_helper_prototype[i];
+                void* name = (void*)helper_prototype->name;
+                ebpf_free(name);
+            }
+        }
+
+        ebpf_free((void*)program_info->program_type_specific_helper_prototype);
+        ebpf_free((void*)program_info->global_helper_prototype);
+        ebpf_free(program_info);
+    }
+}
+
+ebpf_result_t
+ebpf_duplicate_program_info(_In_ const ebpf_program_info_t* info, _Outptr_ ebpf_program_info_t** new_info)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_program_info_t* program_info = NULL;
+
+    EBPF_LOG_ENTRY();
+
+    program_info = (ebpf_program_info_t*)ebpf_allocate(sizeof(ebpf_program_info_t));
+    if (program_info == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    program_info->header.version = EBPF_PROGRAM_INFORMATION_CURRENT_VERSION;
+    program_info->header.size = EBPF_PROGRAM_INFORMATION_CURRENT_VERSION_SIZE;
+
+    program_info->count_of_global_helpers = info->count_of_global_helpers;
+    if (info->count_of_global_helpers > 0) {
+        result = _duplicate_helper_function_prototype_array(
+            info->global_helper_prototype, info->count_of_global_helpers, &program_info->global_helper_prototype);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+    }
+
+    program_info->count_of_program_type_specific_helpers = info->count_of_program_type_specific_helpers;
+    if (info->count_of_program_type_specific_helpers > 0) {
+        result = _duplicate_helper_function_prototype_array(
+            info->program_type_specific_helper_prototype,
+            info->count_of_program_type_specific_helpers,
+            &program_info->program_type_specific_helper_prototype);
+    }
+
+    result = _duplicate_program_descriptor(info->program_type_descriptor, &program_info->program_type_descriptor);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
+    *new_info = program_info;
+    program_info = NULL;
+
+Exit:
+    ebpf_program_info_free(program_info);
+
+    EBPF_RETURN_RESULT(result);
+}
+
+static void
+_ebpf_helper_function_addresses_free(_In_opt_ ebpf_helper_function_addresses_t* helper_function_addresses)
+{
+    if (helper_function_addresses == NULL) {
+        return;
+    }
+
+    ebpf_free(helper_function_addresses->helper_function_address);
+    ebpf_free(helper_function_addresses);
+}
+
+static ebpf_result_t
+_duplicate_helper_function_addresses(
+    _In_ const ebpf_helper_function_addresses_t* helper_function_addresses,
+    _Outptr_ ebpf_helper_function_addresses_t** new_helper_function_addresses)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_helper_function_addresses_t* helper_function_addresses_copy = NULL;
+
+    helper_function_addresses_copy =
+        (ebpf_helper_function_addresses_t*)ebpf_allocate(sizeof(ebpf_helper_function_addresses_t));
+    if (helper_function_addresses_copy == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    memcpy(helper_function_addresses_copy, helper_function_addresses, helper_function_addresses->header.size);
+    helper_function_addresses_copy->header.version = EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION;
+    helper_function_addresses_copy->header.size = EBPF_HELPER_FUNCTION_ADDRESSES_CURRENT_VERSION_SIZE;
+
+    helper_function_addresses_copy->helper_function_address =
+        (uint64_t*)ebpf_allocate(helper_function_addresses->helper_function_count * sizeof(uint64_t));
+    if (helper_function_addresses_copy->helper_function_address == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    memcpy(
+        helper_function_addresses_copy->helper_function_address,
+        helper_function_addresses->helper_function_address,
+        helper_function_addresses->helper_function_count * sizeof(uint64_t));
+
+    *new_helper_function_addresses = helper_function_addresses_copy;
+    helper_function_addresses_copy = NULL;
+
+Exit:
+    _ebpf_helper_function_addresses_free(helper_function_addresses_copy);
+
+    return result;
+}
+
+void
+ebpf_program_data_free(_In_opt_ ebpf_program_data_t* program_data)
+{
+    if (program_data == NULL) {
+        return;
+    }
+
+    ebpf_program_info_free((ebpf_program_info_t*)program_data->program_info);
+    _ebpf_helper_function_addresses_free(
+        (ebpf_helper_function_addresses_t*)program_data->global_helper_function_addresses);
+    _ebpf_helper_function_addresses_free(
+        (ebpf_helper_function_addresses_t*)program_data->program_type_specific_helper_function_addresses);
+    ebpf_free(program_data);
+}
+
+ebpf_result_t
+ebpf_duplicate_program_data(
+    _In_ const ebpf_program_data_t* program_data, _Outptr_ ebpf_program_data_t** new_program_data)
+{
+    ebpf_result_t result = EBPF_SUCCESS;
+    ebpf_program_data_t* program_data_copy = NULL;
+
+    EBPF_LOG_ENTRY();
+
+    program_data_copy = (ebpf_program_data_t*)ebpf_allocate(sizeof(ebpf_program_data_t));
+    if (program_data_copy == NULL) {
+        result = EBPF_NO_MEMORY;
+        goto Exit;
+    }
+
+    memcpy(program_data_copy, program_data, program_data->header.size);
+    program_data_copy->header.version = EBPF_PROGRAM_DATA_CURRENT_VERSION;
+    program_data_copy->header.size = EBPF_PROGRAM_DATA_CURRENT_VERSION_SIZE;
+
+    if (program_data->global_helper_function_addresses != NULL) {
+        result = _duplicate_helper_function_addresses(
+            program_data->global_helper_function_addresses, &program_data_copy->global_helper_function_addresses);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+    }
+
+    if (program_data->program_type_specific_helper_function_addresses != NULL) {
+        result = _duplicate_helper_function_addresses(
+            program_data->program_type_specific_helper_function_addresses,
+            &program_data_copy->program_type_specific_helper_function_addresses);
+        if (result != EBPF_SUCCESS) {
+            goto Exit;
+        }
+    }
+
+    result = ebpf_duplicate_program_info(program_data->program_info, &program_data_copy->program_info);
+    if (result != EBPF_SUCCESS) {
+        goto Exit;
+    }
+
+    *new_program_data = program_data_copy;
+    program_data_copy = NULL;
+
+Exit:
+    ebpf_program_data_free(program_data_copy);
+
+    EBPF_RETURN_RESULT(result);
 }

--- a/scripts/config_test_vm.psm1
+++ b/scripts/config_test_vm.psm1
@@ -609,10 +609,13 @@ function Get-RegressionTestArtifacts
 
     Write-Log "Extracting $ArtifactName"
     Expand-Archive -Path "$DownloadPath\artifact.zip" -DestinationPath $DownloadPath -Force
+    Write-Log "Extracting $DownloadPath\build-$Configuration.zip"
+    Expand-Archive -Path "$DownloadPath\build-$Configuration.zip" -DestinationPath $DownloadPath -Force
+
 
     # Copy all the drivers, DLLs and exe to pwd.
     Write-Log "Copy regression test artifacts to main folder" -ForegroundColor Green
-    $ArtifactPath = "$DownloadPath\Build-x64 $Configuration"
+    $ArtifactPath = "$DownloadPath\$Configuration"
     Push-Location $ArtifactPath
     Get-ChildItem -Path .\* -Include *.sys | Move-Item -Destination $OriginalPath -Force
     Get-ChildItem -Path .\* -Include *.dll | Move-Item -Destination $OriginalPath -Force


### PR DESCRIPTION
## Description

This PR patches some more gaps in #3326 that was found by the regression tests introduced by #3421. Specifically, the previous PR did not take into account the array of `ebpf_helper_function_prototype_t` in `ebpf_program_info_t`. Processing program information from an older extension can cause crashes if the size of the individual array elements are not considered. The solution was to "normalize" input `ebpf_program_data` to the latest version with safe defaults before processing them.

## Testing

CI/CD with kernel mode regression tests.

## Documentation

No documentation impact.

## Installation

No installer impact._
