### PR TITLE
Fix incorrect fuzzer settings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -22,13 +22,10 @@
   <PropertyGroup Condition="'$(Configuration)'=='Debug' Or '$(Configuration)'=='FuzzerDebug' Or '$(Configuration)'=='NativeOnlyDebug'">
     <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MDd-x86_64.lib</FuzzerLibs>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Fuzzer)'=='Release|True'">
+  <PropertyGroup Condition="'$(Fuzzer)'=='True' OR '$(Configuration)'=='FuzzerDebug'">
     <EnableASAN>true</EnableASAN>
-    <AdditionalOptions>/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Fuzzer)'=='Debug|True' Or '$(Configuration)'=='FuzzerDebug'">
-    <EnableASAN>true</EnableASAN>
-    <AdditionalOptions>/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+    <AdditionalOptions>/fsanitize=address /fsanitize=fuzzer /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+    <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MDd-x86_64.lib</FuzzerLibs>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Fuzzer)'!='True' And '$(Configuration)'!='FuzzerDebug'">
     <SpectreMitigation>Spectre</SpectreMitigation>
@@ -44,7 +41,6 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <ControlFlowGuard>Guard</ControlFlowGuard>
-      <AdditionalOptions>/ZH:SHA_256 /we4062 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(WindowsSdkDir)Include\10.0.22621.0\km;$(SolutionDir)external\ebpf-verifier\build\packages\boost\lib\native\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/external/Directory.Build.props
+++ b/external/Directory.Build.props
@@ -14,7 +14,7 @@
     <EnableASAN>true</EnableASAN>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Fuzzer)'=='True' OR '$(Configuration)'=='FuzzerDebug'">
-    <AdditionalOptions>/fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+    <AdditionalOptions>/fsanitize=address /fsanitize=fuzzer /fsanitize=fuzzer /fsanitize-coverage=inline-bool-flag /fsanitize-coverage=edge /fsanitize-coverage=trace-cmp /fsanitize-coverage=trace-div /ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     <FuzzerLibs>libsancov.lib;clang_rt.fuzzer_MDd-x86_64.lib</FuzzerLibs>
   </PropertyGroup>
   <ItemDefinitionGroup>

--- a/libs/runtime/ebpf_object.h
+++ b/libs/runtime/ebpf_object.h
@@ -133,8 +133,8 @@ extern "C"
     {
         uint32_t marker; ///< Contains the 32bit value 'eobj' when the object is valid and is inverted when the object
                          ///< is freed.
-        uint32_t zero_fill;                              ///< Zero fill to make the reference count is 8-byte aligned.
-        volatile int64_t reference_count;                ///< Reference count for the object.
+        uint32_t zero_fill;               ///< Zero fill to make sure the reference count is 8-byte aligned.
+        volatile int64_t reference_count; ///< Reference count for the object.
         ebpf_base_acquire_reference_t acquire_reference; ///< Function to acquire a reference on this object.
         ebpf_base_release_reference_t release_reference; ///< Function to release a reference on this object.
     } ebpf_base_object_t;


### PR DESCRIPTION
## Description

This pull request primarily involves changes in the `Directory.Build.props` file and a minor change in the `libs/runtime/ebpf_object.h` file. The changes in `Directory.Build.props` are aimed at modifying the conditions and options for the `PropertyGroup` and `ClCompile` configurations. The change in `libs/runtime/ebpf_object.h` is a minor edit to a comment for clarity.

Changes in `Directory.Build.props`:

* Modified the condition for a `PropertyGroup` configuration to check if `$(Fuzzer)` is `True` or `$(Configuration)` is `FuzzerDebug`. The `AdditionalOptions` for this configuration have been updated to include `/fsanitize=address` and `/fsanitize=fuzzer`. Also, `FuzzerLibs` has been added to this configuration.
* Removed `AdditionalOptions` from the `ClCompile` configuration.

Change in `libs/runtime/ebpf_object.h`:

* Edited a comment related to `zero_fill` to improve clarity.

## Testing

CI/CD
To confirm connect settings:
```
msbuild /verbosity:diagnostic /p:Configuration=FuzzerDebug /p:Platform=x64 ebpf-for-windows.sln | findstr "^AdditionalOptions" | findstr /v /c:"/fsanitize=fuzzer"
```

Should be an empty set.

## Documentation

No.

## Installation

No.
