### PR TITLE
Revert overly strict check in link attach to provider

### DIFF
--- a/libs/execution_context/ebpf_link.c
+++ b/libs/execution_context/ebpf_link.c
@@ -153,13 +153,23 @@ _ebpf_link_client_attach_provider(
     }
 
     if (memcmp(&provider_registration_instance->ModuleId->Guid, &link->attach_type, sizeof(link->attach_type)) != 0) {
-        // This is not the provider we are looking for.
+        EBPF_LOG_MESSAGE_GUID_GUID(
+            EBPF_TRACELOG_LEVEL_VERBOSE,
+            EBPF_TRACELOG_KEYWORD_LINK,
+            "Attach provider ModuleId does not match link.",
+            &provider_registration_instance->ModuleId->Guid,
+            &link->attach_type);
         status = STATUS_NOINTERFACE;
         goto Done;
     }
 
     if (memcmp(&attach_provider_data->supported_program_type, &link->program_type, sizeof(link->program_type)) != 0) {
-        // This is not the provider we are looking for.
+        EBPF_LOG_MESSAGE_GUID_GUID(
+            EBPF_TRACELOG_LEVEL_VERBOSE,
+            EBPF_TRACELOG_KEYWORD_LINK,
+            "Attach provider program type does not match link.",
+            &provider_registration_instance->ModuleId->Guid,
+            &link->attach_type);
         status = STATUS_NOINTERFACE;
         goto Done;
     }

--- a/libs/execution_context/ebpf_program.c
+++ b/libs/execution_context/ebpf_program.c
@@ -401,10 +401,12 @@ _ebpf_program_type_specific_program_information_attach_provider(
 
     if (!_ebpf_program_match_provider_data_module_id(
             provider_registration_instance->ModuleId, &program->parameters.program_type)) {
-        EBPF_LOG_MESSAGE(
+        EBPF_LOG_MESSAGE_GUID_GUID(
             EBPF_TRACELOG_LEVEL_ERROR,
             EBPF_TRACELOG_KEYWORD_PROGRAM,
-            "Program information provider module ID mismatch.");
+            "Program information provider module ID mismatch.",
+            &program->parameters.program_type,
+            &provider_registration_instance->ModuleId->Guid);
         status = STATUS_INVALID_PARAMETER;
         goto Done;
     }

--- a/libs/shared/shared_common.c
+++ b/libs/shared/shared_common.c
@@ -105,9 +105,7 @@ ebpf_validate_attach_provider_data(_In_ const ebpf_attach_provider_data_t* attac
     return (
         (attach_provider_data != NULL) &&
         _ebpf_validate_extension_object_header(EBPF_ATTACH_PROVIDER_DATA, &attach_provider_data->header) &&
-        !IsEqualGUID(&attach_provider_data->supported_program_type, &GUID_NULL) &&
-        (attach_provider_data->link_type < BPF_LINK_TYPE_MAX) &&
-        (attach_provider_data->bpf_attach_type < __MAX_BPF_ATTACH_TYPE));
+        !IsEqualGUID(&attach_provider_data->supported_program_type, &GUID_NULL));
 }
 
 static bool


### PR DESCRIPTION
## Description
Resolves: #3484

The values bpf_attach_type and link_type aren't meaningful to ebpfcore and it shouldn't block new values.

Copilot summary:
This pull request primarily focuses on enhancing the logging and error reporting mechanism in the `libs/execution_context` and `libs/shared` directories. The key changes include the addition of more detailed logging messages and the removal of certain conditions in the `ebpf_validate_attach_provider_data` function.

Enhancements to logging and error reporting:

* [`libs/execution_context/ebpf_link.c`](diffhunk://#diff-c14a8d075874a74f3dc279088def67e69e031f00016092c8da47dba0bb4513a1L156-R172): In the `_ebpf_link_client_attach_provider` function, the logging mechanism has been updated to provide more detailed information when the provider's `ModuleId` or `program_type` does not match the link's `attach_type` or `program_type` respectively.
* [`libs/execution_context/ebpf_program.c`](diffhunk://#diff-6bd70efed6714c9e250113aa729f24539066345c2433fccee1928c62f6657320L404-R409): In the `_ebpf_program_type_specific_program_information_attach_provider` function, the log message now includes the `program_type` and `ModuleId` in case of a module ID mismatch.
* [`libs/shared/shared_common.c`](diffhunk://#diff-f43c036127278a98c696730171363de607c6b872d075959686ad951c0928216dL108-R108): In the `ebpf_validate_attach_provider_data` function, the conditions checking the `link_type` and `bpf_attach_type` have been removed, simplifying the function.

## Testing

CI/CD + testing with ntosebpfext

## Documentation

No.

## Installation

No.
