### PR TITLE
The netperf run fails due to missing Azure 2025 results

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -632,19 +632,6 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-  upload_netperf_results_azure_2025:
-    needs: netperf
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: ./.github/workflows/upload-perf-results.yml
-    with:
-      name: upload_netperf_results_azure_2025
-      result_artifact: netperf_azure_2025_x64
-      platform: Azure Windows 2025
-    secrets:
-      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
   upload_netperf_results_lab_2022:
     needs: netperf
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/netperf.yml
+++ b/.github/workflows/netperf.yml
@@ -53,12 +53,6 @@ jobs:
             name: Test-Logs-netperf_azure_2022_x64
             path: netperf/ebpf_azure_2022_x64/ebpf.csv
 
-      - name: upload_results_azure_2025_x64
-        uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba
-        with:
-            name: Test-Logs-netperf_azure_2025_x64
-            path: netperf/ebpf_azure_2025_x64/ebpf.csv
-
       - name: upload_results_lab_2022_x64
         uses: actions/upload-artifact@1746f4ab65b179e0ea60a494b83293b640dd5bba
         with:


### PR DESCRIPTION
## Description

This pull request includes changes to the CI/CD pipeline configuration files. The changes remove the job for uploading netperf results for Azure 2025 from the `.github/workflows/cicd.yml` file and the step for uploading test logs for Azure 2025 from the `.github/workflows/netperf.yml` file.

CI/CD pipeline changes:

* [`.github/workflows/cicd.yml`](diffhunk://#diff-6727e33ccc9195d67f0786e1384f8f1cdaf4090c3e77547943105bd2b28c99d0L635-L647): Removed the job `upload_netperf_results_azure_2025` which was responsible for uploading netperf results for Azure 2025. This job was dependent on the `netperf` job and was only triggered on schedule or workflow dispatch events.
* [`.github/workflows/netperf.yml`](diffhunk://#diff-f2ba71ce9002e907f7355bdaf9e43385e451541fd886c97f1d89f80cf9697a46L56-L61): Removed the step `upload_results_azure_2025_x64` which was responsible for uploading test logs for Azure 2025. This step was part of the `netperf` job.

## Testing

CI/CD

## Documentation

No.

## Installation

No,
