### PR TITLE
Update all non-deterministic tests to run 3x the normal CI/CD workflow on the release validation pipeline

### DIFF
--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -242,12 +242,44 @@ jobs:
       gather_dumps: true
 
   # Run the quick stress tests in GitHub.
-  stress:
+  # Stress Tests should run 3x the normal CI/CD workflow
+  # Iteration 1
+  stress-1:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: stress
+      name: stress-1
+      # Until there is a dedicated stress test, re-use the perf test.
+      test_command: .\ebpf_performance.exe -d yes
+      build_artifact: Build-x64
+      environment: windows-2022
+      # No code coverage on stress.
+      code_coverage: false
+      gather_dumps: true
+
+  # Iteration 2
+  stress-2:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: stress-2
+      # Until there is a dedicated stress test, re-use the perf test.
+      test_command: .\ebpf_performance.exe -d yes
+      build_artifact: Build-x64
+      environment: windows-2022
+      # No code coverage on stress.
+      code_coverage: false
+      gather_dumps: true
+
+  # Iteration 3
+  stress-3:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: stress-3
       # Until there is a dedicated stress test, re-use the perf test.
       test_command: .\ebpf_performance.exe -d yes
       build_artifact: Build-x64
@@ -303,13 +335,14 @@ jobs:
 
   # Run a fast multi-threaded stress test pass against the usersim user-mode 'mock' framework.
   # Added as a 'per-PR' test to catch usersim regressions and/or run-time usage issues.
+  # Stress Tests should run 3x the normal CI/CD workflow
   quick_user_mode_multi_threaded_stress_test:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: quick_user_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_um -tt=8 -td=2
+      test_command: .\ebpf_stress_tests_um -tt=8 -td=18
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: false
@@ -355,13 +388,14 @@ jobs:
       fault_injection: true
 
   # Run multi-threaded stress tests against the user mode 'mock' framework.
+  # Stress Tests should run 3x the normal CI/CD workflow
   user_mode_multi_threaded_stress_test:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: user_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_um -tt=8 -td=10
+      test_command: .\ebpf_stress_tests_um -tt=8 -td=30
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: false
@@ -371,12 +405,46 @@ jobs:
 
   # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
   # against the kernel mode eBPF sub-system.
-  km_mt_stress_tests:
+  # Stress Tests should run 3x the normal CI/CD workflow
+  # Iteration 1
+  km_mt_stress_tests-1:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_mt_stress_tests
+      name: km_mt_stress_tests-1
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      build_artifact: Build-x64
+      environment: ebpf_cicd_tests_ws2019
+      code_coverage: false
+      # For this test, we only want kernel mode dumps and not user mode dumps.
+      gather_dumps: false
+
+  # Iteration 2
+  km_mt_stress_tests-2:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: km_mt_stress_tests-2
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      build_artifact: Build-x64
+      environment: ebpf_cicd_tests_ws2019
+      code_coverage: false
+      # For this test, we only want kernel mode dumps and not user mode dumps.
+      gather_dumps: false
+
+  # Iteration 3
+  km_mt_stress_tests-3:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: km_mt_stress_tests-3
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
@@ -388,12 +456,14 @@ jobs:
 
   # Run multi-threaded stress tests with 'restart extension' enabled
   # against the kernel mode eBPF sub-system.
-  km_mt_stress_tests_restart_extension:
+  # Stress Tests should run 3x the normal CI/CD workflow
+  # Iteration 1
+  km_mt_stress_tests_restart_extension-1:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_mt_stress_tests_restart_extension
+      name: km_mt_stress_tests_restart_extension-1
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
       test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
@@ -403,10 +473,42 @@ jobs:
       # For this test, we only want kernel mode dumps and not user mode dumps.
       gather_dumps: false
 
-  ######################################################
-  # Run indeterministic tests multiple times (3 times).
-  ######################################################
-  # FUZZERS ############################################
+  # Iteration 2
+  km_mt_stress_tests_restart_extension-2:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: km_mt_stress_tests_restart_extension-2
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      build_artifact: Build-x64
+      environment: ebpf_cicd_tests_ws2019
+      code_coverage: false
+      # For this test, we only want kernel mode dumps and not user mode dumps.
+      gather_dumps: false
+
+  # Iteration 3
+  km_mt_stress_tests_restart_extension-3:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: km_mt_stress_tests_restart_extension-3
+      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
+      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
+      build_artifact: Build-x64
+      environment: ebpf_cicd_tests_ws2019
+      code_coverage: false
+      # For this test, we only want kernel mode dumps and not user mode dumps.
+      gather_dumps: false
+
+  ########################################################
+  # Run indeterministic tests 3x longer than regular CI/CD
+  ########################################################
+  # FUZZERS ##############################################
   bpf2c_fuzzer:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
@@ -439,7 +541,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: execution_context_fuzzer
-      test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=3000 -artifact_prefix=Artifacts\
+      test_command: .\execution_context_fuzzer.exe execution_context_fuzzer_corpus -use_value_profile=1 -runs=9000 -artifact_prefix=Artifacts\
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: false

--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -242,44 +242,12 @@ jobs:
       gather_dumps: true
 
   # Run the quick stress tests in GitHub.
-  # Stress Tests should run 3x the normal CI/CD workflow
-  # Iteration 1
-  stress-1:
+  stress:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: stress-1
-      # Until there is a dedicated stress test, re-use the perf test.
-      test_command: .\ebpf_performance.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      # No code coverage on stress.
-      code_coverage: false
-      gather_dumps: true
-
-  # Iteration 2
-  stress-2:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: stress-2
-      # Until there is a dedicated stress test, re-use the perf test.
-      test_command: .\ebpf_performance.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      # No code coverage on stress.
-      code_coverage: false
-      gather_dumps: true
-
-  # Iteration 3
-  stress-3:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: stress-3
+      name: stress
       # Until there is a dedicated stress test, re-use the perf test.
       test_command: .\ebpf_performance.exe -d yes
       build_artifact: Build-x64

--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -241,6 +241,53 @@ jobs:
       code_coverage: false
       gather_dumps: true
 
+  # Run the quick stress tests in GitHub.
+  # Stress Tests should run 3x the normal CI/CD workflow
+  # Iteration 1
+  stress-1:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: stress-1
+      # Until there is a dedicated stress test, re-use the perf test.
+      test_command: .\ebpf_performance.exe -d yes
+      build_artifact: Build-x64
+      environment: windows-2022
+      # No code coverage on stress.
+      code_coverage: false
+      gather_dumps: true
+
+  # Iteration 2
+  stress-2:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: stress-2
+      # Until there is a dedicated stress test, re-use the perf test.
+      test_command: .\ebpf_performance.exe -d yes
+      build_artifact: Build-x64
+      environment: windows-2022
+      # No code coverage on stress.
+      code_coverage: false
+      gather_dumps: true
+
+  # Iteration 3
+  stress-3:
+    needs: regular
+    if: github.event_name == 'workflow_dispatch'
+    uses: ./.github/workflows/reusable-test.yml
+    with:
+      name: stress-3
+      # Until there is a dedicated stress test, re-use the perf test.
+      test_command: .\ebpf_performance.exe -d yes
+      build_artifact: Build-x64
+      environment: windows-2022
+      # No code coverage on stress.
+      code_coverage: false
+      gather_dumps: true
+
   # Run the unit tests in GitHub with address sanitizer.
   sanitize_unit_tests:
     needs: sanitize

--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -342,7 +342,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: quick_user_mode_multi_threaded_stress
-      test_command: .\ebpf_stress_tests_um -tt=8 -td=18
+      test_command: .\ebpf_stress_tests_um -tt=8 -td=6
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: false
@@ -406,47 +406,14 @@ jobs:
   # Run multi-threaded stress tests with 'restart extension' disabled (default behavior)
   # against the kernel mode eBPF sub-system.
   # Stress Tests should run 3x the normal CI/CD workflow
-  # Iteration 1
-  km_mt_stress_tests-1:
+  km_mt_stress_tests:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_mt_stress_tests-1
+      name: km_mt_stress_tests
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      code_coverage: false
-      # For this test, we only want kernel mode dumps and not user mode dumps.
-      gather_dumps: false
-
-  # Iteration 2
-  km_mt_stress_tests-2:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_mt_stress_tests-2
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      code_coverage: false
-      # For this test, we only want kernel mode dumps and not user mode dumps.
-      gather_dumps: false
-
-  # Iteration 3
-  km_mt_stress_tests-3:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_mt_stress_tests-3
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -TestDuration 15
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       build_artifact: Build-x64
       environment: ebpf_cicd_tests_ws2019
@@ -457,47 +424,14 @@ jobs:
   # Run multi-threaded stress tests with 'restart extension' enabled
   # against the kernel mode eBPF sub-system.
   # Stress Tests should run 3x the normal CI/CD workflow
-  # Iteration 1
-  km_mt_stress_tests_restart_extension-1:
+  km_mt_stress_tests_restart_extension:
     needs: regular
     if: github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/reusable-test.yml
     with:
-      name: km_mt_stress_tests_restart_extension-1
+      name: km_mt_stress_tests_restart_extension
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      code_coverage: false
-      # For this test, we only want kernel mode dumps and not user mode dumps.
-      gather_dumps: false
-
-  # Iteration 2
-  km_mt_stress_tests_restart_extension-2:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_mt_stress_tests_restart_extension-2
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
-      post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
-      build_artifact: Build-x64
-      environment: ebpf_cicd_tests_ws2019
-      code_coverage: false
-      # For this test, we only want kernel mode dumps and not user mode dumps.
-      gather_dumps: false
-
-  # Iteration 3
-  km_mt_stress_tests_restart_extension-3:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: km_mt_stress_tests_restart_extension-3
-      pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension") -TestDuration 15
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       build_artifact: Build-x64
       environment: ebpf_cicd_tests_ws2019

--- a/.github/workflows/cicd-release-validation.yml
+++ b/.github/workflows/cicd-release-validation.yml
@@ -241,53 +241,6 @@ jobs:
       code_coverage: false
       gather_dumps: true
 
-  # Run the quick stress tests in GitHub.
-  # Stress Tests should run 3x the normal CI/CD workflow
-  # Iteration 1
-  stress-1:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: stress-1
-      # Until there is a dedicated stress test, re-use the perf test.
-      test_command: .\ebpf_performance.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      # No code coverage on stress.
-      code_coverage: false
-      gather_dumps: true
-
-  # Iteration 2
-  stress-2:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: stress-2
-      # Until there is a dedicated stress test, re-use the perf test.
-      test_command: .\ebpf_performance.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      # No code coverage on stress.
-      code_coverage: false
-      gather_dumps: true
-
-  # Iteration 3
-  stress-3:
-    needs: regular
-    if: github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/reusable-test.yml
-    with:
-      name: stress-3
-      # Until there is a dedicated stress test, re-use the perf test.
-      test_command: .\ebpf_performance.exe -d yes
-      build_artifact: Build-x64
-      environment: windows-2022
-      # No code coverage on stress.
-      code_coverage: false
-      gather_dumps: true
-
   # Run the unit tests in GitHub with address sanitizer.
   sanitize_unit_tests:
     needs: sanitize

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -559,7 +559,7 @@ jobs:
     with:
       name: km_mt_stress_tests
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress"
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -TestDuration 5
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       build_artifact: Build-x64
       environment: ebpf_cicd_tests_ws2019
@@ -576,7 +576,7 @@ jobs:
     with:
       name: km_mt_stress_tests_restart_extension
       pre_test: .\setup_ebpf_cicd_tests.ps1 -KmTracing $true -KmTraceType "memory"
-      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension")
+      test_command: .\execute_ebpf_cicd_tests.ps1 -TestMode "Stress" -Options @("RestartExtension") -TestDuration 5
       post_test: .\cleanup_ebpf_cicd_tests.ps1 -KmTracing $true
       build_artifact: Build-x64
       environment: ebpf_cicd_tests_ws2019

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -70,8 +70,7 @@ pipeline, including longer duration fuzz tests, fault injection tests, stress te
 manager must run these tests on the release branch. If any of the tests fail, the release manager must investigate the failure and follow up with issues in GitHub.
 Once potential fixes are merged to the release branch repeat the process until the workflow completes successfully.
 
-Note: If any non-deterministic tests (such as fuzzer or stress) are added in the future, the release validation workflow should be updated to run 3x the normal
-CI/CD workflow (either 3x the duration or 3 instances of the test).
+Note: If any non-deterministic tests (such as fuzzer or stress) are added in the future, the release validation workflow should be updated to run 3x the normal CI/CD workflow (3x the duration of the test).
 
 ## Publishing the Release to GitHub
 

--- a/docs/ReleaseProcess.md
+++ b/docs/ReleaseProcess.md
@@ -67,9 +67,11 @@ the [Release Branch Validation](ReleaseProcess.md#release-branch-validation).
 
 The `CI/CD - Release validation` workflow(`cicd-release-validation.yml`) is used to validate a release branch. It contains more tests than the regular CI/CD
 pipeline, including longer duration fuzz tests, fault injection tests, stress tests, performance tests etc. These tests can be manually scheduled. The release
-manager must run these tests on the release branch. Due to the non-deterministic nature of some of the tests, it is recommended that the tests are run at least
-three times on the branch. If any of the tests fail, the release manager must investigate the failure and follow up with issues in GitHub. Once potential fixes
-are merged to the release branch repeat the process until the workflow completes successfully.
+manager must run these tests on the release branch. If any of the tests fail, the release manager must investigate the failure and follow up with issues in GitHub.
+Once potential fixes are merged to the release branch repeat the process until the workflow completes successfully.
+
+Note: If any non-deterministic tests (such as fuzzer or stress) are added in the future, the release validation workflow should be updated to run 3x the normal
+CI/CD workflow (either 3x the duration or 3 instances of the test).
 
 ## Publishing the Release to GitHub
 

--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -11,7 +11,8 @@ param ([parameter(Mandatory = $false)][string] $AdminTarget = "TEST_VM",
        [parameter(Mandatory = $false)][string[]] $Options = @("None"),
        [parameter(Mandatory = $false)][string] $SelfHostedRunnerName,
        [parameter(Mandatory = $false)][int] $TestHangTimeout = 3600,
-       [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps"
+       [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps",
+       [parameter(Mandatory = $false)][int] $TestDuration = 5)
 )
 
 Push-Location $WorkingDirectory
@@ -52,6 +53,7 @@ foreach ($VM in $VMList) {
         -TestHangTimeout $TestHangTimeout `
         -UserModeDumpFolder $UserModeDumpFolder `
         -Options $Options
+        -TestDuration $TestDuration
 }
 
 # This script is used to execute the various kernel mode tests. The required behavior is selected by the $TestMode

--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -12,7 +12,7 @@ param ([parameter(Mandatory = $false)][string] $AdminTarget = "TEST_VM",
        [parameter(Mandatory = $false)][string] $SelfHostedRunnerName,
        [parameter(Mandatory = $false)][int] $TestHangTimeout = 3600,
        [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps",
-       [parameter(Mandatory = $false)][int] $TestDuration = 5)
+       [parameter(Mandatory = $false)][int] $TestDuration = 5
 )
 
 Push-Location $WorkingDirectory

--- a/scripts/execute_ebpf_cicd_tests.ps1
+++ b/scripts/execute_ebpf_cicd_tests.ps1
@@ -37,7 +37,8 @@ Import-Module $PSScriptRoot\vm_run_tests.psm1 `
         $WorkingDirectory,
         $LogFileName,
         $TestHangTimeout,
-        $UserModeDumpFolder) `
+        $UserModeDumpFolder,
+        $TestDuration) `
     -WarningAction SilentlyContinue
 
 # Read the test execution json.

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -283,12 +283,12 @@ function Invoke-CICDStressTests
     $LASTEXITCODE = 0
 
     $TestCommand = "ebpf_stress_tests_km"
-    $TestArguments = " "
-    if ($RestartExtension -eq $false) {
-        $TestArguments = "-tt=8 -td=" + $TestDuration
-    } else {
-        $TestArguments = "-tt=8 -erd=1000 -er=1 -td=" + $TestDuration
+    $TestArguments = " -tt=8 -td=$testDuration"
+    if ($RestartExtension -eq $true) {
+        $TestArguments = " -erd=1000 -er=1"
     }
+
+    Write-Log "Executing $TestCommand with arguments: $TestArguments"
 
     $TestRunScript = ".\Run-Self-Hosted-Runner-Test.ps1"
     & $TestRunScript `

--- a/scripts/run_driver_tests.psm1
+++ b/scripts/run_driver_tests.psm1
@@ -272,7 +272,8 @@ function Invoke-CICDStressTests
           [parameter(Mandatory = $false)][int] $TestHangTimeout = 3600,
           [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps",
           [parameter(Mandatory = $false)][bool] $NeedKernelDump = $true,
-          [parameter(Mandatory = $false)][bool] $RestartExtension = $false)
+          [parameter(Mandatory = $false)][bool] $RestartExtension = $false,
+          [parameter(Mandatory = $false)][int] $TestDuration = 5)
 
     Push-Location $WorkingDirectory
     $env:EBPF_ENABLE_WER_REPORT = "yes"
@@ -284,9 +285,9 @@ function Invoke-CICDStressTests
     $TestCommand = "ebpf_stress_tests_km"
     $TestArguments = " "
     if ($RestartExtension -eq $false) {
-        $TestArguments = "-tt=8 -td=5"
+        $TestArguments = "-tt=8 -td=" + $TestDuration
     } else {
-        $TestArguments = "-tt=8 -td=5 -erd=1000 -er=1"
+        $TestArguments = "-tt=8 -erd=1000 -er=1 -td=" + $TestDuration
     }
 
     $TestRunScript = ".\Run-Self-Hosted-Runner-Test.ps1"

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -87,7 +87,7 @@ function Invoke-CICDTestsOnVM
             $TestMode,
             $TestHangTimeout,
             $UserModeDumpFolder,
-            $Options
+            $Options,
             $TestDuration) -ErrorAction Stop
 }
 

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -8,7 +8,8 @@ param ([Parameter(Mandatory = $True)] [string] $Admin,
        [Parameter(Mandatory = $True)] [string] $WorkingDirectory,
        [Parameter(Mandatory = $True)] [string] $LogFileName,
        [parameter(Mandatory = $false)][int] $TestHangTimeout = 3600,
-       [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps")
+       [parameter(Mandatory = $false)][string] $UserModeDumpFolder = "C:\Dumps",
+       [parameter(Mandatory = $false)][int] $TestDuration = 5)
 
 Push-Location $WorkingDirectory
 

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -39,7 +39,8 @@ function Invoke-CICDTestsOnVM
               [parameter(Mandatory = $True)][string] $TestMode,
               [parameter(Mandatory = $true)][int] $TestHangTimeout,
               [parameter(Mandatory = $true)][string] $UserModeDumpFolder,
-              [parameter(Mandatory = $True)][string[]] $Options)
+              [parameter(Mandatory = $True)][string[]] $Options,
+              [parameter(Mandatory = $True)][int] $TestDuration)
 
         $WorkingDirectory = "$Env:SystemDrive\$WorkingDirectory"
         Import-Module $WorkingDirectory\common.psm1 -ArgumentList ($LogFileName) -Force -WarningAction SilentlyContinue
@@ -86,7 +87,8 @@ function Invoke-CICDTestsOnVM
             $TestMode,
             $TestHangTimeout,
             $UserModeDumpFolder,
-            $Options) -ErrorAction Stop
+            $Options
+            $TestDuration) -ErrorAction Stop
 }
 
 function Add-eBPFProgramOnVM

--- a/scripts/vm_run_tests.psm1
+++ b/scripts/vm_run_tests.psm1
@@ -25,7 +25,8 @@ function Invoke-CICDTestsOnVM
           [parameter(Mandatory = $False)][string] $TestMode = "CI/CD",
           [parameter(Mandatory = $False)][int] $TestHangTimeout = 3600,
           [parameter(Mandatory = $False)][string] $UserModeDumpFolder = "C:\Dumps",
-          [parameter(Mandatory = $False)][string[]] $Options = @())
+          [parameter(Mandatory = $False)][string[]] $Options = @(),
+          [parameter(Mandatory = $False)][int] $TestDuration = 5)
 
     Write-Log "Running eBPF $TestMode tests on $VMName"
     $TestCredential = New-Credential -Username $Admin -AdminPassword $AdminPassword
@@ -64,6 +65,7 @@ function Invoke-CICDTestsOnVM
                     -RestartExtension $RestartExtension `
                     -TestHangTimeout $TestHangTimeout `
                     -UserModeDumpFolder $UserModeDumpFolder `
+                    -TestDuration $TestDuration `
                     2>&1 | Write-Log
             }
             "performance" {


### PR DESCRIPTION
## Description
Release managers were instructed to run the release validation workflow 3 times to ensure non-deterministic tests had enough time/attempts to run. This change updates the release validation to take care of this, and the manager should now only need to run the workflow once.

Closes #3376

## Testing
None.

## Documentation
Updated the release process documentation to indicate that only 1 run is required now.

## Installation
n/a