### PR TITLE
Fix volatile usage

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,7 +44,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>/ZH:SHA_256 /we4062 %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/ZH:SHA_256 /we4062 /volatile:ms /volatile:iso  /we4746 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(SolutionDir)external\ebpf-verifier\build\packages\boost\lib\native\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>


### PR DESCRIPTION
## Description

This pull request includes a modification to the `Directory.Build.props` file. The change involves the addition of `/volatile:ms /volatile:iso /we4746` to the `AdditionalOptions` attribute in the `ClCompile` tag. These options are used to interpretation of the volatile flag and to enable warning 4746 which covers naked volatile access.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
