### PR TITLE
Change allocator to reject large allocation sizes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -351,7 +351,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: verifier_fuzzer
-      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\
+      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=300 -artifact_prefix=Artifacts\ allocator_may_return_null=1
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: false
@@ -365,7 +365,7 @@ jobs:
     uses: ./.github/workflows/reusable-test.yml
     with:
       name: verifier_fuzzer
-      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\
+      test_command: .\verifier_fuzzer.exe verifier_corpus -use_value_profile=1 -max_total_time=900 -artifact_prefix=Artifacts\ allocator_may_return_null=1
       build_artifact: Build-x64
       environment: windows-2022
       code_coverage: false


### PR DESCRIPTION
## Description

This pull request includes changes to the Continuous Integration/Continuous Deployment (CI/CD) configuration in the `.github/workflows/cicd.yml` file. The changes specifically modify the `test_command` parameter in the `jobs:` section for the `verifier_fuzzer` job. The `test_command` now includes an additional flag `allocator_may_return_null=1`.

Changes:

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L354-R354): Modified the `test_command` parameter in the `jobs:` section for the `verifier_fuzzer` job to include the `allocator_may_return_null=1` flag. This flag was added in two instances where the `verifier_fuzzer` job was defined. [[1]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L354-R354) [[2]](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L368-R368)

## Testing

CI/CD

## Documentation

No.

## Installation

No.
