### PR TITLE
Update verifier to latest

### DIFF
--- a/libs/api/windows_platform.cpp
+++ b/libs/api/windows_platform.cpp
@@ -103,4 +103,5 @@ const ebpf_platform_t g_ebpf_platform_windows = {
     _parse_maps_section_windows,
     get_map_descriptor_windows,
     get_map_type_windows,
-    _resolve_inner_map_references_windows};
+    _resolve_inner_map_references_windows,
+    bpf_conformance_groups_t::default_groups};

--- a/libs/service/windows_platform_service.cpp
+++ b/libs/service/windows_platform_service.cpp
@@ -22,4 +22,5 @@ const ebpf_platform_t g_ebpf_platform_windows_service = {
     nullptr, // parse_maps_section_windows,
     get_map_descriptor_windows,
     get_map_type_windows,
-};
+    nullptr, // resolve_inner_map_references
+    bpf_conformance_groups_t::default_groups};


### PR DESCRIPTION
## Description

Update ebpf-verifier to latest version
Use default set of conformance groups

Replaces #3444

## Testing

Covered by existing tests.

## Documentation

No impact

## Installation

No impact
