### PR TITLE
Increase stack depth for PR fault_injection tests

### DIFF
--- a/.github/workflows/reusable-test.yml
+++ b/.github/workflows/reusable-test.yml
@@ -220,7 +220,7 @@ jobs:
       shell: cmd
       run: |
           set EBPF_ENABLE_WER_REPORT=yes
-          OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 4
+          OpenCppCoverage.exe -q --cover_children --sources %CD% --excluded_sources %CD%\external\Catch2 --export_type cobertura:ebpf_for_windows.xml --working_dir ${{env.BUILD_PLATFORM}}\${{env.BUILD_CONFIGURATION}} -- powershell.exe .\Test-FaultInjection.ps1 ${{env.DUMP_PATH}} ${{env.TEST_TIMEOUT}} ${{env.TEST_COMMAND}} 8
 
     - name: Run test with low resource simulation
       if: (inputs.code_coverage != true) && (inputs.fault_injection == true) && (steps.skip_check.outputs.should_skip != 'true')

--- a/tests/end_to_end/end_to_end.cpp
+++ b/tests/end_to_end/end_to_end.cpp
@@ -2946,6 +2946,7 @@ extension_reload_test(ebpf_execution_type_t execution_type)
     bpf_object_ptr unique_test_sample_ebpf_object;
     int program_fd = -1;
     const char* error_message = nullptr;
+    int result;
 
     // Should fail.
     REQUIRE(
@@ -2966,14 +2967,19 @@ extension_reload_test(ebpf_execution_type_t execution_type)
         program_info_provider_t sample_program_info;
         REQUIRE(sample_program_info.initialize(EBPF_PROGRAM_TYPE_SAMPLE) == EBPF_SUCCESS);
 
-        REQUIRE(
-            ebpf_program_load(
-                execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_ebpf_um.dll" : "test_sample_ebpf.o",
-                BPF_PROG_TYPE_UNSPEC,
-                execution_type,
-                &unique_test_sample_ebpf_object,
-                &program_fd,
-                &error_message) == 0);
+        result = ebpf_program_load(
+            execution_type == EBPF_EXECUTION_NATIVE ? "test_sample_ebpf_um.dll" : "test_sample_ebpf.o",
+            BPF_PROG_TYPE_UNSPEC,
+            execution_type,
+            &unique_test_sample_ebpf_object,
+            &program_fd,
+            &error_message);
+
+        if (error_message) {
+            printf("ebpf_program_load failed with %s\n", error_message);
+            ebpf_free((void*)error_message);
+        }
+        REQUIRE(result == 0);
 
         bpf_link* link = nullptr;
         // Attach only to the single interface being tested.


### PR DESCRIPTION
## Description

The current stack depth of 4 used for fault injection tests in PR is not able to currently find many issues. One reason can be that due to memory allocation wrappers used, 2 stacks are used just by `ebpf_allocate` and `cxplat_allocate`, leaving only 2 more stacks frames to be unique.

This PR increases the stack depth to 8. This change increases the `fault_injection` test time from ~4.5 minutes to ~9 minutes.

PR also contains a memory leak fix in unit_tests that was caught by increasing stack size to 8.

## Testing

This PR updates tests.

## Documentation

No

## Installation

No
