### PR TITLE
Add missing required option for reusable-build.yml

### DIFF
--- a/.github/workflows/perf.yml
+++ b/.github/workflows/perf.yml
@@ -29,6 +29,7 @@ jobs:
     uses: ./.github/workflows/reusable-build.yml
     with:
       ref: ${{ github.ref }}
+      repository: ${{ github.repository }}
       build_artifact: Build-x64
       build_options: /p:ReleaseJIT='False'
       configurations: '["Release"]'


### PR DESCRIPTION
## Description

This pull request includes a minor change to the `.github/workflows/perf.yml` file. The change adds a `repository` field to the `with` section under `jobs`. This field is set to the current GitHub repository, which allows the workflow to know which repository to use for the build.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
