### PR TITLE
Update ebpf verifier

### DIFF
--- a/ebpfapi/dllmain.cpp
+++ b/ebpfapi/dllmain.cpp
@@ -32,3 +32,15 @@ DllMain(HMODULE hModule, unsigned long ul_reason_for_call, void* lpReserved)
     }
     return TRUE;
 }
+
+// This entry point exists to satisfy the requirements of the fuzzing engine, but it is not used.
+#if defined(FUZZER_DEBUG)
+extern "C" int __cdecl LLVMFuzzerTestOneInput(const uint8_t* data, size_t size)
+{
+    UNREFERENCED_PARAMETER(data);
+    UNREFERENCED_PARAMETER(size);
+
+    __fastfail(0);
+    return 0;
+}
+#endif

--- a/ebpfapi/ebpfapi.vcxproj
+++ b/ebpfapi/ebpfapi.vcxproj
@@ -154,7 +154,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='FuzzerDebug|x64'">
     <ClCompile>
-      <PreprocessorDefinitions>_DEBUG;EBPFAPI_EXPORTS;_WINDOWS;_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_DEBUG;EBPFAPI_EXPORTS;_WINDOWS;_USRDLL;FUZZER_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>pch.h</PrecompiledHeaderFile>
       <RuntimeLibrary>MultiThreadedDebugDll</RuntimeLibrary>


### PR DESCRIPTION
## Description

This pull request primarily involves changes to set up and support fuzz testing. The most significant changes include the addition of a new entry point in `dllmain.cpp`, the addition of a preprocessor definition in the `ebpfapi.vcxproj` file, and an update to the `ebpf-verifier` subproject.

Fuzz testing setup:

* [`ebpfapi/dllmain.cpp`](diffhunk://#diff-9a0fe5a5bacad3cf88ecd2809b3a5e8262ea280a656a1be38d8bb629e54628a5R35-R46): A new entry point `LLVMFuzzerTestOneInput` has been added to satisfy the requirements of the fuzzing engine. This function is not used in normal operation but is required for fuzz testing.

Project configuration:

* [`ebpfapi/ebpfapi.vcxproj`](diffhunk://#diff-f24d2e799e853ec88d6f9c478d3b150d7897efd5e687b8743c616b4a114f4026L157-R157): The preprocessor definition `FUZZER_DEBUG` has been added to the `FuzzerDebug|x64` configuration. This definition is used to conditionally compile code specific to fuzz testing.

Subproject update:

* [`external/ebpf-verifier`](diffhunk://#diff-0f47f98c433f156a9980e12abb7595d356ac1690a2e6ddbc3d51f7a4f0c7621eL1-R1): The commit reference for the `ebpf-verifier` subproject has been updated. This could include various changes, but the specific details would need to be checked in the `ebpf-verifier` repository.

## Testing

CI/CD

## Documentation

No.

## Installation

No.
